### PR TITLE
fix: restore generation deduplication without storage timeouts

### DIFF
--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -1,4 +1,8 @@
-import { createExecutionContext, env, SELF } from "cloudflare:test";
+import {
+    createExecutionContext,
+    env,
+    waitOnExecutionContext,
+} from "cloudflare:test";
 import type { Logger } from "@logtape/logtape";
 import { verifyAgentRunToken } from "@shared/auth/agent-run-token.ts";
 import {
@@ -57,11 +61,13 @@ import { drizzle } from "drizzle-orm/d1";
 import { Hono } from "hono";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Env } from "@/env.ts";
+import { withInlineGenerationCoordinator } from "../test/helpers/inline-generation-coordinator.ts";
 import {
     communityImageSupportedEndpoints,
     getCommunityModelRegistryEntries,
 } from "./community-models.ts";
 import { callCommunityImageEndpoint } from "./image/communityEndpoint.ts";
+import worker from "./index.ts";
 import {
     getGenerationModelRegistry,
     resetGenerationModelRegistryCache,
@@ -140,6 +146,21 @@ async function fetchEnterApi(
 ): Promise<Response> {
     const ctx = createExecutionContext();
     return app.fetch(request, env, ctx);
+}
+
+async function fetchGen(
+    input: RequestInfo | URL,
+    init?: RequestInit,
+): Promise<Response> {
+    const ctx = createExecutionContext();
+    const response = await worker.fetch(
+        new Request(input, init),
+        withInlineGenerationCoordinator(env),
+        ctx,
+    );
+    const body = response.body ? await response.arrayBuffer() : null;
+    await waitOnExecutionContext(ctx);
+    return new Response(body, response);
 }
 
 async function signedSessionCookie(token: string): Promise<string> {
@@ -1119,7 +1140,7 @@ fixtureTest(
         });
         vi.stubGlobal("fetch", fetchMock);
 
-        const response = await SELF.fetch(
+        const response = await fetchGen(
             new Request("https://gen.pollinations.ai/v1/chat/completions", {
                 method: "POST",
                 headers: {
@@ -1148,7 +1169,7 @@ fixtureTest(
             usage: { prompt_tokens: 2, completion_tokens: 3, total_tokens: 5 },
         });
 
-        const legacyResponse = await SELF.fetch(
+        const legacyResponse = await fetchGen(
             new Request("https://gen.pollinations.ai/v1/chat/completions", {
                 method: "POST",
                 headers: {
@@ -1245,7 +1266,7 @@ fixtureTest(
 
         // A non-owner caller: the private model resolves to "invalid model",
         // indistinguishable from an unknown name so it isn't discoverable.
-        const otherResponse = await SELF.fetch(
+        const otherResponse = await fetchGen(
             new Request("https://gen.pollinations.ai/v1/chat/completions", {
                 method: "POST",
                 headers: {
@@ -1261,7 +1282,7 @@ fixtureTest(
         expect(otherResponse.status).toBe(400);
 
         // The owner reaches their own private model.
-        const ownerResponse = await SELF.fetch(
+        const ownerResponse = await fetchGen(
             new Request("https://gen.pollinations.ai/v1/chat/completions", {
                 method: "POST",
                 headers: {
@@ -1280,7 +1301,7 @@ fixtureTest(
         });
 
         const catalogIncludesModel = async (authorization?: string) => {
-            const modelsResponse = await SELF.fetch(
+            const modelsResponse = await fetchGen(
                 new Request("https://gen.pollinations.ai/text/models", {
                     headers: authorization
                         ? { Authorization: `Bearer ${authorization}` }
@@ -1308,7 +1329,7 @@ fixtureTest(
         const { key: zeroBalanceCallerKey } = await createTestApiKey({
             user: { tierBalance: 0, packBalance: 0 },
         });
-        const freePublicResponse = await SELF.fetch(
+        const freePublicResponse = await fetchGen(
             new Request("https://gen.pollinations.ai/v1/chat/completions", {
                 method: "POST",
                 headers: {
@@ -1399,7 +1420,7 @@ fixtureTest(
             }),
         );
 
-        const response = await SELF.fetch(
+        const response = await fetchGen(
             new Request("https://gen.pollinations.ai/v1/chat/completions", {
                 method: "POST",
                 headers: {
@@ -1502,7 +1523,7 @@ fixtureTest(
             }),
         );
 
-        const response = await SELF.fetch(
+        const response = await fetchGen(
             new Request(
                 `https://gen.pollinations.ai/text/hello?model=${encodeURIComponent(
                     modelId,
@@ -1519,7 +1540,8 @@ fixtureTest(
         expect(response.headers.get("cache-control")).toBe(
             IMMUTABLE_CACHE_CONTROL,
         );
-        expect(response.headers.get("x-cache")).toBe("MISS");
+        expect(response.headers.get("x-cache")).toBe("HIT");
+        expect(response.headers.get("x-cache-type")).toBeNull();
         expect(response.headers.get("x-cache-key")).toBeTruthy();
         await expect(response.text()).resolves.toBe("simple ok");
     },
@@ -1553,13 +1575,13 @@ fixtureTest(
             updatedAt: new Date(),
         });
 
-        const textResponse = await SELF.fetch(
+        const textResponse = await fetchGen(
             "https://gen.pollinations.ai/text/models",
         );
-        const allResponse = await SELF.fetch(
+        const allResponse = await fetchGen(
             "https://gen.pollinations.ai/models",
         );
-        const openaiResponse = await SELF.fetch(
+        const openaiResponse = await fetchGen(
             "https://gen.pollinations.ai/v1/models",
         );
 
@@ -1657,10 +1679,10 @@ fixtureTest(
 
         const [allResponse, openaiResponse, textResponse, restrictedResponse] =
             await Promise.all([
-                SELF.fetch("https://gen.pollinations.ai/models"),
-                SELF.fetch("https://gen.pollinations.ai/v1/models"),
-                SELF.fetch("https://gen.pollinations.ai/text/models"),
-                SELF.fetch("https://gen.pollinations.ai/models", {
+                fetchGen("https://gen.pollinations.ai/models"),
+                fetchGen("https://gen.pollinations.ai/v1/models"),
+                fetchGen("https://gen.pollinations.ai/text/models"),
+                fetchGen("https://gen.pollinations.ai/models", {
                     headers: {
                         Authorization: `Bearer ${restrictedApiKey}`,
                     },
@@ -1804,13 +1826,13 @@ fixtureTest(
             updatedAt: new Date(),
         });
 
-        const textResponse = await SELF.fetch(
+        const textResponse = await fetchGen(
             "https://gen.pollinations.ai/text/models",
         );
-        const allResponse = await SELF.fetch(
+        const allResponse = await fetchGen(
             "https://gen.pollinations.ai/models",
         );
-        const openaiResponse = await SELF.fetch(
+        const openaiResponse = await fetchGen(
             "https://gen.pollinations.ai/v1/models",
         );
 
@@ -1867,7 +1889,7 @@ fixtureTest(
         });
 
         for (const requestedModel of [modelId, legacyModelId]) {
-            const response = await SELF.fetch(
+            const response = await fetchGen(
                 "https://gen.pollinations.ai/v1/chat/completions",
                 {
                     method: "POST",
@@ -2084,14 +2106,14 @@ fixtureTest(
         });
         vi.stubGlobal("fetch", fetchMock);
 
-        const modelsResponse = await SELF.fetch(
+        const modelsResponse = await fetchGen(
             "https://gen.pollinations.ai/text/models",
         );
         expect(modelsResponse.status).toBe(200);
         const models = (await modelsResponse.json()) as { name: string }[];
         expect(models.some((model) => model.name === modelId)).toBe(true);
 
-        const generationResponse = await SELF.fetch(
+        const generationResponse = await fetchGen(
             new Request("https://gen.pollinations.ai/v1/chat/completions", {
                 method: "POST",
                 headers: {
@@ -2294,7 +2316,7 @@ fixtureTest(
             error: "rate_limited",
         });
 
-        const response = await SELF.fetch(
+        const response = await fetchGen(
             new Request("https://gen.pollinations.ai/v1/chat/completions", {
                 method: "POST",
                 headers: {
@@ -2538,7 +2560,7 @@ fixtureTest(
             inputModalities: ["text", "image"],
         });
 
-        const simpleImageResponse = await SELF.fetch(
+        const simpleImageResponse = await fetchGen(
             new Request(
                 `https://gen.pollinations.ai/image/green%20sprout?model=${encodeURIComponent(
                     registered.modelId,
@@ -2567,7 +2589,7 @@ fixtureTest(
             Array.from(new Uint8Array(await simpleImageResponse.arrayBuffer())),
         ).toEqual(TEST_PNG_BYTES);
 
-        const openaiImageResponse = await SELF.fetch(
+        const openaiImageResponse = await fetchGen(
             new Request("https://gen.pollinations.ai/v1/images/generations", {
                 method: "POST",
                 headers: {
@@ -2607,7 +2629,7 @@ fixtureTest(
             new Blob([new Uint8Array(TEST_PNG_BYTES)], { type: "image/png" }),
             "source.png",
         );
-        const openaiEditResponse = await SELF.fetch(
+        const openaiEditResponse = await fetchGen(
             new Request("https://gen.pollinations.ai/v1/images/edits", {
                 method: "POST",
                 headers: { Authorization: `Bearer ${apiKey}` },
@@ -2624,7 +2646,7 @@ fixtureTest(
             },
         });
 
-        const simpleEditResponse = await SELF.fetch(
+        const simpleEditResponse = await fetchGen(
             new Request(
                 `https://gen.pollinations.ai/image/turn%20it%20red?model=${encodeURIComponent(
                     registered.modelId,
@@ -2643,7 +2665,7 @@ fixtureTest(
             Array.from(new Uint8Array(await simpleEditResponse.arrayBuffer())),
         ).toEqual(TEST_PNG_BYTES);
 
-        const urlImageResponse = await SELF.fetch(
+        const urlImageResponse = await fetchGen(
             new Request("https://gen.pollinations.ai/v1/images/generations", {
                 method: "POST",
                 headers: {
@@ -2665,7 +2687,7 @@ fixtureTest(
             },
         });
 
-        const invalidMediaResponse = await SELF.fetch(
+        const invalidMediaResponse = await fetchGen(
             new Request("https://gen.pollinations.ai/v1/images/generations", {
                 method: "POST",
                 headers: {
@@ -2680,16 +2702,16 @@ fixtureTest(
         );
         expect(invalidMediaResponse.status).toBe(502);
 
-        const imageModelsResponse = await SELF.fetch(
+        const imageModelsResponse = await fetchGen(
             "https://gen.pollinations.ai/image/models",
         );
-        const textModelsResponse = await SELF.fetch(
+        const textModelsResponse = await fetchGen(
             "https://gen.pollinations.ai/text/models",
         );
-        const allModelsResponse = await SELF.fetch(
+        const allModelsResponse = await fetchGen(
             "https://gen.pollinations.ai/models",
         );
-        const openaiModelsResponse = await SELF.fetch(
+        const openaiModelsResponse = await fetchGen(
             "https://gen.pollinations.ai/v1/models",
         );
 
@@ -3927,7 +3949,7 @@ fixtureTest(
                 }),
             );
 
-            const response = await SELF.fetch(
+            const response = await fetchGen(
                 new Request("https://gen.pollinations.ai/v1/chat/completions", {
                     method: "POST",
                     headers: {
@@ -4020,7 +4042,7 @@ fixtureTest(
         });
         vi.stubGlobal("fetch", fetchMock);
 
-        const response = await SELF.fetch(
+        const response = await fetchGen(
             new Request("https://gen.pollinations.ai/v1/chat/completions", {
                 method: "POST",
                 headers: {
@@ -4112,7 +4134,7 @@ fixtureTest(
         });
         vi.stubGlobal("fetch", fetchMock);
 
-        const response = await SELF.fetch(
+        const response = await fetchGen(
             new Request("https://gen.pollinations.ai/v1/chat/completions", {
                 method: "POST",
                 headers: {
@@ -4195,7 +4217,7 @@ fixtureTest(
         });
         vi.stubGlobal("fetch", fetchMock);
 
-        const response = await SELF.fetch(
+        const response = await fetchGen(
             new Request(
                 `https://gen.pollinations.ai/image/green%20sprout?model=${encodeURIComponent(primaryModelId)}`,
                 { headers: { Authorization: `Bearer ${apiKey}` } },
@@ -4289,7 +4311,7 @@ fixtureTest(
             }),
         );
 
-        const response = await SELF.fetch(
+        const response = await fetchGen(
             new Request(
                 `https://gen.pollinations.ai/image/green%20sprout?model=${encodeURIComponent(modelIds[0])}`,
                 { headers: { Authorization: `Bearer ${apiKey}` } },
@@ -4313,7 +4335,7 @@ fixtureTest(
         // The OpenAI-compatible route replaces the generated response with
         // JSON, so it has to carry the fallback marker across itself —
         // otherwise tracking reads the rescue as a plain first-try success.
-        const openaiResponse = await SELF.fetch(
+        const openaiResponse = await fetchGen(
             new Request("https://gen.pollinations.ai/v1/images/generations", {
                 method: "POST",
                 headers: {
@@ -4371,7 +4393,7 @@ fixtureTest(
         vi.stubGlobal("fetch", fetchMock);
 
         const generate = async () => {
-            const response = await SELF.fetch(
+            const response = await fetchGen(
                 new Request(
                     `https://gen.pollinations.ai/image/green%20sprout?model=${encodeURIComponent(primaryModelId)}`,
                     { headers: { Authorization: `Bearer ${apiKey}` } },
@@ -4452,7 +4474,7 @@ fixtureTest(
         });
         vi.stubGlobal("fetch", fetchMock);
 
-        const response = await SELF.fetch(
+        const response = await fetchGen(
             new Request("https://gen.pollinations.ai/v1/chat/completions", {
                 method: "POST",
                 headers: {
@@ -4475,7 +4497,7 @@ fixtureTest(
         expect(gatewayCalls[0].customHost).toBe(primaryHost);
 
         // The same key calling the fallback directly is refused.
-        const direct = await SELF.fetch(
+        const direct = await fetchGen(
             new Request("https://gen.pollinations.ai/v1/chat/completions", {
                 method: "POST",
                 headers: {

--- a/gen.pollinations.ai/src/docs/apidocs-recipes.md
+++ b/gen.pollinations.ai/src/docs/apidocs-recipes.md
@@ -180,5 +180,5 @@ Each upload gets its own unique id — re-uploading the same bytes yields a new 
 
 - **Use `pk_` keys in browsers.** Anywhere a `sk_` key could be read off the wire, use a publishable key with a tight budget and an allow-list of models.
 - **One key per app.** Child keys scope budget and permissions independently — easier to audit, easier to revoke without touching production.
-- **Image/audio `GET` URLs are cache-friendly.** They're idempotent on `(prompt, model, seed)` — cache them on a CDN if you serve the same generations to many users.
+- **Retry the same request after a timeout.** Keep the endpoint, body, query parameters, and seed unchanged. Your retry waits for the generation already in progress or receives the completed cached result instead of starting another generation.
 - **Watch `429` and `503`.** A `Retry-After` header tells you how long to back off. `502` from us means upstream provider — usually transient.

--- a/gen.pollinations.ai/src/docs/errors.md
+++ b/gen.pollinations.ai/src/docs/errors.md
@@ -20,3 +20,11 @@ All errors return JSON with a consistent shape:
 | `402` | Insufficient pollen balance |
 | `403` | API key lacks required permission |
 | `500` | Internal server error |
+
+### Timeouts and retries
+
+If your client or proxy times out, send the exact same request again. Keep the endpoint, body, query parameters, and seed unchanged.
+
+The generation continues after the connection closes. The retry waits for the generation already in progress or receives the completed cached result, instead of starting another generation. Only the generation is billed; retries and cache hits are not.
+
+This applies to cache-backed, non-streaming text, embedding, image, video, 3D, audio, and transcription requests, including the OpenAI-compatible endpoints. Streaming text and uncached endpoints run independently.

--- a/gen.pollinations.ai/src/durable-objects/GenerationCoordinator.ts
+++ b/gen.pollinations.ai/src/durable-objects/GenerationCoordinator.ts
@@ -16,6 +16,13 @@ type PersistedJob = Omit<GenerationJob, "request"> & {
     bodyChunks: number;
 };
 
+function bodyChunkKeys(count: number): string[] {
+    return Array.from(
+        { length: count },
+        (_, index) => `${BODY_KEY_PREFIX}${index}`,
+    );
+}
+
 async function cacheExists(
     env: CloudflareBindings,
     cache: GenerationCacheIdentity,
@@ -48,7 +55,9 @@ export class GenerationCoordinator extends DurableObject<CloudflareBindings> {
             const stored = await this.ctx.storage.get<PersistedJob>(JOB_KEY);
 
             if (cachePresent) {
-                if (stored) await this.clear();
+                if (stored) {
+                    await this.clear(stored.bodyChunks, true);
+                }
                 immediate = { status: "cached" };
                 return;
             }
@@ -68,13 +77,13 @@ export class GenerationCoordinator extends DurableObject<CloudflareBindings> {
     }
 
     async alarm(): Promise<void> {
+        const stored = await this.ctx.storage.get<PersistedJob>(JOB_KEY);
+        if (!stored) return;
+
         let settlement: Promise<void> | undefined;
         try {
-            const stored = await this.ctx.storage.get<PersistedJob>(JOB_KEY);
-            if (!stored) return;
-
             if (await cacheExists(this.env, stored.cache)) {
-                await this.finish({ status: "cached" });
+                await this.finish({ status: "cached" }, stored.bodyChunks);
                 return;
             }
 
@@ -91,10 +100,13 @@ export class GenerationCoordinator extends DurableObject<CloudflareBindings> {
                 this.env,
             );
             settlement = execution.settlement;
-            await this.finish(execution.result);
+            await this.finish(execution.result, stored.bodyChunks);
         } catch (error) {
             console.error("Detached generation failed", error);
-            await this.finish(unavailable("Detached generation failed"));
+            await this.finish(
+                unavailable("Detached generation failed"),
+                stored.bodyChunks,
+            );
         } finally {
             if (settlement) await settlement;
         }
@@ -135,10 +147,7 @@ export class GenerationCoordinator extends DurableObject<CloudflareBindings> {
     private async restore(job: PersistedJob): Promise<GenerationJob> {
         let body: Uint8Array | undefined;
         if (job.bodyChunks > 0) {
-            const keys = Array.from(
-                { length: job.bodyChunks },
-                (_, index) => `${BODY_KEY_PREFIX}${index}`,
-            );
+            const keys = bodyChunkKeys(job.bodyChunks);
             const storedChunks = await this.ctx.storage.get<Uint8Array>(keys);
             const chunks = keys.map((key) => storedChunks.get(key));
             if (chunks.some((chunk) => chunk === undefined)) {
@@ -170,16 +179,22 @@ export class GenerationCoordinator extends DurableObject<CloudflareBindings> {
         };
     }
 
-    private async finish(outcome: GenerationOutcome): Promise<void> {
+    private async finish(
+        outcome: GenerationOutcome,
+        bodyChunks: number,
+    ): Promise<void> {
         await this.ctx.blockConcurrencyWhile(async () => {
-            await this.clear();
+            await this.clear(bodyChunks);
             for (const resolve of this.waiters) resolve(outcome);
             this.waiters.clear();
         });
     }
 
-    private async clear(): Promise<void> {
-        await this.ctx.storage.deleteAlarm();
-        await this.ctx.storage.deleteAll();
+    private async clear(
+        bodyChunks: number,
+        cancelAlarm = false,
+    ): Promise<void> {
+        if (cancelAlarm) await this.ctx.storage.deleteAlarm();
+        await this.ctx.storage.delete([JOB_KEY, ...bodyChunkKeys(bodyChunks)]);
     }
 }

--- a/gen.pollinations.ai/src/durable-objects/GenerationCoordinator.ts
+++ b/gen.pollinations.ai/src/durable-objects/GenerationCoordinator.ts
@@ -1,4 +1,185 @@
 import { DurableObject } from "cloudflare:workers";
+import type {
+    GenerationCacheIdentity,
+    GenerationJob,
+    GenerationOutcome,
+    GenerationRequestSnapshot,
+} from "@/middleware/generation-deduplication.ts";
+import { executeGeneration } from "@/utils/execute-generation.ts";
 
-/** Retained because deployed Durable Object migration history is append-only. */
-export class GenerationCoordinator extends DurableObject<CloudflareBindings> {}
+const JOB_KEY = "job";
+const BODY_KEY_PREFIX = "body:";
+const BODY_CHUNK_BYTES = 1_000_000;
+
+type PersistedJob = Omit<GenerationJob, "request"> & {
+    request: Omit<GenerationRequestSnapshot, "body">;
+    bodyChunks: number;
+};
+
+async function cacheExists(
+    env: CloudflareBindings,
+    cache: GenerationCacheIdentity,
+): Promise<boolean> {
+    const bucket =
+        cache.storage === "media" ? env.IMAGE_BUCKET : env.TEXT_BUCKET;
+    return (await bucket.head(cache.key)) !== null;
+}
+
+function unavailable(message: string): GenerationOutcome {
+    return {
+        status: "failed",
+        error: {
+            httpStatus: 503,
+            headers: [["content-type", "text/plain; charset=UTF-8"]],
+            body: new TextEncoder().encode(message),
+        },
+    };
+}
+
+export class GenerationCoordinator extends DurableObject<CloudflareBindings> {
+    private readonly waiters = new Set<(outcome: GenerationOutcome) => void>();
+
+    async startAndWait(job: GenerationJob): Promise<GenerationOutcome> {
+        let immediate: GenerationOutcome | undefined;
+        let wait: Promise<GenerationOutcome> | undefined;
+
+        await this.ctx.blockConcurrencyWhile(async () => {
+            const cachePresent = await cacheExists(this.env, job.cache);
+            const stored = await this.ctx.storage.get<PersistedJob>(JOB_KEY);
+
+            if (cachePresent) {
+                if (stored) await this.clear();
+                immediate = { status: "cached" };
+                return;
+            }
+
+            if (!stored) {
+                await this.persist(job);
+            }
+
+            wait = new Promise<GenerationOutcome>((resolve) => {
+                this.waiters.add(resolve);
+            });
+        });
+
+        if (immediate) return immediate;
+        if (!wait) throw new Error("Generation waiter was not registered");
+        return wait;
+    }
+
+    async alarm(): Promise<void> {
+        let settlement: Promise<void> | undefined;
+        try {
+            const stored = await this.ctx.storage.get<PersistedJob>(JOB_KEY);
+            if (!stored) return;
+
+            if (await cacheExists(this.env, stored.cache)) {
+                await this.finish({ status: "cached" });
+                return;
+            }
+
+            const job = await this.restore(stored);
+            const execution = await executeGeneration(
+                new Request(job.request.url, {
+                    method: job.request.method,
+                    headers: job.request.headers,
+                    body: job.request.body?.slice().buffer,
+                }),
+                job.auth,
+                job.requestId,
+                job.balanceCheckResult,
+                this.env,
+            );
+            settlement = execution.settlement;
+            await this.finish(execution.result);
+        } catch (error) {
+            console.error("Detached generation failed", error);
+            await this.finish(unavailable("Detached generation failed"));
+        } finally {
+            if (settlement) await settlement;
+        }
+    }
+
+    private async persist(job: GenerationJob): Promise<void> {
+        const body = job.request.body;
+        const chunks: Uint8Array[] = [];
+        if (body !== undefined) {
+            const bytes = body;
+            for (let offset = 0; offset < bytes.byteLength; ) {
+                const end = Math.min(
+                    offset + BODY_CHUNK_BYTES,
+                    bytes.byteLength,
+                );
+                chunks.push(bytes.slice(offset, end));
+                offset = end;
+            }
+        }
+
+        const { body: _body, ...request } = job.request;
+        const stored: PersistedJob = {
+            cache: job.cache,
+            auth: job.auth,
+            requestId: job.requestId,
+            balanceCheckResult: job.balanceCheckResult,
+            request,
+            bodyChunks: chunks.length,
+        };
+        const entries: Record<string, unknown> = { [JOB_KEY]: stored };
+        for (const [index, chunk] of chunks.entries()) {
+            entries[`${BODY_KEY_PREFIX}${index}`] = chunk;
+        }
+        await this.ctx.storage.put(entries);
+        await this.ctx.storage.setAlarm(Date.now());
+    }
+
+    private async restore(job: PersistedJob): Promise<GenerationJob> {
+        let body: Uint8Array | undefined;
+        if (job.bodyChunks > 0) {
+            const keys = Array.from(
+                { length: job.bodyChunks },
+                (_, index) => `${BODY_KEY_PREFIX}${index}`,
+            );
+            const storedChunks = await this.ctx.storage.get<Uint8Array>(keys);
+            const chunks = keys.map((key) => storedChunks.get(key));
+            if (chunks.some((chunk) => chunk === undefined)) {
+                throw new Error("Persisted generation request is incomplete");
+            }
+            const size = chunks.reduce(
+                (total, chunk) => total + (chunk?.byteLength ?? 0),
+                0,
+            );
+            const bytes = new Uint8Array(size);
+            let offset = 0;
+            for (const chunk of chunks) {
+                if (!chunk) {
+                    throw new Error(
+                        "Persisted generation request is incomplete",
+                    );
+                }
+                bytes.set(chunk, offset);
+                offset += chunk.byteLength;
+            }
+            body = bytes;
+        }
+        return {
+            cache: job.cache,
+            auth: job.auth,
+            requestId: job.requestId,
+            balanceCheckResult: job.balanceCheckResult,
+            request: { ...job.request, ...(body !== undefined && { body }) },
+        };
+    }
+
+    private async finish(outcome: GenerationOutcome): Promise<void> {
+        await this.ctx.blockConcurrencyWhile(async () => {
+            await this.clear();
+            for (const resolve of this.waiters) resolve(outcome);
+            this.waiters.clear();
+        });
+    }
+
+    private async clear(): Promise<void> {
+        await this.ctx.storage.deleteAlarm();
+        await this.ctx.storage.deleteAll();
+    }
+}

--- a/gen.pollinations.ai/src/image/params.ts
+++ b/gen.pollinations.ai/src/image/params.ts
@@ -1,6 +1,7 @@
 import { IMAGE_SERVICES, type ImageModelName } from "@shared/registry/image.ts";
 import type { ModelDefinition } from "@shared/registry/registry.ts";
 import { z } from "zod";
+import { normalizeSeed, SENTINEL_SEED } from "@/util.ts";
 import { getDefaultSideLength } from "./models.js";
 
 const allowedModels = Object.keys(IMAGE_SERVICES) as [
@@ -21,9 +22,9 @@ const sanitizedBoolean = z
 const sanitizedSeed = z.preprocess((v) => {
     const seed = String(v);
     const parsedSeed = Number.parseInt(seed, 10);
-    const parsed = Number.isInteger(parsedSeed) ? parsedSeed : 42;
-    return parsed;
-}, z.int().min(-1).max(MAX_SEED).catch(42));
+    const parsed = Number.isInteger(parsedSeed) ? parsedSeed : SENTINEL_SEED;
+    return normalizeSeed(parsed);
+}, z.int().min(0).max(MAX_SEED).catch(SENTINEL_SEED));
 
 const sanitizedSideLength = z.preprocess((v) => {
     const parsed = Number.parseInt(v as string, 10);

--- a/gen.pollinations.ai/src/middleware/auth.ts
+++ b/gen.pollinations.ai/src/middleware/auth.ts
@@ -7,6 +7,7 @@ import {
     StagingAccessDeniedError,
 } from "@shared/auth/api-key.ts";
 import type { CommunityEndpointRuntime } from "@shared/community-endpoints.ts";
+import type { Context } from "hono";
 import { createMiddleware } from "hono/factory";
 import { HTTPException } from "hono/http-exception";
 import type { LoggerVariables } from "./logger.ts";
@@ -30,75 +31,101 @@ export type AuthVariables = {
     };
 };
 
+export type GenerationAuthSnapshot = {
+    user: Pick<AuthUser, "id" | "tier">;
+    apiKey?: Omit<AuthenticatedApiKey, "rawKey">;
+    agentRun?: AgentRunClaims;
+};
+
 export type AuthEnv = {
     Bindings: CloudflareBindings;
     Variables: LoggerVariables & AuthVariables & Partial<ModelVariables>;
 };
 
-export const auth = () =>
-    createMiddleware<AuthEnv>(async (c, next) => {
-        const authResult = await (async () => {
-            try {
-                return await authenticateApiKeyRequest({
-                    request: c.req.raw,
-                    env: c.env,
-                    ctx: c.executionCtx,
-                });
-            } catch (error) {
-                if (
-                    error instanceof BannedAccountError ||
-                    error instanceof StagingAccessDeniedError
-                ) {
-                    throw new HTTPException(403, { message: error.message });
-                }
-                throw error;
-            }
-        })();
+function installAuth(
+    c: Context<AuthEnv>,
+    authResult: {
+        user?: AuthUser;
+        apiKey?: AuthenticatedApiKey;
+        agentRun?: AgentRunClaims;
+    },
+): void {
+    const { user, apiKey, agentRun } = authResult;
 
-        const { user, apiKey, agentRun } = authResult || {};
+    const requireAuthorization = async (options?: {
+        message?: string;
+    }): Promise<void> => {
+        if (!user) {
+            throw new HTTPException(401, {
+                message: options?.message,
+            });
+        }
+    };
 
-        const requireAuthorization = async (options?: {
-            message?: string;
-        }): Promise<void> => {
-            if (!user) {
-                throw new HTTPException(401, {
-                    message: options?.message,
-                });
-            }
-        };
+    const requireUser = (): AuthUser => {
+        if (!user) throw new HTTPException(401);
+        return user;
+    };
 
-        const requireUser = (): AuthUser => {
-            if (!user) throw new HTTPException(401);
-            return user;
-        };
+    function requireModelAccess(): void {
+        const model = c.var.model;
+        if (!model) return;
 
-        function requireModelAccess(): void {
-            const model = c.var.model;
-            if (!model) return;
-
-            if (agentRun && model.communityEndpoint) {
-                throw new HTTPException(403, {
-                    message: "Agent run tokens cannot call community models",
-                });
-            }
-
-            if (!apiKey?.permissions?.models) return;
-
-            if (!apiKey.permissions.models.includes(model.resolved)) {
-                throw new HTTPException(403, {
-                    message: `Model '${model.requested}' is not allowed for this API key`,
-                });
-            }
+        if (agentRun && model.communityEndpoint) {
+            throw new HTTPException(403, {
+                message: "Agent run tokens cannot call community models",
+            });
         }
 
-        c.set("auth", {
-            user,
-            apiKey,
-            requireAuthorization,
-            requireUser,
-            requireModelAccess,
-            ...(agentRun && { agentRun }),
-        });
+        if (!apiKey?.permissions?.models) return;
 
+        if (!apiKey.permissions.models.includes(model.resolved)) {
+            throw new HTTPException(403, {
+                message: `Model '${model.requested}' is not allowed for this API key`,
+            });
+        }
+    }
+
+    c.set("auth", {
+        user,
+        apiKey,
+        requireAuthorization,
+        requireUser,
+        requireModelAccess,
+        ...(agentRun && { agentRun }),
+    });
+}
+
+export const auth = () =>
+    createMiddleware<AuthEnv>(async (c, next) => {
+        let authResult: Awaited<ReturnType<typeof authenticateApiKeyRequest>>;
+        try {
+            authResult = await authenticateApiKeyRequest({
+                request: c.req.raw,
+                env: c.env,
+                ctx: c.executionCtx,
+            });
+        } catch (error) {
+            if (
+                error instanceof BannedAccountError ||
+                error instanceof StagingAccessDeniedError
+            ) {
+                throw new HTTPException(403, {
+                    message: error.message,
+                });
+            }
+            throw error;
+        }
+        installAuth(c, authResult || {});
+        await next();
+    });
+
+export const authFromSnapshot = (snapshot: GenerationAuthSnapshot) =>
+    createMiddleware<AuthEnv>(async (c, next) => {
+        installAuth(c, {
+            user: snapshot.user as AuthUser,
+            apiKey: snapshot.apiKey as AuthenticatedApiKey | undefined,
+            agentRun: snapshot.agentRun,
+        });
         await next();
     });

--- a/gen.pollinations.ai/src/middleware/generation-cache.ts
+++ b/gen.pollinations.ai/src/middleware/generation-cache.ts
@@ -1,25 +1,50 @@
-import type { Logger } from "@logtape/logtape";
+import { bytesToHex } from "@shared/client-ip.ts";
+import stableStringify from "fast-json-stable-stringify";
 import type { Context } from "hono";
 import { createMiddleware } from "hono/factory";
+import { HTTPException } from "hono/http-exception";
 import type { RequestIdVariables } from "hono/request-id";
 import type { LoggerVariables } from "@/middleware/logger.ts";
+
+export type GenerationCacheStorage = "media" | "text";
+
+/** Opaque identity shared by coordination and low-volume cache telemetry. */
+export async function hashGenerationCacheIdentity(
+    storage: GenerationCacheStorage,
+    key: string,
+): Promise<string> {
+    const bytes = new TextEncoder().encode(`${storage}:${key}`);
+    return bytesToHex(await crypto.subtle.digest("SHA-256", bytes));
+}
+
+export type GenerationCacheVariables = {
+    generationCache?: {
+        adapter: GenerationCacheAdapter;
+        key: string;
+    };
+    /** Alternate request identity for routes which wrap a media response. */
+    generationCacheUrl?: URL;
+    /** Normalized POST body passed to the generation executor. */
+    generationRequestBody?: string | Uint8Array;
+    /** Multipart body parsed during model resolution and reused downstream. */
+    formData?: FormData;
+    /** Content type for a normalized multipart body. */
+    generationRequestContentType?: string;
+    /** Canonical body identity used by body-aware cache adapters. */
+    generationCacheBody?: string;
+    /** Executor callback used to await durable cache materialization. */
+    registerGenerationCacheWrite?: (promise: Promise<void>) => void;
+};
 
 export type GenerationCacheEnv = {
     Bindings: CloudflareBindings;
     Variables: LoggerVariables & RequestIdVariables & GenerationCacheVariables;
 };
 
-export type GenerationCacheVariables = {
-    /** Alternate request identity for routes which wrap a media response. */
-    generationCacheUrl?: URL;
-};
-
 export type GenerationCacheAdapter = {
+    storage: GenerationCacheStorage;
     label: string;
-    getKey: (
-        c: Context<GenerationCacheEnv>,
-        log: Logger,
-    ) => Promise<string | null> | string | null;
+    getKey: (c: Context<GenerationCacheEnv>) => Promise<string> | string;
     get: (
         c: Context<GenerationCacheEnv>,
         key: string,
@@ -29,43 +54,228 @@ export type GenerationCacheAdapter = {
         c: Context<GenerationCacheEnv>,
         key: string,
         response: Response,
-    ) => Response;
+    ) => { response: Response; write: Promise<void> };
 };
+
+function normalizedJsonBody(body: string): string {
+    try {
+        const parsed = JSON.parse(body);
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+            for (const key of Object.keys(parsed)) {
+                if (key.toLowerCase() === "key") delete parsed[key];
+            }
+        }
+        return stableStringify(parsed);
+    } catch {
+        return body;
+    }
+}
+
+async function normalizedFormData(formData: FormData): Promise<{
+    body: Uint8Array;
+    contentType: string;
+    identity: string;
+}> {
+    const sanitized = new FormData();
+    const identity = new Map<string, unknown[]>();
+
+    for (const [name, value] of formData.entries()) {
+        if (name.toLowerCase() === "key") continue;
+        const values = identity.get(name) ?? [];
+        if (value instanceof File) {
+            const bytes = new Uint8Array(await value.arrayBuffer());
+            values.push({
+                file: value.name,
+                type: value.type,
+                hash: bytesToHex(await crypto.subtle.digest("SHA-256", bytes)),
+            });
+            sanitized.append(name, value, value.name);
+        } else {
+            values.push(value);
+            sanitized.append(name, value);
+        }
+        identity.set(name, values);
+    }
+
+    const encoded = new Response(sanitized);
+    return {
+        body: new Uint8Array(await encoded.arrayBuffer()),
+        contentType: encoded.headers.get("content-type") ?? "",
+        identity: stableStringify(Object.fromEntries(identity)),
+    };
+}
+
+/** Captures one replayable body and one stable identity for every POST route. */
+export const prepareGenerationRequest = createMiddleware<GenerationCacheEnv>(
+    async (c, next) => {
+        if (c.req.method === "GET" || c.req.method === "HEAD") {
+            return next();
+        }
+
+        if (c.var.generationRequestBody !== undefined) {
+            const body = c.var.generationRequestBody;
+            const identity =
+                typeof body === "string"
+                    ? normalizedJsonBody(body)
+                    : bytesToHex(
+                          await crypto.subtle.digest(
+                              "SHA-256",
+                              body.slice().buffer,
+                          ),
+                      );
+            if (typeof body === "string") {
+                c.set("generationRequestBody", identity);
+            }
+            c.set("generationCacheBody", identity);
+            return next();
+        }
+
+        const contentType = c.req.header("content-type") ?? "";
+        if (
+            c.var.formData ||
+            contentType.toLowerCase().includes("multipart/form-data")
+        ) {
+            let formData = c.var.formData;
+            if (!formData) {
+                try {
+                    formData = await c.req.formData();
+                } catch {
+                    throw new HTTPException(400, {
+                        message: "Invalid multipart form data",
+                    });
+                }
+            }
+            const normalized = await normalizedFormData(formData);
+            c.set("generationRequestBody", normalized.body);
+            c.set("generationRequestContentType", normalized.contentType);
+            c.set("generationCacheBody", normalized.identity);
+            return next();
+        }
+
+        const body = normalizedJsonBody(await c.req.text());
+        c.set("generationRequestBody", body);
+        c.set("generationCacheBody", body);
+        return next();
+    },
+);
+
+function replaceCapturedResponse(
+    c: Context<GenerationCacheEnv>,
+    captured: Response,
+): void {
+    if (captured === c.res) return;
+    // Hono's response setter gives the previous response headers precedence.
+    // Copy adapter-owned headers first so they survive the body replacement.
+    for (const [name, value] of captured.headers) {
+        c.res.headers.set(name, value);
+    }
+    c.res = captured;
+}
+
+async function lookup(
+    c: Context<GenerationCacheEnv>,
+    adapter: GenerationCacheAdapter,
+    cacheKey: string,
+): Promise<Response | null> {
+    const log = c.get("log").getChild(adapter.label);
+    log.debug("Cache key: {key}", { key: cacheKey });
+    const cached = await adapter.get(c, cacheKey);
+    if (cached) {
+        log.info("Cache HIT");
+    } else {
+        log.debug("Cache MISS");
+        c.header("X-Cache", "MISS");
+    }
+    return cached;
+}
+
+function capture(
+    c: Context<GenerationCacheEnv>,
+    adapter: GenerationCacheAdapter,
+    cacheKey: string,
+): Promise<void> | undefined {
+    if (
+        !c.res ||
+        c.res.headers.get("X-Cache") === "HIT" ||
+        !adapter.shouldCache(c.res)
+    ) {
+        return;
+    }
+
+    c.get("log").getChild(adapter.label).debug("Caching response");
+    const captured = adapter.capture(c, cacheKey, c.res);
+    replaceCapturedResponse(c, captured.response);
+    return captured.write;
+}
 
 /** Shared cache lifecycle; storage and serialization stay adapter-owned. */
 export function createGenerationCache(adapter: GenerationCacheAdapter) {
     return createMiddleware<GenerationCacheEnv>(async (c, next) => {
         const log = c.get("log").getChild(adapter.label);
-        const cacheKey = await adapter.getKey(c, log);
-        if (!cacheKey) return next();
-
-        log.debug("Cache key: {key}", { key: cacheKey });
-        try {
-            const cached = await adapter.get(c, cacheKey);
-            if (cached) {
-                log.info("Cache HIT");
-                return cached;
+        const cacheKey = await adapter.getKey(c);
+        const streamRequested = (
+            c.var as GenerationCacheEnv["Variables"] & {
+                track?: { streamRequested?: boolean };
             }
-            log.debug("Cache MISS");
-            c.header("X-Cache", "MISS");
+        ).track?.streamRequested;
+        const coordinate = streamRequested !== true;
+
+        try {
+            const cached = await lookup(c, adapter, cacheKey);
+            if (cached) return cached;
         } catch (error) {
             log.error("Error retrieving cached response: {error}", { error });
+            if (coordinate) {
+                return new Response(
+                    "Generation cache is temporarily unavailable",
+                    { status: 503 },
+                );
+            }
+        }
+
+        if (coordinate) {
+            c.set("generationCache", { adapter, key: cacheKey });
         }
 
         await next();
 
-        if (c.res && adapter.shouldCache(c.res)) {
-            log.debug("Caching response");
-            const captured = adapter.capture(c, cacheKey, c.res);
-            if (captured !== c.res) {
-                // Hono's response setter gives the previous response headers
-                // precedence. Copy adapter-owned headers onto that response
-                // first so cache headers survive the body replacement.
-                for (const [name, value] of captured.headers) {
-                    c.res.headers.set(name, value);
-                }
-                c.res = captured;
-            }
+        const cacheWrite = capture(c, adapter, cacheKey);
+        if (cacheWrite) {
+            c.executionCtx.waitUntil(
+                cacheWrite.catch((error) => {
+                    log.error("Error caching response: {error}", { error });
+                }),
+            );
         }
+    });
+}
+
+/** Cache lifecycle used only by the detached generation executor. */
+export function createGenerationExecutionCache(
+    adapter: GenerationCacheAdapter,
+) {
+    return createMiddleware<GenerationCacheEnv>(async (c, next) => {
+        const log = c.get("log").getChild(adapter.label);
+        const cacheKey = await adapter.getKey(c);
+
+        try {
+            const cached = await lookup(c, adapter, cacheKey);
+            if (cached) return cached;
+        } catch (error) {
+            log.error("Error retrieving cached response: {error}", { error });
+            return new Response("Generation cache is temporarily unavailable", {
+                status: 503,
+            });
+        }
+
+        c.set("generationCache", { adapter, key: cacheKey });
+        await next();
+
+        const cacheWrite = capture(c, adapter, cacheKey);
+        if (!cacheWrite) return;
+
+        const register = c.var.registerGenerationCacheWrite;
+        if (!register) throw new Error("Generation cache registrar is missing");
+        register(cacheWrite);
     });
 }

--- a/gen.pollinations.ai/src/middleware/generation-deduplication.ts
+++ b/gen.pollinations.ai/src/middleware/generation-deduplication.ts
@@ -192,9 +192,19 @@ export const deduplicateGeneration = createMiddleware<DeduplicationEnv>(
         try {
             outcome = (await stub.startAndWait(job)) as GenerationOutcome;
         } catch (error) {
+            const rpcError = error as Error & {
+                durableObjectReset?: boolean;
+                overloaded?: boolean;
+                retryable?: boolean;
+            };
             c.get("log").error(
-                "Generation coordination failed before completion: {error}",
-                { error },
+                "Generation coordination failed before completion: {errorMessage}",
+                {
+                    errorMessage: rpcError.message ?? String(error),
+                    durableObjectReset: rpcError.durableObjectReset,
+                    overloaded: rpcError.overloaded,
+                    retryable: rpcError.retryable,
+                },
             );
             return new Response("Generation coordination is unavailable", {
                 status: 503,

--- a/gen.pollinations.ai/src/middleware/generation-deduplication.ts
+++ b/gen.pollinations.ai/src/middleware/generation-deduplication.ts
@@ -1,0 +1,233 @@
+import type { BalanceCheckResult } from "@shared/billing/balance.ts";
+import { SAFETY_HEADER_NAME } from "@shared/schemas/safety.ts";
+import type { Context } from "hono";
+import { createMiddleware } from "hono/factory";
+import type {
+    AuthVariables,
+    GenerationAuthSnapshot,
+} from "@/middleware/auth.ts";
+import type { BalanceVariables } from "@/middleware/balance.ts";
+import type {
+    GenerationCacheAdapter,
+    GenerationCacheEnv,
+    GenerationCacheStorage,
+} from "@/middleware/generation-cache.ts";
+import { hashGenerationCacheIdentity } from "@/middleware/generation-cache.ts";
+
+const EXECUTOR_HEADERS = new Set([
+    "accept",
+    "cf-connecting-ip",
+    "content-type",
+    "referer",
+    "user-agent",
+    "x-forwarded-host",
+    "x-original-client-ip",
+    SAFETY_HEADER_NAME.toLowerCase(),
+]);
+
+export type GenerationErrorSnapshot = {
+    httpStatus: number;
+    headers: [string, string][];
+    body: Uint8Array;
+};
+
+export type GenerationCacheIdentity = {
+    storage: GenerationCacheStorage;
+    key: string;
+};
+
+export type GenerationRequestSnapshot = {
+    url: string;
+    method: string;
+    headers: [string, string][];
+    body?: Uint8Array;
+};
+
+export type GenerationJob = {
+    cache: GenerationCacheIdentity;
+    request: GenerationRequestSnapshot;
+    auth: GenerationAuthSnapshot;
+    requestId: string;
+    balanceCheckResult: BalanceCheckResult;
+};
+
+export type GenerationOutcome =
+    | { status: "cached" }
+    | { status: "failed"; error: GenerationErrorSnapshot };
+
+type DeduplicationEnv = {
+    Bindings: CloudflareBindings;
+    Variables: GenerationCacheEnv["Variables"] &
+        AuthVariables & {
+            balance: BalanceVariables["balance"];
+            track?: {
+                streamRequested?: boolean;
+                detachedExecutionTracked?: boolean;
+            };
+        };
+};
+
+function createAuthSnapshot(
+    auth: AuthVariables["auth"],
+): GenerationAuthSnapshot {
+    const user = auth.requireUser();
+    let apiKey: GenerationAuthSnapshot["apiKey"];
+    if (auth.apiKey) {
+        const { rawKey: _rawKey, ...persistedApiKey } = auth.apiKey;
+        apiKey = persistedApiKey;
+    }
+    return {
+        user: { id: user.id, tier: user.tier },
+        ...(apiKey && { apiKey }),
+        ...(auth.agentRun && { agentRun: auth.agentRun }),
+    };
+}
+
+function sanitizeUrl(rawUrl: string): string {
+    const url = new URL(rawUrl);
+    for (const key of [...url.searchParams.keys()]) {
+        if (key.toLowerCase() === "key") url.searchParams.delete(key);
+    }
+    return url.toString();
+}
+
+function sanitizeJsonBody(body: string): string {
+    try {
+        const parsed = JSON.parse(body);
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+            for (const key of Object.keys(parsed)) {
+                if (key.toLowerCase() === "key") delete parsed[key];
+            }
+        }
+        return JSON.stringify(parsed);
+    } catch {
+        return body;
+    }
+}
+
+async function createJob(
+    c: Context<DeduplicationEnv>,
+    adapter: GenerationCacheAdapter,
+    key: string,
+): Promise<GenerationJob> {
+    const balanceCheckResult = c.var.balance.balanceCheckResult;
+    if (!balanceCheckResult) {
+        throw new Error("Generation balance snapshot is missing");
+    }
+
+    let body: Uint8Array | undefined;
+    if (c.req.method !== "GET" && c.req.method !== "HEAD") {
+        const captured = c.var.generationRequestBody;
+        body =
+            captured instanceof Uint8Array
+                ? captured
+                : new TextEncoder().encode(
+                      sanitizeJsonBody(captured ?? (await c.req.text())),
+                  );
+    }
+
+    const headers = [...c.req.raw.headers.entries()].filter(([name]) =>
+        EXECUTOR_HEADERS.has(name.toLowerCase()),
+    );
+    if (c.var.generationRequestContentType) {
+        const contentType = c.var.generationRequestContentType;
+        const existing = headers.findIndex(
+            ([name]) => name.toLowerCase() === "content-type",
+        );
+        if (existing === -1) headers.push(["content-type", contentType]);
+        else headers[existing] = [headers[existing][0], contentType];
+    }
+
+    return {
+        cache: { storage: adapter.storage, key },
+        request: {
+            url: sanitizeUrl(c.req.url),
+            method: c.req.method,
+            headers,
+            ...(body !== undefined && { body }),
+        },
+        auth: createAuthSnapshot(c.var.auth),
+        requestId: c.get("requestId"),
+        balanceCheckResult,
+    };
+}
+
+function failedResponse(error: GenerationErrorSnapshot): Response {
+    const status =
+        error.httpStatus >= 400 && error.httpStatus <= 599
+            ? error.httpStatus
+            : 502;
+    const headers = new Headers(error.headers);
+    const body = error.body.buffer.slice(
+        error.body.byteOffset,
+        error.body.byteOffset + error.body.byteLength,
+    ) as ArrayBuffer;
+    return new Response(body, { status, headers });
+}
+
+/** Runs after generationAccess, so every caller is authorized before joining. */
+export const deduplicateGeneration = createMiddleware<DeduplicationEnv>(
+    async (c, next) => {
+        if (c.var.track?.streamRequested === true) {
+            return next();
+        }
+
+        const cache = c.var.generationCache;
+        if (!cache || !c.env.GENERATION_COORDINATOR) {
+            c.get("log").error(
+                "Generation cache identity or coordinator binding is missing",
+            );
+            return new Response("Generation coordination is unavailable", {
+                status: 503,
+            });
+        }
+
+        const name = await hashGenerationCacheIdentity(
+            cache.adapter.storage,
+            cache.key,
+        );
+        const stub = c.env.GENERATION_COORDINATOR.getByName(name);
+        const job = await createJob(c, cache.adapter, cache.key);
+        let outcome: GenerationOutcome;
+        try {
+            outcome = (await stub.startAndWait(job)) as GenerationOutcome;
+        } catch (error) {
+            c.get("log").error(
+                "Generation coordination failed before completion: {error}",
+                { error },
+            );
+            return new Response("Generation coordination is unavailable", {
+                status: 503,
+            });
+        }
+        if (outcome.status === "failed") {
+            if (c.var.track) c.var.track.detachedExecutionTracked = true;
+            return failedResponse(outcome.error);
+        }
+
+        let response: Response | null;
+        try {
+            response = await cache.adapter.get(
+                c as unknown as Context<GenerationCacheEnv>,
+                cache.key,
+            );
+        } catch (error) {
+            c.get("log").error(
+                "Error reading completed generation from cache: {error}",
+                { error },
+            );
+            return new Response("Generation cache is temporarily unavailable", {
+                status: 503,
+            });
+        }
+        if (!response) {
+            return new Response(
+                "Generation completed without a durable cache entry",
+                { status: 503 },
+            );
+        }
+        c.header("X-Cache", "HIT");
+        response.headers.set("X-Cache", "HIT");
+        return response;
+    },
+);

--- a/gen.pollinations.ai/src/middleware/media-cache.ts
+++ b/gen.pollinations.ai/src/middleware/media-cache.ts
@@ -12,11 +12,16 @@ import { IMMUTABLE_CACHE_CONTROL } from "@shared/http/cache-control.ts";
 import { refreshR2ObjectTtl } from "@shared/r2-storage.ts";
 import { SAFETY_HEADER_NAME } from "@shared/schemas/safety.ts";
 import {
-    cacheMediaResponse,
     generateCacheKey,
+    putMediaResponse,
     setHttpMetadataHeaders,
 } from "@/utils/media-cache.ts";
-import { createGenerationCache } from "./generation-cache.ts";
+import {
+    createGenerationCache,
+    createGenerationExecutionCache,
+    type GenerationCacheAdapter,
+    hashGenerationCacheIdentity,
+} from "./generation-cache.ts";
 
 type MediaCacheConfig = {
     /** Content types to cache, e.g. ["image/", "video/"] or ["audio/"] */
@@ -27,11 +32,21 @@ type MediaCacheConfig = {
     label: string;
 };
 
-export function createMediaCache(config: MediaCacheConfig) {
-    return createGenerationCache({
+function mediaCacheAdapter(config: MediaCacheConfig): GenerationCacheAdapter {
+    return {
+        storage: "media",
         label: config.label,
-        getKey(c) {
+        async getKey(c) {
             const cacheUrl = c.var.generationCacheUrl ?? new URL(c.req.url);
+            if (!c.var.generationCacheUrl && c.var.generationCacheBody) {
+                cacheUrl.searchParams.set(
+                    "__request_body",
+                    await hashGenerationCacheIdentity(
+                        "media",
+                        c.var.generationCacheBody,
+                    ),
+                );
+            }
             return generateCacheKey(
                 cacheUrl,
                 c.var.generationCacheUrl
@@ -51,7 +66,6 @@ export function createMediaCache(config: MediaCacheConfig) {
             );
             c.header("Cache-Control", IMMUTABLE_CACHE_CONTROL);
             c.header("X-Cache", "HIT");
-            c.header("X-Cache-Type", "EXACT");
             return c.body(
                 refreshR2ObjectTtl(
                     c.env.IMAGE_BUCKET,
@@ -76,32 +90,41 @@ export function createMediaCache(config: MediaCacheConfig) {
             );
         },
         capture(c, cacheKey, response) {
-            cacheMediaResponse(
-                c.env.IMAGE_BUCKET,
-                cacheKey,
-                c,
-                config.defaultContentType,
+            return {
                 response,
-            );
-            return response;
+                write: putMediaResponse(
+                    c.env.IMAGE_BUCKET,
+                    cacheKey,
+                    c,
+                    config.defaultContentType,
+                    response,
+                ),
+            };
         },
-    });
+    };
 }
 
-export const imageCache = createMediaCache({
+const imageAdapter = mediaCacheAdapter({
     mediaTypes: ["image/", "video/"],
     defaultContentType: "image/jpeg",
     label: "image-cache",
 });
+export const imageCache = createGenerationCache(imageAdapter);
+export const imageExecutionCache = createGenerationExecutionCache(imageAdapter);
 
-export const audioCache = createMediaCache({
+const audioAdapter = mediaCacheAdapter({
     mediaTypes: ["audio/"],
     defaultContentType: "audio/mpeg",
     label: "audio-cache",
 });
+export const audioCache = createGenerationCache(audioAdapter);
+export const audioExecutionCache = createGenerationExecutionCache(audioAdapter);
 
-export const model3dCache = createMediaCache({
+const model3dAdapter = mediaCacheAdapter({
     mediaTypes: ["model/"],
     defaultContentType: "model/gltf-binary",
     label: "3d-cache",
 });
+export const model3dCache = createGenerationCache(model3dAdapter);
+export const model3dExecutionCache =
+    createGenerationExecutionCache(model3dAdapter);

--- a/gen.pollinations.ai/src/middleware/rate-limit-durable.ts
+++ b/gen.pollinations.ai/src/middleware/rate-limit-durable.ts
@@ -1,4 +1,5 @@
 import { getRealClientIp } from "@shared/client-ip.ts";
+import type { Context } from "hono";
 import { createMiddleware } from "hono/factory";
 import type { PollenRateLimiter } from "@/durable-objects/PollenRateLimiter.ts";
 import type { AuthVariables } from "@/middleware/auth.ts";
@@ -16,50 +17,54 @@ type FrontendKeyRateLimitEnv = {
     Variables: AuthVariables & LoggerVariables & FrontendKeyRateLimitVariables;
 };
 
+function rateLimitStub(
+    c: Context<FrontendKeyRateLimitEnv>,
+): DurableObjectStub<PollenRateLimiter> | null {
+    const log = c.get("log").getChild("ratelimit");
+    const apiKey = c.var.auth.apiKey;
+    if (!apiKey) {
+        log.debug("Skipping rate limit, no API key");
+        return null;
+    }
+    const apiKeyMetadata = apiKey.metadata as
+        | Record<string, unknown>
+        | undefined;
+    if (apiKeyMetadata?.keyType !== "publishable") {
+        log.debug("Skipping rate limit, not a publishable key");
+        return null;
+    }
+
+    const ip = getRealClientIp(c);
+    const identifier = `pk_${apiKey.id}:ip:${ip}`;
+    const rateLimiter = c.env.POLLEN_RATE_LIMITER;
+    if (!rateLimiter) {
+        log.warn(
+            "Skipping rate limit for publishable key, POLLEN_RATE_LIMITER binding is missing",
+            { keyId: apiKey.id, ip, identifier },
+        );
+        return null;
+    }
+
+    return rateLimiter.get(
+        rateLimiter.idFromName(identifier),
+    ) as DurableObjectStub<PollenRateLimiter>;
+}
+
+function attachPollenConsumer(
+    c: Context<FrontendKeyRateLimitEnv>,
+    stub: DurableObjectStub<PollenRateLimiter>,
+): void {
+    c.set("frontendKeyRateLimit", {
+        consumePollen: (cost: number) => stub.consumePollen(cost),
+    });
+}
+
 export const frontendKeyRateLimit = createMiddleware<FrontendKeyRateLimitEnv>(
     async (c, next) => {
-        const log = c.get("log").getChild("ratelimit");
+        const stub = rateLimitStub(c);
+        if (!stub) return next();
 
-        const apiKey = c.var?.auth?.apiKey;
-        if (!apiKey) {
-            log.debug("Skipping rate limit, no API key");
-            return next();
-        }
-        const apiKeyMetadata = apiKey.metadata as
-            | Record<string, unknown>
-            | undefined;
-        if (apiKeyMetadata?.keyType !== "publishable") {
-            log.debug("Skipping rate limit, not a publishable key");
-            return next();
-        }
-
-        const ip = getRealClientIp(c);
-        const identifier = `pk_${apiKey.id}:ip:${ip}`;
-
-        log.debug(
-            "Applying rate limit for publishable key: id={keyId} ip={ip} identifier={identifier}",
-            {
-                keyId: apiKey.id,
-                ip,
-                identifier,
-            },
-        );
-
-        const rateLimiter = c.env.POLLEN_RATE_LIMITER;
-        if (!rateLimiter) {
-            log.warn(
-                "Skipping rate limit for publishable key, POLLEN_RATE_LIMITER binding is missing",
-                { keyId: apiKey.id, ip, identifier },
-            );
-            return next();
-        }
-
-        const id = rateLimiter.idFromName(identifier);
-        const stub = rateLimiter.get(
-            id,
-        ) as DurableObjectStub<PollenRateLimiter>;
         const result = await stub.checkRateLimit();
-
         if (!result.allowed) {
             const retryAfterSeconds = safeRound((result.waitMs || 0) / 1000, 2);
             c.header("Retry-After", Math.ceil(retryAfterSeconds).toString());
@@ -73,10 +78,17 @@ export const frontendKeyRateLimit = createMiddleware<FrontendKeyRateLimitEnv>(
             );
         }
 
-        c.set("frontendKeyRateLimit", {
-            consumePollen: (cost: number) => stub.consumePollen(cost),
-        });
+        attachPollenConsumer(c, stub);
 
+        await next();
+    },
+);
+
+/** Restores billing consumption without admitting the same caller twice. */
+export const frontendKeyBilling = createMiddleware<FrontendKeyRateLimitEnv>(
+    async (c, next) => {
+        const stub = rateLimitStub(c);
+        if (stub) attachPollenConsumer(c, stub);
         await next();
     },
 );

--- a/gen.pollinations.ai/src/middleware/text-cache.ts
+++ b/gen.pollinations.ai/src/middleware/text-cache.ts
@@ -10,7 +10,11 @@ import {
     generateCacheKey,
     getCachedResponse,
 } from "@/utils/text-cache.ts";
-import { createGenerationCache } from "./generation-cache.ts";
+import {
+    createGenerationCache,
+    createGenerationExecutionCache,
+    type GenerationCacheAdapter,
+} from "./generation-cache.ts";
 
 /**
  * Text cache middleware
@@ -22,27 +26,15 @@ import { createGenerationCache } from "./generation-cache.ts";
  * Note: Only apply this middleware to cacheable routes (e.g., /v1/chat/completions, /text/:prompt)
  * Non-cacheable routes like /v1/models should NOT use this middleware
  */
-export const textCache = createGenerationCache({
+const textCacheAdapter: GenerationCacheAdapter = {
+    storage: "text",
     label: "text-cache",
-    async getKey(c, log) {
+    async getKey(c) {
         // Hono caches body text across c.req.json()/text(), so this still works
         // after upstream validators have parsed JSON.
         let bodyText: string | undefined;
         if (c.req.method === "POST" || c.req.method === "PUT") {
-            try {
-                bodyText = await c.req.text();
-                if (!bodyText) {
-                    log.debug(
-                        "[TEXT-CACHE] Empty body for POST/PUT, skipping cache",
-                    );
-                    return null;
-                }
-            } catch {
-                log.warn(
-                    "[TEXT-CACHE] Could not read request body, skipping cache",
-                );
-                return null;
-            }
+            bodyText = c.var.generationCacheBody ?? (await c.req.text());
         }
 
         return generateCacheKey(c.req.raw, bodyText);
@@ -52,8 +44,8 @@ export const textCache = createGenerationCache({
         return response.status === 200 && response.body !== null;
     },
     capture(c, cacheKey, response) {
-        const captureStream = createCaptureStream(c, cacheKey, response);
-        const transformedBody = response.body?.pipeThrough(captureStream);
+        const capture = createCaptureStream(c, cacheKey, response);
+        const transformedBody = response.body?.pipeThrough(capture.stream);
         const captured = new Response(transformedBody, {
             status: response.status,
             statusText: response.statusText,
@@ -62,6 +54,10 @@ export const textCache = createGenerationCache({
         captured.headers.set("X-Cache", "MISS");
         captured.headers.set("X-Cache-Key", cacheKey.substring(0, 16));
         captured.headers.set("Cache-Control", IMMUTABLE_CACHE_CONTROL);
-        return captured;
+        return { response: captured, write: capture.write };
     },
-});
+};
+
+export const textCache = createGenerationCache(textCacheAdapter);
+export const textExecutionCache =
+    createGenerationExecutionCache(textCacheAdapter);

--- a/gen.pollinations.ai/src/middleware/track.ts
+++ b/gen.pollinations.ai/src/middleware/track.ts
@@ -71,6 +71,10 @@ import { z } from "zod";
 import { mergeContentFilterResults } from "@/content-filter.ts";
 import type { AuthVariables } from "@/middleware/auth.ts";
 import type { BalanceVariables } from "@/middleware/balance.ts";
+import {
+    type GenerationCacheVariables,
+    hashGenerationCacheIdentity,
+} from "@/middleware/generation-cache.ts";
 import type { LoggerVariables } from "@/middleware/logger.ts";
 import type { ModelVariables } from "@/middleware/model.ts";
 import type { FrontendKeyRateLimitVariables } from "@/middleware/rate-limit-durable.ts";
@@ -129,6 +133,7 @@ export type TrackVariables = {
         modelRequested: string | null;
         resolvedModelRequested: string;
         streamRequested: boolean;
+        detachedExecutionTracked?: boolean;
         overrideResponseTracking: (response: Response) => void;
         // Service layers register normalized request facts that affect
         // pricing. Consumed once at billing time by selectCostVariant.
@@ -150,7 +155,8 @@ export type TrackEnv = {
         BalanceVariables &
         FrontendKeyRateLimitVariables &
         TrackVariables &
-        ModelVariables;
+        ModelVariables &
+        GenerationCacheVariables;
 };
 
 export const track = (eventType: EventType) =>
@@ -205,6 +211,19 @@ export const track = (eventType: EventType) =>
                 c.var.balance.balanceCheckResult?.selectedMeterSlug,
             balances: c.var.balance.balanceCheckResult?.balances || {},
         });
+        let cacheKeyPromise: Promise<string | undefined> | undefined;
+        const cacheKeyForTracking = () => {
+            if (!cacheKeyPromise) {
+                const cache = c.var.generationCache;
+                cacheKeyPromise = cache
+                    ? hashGenerationCacheIdentity(
+                          cache.adapter.storage,
+                          cache.key,
+                      )
+                    : Promise.resolve(undefined);
+            }
+            return cacheKeyPromise;
+        };
 
         /**
          * The one place a generation row is built and sent.
@@ -237,6 +256,7 @@ export const track = (eventType: EventType) =>
                 endTime: row.endTime,
                 balanceTracking: row.balanceTracking,
                 responseTracking: row.responseTracking,
+                cacheKey: await cacheKeyForTracking(),
                 errorTracking: row.errorTracking,
                 markup: row.markup ?? null,
                 communityModelReward: row.communityModelReward ?? null,
@@ -265,6 +285,10 @@ export const track = (eventType: EventType) =>
         });
 
         await next();
+
+        // Detached execution already tracked the provider failure. The outer
+        // caller only receives that captured result and must not emit it again.
+        if (c.var.track.detachedExecutionTracked) return;
 
         c.executionCtx.waitUntil(
             (async () => {
@@ -846,6 +870,7 @@ type TrackingEventInput = {
     eventType: EventType;
     ipSubnet?: string;
     ipHash?: string;
+    cacheKey?: string;
     userTracking: UserData;
     balanceTracking: BalanceData;
     requestTracking: RequestTrackingData;
@@ -887,6 +912,7 @@ function createTrackingEvent({
     eventType,
     ipSubnet,
     ipHash,
+    cacheKey,
     userTracking,
     balanceTracking,
     requestTracking,
@@ -908,6 +934,12 @@ function createTrackingEvent({
         eventType,
         ipSubnet,
         ipHash,
+
+        ...(cacheKey && {
+            cacheHit: responseTracking.cacheHit,
+            cacheType: responseTracking.cacheHit ? "EXACT" : "MISS",
+            cacheKey,
+        }),
 
         ...userTracking,
         ...requestTracking.referrerData,

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -22,6 +22,9 @@ import { z } from "zod";
 import type { Env } from "@/env.ts";
 import { auth } from "@/middleware/auth.ts";
 import { balance } from "@/middleware/balance.ts";
+import { prepareGenerationRequest } from "@/middleware/generation-cache.ts";
+import { deduplicateGeneration } from "@/middleware/generation-deduplication.ts";
+import { audioCache } from "@/middleware/media-cache.ts";
 import { resolveModel } from "@/middleware/model.ts";
 import { frontendKeyRateLimit } from "@/middleware/rate-limit-durable.ts";
 import { edgeRateLimit } from "@/middleware/rate-limit-edge.ts";
@@ -30,10 +33,11 @@ import {
     applySafetyToTexts,
     withSafetyHeaders,
 } from "@/middleware/safety.ts";
+import { textCache } from "@/middleware/text-cache.ts";
 import { track } from "@/middleware/track.ts";
 import googleCloudAuth from "@/text/auth/googleCloudAuth.ts";
-import { arrayBufferToBase64 } from "@/util.ts";
-import { requireGenerationAccess } from "@/utils/generation-access.ts";
+import { arrayBufferToBase64, normalizeSeed } from "@/util.ts";
+import { generationAccess } from "@/utils/generation-access.ts";
 import {
     type FallbackCandidate,
     withModelFallbackResponse,
@@ -122,7 +126,7 @@ const CreateSpeechRequestSchema = z
             description:
                 "ElevenLabs composition_plan for music generation/inpainting. Cannot be combined with a plain prompt upstream.",
         }),
-        seed: z.number().int().min(-1).max(4294967295).optional().meta({
+        seed: z.number().int().min(0).max(4294967295).optional().meta({
             description:
                 "Seed for deterministic output. Same seed + params = best-effort return of the same cached result. Omit for random.",
             example: 42,
@@ -151,7 +155,7 @@ const CreateDialogueRequestSchema = z
         response_format: z
             .enum(["mp3", "opus", "aac", "wav", "pcm"])
             .default("mp3"),
-        seed: z.number().int().min(-1).max(4294967295).optional(),
+        seed: z.number().int().min(0).max(4294967295).optional(),
         safe: SafeSchema,
     })
     .refine(
@@ -2511,7 +2515,7 @@ export async function handleSimpleAudio(c: AudioContext): Promise<Response> {
             text,
             voice: query.voice,
             responseFormat: query.response_format,
-            seed: query.seed,
+            seed: normalizeSeed(query.seed),
             duration: query.duration,
             seconds: query.seconds,
             steps: query.steps,
@@ -2528,6 +2532,310 @@ export async function handleSimpleAudio(c: AudioContext): Promise<Response> {
             log,
         }),
     );
+}
+
+export async function handleDialogue(c: AudioContext): Promise<Response> {
+    const log = c.get("log").getChild("dialogue");
+    let request: z.infer<typeof CreateDialogueRequestSchema>;
+    try {
+        request = CreateDialogueRequestSchema.parse(await c.req.json());
+    } catch (error) {
+        if (error instanceof z.ZodError) {
+            throw new UpstreamError(400 as ContentfulStatusCode, {
+                message: error.issues[0]?.message || "Invalid request body",
+            });
+        }
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message: "Invalid JSON body",
+        });
+    }
+
+    const safeTexts = await applySafetyToTexts(
+        c,
+        request.inputs.map((input) => input.text),
+        request.safe,
+    );
+    const inputs = request.inputs.map((input, index) => ({
+        ...input,
+        text: safeTexts[index],
+    }));
+    const response = await generateElevenLabsDialogue({
+        inputs,
+        responseFormat: request.response_format,
+        seed: request.seed,
+        apiKey: c.env.ELEVENLABS_API_KEY,
+        log,
+    });
+    return withSafetyHeaders(c, response);
+}
+
+export async function handleVoiceChanger(c: AudioContext): Promise<Response> {
+    const log = c.get("log").getChild("voice-changer");
+    const formData = c.get("formData");
+    if (!formData) {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message: "Invalid multipart form data",
+        });
+    }
+
+    const audio = formData.get("audio");
+    if (!(audio instanceof File)) {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message: "Missing required audio file.",
+        });
+    }
+    const voice = formData.get("voice");
+    const responseFormat = formData.get("response_format");
+    const resolvedFormat =
+        typeof responseFormat === "string" && responseFormat !== ""
+            ? responseFormat
+            : "mp3";
+    if (!["mp3", "opus", "aac", "wav", "pcm"].includes(resolvedFormat)) {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message: "response_format must be mp3, opus, aac, wav, or pcm.",
+        });
+    }
+
+    return changeVoiceWithElevenLabs({
+        audio,
+        voice: typeof voice === "string" && voice !== "" ? voice : "alloy",
+        responseFormat: resolvedFormat,
+        apiKey: c.env.ELEVENLABS_API_KEY,
+        log,
+    });
+}
+
+export async function handleVoiceIsolator(c: AudioContext): Promise<Response> {
+    const log = c.get("log").getChild("voice-isolator");
+    const formData = c.get("formData");
+    if (!formData) {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message: "Invalid multipart form data",
+        });
+    }
+    const audio = formData.get("audio");
+    if (!(audio instanceof File)) {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message: "Missing required audio file.",
+        });
+    }
+    return isolateVoiceWithElevenLabs({
+        audio,
+        apiKey: c.env.ELEVENLABS_API_KEY,
+        log,
+    });
+}
+
+export async function handleSpeech(c: AudioContext): Promise<Response> {
+    const log = c.get("log").getChild("tts");
+    const {
+        input,
+        safe,
+        voice,
+        response_format,
+        duration,
+        seconds,
+        steps,
+        negative_prompt,
+        instrumental,
+        store_for_inpainting,
+        conditioning_ref,
+        composition_plan,
+        reference_audio,
+        seed,
+        instruct,
+        loop,
+        prompt_influence,
+    } = await parseSpeechRequest(c);
+    requireElevenMusicOptions(c.var.model.resolved, {
+        referenceAudio: reference_audio,
+        compositionPlan: composition_plan,
+        conditioningRef: conditioning_ref,
+        storeForInpainting: store_for_inpainting,
+    });
+    const safeInput = await applySafety(c, input, safe);
+    const referenceAudio = reference_audio
+        ? await fetchReferenceAudio(reference_audio)
+        : undefined;
+
+    return withAudioFallback(c, (candidate) =>
+        dispatchAudioGeneration(c, candidate.id, {
+            text: safeInput,
+            voice,
+            responseFormat: response_format,
+            seed,
+            duration,
+            seconds,
+            steps,
+            negativePrompt: negative_prompt,
+            instrumental,
+            storeForInpainting: store_for_inpainting,
+            conditioningRef: conditioning_ref,
+            compositionPlan: composition_plan,
+            referenceAudio,
+            instruct,
+            loop,
+            promptInfluence: prompt_influence,
+            apiKey: c.env.ELEVENLABS_API_KEY,
+            dashScopeApiKey: c.env.DASHSCOPE_API_KEY,
+            deepInfraApiKey: c.env.DEEPINFRA_API_KEY,
+            falKey: c.env.FAL_KEY,
+            stabilityApiKey: c.env.STABILITY_API_KEY,
+            log,
+        }),
+    );
+}
+
+export async function handleSpeechWithTimestamps(
+    c: AudioContext,
+): Promise<Response> {
+    const log = c.get("log").getChild("tts-timestamps");
+    const { input, safe, voice, response_format, seed } =
+        await parseSpeechRequest(c);
+    const modelName = c.var.model.resolved;
+    if (!(modelName in ELEVENLABS_TTS_MODEL_IDS)) {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message:
+                "Timestamped speech supports elevenlabs, elevenflash, and eleven-multilingual-v2.",
+        });
+    }
+    if (response_format === "flac") {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message:
+                "Timestamped speech supports mp3, opus, aac, wav, and pcm output.",
+        });
+    }
+    const safeInput = await applySafety(c, input, safe);
+    return withAudioFallback(c, (candidate) =>
+        generateElevenLabsSpeechWithTimestamps({
+            modelName: candidate.id as ElevenLabsTtsModelName,
+            text: safeInput,
+            voice,
+            responseFormat: response_format,
+            seed,
+            apiKey: c.env.ELEVENLABS_API_KEY,
+            log,
+        }),
+    );
+}
+
+export async function handleTranscription(c: AudioContext): Promise<Response> {
+    const log = c.get("log").getChild("transcription");
+    const formData = c.get("formData");
+    if (!formData) {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message: "Invalid multipart form data",
+        });
+    }
+
+    const file = formData.get("file") as File;
+    const language = formData.get("language") as string | null;
+    const prompt = formData.get("prompt") as string | null;
+    const responseFormat = formData.get("response_format") as string | null;
+    const temperatureRaw = formData.get("temperature") as string | null;
+    const temperature =
+        temperatureRaw !== null && temperatureRaw !== ""
+            ? Number(temperatureRaw)
+            : undefined;
+    const speakersExpected = parsePositiveInt(
+        formData.get("speakers_expected"),
+        "speakers_expected",
+    );
+
+    if (!file) {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message: "Missing required field: file",
+        });
+    }
+    if (speakersExpected !== undefined && responseFormat !== "diarized_json") {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message: "speakers_expected requires response_format=diarized_json",
+        });
+    }
+
+    const result = await withAudioFallback(c, async (candidate) => {
+        if (candidate.id === "grok-transcribe") {
+            return transcribeWithXai({
+                file,
+                language: language || undefined,
+                responseFormat: responseFormat || undefined,
+                apiKey: c.env.XAI_API_KEY,
+                log,
+            });
+        }
+        if (candidate.id === "scribe") {
+            return transcribeWithElevenLabs({
+                file,
+                language: language || undefined,
+                responseFormat: responseFormat || undefined,
+                apiKey: c.env.ELEVENLABS_API_KEY,
+                log,
+                numSpeakers: speakersExpected,
+            });
+        }
+        if (
+            candidate.id === "universal-2" ||
+            candidate.id === "universal-3.5-pro"
+        ) {
+            return transcribeWithAssemblyAi({
+                file,
+                language: language || undefined,
+                prompt: prompt || undefined,
+                responseFormat: responseFormat || undefined,
+                temperature,
+                model: candidate.id,
+                apiKey: (c.env as unknown as { ASSEMBLYAI_API_KEY: string })
+                    .ASSEMBLYAI_API_KEY,
+                log,
+                speakersExpected,
+            });
+        }
+
+        const ovhApiKey = c.env.OVHCLOUD_API_KEY;
+        if (!ovhApiKey) {
+            throw new UpstreamError(500 as ContentfulStatusCode, {
+                message:
+                    "Transcription service is not configured (missing API key)",
+            });
+        }
+        validateWhisperResponseFormat(responseFormat);
+
+        const whisperFormData = new FormData();
+        const filename =
+            file.name && file.name !== "blob" ? file.name : "audio.mp3";
+        whisperFormData.append("file", file, filename);
+        if (language) whisperFormData.append("language", language);
+        whisperFormData.append("response_format", "verbose_json");
+        whisperFormData.append("model", "whisper-large-v3");
+        whisperFormData.append("timestamp_granularities[]", "word");
+
+        const whisperUrl =
+            "https://oai.endpoints.kepler.ai.cloud.ovh.net/v1/audio/transcriptions";
+        const response = await ensureUpstreamOk(
+            await fetch(whisperUrl, {
+                method: "POST",
+                headers: { Authorization: `Bearer ${ovhApiKey}` },
+                body: whisperFormData,
+            }),
+            whisperUrl,
+        );
+
+        let whisper: WhisperVerboseJson;
+        try {
+            whisper = JSON.parse(await response.text());
+        } catch {
+            throw new UpstreamError(502 as ContentfulStatusCode, {
+                message: "Whisper returned an unexpected (non-JSON) response",
+            });
+        }
+        const usageHeaders = buildUsageHeaders(
+            candidate.id,
+            createAudioSecondsUsage(extractWhisperUsage(whisper, log)),
+        );
+        return formatWhisperResponse(whisper, responseFormat, usageHeaders);
+    });
+    c.var.track.overrideResponseTracking(result.clone());
+    return result;
 }
 
 export const audioRoutes = new Hono<Env>()
@@ -2613,43 +2921,11 @@ export const audioRoutes = new Hono<Env>()
             supportedEndpoint: "/v1/audio/dialogue",
         }),
         track("generate.audio"),
-        async (c) => {
-            const log = c.get("log").getChild("dialogue");
-            await requireGenerationAccess(c.var, c.env);
-
-            let request: z.infer<typeof CreateDialogueRequestSchema>;
-            try {
-                request = CreateDialogueRequestSchema.parse(await c.req.json());
-            } catch (error) {
-                if (error instanceof z.ZodError) {
-                    throw new UpstreamError(400 as ContentfulStatusCode, {
-                        message:
-                            error.issues[0]?.message || "Invalid request body",
-                    });
-                }
-                throw new UpstreamError(400 as ContentfulStatusCode, {
-                    message: "Invalid JSON body",
-                });
-            }
-
-            const safeTexts = await applySafetyToTexts(
-                c,
-                request.inputs.map((input) => input.text),
-                request.safe,
-            );
-            const inputs = request.inputs.map((input, index) => ({
-                ...input,
-                text: safeTexts[index],
-            }));
-            const response = await generateElevenLabsDialogue({
-                inputs,
-                responseFormat: request.response_format,
-                seed: request.seed,
-                apiKey: c.env.ELEVENLABS_API_KEY,
-                log,
-            });
-            return withSafetyHeaders(c, response);
-        },
+        prepareGenerationRequest,
+        audioCache,
+        generationAccess,
+        deduplicateGeneration,
+        handleDialogue,
     )
     .post(
         "/voice-changer",
@@ -2721,49 +2997,11 @@ export const audioRoutes = new Hono<Env>()
             supportedEndpoint: "/v1/audio/voice-changer",
         }),
         track("generate.audio"),
-        async (c) => {
-            const log = c.get("log").getChild("voice-changer");
-            await requireGenerationAccess(c.var, c.env);
-
-            let formData: FormData;
-            try {
-                formData = c.get("formData") || (await c.req.formData());
-            } catch {
-                throw new UpstreamError(400 as ContentfulStatusCode, {
-                    message: "Invalid multipart form data",
-                });
-            }
-
-            const audio = formData.get("audio");
-            if (!(audio instanceof File)) {
-                throw new UpstreamError(400 as ContentfulStatusCode, {
-                    message: "Missing required audio file.",
-                });
-            }
-            const voice = formData.get("voice");
-            const responseFormat = formData.get("response_format");
-            const resolvedFormat =
-                typeof responseFormat === "string" && responseFormat !== ""
-                    ? responseFormat
-                    : "mp3";
-            if (
-                !["mp3", "opus", "aac", "wav", "pcm"].includes(resolvedFormat)
-            ) {
-                throw new UpstreamError(400 as ContentfulStatusCode, {
-                    message:
-                        "response_format must be mp3, opus, aac, wav, or pcm.",
-                });
-            }
-
-            return changeVoiceWithElevenLabs({
-                audio,
-                voice:
-                    typeof voice === "string" && voice !== "" ? voice : "alloy",
-                responseFormat: resolvedFormat,
-                apiKey: c.env.ELEVENLABS_API_KEY,
-                log,
-            });
-        },
+        prepareGenerationRequest,
+        audioCache,
+        generationAccess,
+        deduplicateGeneration,
+        handleVoiceChanger,
     )
     .post(
         "/voice-isolator",
@@ -2813,32 +3051,11 @@ export const audioRoutes = new Hono<Env>()
             supportedEndpoint: "/v1/audio/voice-isolator",
         }),
         track("generate.audio"),
-        async (c) => {
-            const log = c.get("log").getChild("voice-isolator");
-            await requireGenerationAccess(c.var, c.env);
-
-            let formData: FormData;
-            try {
-                formData = c.get("formData") || (await c.req.formData());
-            } catch {
-                throw new UpstreamError(400 as ContentfulStatusCode, {
-                    message: "Invalid multipart form data",
-                });
-            }
-
-            const audio = formData.get("audio");
-            if (!(audio instanceof File)) {
-                throw new UpstreamError(400 as ContentfulStatusCode, {
-                    message: "Missing required audio file.",
-                });
-            }
-
-            return isolateVoiceWithElevenLabs({
-                audio,
-                apiKey: c.env.ELEVENLABS_API_KEY,
-                log,
-            });
-        },
+        prepareGenerationRequest,
+        audioCache,
+        generationAccess,
+        deduplicateGeneration,
+        handleVoiceIsolator,
     )
     .post(
         "/speech",
@@ -2963,70 +3180,11 @@ export const audioRoutes = new Hono<Env>()
             supportedEndpoint: "/v1/audio/speech",
         }),
         track("generate.audio"),
-        async (c) => {
-            const log = c.get("log").getChild("tts");
-            await requireGenerationAccess(c.var, c.env);
-
-            const {
-                input,
-                safe,
-                voice,
-                response_format,
-                duration,
-                seconds,
-                steps,
-                negative_prompt,
-                instrumental,
-                store_for_inpainting,
-                conditioning_ref,
-                composition_plan,
-                reference_audio,
-                seed,
-                instruct,
-                loop,
-                prompt_influence,
-            } = await parseSpeechRequest(c);
-            requireElevenMusicOptions(c.var.model.resolved, {
-                referenceAudio: reference_audio,
-                compositionPlan: composition_plan,
-                conditioningRef: conditioning_ref,
-                storeForInpainting: store_for_inpainting,
-            });
-            const safeInput = await applySafety(c, input, safe);
-            const referenceAudio = reference_audio
-                ? await fetchReferenceAudio(reference_audio)
-                : undefined;
-
-            const apiKey = (c.env as unknown as { ELEVENLABS_API_KEY: string })
-                .ELEVENLABS_API_KEY;
-
-            return withAudioFallback(c, (candidate) =>
-                dispatchAudioGeneration(c, candidate.id, {
-                    text: safeInput,
-                    voice,
-                    responseFormat: response_format,
-                    seed,
-                    duration,
-                    seconds,
-                    steps,
-                    negativePrompt: negative_prompt,
-                    instrumental,
-                    storeForInpainting: store_for_inpainting,
-                    conditioningRef: conditioning_ref,
-                    compositionPlan: composition_plan,
-                    referenceAudio,
-                    instruct,
-                    loop,
-                    promptInfluence: prompt_influence,
-                    apiKey,
-                    dashScopeApiKey: c.env.DASHSCOPE_API_KEY,
-                    deepInfraApiKey: c.env.DEEPINFRA_API_KEY,
-                    falKey: c.env.FAL_KEY,
-                    stabilityApiKey: c.env.STABILITY_API_KEY,
-                    log,
-                }),
-            );
-        },
+        prepareGenerationRequest,
+        audioCache,
+        generationAccess,
+        deduplicateGeneration,
+        handleSpeech,
     )
     .post(
         "/speech/with-timestamps",
@@ -3143,39 +3301,11 @@ export const audioRoutes = new Hono<Env>()
             supportedEndpoint: "/v1/audio/speech/with-timestamps",
         }),
         track("generate.audio"),
-        async (c) => {
-            const log = c.get("log").getChild("tts-timestamps");
-            await requireGenerationAccess(c.var, c.env);
-
-            const { input, safe, voice, response_format, seed } =
-                await parseSpeechRequest(c);
-            const modelName = c.var.model.resolved;
-            if (!(modelName in ELEVENLABS_TTS_MODEL_IDS)) {
-                throw new UpstreamError(400 as ContentfulStatusCode, {
-                    message:
-                        "Timestamped speech supports elevenlabs, elevenflash, and eleven-multilingual-v2.",
-                });
-            }
-            if (response_format === "flac") {
-                throw new UpstreamError(400 as ContentfulStatusCode, {
-                    message:
-                        "Timestamped speech supports mp3, opus, aac, wav, and pcm output.",
-                });
-            }
-            const safeInput = await applySafety(c, input, safe);
-
-            return withAudioFallback(c, (candidate) =>
-                generateElevenLabsSpeechWithTimestamps({
-                    modelName: candidate.id as ElevenLabsTtsModelName,
-                    text: safeInput,
-                    voice,
-                    responseFormat: response_format,
-                    seed,
-                    apiKey: c.env.ELEVENLABS_API_KEY,
-                    log,
-                }),
-            );
-        },
+        prepareGenerationRequest,
+        textCache,
+        generationAccess,
+        deduplicateGeneration,
+        handleSpeechWithTimestamps,
     )
     .post(
         "/transcriptions",
@@ -3298,149 +3428,11 @@ export const audioRoutes = new Hono<Env>()
             supportedEndpoint: "/v1/audio/transcriptions",
         }),
         track("generate.audio"),
-        async (c) => {
-            const log = c.get("log").getChild("transcription");
-            await requireGenerationAccess(c.var, c.env);
-
-            // Get formData from middleware or parse it
-            let formData: FormData;
-            try {
-                formData = c.get("formData") || (await c.req.formData());
-            } catch (error) {
-                log.warn("Invalid multipart form data: {message}", {
-                    message:
-                        error instanceof Error ? error.message : String(error),
-                });
-                throw new UpstreamError(400 as ContentfulStatusCode, {
-                    message: "Invalid multipart form data",
-                });
-            }
-
-            const file = formData.get("file") as File;
-            const language = formData.get("language") as string | null;
-            const prompt = formData.get("prompt") as string | null;
-            const responseFormat = formData.get("response_format") as
-                | string
-                | null;
-            const temperatureRaw = formData.get("temperature") as string | null;
-            const temperature =
-                temperatureRaw !== null && temperatureRaw !== ""
-                    ? Number(temperatureRaw)
-                    : undefined;
-            const speakersExpected = parsePositiveInt(
-                formData.get("speakers_expected"),
-                "speakers_expected",
-            );
-            const wantsDiarizedJson = responseFormat === "diarized_json";
-
-            if (!file) {
-                throw new UpstreamError(400 as ContentfulStatusCode, {
-                    message: "Missing required field: file",
-                });
-            }
-
-            if (speakersExpected !== undefined && !wantsDiarizedJson) {
-                throw new UpstreamError(400 as ContentfulStatusCode, {
-                    message:
-                        "speakers_expected requires response_format=diarized_json",
-                });
-            }
-
-            const result = await withAudioFallback(c, async (candidate) => {
-                if (candidate.id === "grok-transcribe") {
-                    return transcribeWithXai({
-                        file,
-                        language: language || undefined,
-                        responseFormat: responseFormat || undefined,
-                        apiKey: c.env.XAI_API_KEY,
-                        log,
-                    });
-                }
-
-                if (candidate.id === "scribe") {
-                    return transcribeWithElevenLabs({
-                        file,
-                        language: language || undefined,
-                        responseFormat: responseFormat || undefined,
-                        apiKey: c.env.ELEVENLABS_API_KEY,
-                        log,
-                        numSpeakers: speakersExpected,
-                    });
-                }
-
-                if (
-                    candidate.id === "universal-2" ||
-                    candidate.id === "universal-3.5-pro"
-                ) {
-                    return transcribeWithAssemblyAi({
-                        file,
-                        language: language || undefined,
-                        prompt: prompt || undefined,
-                        responseFormat: responseFormat || undefined,
-                        temperature,
-                        model: candidate.id,
-                        apiKey: (
-                            c.env as unknown as {
-                                ASSEMBLYAI_API_KEY: string;
-                            }
-                        ).ASSEMBLYAI_API_KEY,
-                        log,
-                        speakersExpected,
-                    });
-                }
-
-                const ovhApiKey = c.env.OVHCLOUD_API_KEY;
-                if (!ovhApiKey) {
-                    throw new UpstreamError(500 as ContentfulStatusCode, {
-                        message:
-                            "Transcription service is not configured (missing API key)",
-                    });
-                }
-                validateWhisperResponseFormat(responseFormat);
-
-                // Rebuild the consumed multipart body for each upstream attempt.
-                const whisperFormData = new FormData();
-                const filename =
-                    file.name && file.name !== "blob" ? file.name : "audio.mp3";
-                whisperFormData.append("file", file, filename);
-                if (language) whisperFormData.append("language", language);
-                whisperFormData.append("response_format", "verbose_json");
-                whisperFormData.append("model", "whisper-large-v3");
-                whisperFormData.append("timestamp_granularities[]", "word");
-
-                const whisperUrl =
-                    "https://oai.endpoints.kepler.ai.cloud.ovh.net/v1/audio/transcriptions";
-                const response = await ensureUpstreamOk(
-                    await fetch(whisperUrl, {
-                        method: "POST",
-                        headers: { Authorization: `Bearer ${ovhApiKey}` },
-                        body: whisperFormData,
-                    }),
-                    whisperUrl,
-                );
-
-                let whisper: WhisperVerboseJson;
-                try {
-                    whisper = JSON.parse(await response.text());
-                } catch {
-                    throw new UpstreamError(502 as ContentfulStatusCode, {
-                        message:
-                            "Whisper returned an unexpected (non-JSON) response",
-                    });
-                }
-                const usageHeaders = buildUsageHeaders(
-                    candidate.id,
-                    createAudioSecondsUsage(extractWhisperUsage(whisper, log)),
-                );
-                return formatWhisperResponse(
-                    whisper,
-                    responseFormat,
-                    usageHeaders,
-                );
-            });
-            c.var.track.overrideResponseTracking(result.clone());
-            return result;
-        },
+        prepareGenerationRequest,
+        textCache,
+        generationAccess,
+        deduplicateGeneration,
+        handleTranscription,
     );
 
 export function parsePositiveInt(

--- a/gen.pollinations.ai/src/routes/generation-executor.ts
+++ b/gen.pollinations.ai/src/routes/generation-executor.ts
@@ -1,0 +1,255 @@
+import { validator } from "@shared/middleware/validator.ts";
+import { DEFAULT_3D_MODEL } from "@shared/registry/model3d.ts";
+import {
+    CreateChatCompletionRequestSchema,
+    CreateImageRequestSchema,
+} from "@shared/schemas/openai.ts";
+import { SafeSchema } from "@shared/schemas/safety.ts";
+import { Hono } from "hono";
+import { createFactory } from "hono/factory";
+import { z } from "zod";
+import type { Env } from "@/env.ts";
+import { prepareGenerationRequest } from "@/middleware/generation-cache.ts";
+import {
+    audioExecutionCache,
+    imageExecutionCache,
+    model3dExecutionCache,
+} from "@/middleware/media-cache.ts";
+import { resolveModel } from "@/middleware/model.ts";
+import { textExecutionCache } from "@/middleware/text-cache.ts";
+import { track } from "@/middleware/track.ts";
+import { CreateEmbeddingRequestSchema } from "@/schemas/embeddings.ts";
+import {
+    GenerateImageRequestQueryParamsSchema,
+    GenerateVideoRequestQueryParamsSchema,
+} from "@/schemas/image.ts";
+import {
+    Generate3dRequestBodySchema,
+    Generate3dRequestQueryParamsSchema,
+} from "@/schemas/model3d.ts";
+import { GenerateTextRequestQueryParamsSchema } from "@/schemas/text.ts";
+import {
+    handleDialogue,
+    handleSimpleAudio,
+    handleSpeech,
+    handleSpeechWithTimestamps,
+    handleTranscription,
+    handleVoiceChanger,
+    handleVoiceIsolator,
+} from "./audio.ts";
+import {
+    generateChatCompletion,
+    generateEmbeddingsResponse,
+    generateImageVideo,
+    generateModel3d,
+    generateSimpleText,
+    generateTextContent,
+    simpleAudioQuerySchema,
+    textBodyLimit,
+} from "./generation-handlers.ts";
+import {
+    formatOpenAIImageGeneration,
+    handleImageEdit,
+    handleImageGeneration,
+    prepareOpenAIImageGeneration,
+} from "./images.ts";
+
+const factory = createFactory<Env>();
+
+const imageVideoHandlers = factory.createHandlers(
+    track("generate.image"),
+    imageExecutionCache,
+    generateImageVideo,
+);
+
+const model3dHandlers = factory.createHandlers(
+    resolveModel("generate.image", { defaultModel: DEFAULT_3D_MODEL }),
+    track("generate.image"),
+    model3dExecutionCache,
+    generateModel3d,
+);
+
+export const generationExecutorRoutes = new Hono<Env>();
+
+generationExecutorRoutes.post(
+    "/v1/chat/completions",
+    textBodyLimit,
+    validator("json", CreateChatCompletionRequestSchema),
+    resolveModel("generate.text"),
+    track("generate.text"),
+    textExecutionCache,
+    generateChatCompletion,
+);
+
+generationExecutorRoutes.post(
+    "/v1/embeddings",
+    textBodyLimit,
+    validator("json", CreateEmbeddingRequestSchema),
+    resolveModel("generate.embedding"),
+    track("generate.embedding"),
+    prepareGenerationRequest,
+    textExecutionCache,
+    generateEmbeddingsResponse,
+);
+
+generationExecutorRoutes.post(
+    "/text",
+    textBodyLimit,
+    validator("json", CreateChatCompletionRequestSchema),
+    resolveModel("generate.text"),
+    track("generate.text"),
+    textExecutionCache,
+    generateTextContent,
+);
+
+generationExecutorRoutes.get(
+    "/text/:prompt{[\\s\\S]+}",
+    validator("param", z.object({ prompt: z.string().min(1) })),
+    validator("query", GenerateTextRequestQueryParamsSchema),
+    resolveModel("generate.text"),
+    track("generate.text"),
+    textExecutionCache,
+    generateSimpleText,
+);
+
+generationExecutorRoutes.post(
+    "/3d/:prompt{[\\s\\S]+}",
+    validator("param", z.object({ prompt: z.string().min(1) })),
+    validator(
+        "query",
+        z.object({ key: z.string().optional(), safe: SafeSchema }).strict(),
+    ),
+    validator("json", Generate3dRequestBodySchema),
+    resolveModel("generate.image", { defaultModel: DEFAULT_3D_MODEL }),
+    track("generate.image"),
+    prepareGenerationRequest,
+    model3dExecutionCache,
+    generateModel3d,
+);
+
+generationExecutorRoutes.get(
+    "/image/:prompt{[\\s\\S]+}",
+    validator("param", z.object({ prompt: z.string().min(1) })),
+    validator("query", GenerateImageRequestQueryParamsSchema),
+    resolveModel("generate.image"),
+    ...imageVideoHandlers,
+);
+
+generationExecutorRoutes.get(
+    "/video/:prompt{[\\s\\S]+}",
+    validator("param", z.object({ prompt: z.string().min(1) })),
+    validator("query", GenerateVideoRequestQueryParamsSchema),
+    resolveModel("generate.image", { defaultModel: "veo" }),
+    ...imageVideoHandlers,
+);
+
+generationExecutorRoutes.get(
+    "/3d/:prompt{[\\s\\S]+}",
+    validator("param", z.object({ prompt: z.string().min(1) })),
+    validator("query", Generate3dRequestQueryParamsSchema),
+    ...model3dHandlers,
+);
+
+generationExecutorRoutes.get(
+    "/audio/:text",
+    validator("param", z.object({ text: z.string().min(1) })),
+    validator("query", simpleAudioQuerySchema),
+    resolveModel("generate.audio", {
+        supportedEndpoint: "/audio/{text}",
+    }),
+    track("generate.audio"),
+    audioExecutionCache,
+    handleSimpleAudio,
+);
+
+generationExecutorRoutes.post(
+    "/v1/images/generations",
+    validator("json", CreateImageRequestSchema),
+    resolveModel("generate.image"),
+    track("generate.image"),
+    prepareOpenAIImageGeneration,
+    formatOpenAIImageGeneration,
+    prepareGenerationRequest,
+    imageExecutionCache,
+    handleImageGeneration,
+);
+
+generationExecutorRoutes.post(
+    "/v1/images/edits",
+    resolveModel("generate.image", { defaultModel: "flux" }),
+    track("generate.image"),
+    prepareGenerationRequest,
+    textExecutionCache,
+    handleImageEdit,
+);
+
+generationExecutorRoutes.post(
+    "/v1/audio/dialogue",
+    resolveModel("generate.audio", {
+        defaultModel: "eleven-dialogue",
+        supportedEndpoint: "/v1/audio/dialogue",
+    }),
+    track("generate.audio"),
+    prepareGenerationRequest,
+    audioExecutionCache,
+    handleDialogue,
+);
+
+generationExecutorRoutes.post(
+    "/v1/audio/voice-changer",
+    resolveModel("generate.audio", {
+        defaultModel: "eleven-voice-changer",
+        supportedEndpoint: "/v1/audio/voice-changer",
+    }),
+    track("generate.audio"),
+    prepareGenerationRequest,
+    audioExecutionCache,
+    handleVoiceChanger,
+);
+
+generationExecutorRoutes.post(
+    "/v1/audio/voice-isolator",
+    resolveModel("generate.audio", {
+        defaultModel: "eleven-voice-isolator",
+        supportedEndpoint: "/v1/audio/voice-isolator",
+    }),
+    track("generate.audio"),
+    prepareGenerationRequest,
+    audioExecutionCache,
+    handleVoiceIsolator,
+);
+
+generationExecutorRoutes.post(
+    "/v1/audio/speech",
+    resolveModel("generate.audio", {
+        supportedEndpoint: "/v1/audio/speech",
+    }),
+    track("generate.audio"),
+    prepareGenerationRequest,
+    audioExecutionCache,
+    handleSpeech,
+);
+
+generationExecutorRoutes.post(
+    "/v1/audio/speech/with-timestamps",
+    resolveModel("generate.audio", {
+        defaultModel: "elevenlabs",
+        supportedEndpoint: "/v1/audio/speech/with-timestamps",
+    }),
+    track("generate.audio"),
+    prepareGenerationRequest,
+    textExecutionCache,
+    handleSpeechWithTimestamps,
+);
+
+generationExecutorRoutes.post(
+    "/v1/audio/transcriptions",
+    resolveModel("generate.audio", {
+        defaultModel: "whisper-large-v3",
+        supportedEndpoint: "/v1/audio/transcriptions",
+    }),
+    track("generate.audio"),
+    prepareGenerationRequest,
+    textExecutionCache,
+    handleTranscription,
+);

--- a/gen.pollinations.ai/src/routes/generation-handlers.ts
+++ b/gen.pollinations.ai/src/routes/generation-handlers.ts
@@ -1,0 +1,320 @@
+import { UpstreamError } from "@shared/error.ts";
+import { AUDIO_VOICES } from "@shared/registry/audio.ts";
+import {
+    type CreateChatCompletionRequest,
+    type CreateChatCompletionResponse,
+    CreateChatCompletionResponseSchema,
+} from "@shared/schemas/openai.ts";
+import { SafeSchema, type SafeValue } from "@shared/schemas/safety.ts";
+import type { Context } from "hono";
+import { bodyLimit } from "hono/body-limit";
+import { z } from "zod";
+import {
+    generateEmbeddings,
+    getEmbeddingProviderModelId,
+} from "@/embeddings/handler.ts";
+import type { Env } from "@/env.ts";
+import { handleImagePrompt } from "@/image/handler.ts";
+import {
+    applySafety,
+    applySafetyToChatRequest,
+    applySafetyToTexts,
+    withSafetyHeaders,
+} from "@/middleware/safety.ts";
+import { handle3dPrompt } from "@/model3d/handler.ts";
+import type { CreateEmbeddingRequestSchema } from "@/schemas/embeddings.ts";
+import {
+    handleChatCompletionLocal,
+    handleSimpleTextLocal,
+    handleTextContentLocal,
+} from "@/text/handler.ts";
+import { withModelFallbackResponse } from "../fallback.ts";
+
+export const textBodyLimit = bodyLimit({
+    maxSize: 20 * 1024 * 1024,
+});
+
+export const simpleAudioQuerySchema = z.object({
+    voice: z
+        .enum(AUDIO_VOICES as unknown as [string, ...string[]])
+        .default("alloy")
+        .meta({
+            description: "Voice to use for speech generation (TTS only)",
+            example: "nova",
+        }),
+    response_format: z
+        .enum(["mp3", "opus", "aac", "flac", "wav", "pcm"])
+        .default("mp3")
+        .meta({
+            description:
+                "Audio output format. CSM and Kokoro support mp3, opus, flac, wav, and pcm; Qwen TTS currently returns WAV regardless of this setting; lyria-3-clip and eleven-sfx support mp3 only.",
+            example: "mp3",
+        }),
+    model: z.string().optional().meta({
+        description:
+            "Audio model: TTS (default) or a music-generation model such as lyria-3-clip",
+        example: "tts-1",
+    }),
+    duration: z
+        .string()
+        .optional()
+        .transform((v) => (v ? parseFloat(v) : undefined))
+        .pipe(z.number().min(0.5).max(300).optional())
+        .meta({
+            description:
+                "Music duration in seconds (elevenmusic 3-300; lyria-3-clip fixed at 30)",
+            example: "30",
+        }),
+    seconds: z.coerce.number().min(1).max(380).optional().meta({
+        description:
+            "Audio duration in seconds for stable-audio-3-medium/large, 1-380",
+        example: "30",
+    }),
+    steps: z.coerce.number().int().min(1).max(100).optional().meta({
+        description:
+            "Sampling steps (stable-audio-3-medium 1-100, stable-audio-3-large 4-8)",
+        example: "8",
+    }),
+    negative_prompt: z.string().optional().meta({
+        description: "Negative prompt for stable-audio-3-large",
+        example: "distortion, vocals",
+    }),
+    instrumental: z
+        .enum(["true", "false"])
+        .default("false")
+        .transform((v) => v === "true")
+        .meta({
+            description:
+                "If true, guarantees instrumental output (elevenmusic only)",
+            example: "false",
+        }),
+    instruct: z.string().optional().meta({
+        description: "Emotion/style instruction (qwen-tts-instruct only)",
+        example: "speak softly and warmly",
+    }),
+    loop: z
+        .enum(["true", "false"])
+        .optional()
+        .transform((v) => (v === undefined ? undefined : v === "true"))
+        .meta({
+            description: "Loop the generated sound effect (eleven-sfx only)",
+            example: "false",
+        }),
+    prompt_influence: z
+        .string()
+        .optional()
+        .transform((v) => (v ? Number.parseFloat(v) : undefined))
+        .pipe(z.number().min(0).max(1).optional())
+        .meta({
+            description:
+                "How strictly to follow the prompt, 0-1 (eleven-sfx only)",
+            example: "0.3",
+        }),
+    seed: z.coerce.number().int().min(-1).max(4294967295).optional().meta({
+        description:
+            "Seed passed to the model. Same seed + parameters return the same cached result while available.",
+        example: "42",
+    }),
+    key: z.string().optional().meta({
+        description: "API key (alternative to Authorization header)",
+    }),
+    safe: SafeSchema,
+});
+
+export async function generateImageVideo(c: Context<Env>): Promise<Response> {
+    const query = c.req.valid("query" as never) as { safe?: SafeValue };
+    const prompt = await applySafety(
+        c,
+        c.req.param("prompt") || "",
+        query.safe,
+    );
+    return withSafetyHeaders(c, await handleImagePrompt(c, prompt));
+}
+
+export async function generateModel3d(c: Context<Env>): Promise<Response> {
+    const query = c.req.valid("query" as never) as { safe?: SafeValue };
+    const prompt = await applySafety(
+        c,
+        c.req.param("prompt") || "",
+        query.safe,
+    );
+    return withSafetyHeaders(c, await handle3dPrompt(c, prompt));
+}
+
+export async function generateEmbeddingsResponse(
+    c: Context<Env>,
+): Promise<Response> {
+    const requestBody = c.req.valid("json" as never) as z.infer<
+        typeof CreateEmbeddingRequestSchema
+    >;
+    const { response, servedEntry } = await withModelFallbackResponse(
+        c.var.model,
+        (candidate) =>
+            generateEmbeddings(
+                c.env,
+                {
+                    ...requestBody,
+                    model: getEmbeddingProviderModelId(candidate.id),
+                },
+                candidate.definition ?? c.var.model.definition,
+                candidate.id,
+            ),
+        c.var.track?.failedCalls,
+    );
+    if (servedEntry) c.set("servedModelEntry", servedEntry);
+    return response;
+}
+
+export async function generateChatCompletion(
+    c: Context<Env>,
+): Promise<Response> {
+    const requestBody = await applySafetyToChatRequest(c, {
+        ...(c.req.valid("json" as never) as CreateChatCompletionRequest),
+        model: c.var.model.resolved,
+    });
+
+    const response = await handleChatCompletionLocal(c, requestBody);
+    if (!response.ok) return response;
+
+    assertStreamContentType(c, response, c.var.upstreamRequestUrl);
+
+    let contentFilterHeaders = {};
+    if (!c.var.track.streamRequested) {
+        const responseText = await response.clone().text();
+        try {
+            const parsedResponse = CreateChatCompletionResponseSchema.parse(
+                JSON.parse(responseText),
+                { reportInput: true },
+            );
+            contentFilterHeaders =
+                contentFilterResultsToHeaders(parsedResponse);
+        } catch (parseError) {
+            throw new UpstreamError(502, {
+                message: `Upstream returned response that failed schema validation: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
+                requestUrl: c.var.upstreamRequestUrl,
+                responseBody: responseText,
+                cause: parseError,
+            });
+        }
+    }
+
+    return withSafetyHeaders(
+        c,
+        new Response(response.body, {
+            headers: {
+                ...Object.fromEntries(response.headers),
+                ...contentFilterHeaders,
+            },
+        }),
+    );
+}
+
+export async function generateTextContent(c: Context<Env>): Promise<Response> {
+    const requestBody = await applySafetyToChatRequest(c, {
+        ...(c.req.valid("json" as never) as CreateChatCompletionRequest),
+        model: c.var.model.resolved,
+    });
+    const response = await handleTextContentLocal(c, requestBody);
+    assertStreamContentType(c, response, c.var.upstreamRequestUrl);
+    return withSafetyHeaders(c, response);
+}
+
+export async function generateSimpleText(c: Context<Env>): Promise<Response> {
+    const query = c.req.valid("query" as never) as {
+        safe?: SafeValue;
+        system?: string;
+    };
+    const textInputs =
+        typeof query.system === "string"
+            ? [c.req.param("prompt"), query.system]
+            : [c.req.param("prompt")];
+    const [prompt, system] = await applySafetyToTexts(
+        c,
+        textInputs,
+        query.safe,
+    );
+
+    return withSafetyHeaders(
+        c,
+        await handleSimpleTextLocal(
+            c,
+            prompt,
+            c.var.model.resolved,
+            system ? { system } : undefined,
+        ),
+    );
+}
+
+function assertStreamContentType(
+    c: Context<Env>,
+    response: Response,
+    upstreamRequestUrl: URL | undefined,
+): void {
+    if (c.var.track.streamRequested) {
+        const contentType = response.headers.get("content-type") || "";
+        if (!contentType.includes("text/event-stream")) {
+            throw new UpstreamError(502, {
+                message: `Stream requested for model ${c.var.model.resolved} but upstream returned content-type: ${contentType}`,
+                requestUrl: upstreamRequestUrl,
+                responseBody: contentType,
+            });
+        }
+    }
+}
+
+export function contentFilterResultsToHeaders(
+    response: CreateChatCompletionResponse,
+): Record<string, string> {
+    const promptFilters =
+        response.prompt_filter_results?.[0]?.content_filter_results;
+    const completionFilters = response.choices?.[0]?.content_filter_results;
+    const headerMappings: Array<[string, unknown]> = [
+        ["x-moderation-prompt-hate-severity", promptFilters?.hate?.severity],
+        [
+            "x-moderation-prompt-self-harm-severity",
+            promptFilters?.self_harm?.severity,
+        ],
+        [
+            "x-moderation-prompt-sexual-severity",
+            promptFilters?.sexual?.severity,
+        ],
+        [
+            "x-moderation-prompt-violence-severity",
+            promptFilters?.violence?.severity,
+        ],
+        [
+            "x-moderation-prompt-jailbreak-detected",
+            promptFilters?.jailbreak?.detected,
+        ],
+        [
+            "x-moderation-completion-hate-severity",
+            completionFilters?.hate?.severity,
+        ],
+        [
+            "x-moderation-completion-self-harm-severity",
+            completionFilters?.self_harm?.severity,
+        ],
+        [
+            "x-moderation-completion-sexual-severity",
+            completionFilters?.sexual?.severity,
+        ],
+        [
+            "x-moderation-completion-violence-severity",
+            completionFilters?.violence?.severity,
+        ],
+        [
+            "x-moderation-completion-protected-material-text-detected",
+            completionFilters?.protected_material_text?.detected,
+        ],
+        [
+            "x-moderation-completion-protected-material-code-detected",
+            completionFilters?.protected_material_code?.detected,
+        ],
+    ];
+
+    const headers: Record<string, string> = {};
+    for (const [key, value] of headerMappings) {
+        if (value) headers[key] = String(value);
+    }
+    return headers;
+}

--- a/gen.pollinations.ai/src/routes/images.ts
+++ b/gen.pollinations.ai/src/routes/images.ts
@@ -30,7 +30,6 @@ import type { Env } from "@/env.ts";
 import { generateImageOrVideoResponse } from "@/image/handler.ts";
 import { applySafety, withSafetyHeaders } from "@/middleware/safety.ts";
 import { arrayBufferToBase64 } from "@/util.ts";
-import { requireGenerationAccess } from "@/utils/generation-access.ts";
 
 // --- Helpers ---
 
@@ -247,6 +246,7 @@ export const prepareOpenAIImageGeneration = createMiddleware<Env>(
             body.safe as SafeValue,
         );
         Object.assign(body, resolved, { model, prompt: safePrompt });
+        c.set("generationRequestBody", JSON.stringify(body));
 
         const imageUrl = new URL(
             `/image/${encodeURIComponent(body.prompt)}`,
@@ -336,8 +336,6 @@ export async function handleImageGeneration(c: Context<Env>) {
 }
 
 export async function handleImageEdit(c: Context<Env>) {
-    await requireGenerationAccess(c.var, c.env);
-
     const { prompt, imageUrls, size, quality, seed, safe, extra } =
         await parseEditInput(c);
     const safePrompt = await applySafety(c, prompt, safe);

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -1,14 +1,12 @@
 import { type Context, Hono } from "hono";
-import { bodyLimit } from "hono/body-limit";
+import { every } from "hono/combine";
 import { resolver as baseResolver, describeRoute } from "hono-openapi";
-import {
-    generateEmbeddings,
-    getEmbeddingProviderModelId,
-} from "@/embeddings/handler.ts";
 import type { Env } from "@/env.ts";
-import { handleImagePrompt, handleRegisterServer } from "@/image/handler.ts";
+import { handleRegisterServer } from "@/image/handler.ts";
 import { auth } from "@/middleware/auth.ts";
 import { balance } from "@/middleware/balance.ts";
+import { prepareGenerationRequest } from "@/middleware/generation-cache.ts";
+import { deduplicateGeneration } from "@/middleware/generation-deduplication.ts";
 import {
     audioCache,
     imageCache,
@@ -31,7 +29,6 @@ import {
 const resolver = <T extends Parameters<typeof baseResolver>[0]>(schema: T) =>
     baseResolver(schema, { reused: "ref" });
 
-import { UpstreamError } from "@shared/error.ts";
 import { validator } from "@shared/middleware/validator.ts";
 import { AUDIO_VOICES } from "@shared/registry/audio.ts";
 import {
@@ -48,25 +45,16 @@ import {
     REALTIME_MODEL_NAMES,
 } from "@shared/registry/realtime.ts";
 import {
-    type CreateChatCompletionRequest,
     CreateChatCompletionRequestSchema,
-    type CreateChatCompletionResponse,
     CreateChatCompletionResponseSchema,
     CreateImageRequestSchema,
     CreateImageResponseSchema,
     GetModelsResponseSchema,
 } from "@shared/schemas/openai.ts";
-import { SafeSchema, type SafeValue } from "@shared/schemas/safety.ts";
+import { SafeSchema } from "@shared/schemas/safety.ts";
 import { errorResponseDescriptions } from "@shared/utils/api-docs.ts";
 import { createFactory } from "hono/factory";
 import { z } from "zod";
-import {
-    applySafety,
-    applySafetyToChatRequest,
-    applySafetyToTexts,
-    withSafetyHeaders,
-} from "@/middleware/safety.ts";
-import { handle3dPrompt } from "@/model3d/handler.ts";
 import {
     CreateEmbeddingRequestSchema,
     CreateEmbeddingResponseSchema,
@@ -81,18 +69,22 @@ import {
 } from "@/schemas/model3d.ts";
 import { RealtimeRequestQueryParamsSchema } from "@/schemas/realtime.ts";
 import { GenerateTextRequestQueryParamsSchema } from "@/schemas/text.ts";
-import {
-    handleChatCompletionLocal,
-    handleSimpleTextLocal,
-    handleTextContentLocal,
-} from "@/text/handler.ts";
 import { generationAccess } from "@/utils/generation-access.ts";
-import { withModelFallbackResponse } from "../fallback.ts";
 import {
     type GenerationModelEntry,
     getGenerationModelRegistry,
 } from "../model-registry.ts";
 import { handleSimpleAudio } from "./audio.ts";
+import {
+    generateChatCompletion,
+    generateEmbeddingsResponse,
+    generateImageVideo,
+    generateModel3d,
+    generateSimpleText,
+    generateTextContent,
+    simpleAudioQuerySchema,
+    textBodyLimit,
+} from "./generation-handlers.ts";
 import { handleRealtimeWebSocket } from "./realtime.ts";
 
 // Build dynamic model lists from registry for use in API descriptions
@@ -141,44 +133,26 @@ function describeRealtimeWebSocket(path: "/realtime" | "/v1/realtime") {
 }
 
 const factory = createFactory<Env>();
-const textBodyLimit = bodyLimit({
-    maxSize: 20 * 1024 * 1024,
-});
+
 // Shared handler for image and video generation (used by both /image/ and /video/ routes)
 const imageVideoHandlers = factory.createHandlers(
     track("generate.image"),
     imageCache,
     generationAccess,
-    async (c) => {
-        const query = c.req.valid("query" as never) as { safe?: SafeValue };
-        const prompt = await applySafety(
-            c,
-            c.req.param("prompt") || "",
-            query.safe,
-        );
-        return withSafetyHeaders(c, await handleImagePrompt(c, prompt));
-    },
+    deduplicateGeneration,
+    generateImageVideo,
 );
 
-// Handler for 3D model generation (reuses the "generate.image" EventType,
-// same as video, to avoid touching Tinybird/EventType consumers).
+// 3D shares the image event type to avoid changing Tinybird consumers.
 const model3dHandlers = factory.createHandlers(
     resolveModel("generate.image", { defaultModel: DEFAULT_3D_MODEL }),
     track("generate.image"),
     model3dCache,
     generationAccess,
-    async (c) => {
-        const query = c.req.valid("query" as never) as { safe?: SafeValue };
-        const prompt = await applySafety(
-            c,
-            c.req.param("prompt") || "",
-            query.safe,
-        );
-        return withSafetyHeaders(c, await handle3dPrompt(c, prompt));
-    },
+    deduplicateGeneration,
+    generateModel3d,
 );
 
-// Shared handler for OpenAI-compatible chat completions
 const chatCompletionHandlers = factory.createHandlers(
     textBodyLimit,
     validator("json", CreateChatCompletionRequestSchema),
@@ -186,69 +160,9 @@ const chatCompletionHandlers = factory.createHandlers(
     track("generate.text"),
     textCache,
     generationAccess,
-    async (c) => {
-        // Use resolved model from middleware for the backend request
-        const requestBody = await applySafetyToChatRequest(c, {
-            ...(c.req.valid("json" as never) as CreateChatCompletionRequest),
-            model: c.var.model.resolved,
-        });
-
-        const response = await handleChatCompletionLocal(c, requestBody);
-        if (!response.ok) return response;
-
-        assertStreamContentType(c, response, c.var.upstreamRequestUrl);
-
-        // add content filter headers if not streaming
-        let contentFilterHeaders = {};
-        if (!c.var.track.streamRequested) {
-            const responseText = await response.clone().text();
-            try {
-                const parsedResponse = CreateChatCompletionResponseSchema.parse(
-                    JSON.parse(responseText),
-                    { reportInput: true },
-                );
-                contentFilterHeaders =
-                    contentFilterResultsToHeaders(parsedResponse);
-            } catch (parseError) {
-                throw new UpstreamError(502, {
-                    message: `Upstream returned response that failed schema validation: ${parseError instanceof Error ? parseError.message : String(parseError)}`,
-                    requestUrl: c.var.upstreamRequestUrl,
-                    responseBody: responseText,
-                    cause: parseError,
-                });
-            }
-        }
-
-        return withSafetyHeaders(
-            c,
-            new Response(response.body, {
-                headers: {
-                    ...Object.fromEntries(response.headers),
-                    ...contentFilterHeaders,
-                },
-            }),
-        );
-    },
+    deduplicateGeneration,
+    generateChatCompletion,
 );
-
-// Validate streaming responses: if client requested stream but upstream
-// returned non-SSE, throw rather than forwarding broken data.
-function assertStreamContentType(
-    c: Context<Env>,
-    response: Response,
-    upstreamRequestUrl: URL | undefined,
-): void {
-    if (c.var.track.streamRequested) {
-        const contentType = response.headers.get("content-type") || "";
-        if (!contentType.includes("text/event-stream")) {
-            throw new UpstreamError(502, {
-                message: `Stream requested for model ${c.var.model.resolved} but upstream returned content-type: ${contentType}`,
-                requestUrl: upstreamRequestUrl,
-                responseBody: contentType,
-            });
-        }
-    }
-}
 
 // Helper to filter models by API key permissions and paid balance.
 function filterEntriesByPermissions(
@@ -668,28 +582,11 @@ export const proxyRoutes = new Hono<Env>()
         validator("json", CreateEmbeddingRequestSchema),
         resolveModel("generate.embedding"),
         track("generate.embedding"),
+        prepareGenerationRequest,
+        textCache,
         generationAccess,
-        async (c) => {
-            const requestBody = c.req.valid("json" as never) as z.infer<
-                typeof CreateEmbeddingRequestSchema
-            >;
-            const { response, servedEntry } = await withModelFallbackResponse(
-                c.var.model,
-                (candidate) =>
-                    generateEmbeddings(
-                        c.env,
-                        {
-                            ...requestBody,
-                            model: getEmbeddingProviderModelId(candidate.id),
-                        },
-                        candidate.definition ?? c.var.model.definition,
-                        candidate.id,
-                    ),
-                c.var.track?.failedCalls,
-            );
-            if (servedEntry) c.set("servedModelEntry", servedEntry);
-            return response;
-        },
+        deduplicateGeneration,
+        generateEmbeddingsResponse,
     )
     .post(
         "/text",
@@ -715,18 +612,8 @@ export const proxyRoutes = new Hono<Env>()
         track("generate.text"),
         textCache,
         generationAccess,
-        async (c) => {
-            const requestBody = await applySafetyToChatRequest(c, {
-                ...(c.req.valid(
-                    "json" as never,
-                ) as CreateChatCompletionRequest),
-                model: c.var.model.resolved,
-            });
-
-            const response = await handleTextContentLocal(c, requestBody);
-            assertStreamContentType(c, response, c.var.upstreamRequestUrl);
-            return withSafetyHeaders(c, response);
-        },
+        deduplicateGeneration,
+        generateTextContent,
     )
     .get(
         "/text/:prompt{[\\s\\S]+}",
@@ -764,34 +651,8 @@ export const proxyRoutes = new Hono<Env>()
         track("generate.text"),
         textCache,
         generationAccess,
-        async (c) => {
-            // Use resolved model from middleware
-            const model = c.var.model.resolved;
-
-            const query = c.req.valid("query" as never) as {
-                safe?: SafeValue;
-                system?: string;
-            };
-            const textInputs =
-                typeof query.system === "string"
-                    ? [c.req.param("prompt"), query.system]
-                    : [c.req.param("prompt")];
-            const [prompt, system] = await applySafetyToTexts(
-                c,
-                textInputs,
-                query.safe,
-            );
-
-            return withSafetyHeaders(
-                c,
-                await handleSimpleTextLocal(
-                    c,
-                    prompt,
-                    model,
-                    system ? { system } : undefined,
-                ),
-            );
-        },
+        deduplicateGeneration,
+        generateSimpleText,
     )
     .get(
         // Use :prompt{[\\s\\S]+} regex to capture everything including slashes AND newlines
@@ -940,7 +801,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🧊 3D"],
             summary: "Generate 3D Model With JSON",
             description:
-                "Generate a 3D model from a text prompt or reference image using JSON parameters. POST requests bypass the server-side media cache, so repeated requests regenerate and are billed. `trellis-2` supports `low`, `medium`, and `high` resolution with variable pricing.",
+                "Generate a 3D model from a text prompt or reference image using JSON parameters. `trellis-2` supports `low`, `medium`, and `high` resolution with variable pricing.",
             responses: {
                 200: {
                     description: "Success - Returns the generated 3D model",
@@ -981,18 +842,10 @@ export const proxyRoutes = new Hono<Env>()
         validator("json", Generate3dRequestBodySchema),
         resolveModel("generate.image", { defaultModel: DEFAULT_3D_MODEL }),
         track("generate.image"),
+        every(prepareGenerationRequest, model3dCache),
         generationAccess,
-        async (c) => {
-            const query = c.req.valid("query" as never) as {
-                safe?: SafeValue;
-            };
-            const prompt = await applySafety(
-                c,
-                c.req.param("prompt") || "",
-                query.safe,
-            );
-            return withSafetyHeaders(c, await handle3dPrompt(c, prompt));
-        },
+        deduplicateGeneration,
+        generateModel3d,
     )
     .get(
         "/audio/:text",
@@ -1032,113 +885,14 @@ export const proxyRoutes = new Hono<Env>()
                 }),
             }),
         ),
-        validator(
-            "query",
-            z.object({
-                voice: z
-                    .enum(AUDIO_VOICES as unknown as [string, ...string[]])
-                    .default("alloy")
-                    .meta({
-                        description:
-                            "Voice to use for speech generation (TTS only)",
-                        example: "nova",
-                    }),
-                response_format: z
-                    .enum(["mp3", "opus", "aac", "flac", "wav", "pcm"])
-                    .default("mp3")
-                    .meta({
-                        description:
-                            "Audio output format. CSM and Kokoro support mp3, opus, flac, wav, and pcm; Qwen TTS currently returns WAV regardless of this setting; lyria-3-clip and eleven-sfx support mp3 only.",
-                        example: "mp3",
-                    }),
-                model: z.string().optional().meta({
-                    description:
-                        "Audio model: TTS (default) or a music-generation model such as lyria-3-clip",
-                    example: "tts-1",
-                }),
-                duration: z
-                    .string()
-                    .optional()
-                    .transform((v) => (v ? parseFloat(v) : undefined))
-                    .pipe(z.number().min(0.5).max(300).optional())
-                    .meta({
-                        description:
-                            "Music duration in seconds (elevenmusic 3-300; lyria-3-clip fixed at 30)",
-                        example: "30",
-                    }),
-                seconds: z.coerce.number().min(1).max(380).optional().meta({
-                    description:
-                        "Audio duration in seconds for stable-audio-3-medium/large, 1-380",
-                    example: "30",
-                }),
-                steps: z.coerce.number().int().min(1).max(100).optional().meta({
-                    description:
-                        "Sampling steps (stable-audio-3-medium 1-100, stable-audio-3-large 4-8)",
-                    example: "8",
-                }),
-                negative_prompt: z.string().optional().meta({
-                    description: "Negative prompt for stable-audio-3-large",
-                    example: "distortion, vocals",
-                }),
-                instrumental: z
-                    .enum(["true", "false"])
-                    .default("false")
-                    .transform((v) => v === "true")
-                    .meta({
-                        description:
-                            "If true, guarantees instrumental output (elevenmusic only)",
-                        example: "false",
-                    }),
-                instruct: z.string().optional().meta({
-                    description:
-                        "Emotion/style instruction (qwen-tts-instruct only)",
-                    example: "speak softly and warmly",
-                }),
-                loop: z
-                    .enum(["true", "false"])
-                    .optional()
-                    .transform((v) =>
-                        v === undefined ? undefined : v === "true",
-                    )
-                    .meta({
-                        description:
-                            "Loop the generated sound effect (eleven-sfx only)",
-                        example: "false",
-                    }),
-                prompt_influence: z
-                    .string()
-                    .optional()
-                    .transform((v) => (v ? Number.parseFloat(v) : undefined))
-                    .pipe(z.number().min(0).max(1).optional())
-                    .meta({
-                        description:
-                            "How strictly to follow the prompt, 0-1 (eleven-sfx only)",
-                        example: "0.3",
-                    }),
-                seed: z.coerce
-                    .number()
-                    .int()
-                    .min(-1)
-                    .max(4294967295)
-                    .optional()
-                    .meta({
-                        description:
-                            "Seed passed to the model. Same seed + parameters return the same cached result while available.",
-                        example: "42",
-                    }),
-                key: z.string().optional().meta({
-                    description:
-                        "API key (alternative to Authorization header)",
-                }),
-                safe: SafeSchema,
-            }),
-        ),
+        validator("query", simpleAudioQuerySchema),
         resolveModel("generate.audio", {
             supportedEndpoint: "/audio/{text}",
         }),
         track("generate.audio"),
         audioCache,
         generationAccess,
+        deduplicateGeneration,
         handleSimpleAudio,
     )
     .post(
@@ -1169,9 +923,10 @@ export const proxyRoutes = new Hono<Env>()
         resolveModel("generate.image"),
         track("generate.image"),
         generationAccess,
-        prepareOpenAIImageGeneration,
-        formatOpenAIImageGeneration,
+        every(prepareOpenAIImageGeneration, formatOpenAIImageGeneration),
+        prepareGenerationRequest,
         imageCache,
+        deduplicateGeneration,
         handleImageGeneration,
     )
     .post(
@@ -1202,74 +957,9 @@ export const proxyRoutes = new Hono<Env>()
         }),
         resolveModel("generate.image", { defaultModel: "flux" }),
         track("generate.image"),
+        prepareGenerationRequest,
+        textCache,
+        generationAccess,
+        deduplicateGeneration,
         handleImageEdit,
     );
-
-export function contentFilterResultsToHeaders(
-    response: CreateChatCompletionResponse,
-): Record<string, string> {
-    const promptFilters =
-        response.prompt_filter_results?.[0]?.content_filter_results;
-    const completionFilters = response.choices?.[0]?.content_filter_results;
-
-    const mapToString = (value: unknown): string | undefined =>
-        value ? String(value) : undefined;
-
-    // Build header mappings
-    const headerMappings: Array<[string, unknown]> = [
-        // Prompt filters
-        ["x-moderation-prompt-hate-severity", promptFilters?.hate?.severity],
-        [
-            "x-moderation-prompt-self-harm-severity",
-            promptFilters?.self_harm?.severity,
-        ],
-        [
-            "x-moderation-prompt-sexual-severity",
-            promptFilters?.sexual?.severity,
-        ],
-        [
-            "x-moderation-prompt-violence-severity",
-            promptFilters?.violence?.severity,
-        ],
-        [
-            "x-moderation-prompt-jailbreak-detected",
-            promptFilters?.jailbreak?.detected,
-        ],
-        // Completion filters
-        [
-            "x-moderation-completion-hate-severity",
-            completionFilters?.hate?.severity,
-        ],
-        [
-            "x-moderation-completion-self-harm-severity",
-            completionFilters?.self_harm?.severity,
-        ],
-        [
-            "x-moderation-completion-sexual-severity",
-            completionFilters?.sexual?.severity,
-        ],
-        [
-            "x-moderation-completion-violence-severity",
-            completionFilters?.violence?.severity,
-        ],
-        [
-            "x-moderation-completion-protected-material-text-detected",
-            completionFilters?.protected_material_text?.detected,
-        ],
-        [
-            "x-moderation-completion-protected-material-code-detected",
-            completionFilters?.protected_material_code?.detected,
-        ],
-    ];
-
-    // Convert to headers, filtering out undefined values
-    const headers: Record<string, string> = {};
-    for (const [key, value] of headerMappings) {
-        const stringValue = mapToString(value);
-        if (stringValue !== undefined) {
-            headers[key] = stringValue;
-        }
-    }
-
-    return headers;
-}

--- a/gen.pollinations.ai/src/text/utils/parameterValidators.ts
+++ b/gen.pollinations.ai/src/text/utils/parameterValidators.ts
@@ -1,3 +1,5 @@
+import { normalizeSeed } from "@/util.ts";
+
 function validateFloat(value: unknown): number | undefined {
     if (value === undefined || value === null) return undefined;
     const parsed = Number.parseFloat(String(value));
@@ -56,7 +58,7 @@ export function validateTextGenerationParams(
         presence_penalty: validateFloat(data.presence_penalty),
         frequency_penalty: validateFloat(data.frequency_penalty),
         repetition_penalty: validateFloat(data.repetition_penalty),
-        seed: validateInt(data.seed),
+        seed: normalizeSeed(validateInt(data.seed)),
         stream: validateBoolean(data.stream),
         model: validateString(data.model),
         voice: validateString(data.voice),

--- a/gen.pollinations.ai/src/util.ts
+++ b/gen.pollinations.ai/src/util.ts
@@ -51,3 +51,17 @@ export function parseBooleanLike(value: unknown): boolean | null {
     if (FALSE_TOKENS.includes(normalized)) return false;
     return null;
 }
+
+/**
+ * `seed=-1` used to mean "pick a random seed", which produced a different image
+ * on every call. Generation is now single-flighted and cached by request URL,
+ * so a sentinel that randomizes downstream would key one URL to an arbitrary
+ * result. Map it to a fixed seed instead: callers get a reproducible result and
+ * providers only ever see a real seed or none. Callers wanting variation pass
+ * their own varying seed.
+ */
+export const SENTINEL_SEED = 42;
+
+export function normalizeSeed<T extends number | undefined>(seed: T): T {
+    return (seed === -1 ? SENTINEL_SEED : seed) as T;
+}

--- a/gen.pollinations.ai/src/utils/execute-generation.ts
+++ b/gen.pollinations.ai/src/utils/execute-generation.ts
@@ -1,0 +1,133 @@
+import type { BalanceCheckResult } from "@shared/billing/balance.ts";
+import { handleError } from "@shared/error.ts";
+import { Hono } from "hono";
+import type { Env } from "@/env.ts";
+import {
+    authFromSnapshot,
+    type GenerationAuthSnapshot,
+} from "@/middleware/auth.ts";
+import { balance } from "@/middleware/balance.ts";
+import type {
+    GenerationErrorSnapshot,
+    GenerationOutcome,
+} from "@/middleware/generation-deduplication.ts";
+import { logger } from "@/middleware/logger.ts";
+import { frontendKeyBilling } from "@/middleware/rate-limit-durable.ts";
+import { generationExecutorRoutes } from "@/routes/generation-executor.ts";
+
+async function drainResponse(response: Response): Promise<void> {
+    const reader = response.body?.getReader();
+    if (!reader) return;
+    while (!(await reader.read()).done) {
+        // Draining completes the existing cache transform/clone.
+    }
+}
+
+const ERROR_BODY_BYTES = 64 * 1024;
+const ERROR_HEADERS = new Set(["content-type", "retry-after"]);
+const ERROR_HEADER_PREFIXES = ["x-moderation-", "x-safety-"];
+
+async function captureError(
+    response: Response,
+): Promise<GenerationErrorSnapshot> {
+    const body = new Uint8Array(
+        (await response.arrayBuffer()).slice(0, ERROR_BODY_BYTES),
+    );
+    return {
+        httpStatus: response.status,
+        headers: [...response.headers.entries()].filter(([name]) => {
+            const lowerName = name.toLowerCase();
+            return (
+                ERROR_HEADERS.has(lowerName) ||
+                ERROR_HEADER_PREFIXES.some((prefix) =>
+                    lowerName.startsWith(prefix),
+                )
+            );
+        }),
+        body,
+    };
+}
+
+export type DetachedGeneration = {
+    result: GenerationOutcome;
+    settlement: Promise<void>;
+};
+
+function generationExecutor(
+    auth: GenerationAuthSnapshot,
+    requestId: string,
+    balanceCheckResult: BalanceCheckResult,
+    registerGenerationCacheWrite: (promise: Promise<void>) => void,
+): Hono<Env> {
+    const executor = new Hono<Env>()
+        .use("*", async (c, next) => {
+            c.set("requestId", requestId);
+            c.header("X-Request-Id", requestId);
+            await next();
+        })
+        .use("*", logger)
+        .use("*", authFromSnapshot(auth))
+        .use("*", async (c, next) => {
+            c.set("registerGenerationCacheWrite", registerGenerationCacheWrite);
+            await next();
+        })
+        .use("*", frontendKeyBilling)
+        .use("*", balance)
+        .use("*", async (c, next) => {
+            c.var.balance.balanceCheckResult = balanceCheckResult;
+            await next();
+        })
+        .route("/", generationExecutorRoutes);
+    executor.onError(handleError);
+    return executor;
+}
+
+/** Runs a provider handler under the Durable Object alarm's lifetime. */
+export async function executeGeneration(
+    request: Request,
+    auth: GenerationAuthSnapshot,
+    requestId: string,
+    balanceCheckResult: BalanceCheckResult,
+    env: CloudflareBindings,
+): Promise<DetachedGeneration> {
+    const promises: Promise<unknown>[] = [];
+    let cacheWrite: Promise<void> | undefined;
+    const executionCtx = {
+        waitUntil(promise: Promise<unknown>) {
+            promises.push(promise);
+        },
+        passThroughOnException() {},
+    } as ExecutionContext;
+
+    const response = await generationExecutor(
+        auth,
+        requestId,
+        balanceCheckResult,
+        (promise) => {
+            cacheWrite = promise;
+        },
+    ).fetch(request, env, executionCtx);
+    const settlement = Promise.allSettled(promises).then(() => {});
+
+    try {
+        const failed = !response.ok;
+        const error = failed ? await captureError(response) : undefined;
+        if (!failed) await drainResponse(response);
+
+        if (response.headers.get("x-cache") === "HIT") {
+            return { result: { status: "cached" }, settlement };
+        }
+        if (error) {
+            return { result: { status: "failed", error }, settlement };
+        }
+        if (!cacheWrite) {
+            throw new Error("Generation completed without a cacheable result");
+        }
+
+        await cacheWrite;
+        return { result: { status: "cached" }, settlement };
+    } catch (error) {
+        await settlement;
+        throw error;
+    }
+}

--- a/gen.pollinations.ai/src/utils/media-cache.ts
+++ b/gen.pollinations.ai/src/utils/media-cache.ts
@@ -20,8 +20,12 @@ const CACHED_HEADER_NAMES = [
     "content-disposition",
     "content-security-policy",
     "x-content-type-options",
+    "x-elevenlabs-reference-song-id",
+    "x-elevenlabs-song-id",
     "x-fallback-target",
     "x-model-used",
+    "x-tts-voice",
+    "x-voice-changer-voice",
 ];
 
 function hasActiveSafety(value: string | null | undefined): boolean {
@@ -117,39 +121,26 @@ type MediaCacheEnv = {
     };
 };
 
-export function cacheMediaResponse<TEnv extends MediaCacheEnv>(
+export async function putMediaResponse<TEnv extends MediaCacheEnv>(
     bucket: R2Bucket,
     cacheKey: string,
     c: Context<TEnv>,
     defaultContentType: string,
     response: Response,
-): void {
-    c.executionCtx.waitUntil(
-        response
-            .clone()
-            .arrayBuffer()
-            .then((body) => {
-                if (body.byteLength === 0) {
-                    c.get("log").warn(
-                        "Skipping empty media cache write for {cacheKey}",
-                        { cacheKey },
-                    );
-                    return null;
-                }
+): Promise<void> {
+    const body = await response.clone().arrayBuffer();
+    if (body.byteLength === 0) {
+        c.get("log").warn("Skipping empty media cache write for {cacheKey}", {
+            cacheKey,
+        });
+        throw new Error("Refusing to cache an empty media response");
+    }
 
-                return bucket.put(cacheKey, body, {
-                    httpMetadata: removeUnset({
-                        contentType:
-                            response.headers.get("content-type") ||
-                            defaultContentType,
-                    } as R2HTTPMetadata),
-                    customMetadata: prepareCustomMetadata(response),
-                });
-            })
-            .catch((error) => {
-                c.get("log").error("Error caching response: {error}", {
-                    error,
-                });
-            }),
-    );
+    await bucket.put(cacheKey, body, {
+        httpMetadata: removeUnset({
+            contentType:
+                response.headers.get("content-type") || defaultContentType,
+        } as R2HTTPMetadata),
+        customMetadata: prepareCustomMetadata(response),
+    });
 }

--- a/gen.pollinations.ai/src/utils/text-cache.ts
+++ b/gen.pollinations.ai/src/utils/text-cache.ts
@@ -145,63 +145,51 @@ export async function getCachedResponse<TEnv extends TextCacheEnv>(
     c: Context<TEnv>,
     key: string,
 ): Promise<Response | null> {
-    try {
-        const cachedObject = await c.env.TEXT_BUCKET.get(key);
+    const cachedObject = await c.env.TEXT_BUCKET.get(key);
 
-        if (!cachedObject) {
-            return null;
-        }
-
-        const metadata = cachedObject.customMetadata || {};
-
-        // Build headers from metadata
-        const headers = new Headers();
-        if (metadata.response_content_type) {
-            headers.set("content-type", metadata.response_content_type);
-        }
-        for (const [key, value] of Object.entries(metadata)) {
-            if (key.startsWith("header_")) {
-                headers.set(key.slice("header_".length), value);
-            }
-        }
-
-        // Add cache headers
-        headers.set("X-Cache", "HIT");
-        headers.set("X-Cache-Type", "EXACT");
-        headers.set("X-Cache-Key", key.substring(0, 16));
-        headers.set(
-            "X-Cache-Date",
-            metadata.cachedAt || cachedObject.uploaded.toISOString(),
-        );
-        // Browser cache: immutable since same request = same response
-        headers.set("Cache-Control", IMMUTABLE_CACHE_CONTROL);
-
-        const responseBody = refreshR2ObjectTtl(
-            c.env.TEXT_BUCKET,
-            key,
-            cachedObject,
-            (promise) => c.executionCtx.waitUntil(promise),
-            (error) => {
-                c.get("log")?.error(
-                    "[TEXT-CACHE] Error refreshing cached response TTL: {error}",
-                    { error },
-                );
-            },
-        );
-
-        // Create response from cached object
-        return new Response(responseBody, {
-            status: parseInt(metadata.status || "200", 10),
-            statusText: metadata.statusText || "OK",
-            headers,
-        });
-    } catch (error) {
-        c.get("log")?.error(
-            "[TEXT-CACHE] Error getting cached response: {error}",
-            { error },
-        );
+    if (!cachedObject) {
         return null;
     }
+
+    const metadata = cachedObject.customMetadata || {};
+
+    // Build headers from metadata
+    const headers = new Headers();
+    if (metadata.response_content_type) {
+        headers.set("content-type", metadata.response_content_type);
+    }
+    for (const [key, value] of Object.entries(metadata)) {
+        if (key.startsWith("header_")) {
+            headers.set(key.slice("header_".length), value);
+        }
+    }
+
+    headers.set("X-Cache", "HIT");
+    headers.set("X-Cache-Key", key.substring(0, 16));
+    headers.set(
+        "X-Cache-Date",
+        metadata.cachedAt || cachedObject.uploaded.toISOString(),
+    );
+    headers.set("Cache-Control", IMMUTABLE_CACHE_CONTROL);
+
+    const responseBody = refreshR2ObjectTtl(
+        c.env.TEXT_BUCKET,
+        key,
+        cachedObject,
+        (promise) => c.executionCtx.waitUntil(promise),
+        (error) => {
+            c.get("log")?.error(
+                "[TEXT-CACHE] Error refreshing cached response TTL: {error}",
+                { error },
+            );
+        },
+    );
+
+    return new Response(responseBody, {
+        status: parseInt(metadata.status || "200", 10),
+        statusText: metadata.statusText || "OK",
+        headers,
+    });
 }
 
 /**
@@ -213,12 +201,21 @@ export function createCaptureStream<TEnv extends TextCacheEnv>(
     c: Context<TEnv>,
     cacheKey: string,
     response: Response,
-): TransformStream<Uint8Array, Uint8Array> {
+): {
+    stream: TransformStream<Uint8Array, Uint8Array>;
+    write: Promise<void>;
+} {
     const log = c.get("log");
     let chunks: Uint8Array[] = [];
     let totalSize = 0;
+    let resolveWrite!: () => void;
+    let rejectWrite!: (error: unknown) => void;
+    const write = new Promise<void>((resolve, reject) => {
+        resolveWrite = resolve;
+        rejectWrite = reject;
+    });
 
-    return new TransformStream({
+    const stream = new TransformStream({
         transform(chunk, controller) {
             // Save a copy of the chunk for caching later
             chunks.push(chunk.slice());
@@ -237,47 +234,31 @@ export function createCaptureStream<TEnv extends TextCacheEnv>(
                 },
             );
 
-            // Cache the response in the background once streaming is done
-            c.executionCtx.waitUntil(
-                (async () => {
-                    try {
-                        // Combine all chunks into a single buffer
-                        const completeResponse = new Uint8Array(totalSize);
-                        let offset = 0;
-
-                        for (const chunk of chunks) {
-                            completeResponse.set(chunk, offset);
-                            offset += chunk.byteLength;
-                        }
-
-                        // Prepare metadata
-                        const metadata = prepareMetadata(response);
-
-                        // Store in R2
-                        await c.env.TEXT_BUCKET.put(
-                            cacheKey,
-                            completeResponse,
-                            {
-                                customMetadata: metadata,
-                            },
-                        );
-
-                        log?.info(
-                            "[TEXT-CACHE] Streaming response cached successfully ({size} bytes)",
-                            {
-                                size: totalSize,
-                            },
-                        );
-
-                        // Free memory
-                        chunks = [];
-                    } catch (error) {
-                        log?.error("[TEXT-CACHE] Caching failed: {error}", {
-                            error,
-                        });
+            void (async () => {
+                try {
+                    const completeResponse = new Uint8Array(totalSize);
+                    let offset = 0;
+                    for (const chunk of chunks) {
+                        completeResponse.set(chunk, offset);
+                        offset += chunk.byteLength;
                     }
-                })(),
-            );
+
+                    await c.env.TEXT_BUCKET.put(cacheKey, completeResponse, {
+                        customMetadata: prepareMetadata(response),
+                    });
+                    log?.info(
+                        "[TEXT-CACHE] Streaming response cached successfully ({size} bytes)",
+                        { size: totalSize },
+                    );
+                    resolveWrite();
+                } catch (error) {
+                    rejectWrite(error);
+                } finally {
+                    chunks = [];
+                }
+            })();
         },
     });
+
+    return { stream, write };
 }

--- a/gen.pollinations.ai/test/elevenlabs-dialogue.test.ts
+++ b/gen.pollinations.ai/test/elevenlabs-dialogue.test.ts
@@ -1,18 +1,27 @@
 import {
     createExecutionContext,
     env,
-    SELF,
     waitOnExecutionContext,
 } from "cloudflare:test";
 import { test as workerTest } from "@shared/test/fixtures/index.ts";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import worker from "../src/index.ts";
 import { generateElevenLabsDialogue } from "../src/routes/audio.ts";
+import { withInlineGenerationCoordinator } from "./helpers/inline-generation-coordinator.ts";
 
 const log = {
     info: vi.fn(),
     warn: vi.fn(),
 } as never;
+
+async function fetchGen(input: RequestInfo | URL, init?: RequestInit) {
+    const ctx = createExecutionContext();
+    return worker.fetch(
+        new Request(input, init),
+        withInlineGenerationCoordinator(env),
+        ctx,
+    );
+}
 
 describe("ElevenLabs Text to Dialogue", () => {
     afterEach(() => {
@@ -95,7 +104,7 @@ describe("ElevenLabs Text to Dialogue", () => {
 workerTest(
     "restricts the model to its dialogue endpoint",
     async ({ paidApiKey }) => {
-        const response = await SELF.fetch(
+        const response = await fetchGen(
             "https://gen.pollinations.ai/v1/audio/speech",
             {
                 method: "POST",
@@ -186,10 +195,10 @@ workerTest(
             const ctx = createExecutionContext();
             const response = await worker.fetch(
                 request,
-                {
+                withInlineGenerationCoordinator({
                     ...env,
                     ELEVENLABS_API_KEY: "test-eleven-key",
-                } as unknown as CloudflareBindings,
+                } as unknown as CloudflareBindings),
                 ctx,
             );
             expect(response.status).toBe(200);
@@ -218,7 +227,7 @@ workerTest(
     "rejects oversized dialogue before safety or provider calls",
     async ({ paidApiKey }) => {
         const fetchMock = vi.spyOn(globalThis, "fetch");
-        const response = await SELF.fetch(
+        const response = await fetchGen(
             "https://gen.pollinations.ai/v1/audio/dialogue",
             {
                 method: "POST",
@@ -249,7 +258,7 @@ workerTest(
 workerTest.runIf(Boolean(env.ELEVENLABS_API_KEY))(
     "generates multi-speaker audio through the full local route",
     async ({ paidApiKey }) => {
-        const response = await SELF.fetch(
+        const response = await fetchGen(
             "https://gen.pollinations.ai/v1/audio/dialogue",
             {
                 method: "POST",
@@ -275,7 +284,7 @@ workerTest.runIf(Boolean(env.ELEVENLABS_API_KEY))(
         );
         expect((await response.arrayBuffer()).byteLength).toBeGreaterThan(1000);
 
-        const wavResponse = await SELF.fetch(
+        const wavResponse = await fetchGen(
             "https://gen.pollinations.ai/v1/audio/dialogue",
             {
                 method: "POST",

--- a/gen.pollinations.ai/test/elevenlabs-tts-timestamps.test.ts
+++ b/gen.pollinations.ai/test/elevenlabs-tts-timestamps.test.ts
@@ -1,7 +1,6 @@
 import {
     createExecutionContext,
     env,
-    SELF,
     waitOnExecutionContext,
 } from "cloudflare:test";
 import { getRegistryModelDefinition } from "@shared/registry/registry.ts";
@@ -11,11 +10,21 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import worker from "../src/index.ts";
 import { resetGenerationModelRegistryCache } from "../src/model-registry.ts";
 import { generateElevenLabsSpeechWithTimestamps } from "../src/routes/audio.ts";
+import { withInlineGenerationCoordinator } from "./helpers/inline-generation-coordinator.ts";
 
 const log = {
     info: vi.fn(),
     warn: vi.fn(),
 } as never;
+
+async function fetchGen(input: RequestInfo | URL, init?: RequestInit) {
+    const ctx = createExecutionContext();
+    return worker.fetch(
+        new Request(input, init),
+        withInlineGenerationCoordinator(env),
+        ctx,
+    );
+}
 
 const providerResponse = {
     audio_base64: "SUQz",
@@ -115,7 +124,7 @@ describe("ElevenLabs timestamped TTS", () => {
 workerTest(
     "rejects unsupported FLAC instead of returning PCM under the wrong format",
     async ({ paidApiKey }) => {
-        const response = await SELF.fetch(
+        const response = await fetchGen(
             "https://gen.pollinations.ai/v1/audio/speech/with-timestamps",
             {
                 method: "POST",
@@ -189,10 +198,10 @@ workerTest(
                         }),
                     },
                 ),
-                {
+                withInlineGenerationCoordinator({
                     ...env,
                     ELEVENLABS_API_KEY: "test-eleven-key",
-                } as unknown as CloudflareBindings,
+                } as unknown as CloudflareBindings),
                 ctx,
             );
 
@@ -221,7 +230,7 @@ for (const testCase of [
         `returns ${testCase.format} audio and alignment for ${testCase.model}`,
         async ({ paidApiKey }) => {
             const input = "Timed speech.";
-            const response = await SELF.fetch(
+            const response = await fetchGen(
                 "https://gen.pollinations.ai/v1/audio/speech/with-timestamps",
                 {
                     method: "POST",

--- a/gen.pollinations.ai/test/elevenlabs-voice-changer.test.ts
+++ b/gen.pollinations.ai/test/elevenlabs-voice-changer.test.ts
@@ -1,7 +1,9 @@
-import { env, SELF } from "cloudflare:test";
+import { createExecutionContext, env } from "cloudflare:test";
 import { test as workerTest } from "@shared/test/fixtures/index.ts";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import worker from "../src/index.ts";
 import { changeVoiceWithElevenLabs } from "../src/routes/audio.ts";
+import { withInlineGenerationCoordinator } from "./helpers/inline-generation-coordinator.ts";
 
 const errorLog = vi.fn();
 const log = {
@@ -9,6 +11,14 @@ const log = {
     info: vi.fn(),
     warn: vi.fn(),
 } as never;
+
+async function fetchGen(input: RequestInfo | URL, init?: RequestInit) {
+    return worker.fetch(
+        new Request(input, init),
+        withInlineGenerationCoordinator(env),
+        createExecutionContext(),
+    );
+}
 
 function createOneSecondWav(): File {
     const sampleRate = 16000;
@@ -126,7 +136,7 @@ workerTest(
         formData.append("model", "eleven-voice-changer");
         formData.append("input", "Not a voice-changing request.");
 
-        const response = await SELF.fetch(
+        const response = await fetchGen(
             "https://gen.pollinations.ai/v1/audio/speech",
             {
                 method: "POST",
@@ -152,7 +162,7 @@ workerTest.runIf(Boolean(env.ELEVENLABS_API_KEY))(
         formData.append("voice", "nova");
         formData.append("response_format", "mp3");
 
-        const response = await SELF.fetch(
+        const response = await fetchGen(
             "https://gen.pollinations.ai/v1/audio/voice-changer",
             {
                 method: "POST",

--- a/gen.pollinations.ai/test/elevenlabs-voice-isolator.test.ts
+++ b/gen.pollinations.ai/test/elevenlabs-voice-isolator.test.ts
@@ -1,7 +1,9 @@
-import { env, SELF } from "cloudflare:test";
+import { createExecutionContext, env } from "cloudflare:test";
 import { test as workerTest } from "@shared/test/fixtures/index.ts";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import worker from "../src/index.ts";
 import { isolateVoiceWithElevenLabs } from "../src/routes/audio.ts";
+import { withInlineGenerationCoordinator } from "./helpers/inline-generation-coordinator.ts";
 
 const errorLog = vi.fn();
 const log = {
@@ -9,6 +11,14 @@ const log = {
     info: vi.fn(),
     warn: vi.fn(),
 } as never;
+
+async function fetchGen(input: RequestInfo | URL, init?: RequestInit) {
+    return worker.fetch(
+        new Request(input, init),
+        withInlineGenerationCoordinator(env),
+        createExecutionContext(),
+    );
+}
 
 function createWav(seconds: number): File {
     const sampleRate = 16000;
@@ -115,7 +125,7 @@ workerTest(
         formData.append("model", "eleven-voice-isolator");
         formData.append("input", "Not an isolation request.");
 
-        const response = await SELF.fetch(
+        const response = await fetchGen(
             "https://gen.pollinations.ai/v1/audio/speech",
             {
                 method: "POST",
@@ -139,7 +149,7 @@ workerTest.runIf(Boolean(env.ELEVENLABS_API_KEY))(
         formData.append("model", "voice-isolator");
         formData.append("audio", createWav(5));
 
-        const response = await SELF.fetch(
+        const response = await fetchGen(
             "https://gen.pollinations.ai/v1/audio/voice-isolator",
             {
                 method: "POST",

--- a/gen.pollinations.ai/test/embeddings/embeddings.test.ts
+++ b/gen.pollinations.ai/test/embeddings/embeddings.test.ts
@@ -18,6 +18,7 @@ import { MAX_EMBEDDING_BATCH_SIZE } from "../../src/embeddings/limits.ts";
 import worker from "../../src/index.ts";
 import { resetGenerationModelRegistryCache } from "../../src/model-registry.ts";
 import googleCloudAuth from "../../src/text/auth/googleCloudAuth.ts";
+import { withInlineGenerationCoordinator } from "../helpers/inline-generation-coordinator.ts";
 
 const TEST_EMBEDDING_MODEL = "gemini-2";
 const TEST_PROVIDER_MODEL = "gemini-embedding-2";
@@ -314,7 +315,7 @@ async function fetchWorker(path: string, init: RequestInit = {}) {
     const ctx = createExecutionContext();
     const response = await worker.fetch(
         new Request(`https://gen.pollinations.ai${path}`, init),
-        env,
+        withInlineGenerationCoordinator(env),
         ctx,
     );
     return {
@@ -414,6 +415,7 @@ describe("POST /v1/embeddings", () => {
             expect(response.headers.get("x-model-used")).toBe(
                 TEST_OPENAI_LARGE_MODEL,
             );
+            await response.arrayBuffer();
             expect(mocks.azureOpenAI.state.requests).toMatchObject([
                 { model: TEST_OPENAI_SMALL_PROVIDER_MODEL },
                 { model: TEST_OPENAI_LARGE_PROVIDER_MODEL },
@@ -746,6 +748,7 @@ describe("POST /v1/embeddings", () => {
         });
 
         expect(response.status).toBe(200);
+        await response.arrayBuffer();
         expect(mocks.cohereAzure.state.requests).toEqual([
             {
                 model: TEST_COHERE_PROVIDER_MODEL,

--- a/gen.pollinations.ai/test/generation-coordinator.test.ts
+++ b/gen.pollinations.ai/test/generation-coordinator.test.ts
@@ -1,4 +1,4 @@
-import { runInDurableObject } from "cloudflare:test";
+import { runDurableObjectAlarm, runInDurableObject } from "cloudflare:test";
 import { env } from "cloudflare:workers";
 import { describe, expect, it } from "vitest";
 import type { GenerationJob } from "@/middleware/generation-deduplication.ts";
@@ -27,9 +27,9 @@ function testJob(key: string, body?: string): GenerationJob {
     };
 }
 
-async function waitForAlarm(state: DurableObjectState): Promise<void> {
+async function runScheduledAlarm(stub: DurableObjectStub): Promise<void> {
     for (let attempt = 0; attempt < 100; attempt += 1) {
-        if ((await state.storage.getAlarm()) !== null) return;
+        if (await runDurableObjectAlarm(stub)) return;
         await new Promise((resolve) => setTimeout(resolve, 0));
     }
     throw new Error("Generation alarm was not scheduled");
@@ -56,16 +56,13 @@ describe("GenerationCoordinator", () => {
         );
         const job = testJob(`missing-${crypto.randomUUID()}`);
 
-        const results = await runInDurableObject(
-            stub,
-            async (coordinator, state) => {
-                const owner = coordinator.startAndWait(job);
-                const joiner = coordinator.startAndWait(job);
-                await waitForAlarm(state);
-                await coordinator.alarm();
-                return Promise.all([owner, joiner]);
-            },
-        );
+        const resultsPromise = runInDurableObject(stub, async (coordinator) => {
+            const owner = coordinator.startAndWait(job);
+            const joiner = coordinator.startAndWait(job);
+            return Promise.all([owner, joiner]);
+        });
+        await runScheduledAlarm(stub);
+        const results = await resultsPromise;
         expect(results.every((result) => result.status === "failed")).toBe(
             true,
         );
@@ -75,21 +72,37 @@ describe("GenerationCoordinator", () => {
         const stub = env.GENERATION_COORDINATOR.getByName(
             `test-${crypto.randomUUID()}`,
         );
-        const status = await runInDurableObject(
+        const statusPromise = runInDurableObject(
             stub,
             async (coordinator, state) => {
+                await state.storage.put("sentinel", "keep");
                 const result = coordinator.startAndWait(
                     testJob(
                         `large-${crypto.randomUUID()}`,
                         "x".repeat(2_100_000),
                     ),
                 );
-                await waitForAlarm(state);
-                await coordinator.alarm();
                 return (await result).status;
             },
         );
+        await runScheduledAlarm(stub);
+        const status = await statusPromise;
 
         expect(status).toBe("failed");
+        const remaining = await runInDurableObject(
+            stub,
+            async (_coordinator, state) => ({
+                sentinel: await state.storage.get("sentinel"),
+                job: await state.storage.get("job"),
+                body: await state.storage.get("body:0"),
+                alarm: await state.storage.getAlarm(),
+            }),
+        );
+        expect(remaining).toEqual({
+            sentinel: "keep",
+            job: undefined,
+            body: undefined,
+            alarm: null,
+        });
     });
 });

--- a/gen.pollinations.ai/test/generation-coordinator.test.ts
+++ b/gen.pollinations.ai/test/generation-coordinator.test.ts
@@ -1,6 +1,6 @@
-import { runDurableObjectAlarm, runInDurableObject } from "cloudflare:test";
+import { runInDurableObject } from "cloudflare:test";
 import { env } from "cloudflare:workers";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GenerationJob } from "@/middleware/generation-deduplication.ts";
 
 function testJob(key: string, body?: string): GenerationJob {
@@ -27,13 +27,17 @@ function testJob(key: string, body?: string): GenerationJob {
     };
 }
 
-async function runScheduledAlarm(stub: DurableObjectStub): Promise<void> {
+async function waitForAlarm(state: DurableObjectState): Promise<void> {
     for (let attempt = 0; attempt < 100; attempt += 1) {
-        if (await runDurableObjectAlarm(stub)) return;
+        if ((await state.storage.getAlarm()) !== null) return;
         await new Promise((resolve) => setTimeout(resolve, 0));
     }
     throw new Error("Generation alarm was not scheduled");
 }
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
 
 describe("GenerationCoordinator", () => {
     it("returns an existing cached generation without scheduling work", async () => {
@@ -51,28 +55,34 @@ describe("GenerationCoordinator", () => {
     });
 
     it("joins concurrent callers for the same cache identity", async () => {
+        vi.spyOn(Date, "now").mockReturnValue(Date.now() + 60_000);
         const stub = env.GENERATION_COORDINATOR.getByName(
             `test-${crypto.randomUUID()}`,
         );
         const job = testJob(`missing-${crypto.randomUUID()}`);
 
-        const resultsPromise = runInDurableObject(stub, async (coordinator) => {
-            const owner = coordinator.startAndWait(job);
-            const joiner = coordinator.startAndWait(job);
-            return Promise.all([owner, joiner]);
-        });
-        await runScheduledAlarm(stub);
-        const results = await resultsPromise;
+        const results = await runInDurableObject(
+            stub,
+            async (coordinator, state) => {
+                const owner = coordinator.startAndWait(job);
+                const joiner = coordinator.startAndWait(job);
+                await waitForAlarm(state);
+                await coordinator.alarm();
+                await state.storage.deleteAlarm();
+                return Promise.all([owner, joiner]);
+            },
+        );
         expect(results.every((result) => result.status === "failed")).toBe(
             true,
         );
     });
 
     it("persists request bodies larger than one storage value", async () => {
+        vi.spyOn(Date, "now").mockReturnValue(Date.now() + 60_000);
         const stub = env.GENERATION_COORDINATOR.getByName(
             `test-${crypto.randomUUID()}`,
         );
-        const statusPromise = runInDurableObject(
+        const status = await runInDurableObject(
             stub,
             async (coordinator, state) => {
                 await state.storage.put("sentinel", "keep");
@@ -82,11 +92,12 @@ describe("GenerationCoordinator", () => {
                         "x".repeat(2_100_000),
                     ),
                 );
+                await waitForAlarm(state);
+                await coordinator.alarm();
+                await state.storage.deleteAlarm();
                 return (await result).status;
             },
         );
-        await runScheduledAlarm(stub);
-        const status = await statusPromise;
 
         expect(status).toBe("failed");
         const remaining = await runInDurableObject(

--- a/gen.pollinations.ai/test/generation-coordinator.test.ts
+++ b/gen.pollinations.ai/test/generation-coordinator.test.ts
@@ -1,0 +1,95 @@
+import { runInDurableObject } from "cloudflare:test";
+import { env } from "cloudflare:workers";
+import { describe, expect, it } from "vitest";
+import type { GenerationJob } from "@/middleware/generation-deduplication.ts";
+
+function testJob(key: string, body?: string): GenerationJob {
+    return {
+        cache: { storage: "text", key },
+        request: {
+            url: "https://gen.pollinations.ai/robots.txt",
+            method: body === undefined ? "GET" : "POST",
+            headers: [],
+            ...(body !== undefined && {
+                body: new TextEncoder().encode(body),
+            }),
+        },
+        auth: {
+            user: { id: "user-1", tier: "seed" },
+            apiKey: { id: "key-1" },
+        },
+        requestId: "request-1",
+        balanceCheckResult: {
+            selectedMeterId: "local:tier",
+            selectedMeterSlug: "v1:meter:tier",
+            balances: { "v1:meter:tier": 1, "v1:meter:pack": 2 },
+        },
+    };
+}
+
+async function waitForAlarm(state: DurableObjectState): Promise<void> {
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+        if ((await state.storage.getAlarm()) !== null) return;
+        await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+    throw new Error("Generation alarm was not scheduled");
+}
+
+describe("GenerationCoordinator", () => {
+    it("returns an existing cached generation without scheduling work", async () => {
+        const key = `cached-${crypto.randomUUID()}`;
+        await env.TEXT_BUCKET.put(key, "cached");
+        const stub = env.GENERATION_COORDINATOR.getByName(
+            `test-${crypto.randomUUID()}`,
+        );
+
+        const result = await runInDurableObject(stub, (coordinator) =>
+            coordinator.startAndWait(testJob(key)),
+        );
+
+        expect(result).toEqual({ status: "cached" });
+    });
+
+    it("joins concurrent callers for the same cache identity", async () => {
+        const stub = env.GENERATION_COORDINATOR.getByName(
+            `test-${crypto.randomUUID()}`,
+        );
+        const job = testJob(`missing-${crypto.randomUUID()}`);
+
+        const results = await runInDurableObject(
+            stub,
+            async (coordinator, state) => {
+                const owner = coordinator.startAndWait(job);
+                const joiner = coordinator.startAndWait(job);
+                await waitForAlarm(state);
+                await coordinator.alarm();
+                return Promise.all([owner, joiner]);
+            },
+        );
+        expect(results.every((result) => result.status === "failed")).toBe(
+            true,
+        );
+    });
+
+    it("persists request bodies larger than one storage value", async () => {
+        const stub = env.GENERATION_COORDINATOR.getByName(
+            `test-${crypto.randomUUID()}`,
+        );
+        const status = await runInDurableObject(
+            stub,
+            async (coordinator, state) => {
+                const result = coordinator.startAndWait(
+                    testJob(
+                        `large-${crypto.randomUUID()}`,
+                        "x".repeat(2_100_000),
+                    ),
+                );
+                await waitForAlarm(state);
+                await coordinator.alarm();
+                return (await result).status;
+            },
+        );
+
+        expect(status).toBe("failed");
+    });
+});

--- a/gen.pollinations.ai/test/generation-deduplication.test.ts
+++ b/gen.pollinations.ai/test/generation-deduplication.test.ts
@@ -1,0 +1,464 @@
+import type { Logger } from "@logtape/logtape";
+import { Hono } from "hono";
+import type { RequestIdVariables } from "hono/request-id";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AuthVariables } from "@/middleware/auth.ts";
+import type { BalanceVariables } from "@/middleware/balance.ts";
+import {
+    createGenerationCache,
+    type GenerationCacheAdapter,
+    type GenerationCacheVariables,
+    prepareGenerationRequest,
+} from "@/middleware/generation-cache.ts";
+import {
+    deduplicateGeneration,
+    type GenerationJob,
+} from "@/middleware/generation-deduplication.ts";
+import type { LoggerVariables } from "@/middleware/logger.ts";
+
+const testLog = {
+    getChild: () => testLog,
+    debug() {},
+    info() {},
+    warn() {},
+    error() {},
+} as unknown as Logger;
+
+type TestEnv = {
+    Bindings: CloudflareBindings;
+    Variables: LoggerVariables &
+        RequestIdVariables &
+        AuthVariables &
+        BalanceVariables &
+        GenerationCacheVariables & {
+            track: { streamRequested: boolean };
+            formData?: FormData;
+        };
+};
+
+function executionContext(): ExecutionContext {
+    return {
+        waitUntil() {},
+        passThroughOnException() {},
+    } as unknown as ExecutionContext;
+}
+
+function createAdapter(cache: Map<string, string>): GenerationCacheAdapter {
+    return {
+        storage: "text",
+        label: "test-cache",
+        getKey: () => "same-request",
+        get: async (_c, key) => {
+            const body = cache.get(key);
+            return body
+                ? new Response(body, { headers: { "X-Cache": "HIT" } })
+                : null;
+        },
+        shouldCache: (response) => response.ok,
+        capture: (_c, key, response) => ({
+            response,
+            write: Promise.resolve().then(() => {
+                cache.set(key, "origin");
+            }),
+        }),
+    };
+}
+
+function createApp(
+    adapter: GenerationCacheAdapter,
+    stream = false,
+    executorBody?: string,
+) {
+    let preflights = 0;
+    let originHits = 0;
+    const app = new Hono<TestEnv>()
+        .use("*", async (c, next) => {
+            c.set("log", testLog);
+            c.set("requestId", "request-1");
+            c.set("balance", {
+                getBalance: async () => ({
+                    tierBalance: 1,
+                    packBalance: 2,
+                }),
+                balanceCheckResult: {
+                    selectedMeterId: "local:tier",
+                    selectedMeterSlug: "v1:meter:tier",
+                    balances: { "v1:meter:tier": 1, "v1:meter:pack": 2 },
+                },
+            });
+            c.set("track", { streamRequested: stream });
+            if (executorBody) c.set("generationRequestBody", executorBody);
+            c.set("auth", {
+                user: { id: "user-1", tier: "seed" } as never,
+                apiKey: { id: "key-1", rawKey: "pk-secret" },
+                requireAuthorization: async () => {},
+                requireUser: () => ({ id: "user-1", tier: "seed" }) as never,
+                requireModelAccess: () => {},
+            });
+            await next();
+        })
+        .all(
+            "/generate",
+            createGenerationCache(adapter),
+            async (_c, next) => {
+                preflights += 1;
+                await next();
+            },
+            deduplicateGeneration,
+            () => {
+                originHits += 1;
+                return new Response("origin");
+            },
+        );
+    return {
+        app,
+        get preflights() {
+            return preflights;
+        },
+        get originHits() {
+            return originHits;
+        },
+    };
+}
+
+describe("generation request deduplication", () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("authorizes every caller but starts one detached generation", async () => {
+        const cache = new Map<string, string>();
+        const jobs: GenerationJob[] = [];
+        let active: Promise<void> | undefined;
+        let owners = 0;
+        const coordinator = {
+            async startAndWait(job: GenerationJob) {
+                jobs.push(job);
+                if (!active) {
+                    owners += 1;
+                    active = Promise.resolve().then(() => {
+                        cache.set("same-request", "generated-once");
+                    });
+                }
+                await active;
+                return { status: "cached" as const };
+            },
+        };
+        const generation = createApp(
+            createAdapter(cache),
+            false,
+            JSON.stringify({
+                model: "resolved-model",
+                prompt: "hello",
+                seed: 123,
+                key: "body-secret",
+            }),
+        );
+        const bindings = {
+            GENERATION_COORDINATOR: { getByName: () => coordinator },
+        } as unknown as CloudflareBindings;
+        const request = () =>
+            new Request(
+                "https://gen.pollinations.ai/generate?model=test&key=query-secret",
+                {
+                    method: "POST",
+                    headers: {
+                        Authorization: "Bearer header-secret",
+                        "CF-Connecting-IP": "203.0.113.42",
+                        "Content-Type": "application/json",
+                        "X-Forwarded-Host": "gen.pollinations.ai",
+                        "X-Original-Client-IP": "203.0.113.42",
+                    },
+                    body: JSON.stringify({
+                        model: "test",
+                        prompt: "hello",
+                        key: "body-secret",
+                    }),
+                },
+            );
+
+        const [owner, joiner] = await Promise.all([
+            generation.app.fetch(request(), bindings, executionContext()),
+            generation.app.fetch(request(), bindings, executionContext()),
+        ]);
+
+        expect(await owner.text()).toBe("generated-once");
+        expect(await joiner.text()).toBe("generated-once");
+        expect(generation.preflights).toBe(2);
+        expect(generation.originHits).toBe(0);
+        expect(owners).toBe(1);
+        expect(owner.headers.get("X-Cache-Type")).toBeNull();
+        expect(joiner.headers.get("X-Cache-Type")).toBeNull();
+        expect(owner.headers.get("X-Cache")).toBe("HIT");
+        expect(joiner.headers.get("X-Cache")).toBe("HIT");
+        expect(jobs[0].request.url).toBe(
+            "https://gen.pollinations.ai/generate?model=test",
+        );
+        expect(jobs[0].request.headers).not.toContainEqual([
+            "authorization",
+            "Bearer header-secret",
+        ]);
+        expect(jobs[0].request.headers).toEqual(
+            expect.arrayContaining([
+                ["cf-connecting-ip", "203.0.113.42"],
+                ["x-forwarded-host", "gen.pollinations.ai"],
+                ["x-original-client-ip", "203.0.113.42"],
+            ]),
+        );
+        expect(jobs[0].auth.apiKey).not.toHaveProperty("rawKey");
+        expect(jobs[0].requestId).toBe("request-1");
+        expect(jobs[0].balanceCheckResult.balances).toEqual({
+            "v1:meter:tier": 1,
+            "v1:meter:pack": 2,
+        });
+        expect(new TextDecoder().decode(jobs[0].request.body)).toBe(
+            JSON.stringify({
+                model: "resolved-model",
+                prompt: "hello",
+                seed: 123,
+            }),
+        );
+    });
+
+    it("leaves explicit streams on the direct request path", async () => {
+        const cache = new Map<string, string>();
+        let starts = 0;
+        const generation = createApp(createAdapter(cache), true);
+        const bindings = {
+            GENERATION_COORDINATOR: {
+                getByName: () => ({
+                    startAndWait: async () => {
+                        starts += 1;
+                        return { status: "cached" };
+                    },
+                }),
+            },
+        } as unknown as CloudflareBindings;
+
+        const response = await generation.app.fetch(
+            new Request("https://gen.pollinations.ai/generate"),
+            bindings,
+            executionContext(),
+        );
+
+        expect(await response.text()).toBe("origin");
+        expect(starts).toBe(0);
+        expect(generation.originHits).toBe(1);
+    });
+
+    it("replays multipart files without putting API keys in the job", async () => {
+        const cache = new Map<string, string>();
+        const jobs: GenerationJob[] = [];
+        const adapter = createAdapter(cache);
+        adapter.getKey = (c) => c.var.generationCacheBody ?? "";
+        const app = new Hono<TestEnv>()
+            .use("*", async (c, next) => {
+                c.set("log", testLog);
+                c.set("requestId", "request-1");
+                c.set("balance", {
+                    getBalance: async () => ({
+                        tierBalance: 1,
+                        packBalance: 2,
+                    }),
+                    balanceCheckResult: {
+                        selectedMeterId: "local:tier",
+                        selectedMeterSlug: "v1:meter:tier",
+                        balances: {
+                            "v1:meter:tier": 1,
+                            "v1:meter:pack": 2,
+                        },
+                    },
+                });
+                c.set("track", { streamRequested: false });
+                c.set("formData", await c.req.formData());
+                c.set("auth", {
+                    user: { id: "user-1", tier: "seed" } as never,
+                    apiKey: { id: "key-1", rawKey: "pk-secret" },
+                    requireAuthorization: async () => {},
+                    requireUser: () =>
+                        ({ id: "user-1", tier: "seed" }) as never,
+                    requireModelAccess: () => {},
+                });
+                await next();
+            })
+            .post(
+                "/upload",
+                prepareGenerationRequest,
+                createGenerationCache(adapter),
+                deduplicateGeneration,
+            );
+        const bindings = {
+            GENERATION_COORDINATOR: {
+                getByName: () => ({
+                    startAndWait: async (job: GenerationJob) => {
+                        jobs.push(job);
+                        cache.set(job.cache.key, "generated");
+                        return { status: "cached" as const };
+                    },
+                }),
+            },
+        } as unknown as CloudflareBindings;
+        const form = new FormData();
+        form.append("model", "voice-transform");
+        form.append("key", "body-secret");
+        form.append(
+            "audio",
+            new File([new Uint8Array([1, 2, 3])], "voice.wav", {
+                type: "audio/wav",
+            }),
+        );
+
+        const response = await app.fetch(
+            new Request("https://gen.pollinations.ai/upload", {
+                method: "POST",
+                body: form,
+            }),
+            bindings,
+            executionContext(),
+        );
+
+        expect(await response.text()).toBe("generated");
+        expect(jobs).toHaveLength(1);
+        const job = jobs[0];
+        const contentType = new Headers(job.request.headers).get(
+            "content-type",
+        );
+        expect(contentType).toContain("multipart/form-data; boundary=");
+        const replayed = await new Request(job.request.url, {
+            method: "POST",
+            headers: job.request.headers,
+            body: job.request.body?.slice().buffer,
+        }).formData();
+        expect(replayed.get("key")).toBeNull();
+        expect(replayed.get("model")).toBe("voice-transform");
+        const audio = replayed.get("audio");
+        expect(audio).toBeInstanceOf(File);
+        expect(new Uint8Array(await (audio as File).arrayBuffer())).toEqual(
+            new Uint8Array([1, 2, 3]),
+        );
+    });
+
+    it("fails closed when the coordinator binding is missing", async () => {
+        const generation = createApp(createAdapter(new Map()));
+
+        const response = await generation.app.fetch(
+            new Request("https://gen.pollinations.ai/generate"),
+            {} as CloudflareBindings,
+            executionContext(),
+        );
+
+        expect(response.status).toBe(503);
+        expect(await response.text()).toBe(
+            "Generation coordination is unavailable",
+        );
+        expect(generation.originHits).toBe(0);
+    });
+
+    it("preserves a detached generation error for every caller", async () => {
+        const generation = createApp(createAdapter(new Map()));
+        const bindings = {
+            GENERATION_COORDINATOR: {
+                getByName: () => ({
+                    startAndWait: async () => ({
+                        status: "failed",
+                        error: {
+                            httpStatus: 422,
+                            headers: [
+                                ["content-type", "application/json"],
+                                ["retry-after", "30"],
+                            ],
+                            body: new TextEncoder().encode(
+                                JSON.stringify({ error: "blocked" }),
+                            ),
+                        },
+                    }),
+                }),
+            },
+        } as unknown as CloudflareBindings;
+
+        const response = await generation.app.fetch(
+            new Request("https://gen.pollinations.ai/generate"),
+            bindings,
+            executionContext(),
+        );
+
+        expect(response.status).toBe(422);
+        expect(response.headers.get("content-type")).toContain(
+            "application/json",
+        );
+        expect(response.headers.get("retry-after")).toBe("30");
+        expect(response.headers.get("x-cache-type")).toBeNull();
+        expect(await response.json()).toEqual({ error: "blocked" });
+    });
+
+    it("keeps connected callers waiting past 90 seconds", async () => {
+        vi.useFakeTimers();
+        let coordinatorName = "";
+        const cache = new Map<string, string>();
+        let finish!: (result: { status: "cached" }) => void;
+        const generation = createApp(createAdapter(cache));
+        const bindings = {
+            GENERATION_COORDINATOR: {
+                getByName: (name: string) => {
+                    coordinatorName = name;
+                    return {
+                        startAndWait: () =>
+                            new Promise((resolve) => {
+                                finish = resolve;
+                            }),
+                    };
+                },
+            },
+        } as unknown as CloudflareBindings;
+
+        let settled = false;
+        const responsePromise = Promise.resolve(
+            generation.app.fetch(
+                new Request("https://gen.pollinations.ai/generate"),
+                bindings,
+                executionContext(),
+            ),
+        );
+        void responsePromise.then(() => {
+            settled = true;
+        });
+        await vi.waitFor(() => {
+            expect(finish).toBeTypeOf("function");
+        });
+        await vi.advanceTimersByTimeAsync(3 * 60_000);
+        expect(settled).toBe(false);
+
+        cache.set("same-request", "generated-after-three-minutes");
+        finish({ status: "cached" });
+        const response = await responsePromise;
+
+        expect(response.status).toBe(200);
+        expect(await response.text()).toBe("generated-after-three-minutes");
+        expect(coordinatorName).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it("returns 503 when coordination fails without starting a direct generation", async () => {
+        const generation = createApp(createAdapter(new Map()));
+        const bindings = {
+            GENERATION_COORDINATOR: {
+                getByName: () => ({
+                    startAndWait: async () => {
+                        throw new Error("rpc reset");
+                    },
+                }),
+            },
+        } as unknown as CloudflareBindings;
+
+        const response = await generation.app.fetch(
+            new Request("https://gen.pollinations.ai/generate"),
+            bindings,
+            executionContext(),
+        );
+
+        expect(response.status).toBe(503);
+        expect(await response.text()).toBe(
+            "Generation coordination is unavailable",
+        );
+        expect(generation.originHits).toBe(0);
+    });
+});

--- a/gen.pollinations.ai/test/generation-vcr.test.ts
+++ b/gen.pollinations.ai/test/generation-vcr.test.ts
@@ -15,6 +15,7 @@ import { createMockTinybird } from "@shared/test/mocks/tinybird.ts";
 import { createMockVcr } from "@shared/test/mocks/vcr.ts";
 import { afterEach, expect, inject } from "vitest";
 import worker from "../src/index.ts";
+import { withInlineGenerationCoordinator } from "./helpers/inline-generation-coordinator.ts";
 
 const snapshotServerUrl = inject("snapshotServerUrl");
 const png1x1Base64 =
@@ -419,7 +420,7 @@ async function fetchWorker(path: string, init: RequestInit) {
     const ctx = createExecutionContext();
     const response = await worker.fetch(
         new Request(`https://gen.pollinations.ai${path}`, init),
-        env,
+        withInlineGenerationCoordinator(env),
         ctx,
     );
 
@@ -805,6 +806,7 @@ test("non-stream chat completions keep moderation telemetry in generation events
     expect(response.headers.get("x-moderation-prompt-hate-severity")).toBe(
         "safe",
     );
+    await response.arrayBuffer();
     await wait();
 
     expect(mocks.tinybird.state.events).toHaveLength(1);
@@ -1149,6 +1151,8 @@ test("OpenAI image generation returns token usage", async ({
     });
 
     expect(response.status).toBe(200);
+    expect(response.headers.get("x-cache")).toBe("HIT");
+    expect(response.headers.get("x-cache-type")).toBeNull();
     await expect(response.json()).resolves.toMatchObject({
         data: [{ b64_json: expect.any(String) }],
         usage: {
@@ -1235,6 +1239,7 @@ test("the sana alias routes to the dreamshaper pool and records its flat price",
 
     expect(response.status).toBe(200);
     expect(response.headers.get("x-model-used")).toBe("dreamshaper");
+    await response.arrayBuffer();
     await wait();
 
     expect(mocks.tinybird.state.events).toHaveLength(1);

--- a/gen.pollinations.ai/test/helpers/inline-generation-coordinator.ts
+++ b/gen.pollinations.ai/test/helpers/inline-generation-coordinator.ts
@@ -1,0 +1,31 @@
+import type { GenerationJob } from "@/middleware/generation-deduplication.ts";
+import { executeGeneration } from "@/utils/execute-generation.ts";
+
+/** Keeps provider mocks in one isolate while exercising the real middleware. */
+export function withInlineGenerationCoordinator(
+    bindings: CloudflareBindings,
+): CloudflareBindings {
+    const coordinated = { ...bindings } as CloudflareBindings;
+    coordinated.GENERATION_COORDINATOR = {
+        getByName() {
+            return {
+                async startAndWait(job: GenerationJob) {
+                    const execution = await executeGeneration(
+                        new Request(job.request.url, {
+                            method: job.request.method,
+                            headers: job.request.headers,
+                            body: job.request.body?.slice().buffer,
+                        }),
+                        job.auth,
+                        job.requestId,
+                        job.balanceCheckResult,
+                        coordinated,
+                    );
+                    await execution.settlement;
+                    return execution.result;
+                },
+            } as never;
+        },
+    } as never;
+    return coordinated;
+}

--- a/gen.pollinations.ai/test/image/costVariants-e2e.test.ts
+++ b/gen.pollinations.ai/test/image/costVariants-e2e.test.ts
@@ -12,6 +12,7 @@ import { createMockTinybird } from "@shared/test/mocks/tinybird.ts";
 import { afterEach, expect } from "vitest";
 import { syncImageEnv } from "../../src/image/env.ts";
 import worker from "../../src/index.ts";
+import { withInlineGenerationCoordinator } from "../helpers/inline-generation-coordinator.ts";
 
 const INPUT_IMAGE_URL = "https://media.example.test/input.png";
 const OUTPUT_IMAGE_URL = "https://media.example.test/output.png";
@@ -112,7 +113,7 @@ async function generate(path: string, apiKey: string) {
         new Request(`https://gen.pollinations.ai${path}`, {
             headers: { authorization: `Bearer ${apiKey}` },
         }),
-        env,
+        withInlineGenerationCoordinator(env),
         ctx,
     );
     const failureBody =

--- a/gen.pollinations.ai/test/image/nanobanana-e2e.test.ts
+++ b/gen.pollinations.ai/test/image/nanobanana-e2e.test.ts
@@ -12,6 +12,7 @@ import { createMockTinybird } from "@shared/test/mocks/tinybird.ts";
 import { afterEach, expect } from "vitest";
 import { syncImageEnv } from "../../src/image/env.ts";
 import worker from "../../src/index.ts";
+import { withInlineGenerationCoordinator } from "../helpers/inline-generation-coordinator.ts";
 
 const png1x1Base64 =
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lPFCAAAAAABJRU5ErkJggg==";
@@ -77,7 +78,7 @@ async function fetchWorker(path: string, init: RequestInit) {
     const ctx = createExecutionContext();
     const response = await worker.fetch(
         new Request(`https://gen.pollinations.ai${path}`, init),
-        env,
+        withInlineGenerationCoordinator(env),
         ctx,
     );
     return { response, wait: () => waitOnExecutionContext(ctx) };

--- a/gen.pollinations.ai/test/image/params.test.ts
+++ b/gen.pollinations.ai/test/image/params.test.ts
@@ -1,14 +1,15 @@
 import { describe, expect, it } from "vitest";
 import { ImageParamsSchema } from "../../src/image/params.ts";
+import { SENTINEL_SEED } from "../../src/util.ts";
 
 describe("ImageParamsSchema", () => {
-    it("preserves seed -1 as a literal seed", () => {
+    it("normalizes seed -1 to the sentinel seed", () => {
         const result = ImageParamsSchema.parse({
             model: "flux",
             seed: -1,
         });
 
-        expect(result.seed).toBe(-1);
+        expect(result.seed).toBe(SENTINEL_SEED);
     });
 
     it("rejects transparent backgrounds for gpt-image-2", () => {

--- a/gen.pollinations.ai/test/image/zImageFalFallback.test.ts
+++ b/gen.pollinations.ai/test/image/zImageFalFallback.test.ts
@@ -11,6 +11,7 @@ import {
 import { createMockTinybird } from "@shared/test/mocks/tinybird.ts";
 import { afterEach, expect } from "vitest";
 import worker from "../../src/index.ts";
+import { withInlineGenerationCoordinator } from "../helpers/inline-generation-coordinator.ts";
 
 const imageBackendHost = "zimage-backend.test";
 const falHost = "fal.run";
@@ -81,7 +82,7 @@ async function fetchWorker(path: string, init: RequestInit) {
     const ctx = createExecutionContext();
     const response = await worker.fetch(
         new Request(`https://gen.pollinations.ai${path}`, init),
-        env,
+        withInlineGenerationCoordinator(env),
         ctx,
     );
     return { response, wait: () => waitOnExecutionContext(ctx) };
@@ -118,6 +119,7 @@ test("uses Fal only after the Vast Z-Image pool exhausts its 503s", async ({
     expect(response.status, failureBody).toBe(200);
     expect(response.headers.get("x-model-used")).toBe("zimage-fal");
     expect(response.headers.get("x-fallback-target")).toBe("config.targets[1]");
+    await response.arrayBuffer();
     expect(mocks.fal.state.falRequests).toEqual([
         {
             prompt: "a red apple",

--- a/gen.pollinations.ai/test/index.test.ts
+++ b/gen.pollinations.ai/test/index.test.ts
@@ -6,8 +6,10 @@ import {
 import { getTextModelsInfo } from "@shared/registry/model-info.ts";
 import { test as fixtureTest } from "@shared/test/fixtures/index.ts";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { GenerationJob } from "@/middleware/generation-deduplication.ts";
 import worker from "../src/index.ts";
 import googleCloudAuth from "../src/text/auth/googleCloudAuth.ts";
+import { withInlineGenerationCoordinator } from "./helpers/inline-generation-coordinator.ts";
 
 const TRANSCRIPTION_MODEL_IDS = [
     "whisper",
@@ -65,6 +67,23 @@ async function optionsWorker(
 }
 
 describe("gen worker routing", () => {
+    it("returns 401 for unauthenticated generation cache misses", async () => {
+        const ctx = createExecutionContext();
+        const response = await worker.fetch(
+            new Request(
+                "https://staging.gen.pollinations.ai/image/unauthenticated-cache-miss?model=zimage",
+            ),
+            env,
+            ctx,
+        );
+
+        expect(response.status).toBe(401);
+        await expect(response.json()).resolves.toMatchObject({
+            error: { code: "UNAUTHORIZED" },
+        });
+        await waitOnExecutionContext(ctx);
+    });
+
     it("serves root metadata for social previews", async () => {
         const response = await fetchWorker("/");
 
@@ -536,6 +555,91 @@ describe("gen worker routing", () => {
     });
 });
 
+fixtureTest(
+    "coordinates every finite POST generation endpoint",
+    async ({ paidApiKey }) => {
+        const coordinatedPaths: string[] = [];
+        const bindings = {
+            ...env,
+            GENERATION_COORDINATOR: {
+                getByName: () => ({
+                    startAndWait: async (job: GenerationJob) => {
+                        coordinatedPaths.push(
+                            new URL(job.request.url).pathname,
+                        );
+                        return {
+                            status: "failed" as const,
+                            error: {
+                                httpStatus: 418,
+                                headers: [["content-type", "text/plain"]],
+                                body: new TextEncoder().encode("coordinated"),
+                            },
+                        };
+                    },
+                }),
+            },
+        } as unknown as CloudflareBindings;
+        const json = (path: string, body: Record<string, unknown>) =>
+            new Request(`https://staging.gen.pollinations.ai${path}`, {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${paidApiKey}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify(body),
+            });
+        const multipart = (
+            path: string,
+            fileField: string,
+            extra: Record<string, string> = {},
+        ) => {
+            const body = new FormData();
+            for (const [name, value] of Object.entries(extra)) {
+                body.append(name, value);
+            }
+            body.append(
+                fileField,
+                new File([new Uint8Array([1, 2, 3])], "input.wav", {
+                    type: "audio/wav",
+                }),
+            );
+            return new Request(`https://staging.gen.pollinations.ai${path}`, {
+                method: "POST",
+                headers: { Authorization: `Bearer ${paidApiKey}` },
+                body,
+            });
+        };
+        const requests = [
+            json("/v1/embeddings", { input: "hello" }),
+            json("/3d/object", {}),
+            json("/v1/images/edits", {
+                prompt: "make it blue",
+                image: "https://example.com/source.png",
+            }),
+            json("/v1/audio/dialogue", {
+                inputs: [{ text: "hello", voice: "alloy" }],
+            }),
+            multipart("/v1/audio/voice-changer", "audio"),
+            multipart("/v1/audio/voice-isolator", "audio"),
+            json("/v1/audio/speech", { input: "hello" }),
+            json("/v1/audio/speech/with-timestamps", { input: "hello" }),
+            multipart("/v1/audio/transcriptions", "file"),
+        ];
+
+        for (const request of requests) {
+            const ctx = createExecutionContext();
+            const response = await worker.fetch(request, bindings, ctx);
+            expect(response.status).toBe(418);
+            expect(await response.text()).toBe("coordinated");
+            await waitOnExecutionContext(ctx);
+        }
+
+        expect(coordinatedPaths).toEqual(
+            requests.map((request) => new URL(request.url).pathname),
+        );
+    },
+);
+
 describe("model status", () => {
     it("reports the source timestamp and marks stale fallback data", async () => {
         let now = 1_000;
@@ -638,10 +742,10 @@ fixtureTest(
             },
         );
 
-        const bindings = {
+        const bindings = withInlineGenerationCoordinator({
             ...env,
             OPENROUTER_API_KEY: "test-openrouter-key",
-        } as unknown as CloudflareBindings;
+        } as unknown as CloudflareBindings);
 
         const getContext = createExecutionContext();
         const getResponse = await worker.fetch(
@@ -736,7 +840,7 @@ fixtureTest(
         );
         expect(urlResponse.status).toBe(200);
         expect(urlResponse.headers.get("x-cache")).toBe("HIT");
-        expect(urlResponse.headers.get("x-cache-type")).toBe("EXACT");
+        expect(urlResponse.headers.get("x-cache-type")).toBeNull();
         const urlGeneration = (await urlResponse.json()) as {
             data: Array<{ url: string; media_type?: string }>;
         };
@@ -751,7 +855,7 @@ fixtureTest(
         );
         expect(cachedResponse.status).toBe(200);
         expect(cachedResponse.headers.get("x-cache")).toBe("HIT");
-        expect(cachedResponse.headers.get("x-cache-type")).toBe("EXACT");
+        expect(cachedResponse.headers.get("x-cache-type")).toBeNull();
         expect(cachedResponse.headers.get("content-type")).toBe(
             "image/svg+xml",
         );
@@ -870,10 +974,10 @@ fixtureTest(
                     headers: { Authorization: `Bearer ${paidApiKey}` },
                 },
             ),
-            {
+            withInlineGenerationCoordinator({
                 ...env,
                 DASHSCOPE_API_KEY: "test-dashscope-key",
-            } as unknown as CloudflareBindings,
+            } as unknown as CloudflareBindings),
             ctx,
         );
 
@@ -884,6 +988,7 @@ fixtureTest(
             "10",
         );
         expect(response.headers.get("x-tts-voice")).toBe("Serena");
+        await response.arrayBuffer();
 
         await waitOnExecutionContext(ctx);
 
@@ -948,10 +1053,10 @@ fixtureTest(
                     headers: { Authorization: `Bearer ${paidApiKey}` },
                 },
             ),
-            {
+            withInlineGenerationCoordinator({
                 ...env,
                 DEEPINFRA_API_KEY: "test-deepinfra-key",
-            } as unknown as CloudflareBindings,
+            } as unknown as CloudflareBindings),
             ctx,
         );
 
@@ -1037,10 +1142,10 @@ fixtureTest(
                         }),
                     },
                 ),
-                {
+                withInlineGenerationCoordinator({
                     ...env,
                     DEEPINFRA_API_KEY: "test-deepinfra-key",
-                } as unknown as CloudflareBindings,
+                } as unknown as CloudflareBindings),
                 ctx,
             );
 
@@ -1107,10 +1212,10 @@ fixtureTest(
                     response_format: "wav",
                 }),
             }),
-            {
+            withInlineGenerationCoordinator({
                 ...env,
                 DEEPINFRA_API_KEY: "test-deepinfra-key",
-            } as unknown as CloudflareBindings,
+            } as unknown as CloudflareBindings),
             postContext,
         );
 
@@ -1121,6 +1226,7 @@ fixtureTest(
             postResponse.headers.get("x-usage-completion-audio-tokens"),
         ).toBe("4");
         expect(postResponse.headers.get("x-tts-voice")).toBe("bf_emma");
+        await postResponse.arrayBuffer();
         await waitOnExecutionContext(postContext);
 
         const getContext = createExecutionContext();
@@ -1131,16 +1237,17 @@ fixtureTest(
                     headers: { Authorization: `Bearer ${paidApiKey}` },
                 },
             ),
-            {
+            withInlineGenerationCoordinator({
                 ...env,
                 DEEPINFRA_API_KEY: "test-deepinfra-key",
-            } as unknown as CloudflareBindings,
+            } as unknown as CloudflareBindings),
             getContext,
         );
 
         expect(getResponse.status).toBe(200);
         expect(getResponse.headers.get("x-model-used")).toBe("kokoro");
         expect(getResponse.headers.get("x-tts-voice")).toBe("af_alloy");
+        await getResponse.arrayBuffer();
         await waitOnExecutionContext(getContext);
 
         expect(providerBodies).toEqual([
@@ -1204,10 +1311,10 @@ fixtureTest(
                         }),
                     },
                 ),
-                {
+                withInlineGenerationCoordinator({
                     ...env,
                     DEEPINFRA_API_KEY: "test-deepinfra-key",
-                } as unknown as CloudflareBindings,
+                } as unknown as CloudflareBindings),
                 ctx,
             );
 
@@ -1282,10 +1389,10 @@ fixtureTest(
                     headers: { Authorization: `Bearer ${paidApiKey}` },
                 },
             ),
-            {
+            withInlineGenerationCoordinator({
                 ...env,
                 GOOGLE_PROJECT_ID: "test-project",
-            } as unknown as CloudflareBindings,
+            } as unknown as CloudflareBindings),
             ctx,
         );
 
@@ -1363,10 +1470,10 @@ fixtureTest(
                         body: JSON.stringify(testCase.body),
                     },
                 ),
-                {
+                withInlineGenerationCoordinator({
                     ...env,
                     GOOGLE_PROJECT_ID: "test-project",
-                } as unknown as CloudflareBindings,
+                } as unknown as CloudflareBindings),
                 ctx,
             );
 
@@ -1493,15 +1600,16 @@ fixtureTest(
                     reference_audio: referenceAudioUrl,
                 }),
             }),
-            {
+            withInlineGenerationCoordinator({
                 ...env,
                 ELEVENLABS_API_KEY: "test-eleven-key",
-            } as unknown as CloudflareBindings,
+            } as unknown as CloudflareBindings),
             ctx,
         );
 
         expect(response.status).toBe(200);
         expect(response.headers.get("x-usage-prompt-audio-seconds")).toBe("30");
+        await response.arrayBuffer();
         await waitOnExecutionContext(ctx);
         expect(calls).toEqual(
             expect.arrayContaining([referenceAudioUrl, uploadUrl, composeUrl]),
@@ -1537,7 +1645,7 @@ fixtureTest("rejects private reference_audio URLs", async ({ paidApiKey }) => {
                 reference_audio: "https://localhost/reference.mp3",
             }),
         }),
-        env as unknown as CloudflareBindings,
+        withInlineGenerationCoordinator(env as unknown as CloudflareBindings),
         ctx,
     );
 
@@ -1592,7 +1700,9 @@ fixtureTest(
                     reference_audio: referenceAudioUrl,
                 }),
             }),
-            env as unknown as CloudflareBindings,
+            withInlineGenerationCoordinator(
+                env as unknown as CloudflareBindings,
+            ),
             ctx,
         );
 
@@ -1669,7 +1779,9 @@ fixtureTest(
                         }),
                     },
                 ),
-                env as unknown as CloudflareBindings,
+                withInlineGenerationCoordinator(
+                    env as unknown as CloudflareBindings,
+                ),
                 ctx,
             );
 
@@ -1706,7 +1818,9 @@ fixtureTest(
                         body: formData,
                     },
                 ),
-                env as unknown as CloudflareBindings,
+                withInlineGenerationCoordinator(
+                    env as unknown as CloudflareBindings,
+                ),
                 ctx,
             );
 
@@ -1813,10 +1927,10 @@ fixtureTest(
                     headers: { Authorization: `Bearer ${paidApiKey}` },
                 },
             ),
-            {
+            withInlineGenerationCoordinator({
                 ...env,
                 FAL_KEY: "test-fal-key",
-            } as unknown as CloudflareBindings,
+            } as unknown as CloudflareBindings),
             ctx,
         );
 
@@ -1831,6 +1945,7 @@ fixtureTest(
         );
         // no reference clip → no input audio unit billed.
         expect(response.headers.get("x-usage-prompt-audio-tokens")).toBeNull();
+        await response.arrayBuffer();
 
         await waitOnExecutionContext(ctx);
 
@@ -1911,10 +2026,10 @@ fixtureTest(
                     reference_audio: referenceAudioUrl,
                 }),
             }),
-            {
+            withInlineGenerationCoordinator({
                 ...env,
                 FAL_KEY: "test-fal-key",
-            } as unknown as CloudflareBindings,
+            } as unknown as CloudflareBindings),
             ctx,
         );
 
@@ -1930,6 +2045,7 @@ fixtureTest(
         expect(response.headers.get("x-usage-prompt-audio-tokens")).toBe("1");
         // reference clip is forwarded as a base64 data-URI audio_url.
         expect(String(sentAudioUrl)).toMatch(/^data:audio\/wav;base64,/);
+        await response.arrayBuffer();
 
         await waitOnExecutionContext(ctx);
 
@@ -2024,10 +2140,10 @@ fixtureTest(
                     headers: { Authorization: `Bearer ${paidApiKey}` },
                 },
             ),
-            {
+            withInlineGenerationCoordinator({
                 ...env,
                 STABILITY_API_KEY: "test-stability-key",
-            } as unknown as CloudflareBindings,
+            } as unknown as CloudflareBindings),
             ctx,
         );
 
@@ -2039,6 +2155,7 @@ fixtureTest(
         expect(response.headers.get("x-usage-completion-audio-tokens")).toBe(
             "1",
         );
+        await response.arrayBuffer();
 
         await waitOnExecutionContext(ctx);
 
@@ -2129,10 +2246,10 @@ fixtureTest(
                     reference_audio: referenceAudioUrl,
                 }),
             }),
-            {
+            withInlineGenerationCoordinator({
                 ...env,
                 STABILITY_API_KEY: "test-stability-key",
-            } as unknown as CloudflareBindings,
+            } as unknown as CloudflareBindings),
             ctx,
         );
 
@@ -2144,6 +2261,7 @@ fixtureTest(
         expect(response.headers.get("x-usage-completion-audio-tokens")).toBe(
             "1",
         );
+        await response.arrayBuffer();
 
         await waitOnExecutionContext(ctx);
 
@@ -2190,10 +2308,10 @@ fixtureTest(
                 "https://staging.gen.pollinations.ai/audio/tick?model=eleven-sfx&prompt_influence=abc",
                 { headers: { Authorization: `Bearer ${paidApiKey}` } },
             ),
-            {
+            withInlineGenerationCoordinator({
                 ...env,
                 ELEVENLABS_API_KEY: "test-eleven-key",
-            } as unknown as CloudflareBindings,
+            } as unknown as CloudflareBindings),
             ctx,
         );
 
@@ -2240,10 +2358,10 @@ fixtureTest(
                     input: "Hello",
                 }),
             }),
-            {
+            withInlineGenerationCoordinator({
                 ...env,
                 ELEVENLABS_API_KEY: "should-not-be-used",
-            } as unknown as CloudflareBindings,
+            } as unknown as CloudflareBindings),
             ctx,
         );
 
@@ -2271,12 +2389,12 @@ fixtureTest(
 
         const response = await fetchWorker(
             "/v1/audio/transcriptions",
-            {
+            withInlineGenerationCoordinator({
                 ...env,
                 // Blank the whisper key so a rejection regression fails here
                 // instead of reaching the live provider.
                 OVHCLOUD_API_KEY: "",
-            } as unknown as CloudflareBindings,
+            } as unknown as CloudflareBindings),
             {
                 method: "POST",
                 headers: { Authorization: `Bearer ${apiKey}` },

--- a/gen.pollinations.ai/test/media-cache.test.ts
+++ b/gen.pollinations.ai/test/media-cache.test.ts
@@ -8,6 +8,7 @@ import { createTestR2Bucket } from "@shared/test/mocks/r2.ts";
 import { Hono } from "hono";
 import type { RequestIdVariables } from "hono/request-id";
 import { describe, expect, it } from "vitest";
+import type { GenerationCacheVariables } from "@/middleware/generation-cache.ts";
 import type { LoggerVariables } from "@/middleware/logger.ts";
 import { audioCache, imageCache } from "@/middleware/media-cache.ts";
 
@@ -21,7 +22,7 @@ const testLog = {
 
 type TestEnv = {
     Bindings: CloudflareBindings;
-    Variables: LoggerVariables & RequestIdVariables;
+    Variables: LoggerVariables & RequestIdVariables & GenerationCacheVariables;
 };
 
 type MediaCache = typeof imageCache;
@@ -95,6 +96,31 @@ async function consumeAndWait(result: Awaited<ReturnType<typeof dispatch>>) {
 }
 
 describe("media cache", () => {
+    it("coordinates audio cache misses like other finite media", async () => {
+        let coordinated = false;
+        const app = new Hono<TestEnv>()
+            .use("*", async (c, next) => {
+                c.set("log", testLog);
+                c.set("requestId", "test-request");
+                await next();
+            })
+            .get("/audio/:text", audioCache, (c) => {
+                coordinated = c.var.generationCache !== undefined;
+                return new Response("audio", {
+                    headers: { "Content-Type": "audio/mpeg" },
+                });
+            });
+
+        const result = await dispatch(
+            app,
+            "/audio/hello",
+            undefined,
+            createMediaCacheEnv(),
+        );
+        expect(await consumeAndWait(result)).toBe("audio");
+        expect(coordinated).toBe(true);
+    });
+
     it.each([
         { label: "image", cache: imageCache, contentType: "image/png" },
         {
@@ -212,6 +238,40 @@ describe("media cache", () => {
             "fallback-model",
         );
         expect(originHits).toBe(1);
+    });
+
+    it("preserves generation metadata on media cache hits", async () => {
+        const app = new Hono<TestEnv>()
+            .use("*", async (c, next) => {
+                c.set("log", testLog);
+                c.set("requestId", "test-request");
+                await next();
+            })
+            .get(
+                "/media/:prompt",
+                audioCache,
+                () =>
+                    new Response("audio", {
+                        headers: {
+                            "Content-Type": "audio/wav",
+                            "X-Model-Used": "qwen-tts",
+                            "X-TTS-Voice": "Serena",
+                            "X-Usage-Completion-Audio-Tokens": "10",
+                        },
+                    }),
+            );
+        const env = createMediaCacheEnv();
+
+        const warm = await dispatch(app, "/media/metadata", undefined, env);
+        await consumeAndWait(warm);
+        const hit = await dispatch(app, "/media/metadata", undefined, env);
+        await consumeAndWait(hit);
+
+        expect(hit.response.headers.get("X-Model-Used")).toBe("qwen-tts");
+        expect(hit.response.headers.get("X-TTS-Voice")).toBe("Serena");
+        expect(
+            hit.response.headers.get("X-Usage-Completion-Audio-Tokens"),
+        ).toBe("10");
     });
 
     it("refreshes cached media TTL on aged cache hits", async () => {

--- a/gen.pollinations.ai/test/model3d/createAndReturnModel3d.test.ts
+++ b/gen.pollinations.ai/test/model3d/createAndReturnModel3d.test.ts
@@ -1,12 +1,14 @@
-import { env, SELF } from "cloudflare:test";
+import { createExecutionContext, env } from "cloudflare:test";
 import { getRegistryModelDefinition } from "@shared/registry/registry.ts";
 import { FALLBACK_TARGET_HEADER } from "@shared/registry/usage-headers.ts";
 import { test as workerTest } from "@shared/test/fixtures/index.ts";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import worker from "../../src/index.ts";
 import { resetGenerationModelRegistryCache } from "../../src/model-registry.ts";
 import { createAndReturnModel3d } from "../../src/model3d/createAndReturnModel3d.ts";
 import { syncModel3dEnvironment } from "../../src/model3d/env.ts";
 import type { Model3dParams } from "../../src/model3d/params.ts";
+import { withInlineGenerationCoordinator } from "../helpers/inline-generation-coordinator.ts";
 
 beforeEach(() => {
     syncModel3dEnvironment({
@@ -19,6 +21,14 @@ beforeEach(() => {
 afterEach(() => {
     vi.restoreAllMocks();
 });
+
+async function fetchGen(input: RequestInfo | URL, init?: RequestInit) {
+    return worker.fetch(
+        new Request(input, init),
+        withInlineGenerationCoordinator(env),
+        createExecutionContext(),
+    );
+}
 
 function baseParams(
     model: string,
@@ -101,7 +111,7 @@ workerTest("uses the shared fallback loop for 3D", async ({ paidApiKey }) => {
             },
         );
 
-        const response = await SELF.fetch(
+        const response = await fetchGen(
             `https://gen.pollinations.ai/3d/${crypto.randomUUID()}?model=hyper3d-rodin&image=https%3A%2F%2Fexample.com%2Fref.jpg`,
             { headers: { Authorization: `Bearer ${paidApiKey}` } },
         );
@@ -158,7 +168,7 @@ workerTest(
             );
 
             for (const resolution of ["low", "medium", "high"]) {
-                const response = await SELF.fetch(
+                const response = await fetchGen(
                     `https://gen.pollinations.ai/3d/${crypto.randomUUID()}?model=trellis-2-${resolution}&image=https%3A%2F%2Fexample.com%2Fref.jpg`,
                     { headers: { Authorization: `Bearer ${paidApiKey}` } },
                 );
@@ -168,7 +178,7 @@ workerTest(
                 expect(await response.text()).toBe("glTF");
             }
 
-            const overrideResponse = await SELF.fetch(
+            const overrideResponse = await fetchGen(
                 `https://gen.pollinations.ai/3d/${crypto.randomUUID()}?model=trellis-2-high&resolution=low&image=https%3A%2F%2Fexample.com%2Fref.jpg`,
                 { headers: { Authorization: `Bearer ${paidApiKey}` } },
             );
@@ -177,7 +187,7 @@ workerTest(
 
             const cachePrompt = crypto.randomUUID();
             for (const resolution of ["low", "high"]) {
-                const response = await SELF.fetch(
+                const response = await fetchGen(
                     `https://gen.pollinations.ai/3d/${cachePrompt}?model=trellis-2&resolution=${resolution}&image=https%3A%2F%2Fexample.com%2Fref.jpg`,
                     { headers: { Authorization: `Bearer ${paidApiKey}` } },
                 );
@@ -220,7 +230,7 @@ workerTest(
             },
         );
 
-        const response = await SELF.fetch(
+        const response = await fetchGen(
             `https://gen.pollinations.ai/3d/invalid-${crypto.randomUUID()}?model=trellis-2&resolution=low&image=https%3A%2F%2Fexample.com%2Fref.jpg`,
             { headers: { Authorization: `Bearer ${paidApiKey}` } },
         );

--- a/gen.pollinations.ai/test/model3d/post.test.ts
+++ b/gen.pollinations.ai/test/model3d/post.test.ts
@@ -14,6 +14,7 @@ import { drizzle } from "drizzle-orm/d1";
 import { afterEach, beforeEach, expect } from "vitest";
 import worker from "../../src/index.ts";
 import { syncModel3dEnvironment } from "../../src/model3d/env.ts";
+import { withInlineGenerationCoordinator } from "../helpers/inline-generation-coordinator.ts";
 
 type ProviderBody = Record<string, unknown>;
 
@@ -109,7 +110,7 @@ async function fetch3d(
     const ctx = createExecutionContext();
     const response = await worker.fetch(
         new Request(`https://gen.pollinations.ai${path}`, init),
-        env,
+        withInlineGenerationCoordinator(env),
         ctx,
     );
     await response.clone().arrayBuffer();
@@ -117,7 +118,7 @@ async function fetch3d(
     return response;
 }
 
-test("POST /3d sends JSON Trellis parameters through billing without URL-only caching", async () => {
+test("POST /3d caches distinct JSON Trellis parameter sets", async () => {
     syncModel3dEnvironment({
         ...env,
         INFERENCEPORT_API_KEY: "ip_test_token",
@@ -147,7 +148,7 @@ test("POST /3d sends JSON Trellis parameters through billing without URL-only ca
         });
 
         expect(response.status).toBe(200);
-        expect(response.headers.get("X-Cache")).toBeNull();
+        expect(response.headers.get("X-Cache")).toBe("HIT");
         expect(await response.text()).toBe("glTF");
     }
 
@@ -307,7 +308,7 @@ test("GET /3d keeps query behavior and Trellis resolution", async ({
     );
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("X-Cache")).toBe("MISS");
+    expect(response.headers.get("X-Cache")).toBe("HIT");
     expect(mocks.inferenceport.state.bodies[0]).toMatchObject({
         resolution: "medium",
     });

--- a/gen.pollinations.ai/test/rate-limit-durable.test.ts
+++ b/gen.pollinations.ai/test/rate-limit-durable.test.ts
@@ -1,0 +1,67 @@
+import type { Logger } from "@logtape/logtape";
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import type { AuthVariables } from "@/middleware/auth.ts";
+import type { LoggerVariables } from "@/middleware/logger.ts";
+import {
+    type FrontendKeyRateLimitVariables,
+    frontendKeyBilling,
+} from "@/middleware/rate-limit-durable.ts";
+
+const testLog = {
+    getChild: () => testLog,
+    debug() {},
+    info() {},
+    warn() {},
+    error() {},
+} as unknown as Logger;
+
+type TestEnv = {
+    Bindings: CloudflareBindings;
+    Variables: AuthVariables & LoggerVariables & FrontendKeyRateLimitVariables;
+};
+
+function createApp() {
+    return new Hono<TestEnv>()
+        .use("*", async (c, next) => {
+            c.set("log", testLog);
+            c.set("auth", {
+                apiKey: {
+                    id: "publishable-key",
+                    metadata: { keyType: "publishable" },
+                } as never,
+                requireAuthorization: async () => {},
+                requireUser: () => ({ id: "user-1", tier: "seed" }) as never,
+                requireModelAccess: () => {},
+            });
+            await next();
+        })
+        .use(frontendKeyBilling)
+        .get("/", async (c) => {
+            await c.var.frontendKeyRateLimit?.consumePollen(0.25);
+            return c.text("ok");
+        });
+}
+
+describe("publishable key rate limiting", () => {
+    it("consumes detached generation cost without a second admission", async () => {
+        const checkRateLimit = vi.fn(async () => ({ allowed: true }));
+        const consumePollen = vi.fn(async () => {});
+        const env = {
+            POLLEN_RATE_LIMITER: {
+                idFromName: () => ({ toString: () => "limiter" }),
+                get: () => ({ checkRateLimit, consumePollen }),
+            },
+        } as unknown as CloudflareBindings;
+        const response = await createApp().fetch(
+            new Request("https://gen.pollinations.ai/", {
+                headers: { "CF-Connecting-IP": "203.0.113.42" },
+            }),
+            env,
+        );
+
+        expect(response.status).toBe(200);
+        expect(checkRateLimit).not.toHaveBeenCalled();
+        expect(consumePollen).toHaveBeenCalledWith(0.25);
+    });
+});

--- a/gen.pollinations.ai/test/text-cache.test.ts
+++ b/gen.pollinations.ai/test/text-cache.test.ts
@@ -220,7 +220,7 @@ describe("text cache", () => {
         await waitOnExecutionContext(secondCtx);
 
         expect(second.headers.get("X-Cache")).toBe("HIT");
-        expect(second.headers.get("X-Cache-Type")).toBe("EXACT");
+        expect(second.headers.get("X-Cache-Type")).toBeNull();
         expect(second.headers.get("Cache-Control")).toBe(
             IMMUTABLE_CACHE_CONTROL,
         );

--- a/gen.pollinations.ai/test/text/requestUtils.test.ts
+++ b/gen.pollinations.ai/test/text/requestUtils.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { getRequestData } from "../../src/text/requestUtils.js";
+import { SENTINEL_SEED } from "../../src/util.ts";
 
 describe("getRequestData", () => {
-    it("preserves seed -1 as a literal seed", () => {
+    it("normalizes seed -1 to the sentinel seed", () => {
         const requestData = getRequestData({
             query: { seed: "-1" },
             body: {},
@@ -12,7 +13,7 @@ describe("getRequestData", () => {
             headers: {},
         });
 
-        expect(requestData.seed).toBe(-1);
+        expect(requestData.seed).toBe(SENTINEL_SEED);
     });
 
     it("coerces token limits from query strings", () => {

--- a/gen.pollinations.ai/test/tracking-observability.test.ts
+++ b/gen.pollinations.ai/test/tracking-observability.test.ts
@@ -26,6 +26,10 @@ import { Hono } from "hono";
 import { requestId } from "hono/request-id";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Env } from "@/env.ts";
+import type {
+    GenerationCacheAdapter,
+    GenerationCacheVariables,
+} from "@/middleware/generation-cache.ts";
 import { logger } from "@/middleware/logger.ts";
 import type { ModelVariables } from "@/middleware/model.ts";
 import {
@@ -51,6 +55,7 @@ function createTestApp(
     },
     servedModelEntry?: ModelVariables["servedModelEntry"],
     responseHeaders: Record<string, string> = {},
+    generationCache?: GenerationCacheVariables["generationCache"],
 ) {
     const app = new Hono<Env>();
 
@@ -75,6 +80,7 @@ function createTestApp(
         c.set("frontendKeyRateLimit", { consumePollen });
         c.set("model", model);
         if (servedModelEntry) c.set("servedModelEntry", servedModelEntry);
+        if (generationCache) c.set("generationCache", generationCache);
         await next();
     });
     app.post(
@@ -466,6 +472,81 @@ describe("tracking observability", () => {
         expect(event).not.toHaveProperty("cacheKey");
         expect(consumePollen).toHaveBeenCalledWith(expect.any(Number));
         expect(consumePollen.mock.calls[0]?.[0]).toBeGreaterThan(0);
+    });
+
+    it("tracks provider work but not coalesced cache hits", async () => {
+        const tinybirdRequests: Request[] = [];
+        vi.spyOn(globalThis, "fetch").mockImplementation(
+            async (input, init) => {
+                tinybirdRequests.push(new Request(input, init));
+                return new Response("ok");
+            },
+        );
+        const providerConsume = vi.fn<(amount: number) => Promise<void>>(
+            async () => {},
+        );
+        const joinerConsume = vi.fn<(amount: number) => Promise<void>>(
+            async () => {},
+        );
+        const generationCache = {
+            adapter: { storage: "text" } as GenerationCacheAdapter,
+            key: "same-request",
+        };
+        const bindings = {
+            DB: env.DB,
+            ENVIRONMENT: "test",
+            LOG_LEVEL: "debug",
+            LOG_FORMAT: "text",
+            BETTER_AUTH_SECRET: "test_secret",
+            TINYBIRD_INGEST_URL:
+                "https://tinybird.test/v0/events?name=generation_event_v2",
+            TINYBIRD_INGEST_TOKEN: "test_tinybird_token",
+        } as CloudflareBindings;
+        const request = () =>
+            new Request("https://gen.pollinations.ai/v1/chat/completions", {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify({
+                    model: "openai",
+                    stream: false,
+                    messages: [{ role: "user", content: "test" }],
+                }),
+            });
+
+        const providerCtx = createExecutionContext();
+        await createTestApp(
+            providerConsume,
+            trackingUser,
+            undefined,
+            undefined,
+            { "x-cache": "MISS" },
+            generationCache,
+        ).fetch(request(), bindings, providerCtx);
+        await waitOnExecutionContext(providerCtx);
+
+        const joinerCtx = createExecutionContext();
+        await createTestApp(
+            joinerConsume,
+            trackingUser,
+            undefined,
+            undefined,
+            { "x-cache": "HIT" },
+            generationCache,
+        ).fetch(request(), bindings, joinerCtx);
+        await waitOnExecutionContext(joinerCtx);
+
+        expect(tinybirdRequests).toHaveLength(1);
+        const providerEvent =
+            (await tinybirdRequests[0].json()) as TinybirdEvent;
+        expect(providerEvent).toMatchObject({
+            cacheHit: false,
+            cacheType: "MISS",
+            isBilledUsage: true,
+        });
+        expect(providerEvent.cacheKey).toMatch(/^[a-f0-9]{64}$/);
+        expect(providerEvent.cacheKey).not.toContain("same-request");
+        expect(providerConsume.mock.calls[0]?.[0]).toBeGreaterThan(0);
+        expect(joinerConsume).toHaveBeenCalledWith(0);
     });
 
     it("does not bill a successful text response when upstream usage is missing", async () => {

--- a/gen.pollinations.ai/vite.config.ts
+++ b/gen.pollinations.ai/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     },
     assetsInclude: ["**/*.md"],
     resolve: {
-        dedupe: ["zod"],
+        dedupe: ["hono", "hono-openapi", "zod"],
         alias: [
             // piexif-ts package.json points "module"/"browser" at non-existent files;
             // pin resolution to the published UMD bundle that actually ships.

--- a/gen.pollinations.ai/vitest.config.ts
+++ b/gen.pollinations.ai/vitest.config.ts
@@ -14,6 +14,7 @@ const genAliases = [
     "content-filter.ts",
     "cache",
     "durable-objects/PollenRateLimiter.ts",
+    "durable-objects/GenerationCoordinator.ts",
     "env.ts",
     "error.ts",
     "events.ts",
@@ -21,6 +22,8 @@ const genAliases = [
     "logger.ts",
     "middleware/auth.ts",
     "middleware/balance.ts",
+    "middleware/generation-cache.ts",
+    "middleware/generation-deduplication.ts",
     "middleware/logger.ts",
     "middleware/media-cache.ts",
     "middleware/model.ts",
@@ -30,6 +33,7 @@ const genAliases = [
     "middleware/text-cache.ts",
     "middleware/track.ts",
     "middleware/validator.ts",
+    "routes/generation-executor.ts",
     "schemas/embeddings.ts",
     "schemas/image.ts",
     "schemas/model3d.ts",
@@ -40,6 +44,7 @@ const genAliases = [
     "util.ts",
     "utils/api-docs.ts",
     "utils/bedrock-guardrail.ts",
+    "utils/execute-generation.ts",
     "utils/generation-access.ts",
     "utils/media-cache.ts",
     "utils/model-stats.ts",
@@ -49,6 +54,7 @@ const genAliases = [
 
 const baseConfig = defineConfig({
     resolve: {
+        dedupe: ["hono", "hono-openapi"],
         alias: [
             ...genAliases.map((path) => ({
                 find: `@/${path}`,

--- a/shared/schemas/generation-event.ts
+++ b/shared/schemas/generation-event.ts
@@ -23,6 +23,12 @@ export type TinybirdEvent = {
     environment?: string;
     eventType: EventType;
 
+    // Cache identity is emitted only for requests that reached cache-backed
+    // generation handling. The key is SHA-256 hashed before ingestion.
+    cacheHit?: boolean;
+    cacheType?: string;
+    cacheKey?: string;
+
     // User
     userId?: string;
     userTier?: string;


### PR DESCRIPTION
- Restores generation request deduplication after the production rollback
- Replaces Durable Object `deleteAll()` cleanup with targeted job/body deletion
- Uses realistic alarm consumption in coordinator tests and verifies unrelated storage survives cleanup
- Keeps the existing append-only Durable Object migration

Tests: gen typecheck; focused deduplication tests; full gen suite (965 passed, 6 skipped).