### PR TITLE
fix: default app keys to zero budget

### DIFF
--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -110,7 +110,9 @@ const CreateKeySchema = z.object({
         .number()
         .nullable()
         .optional()
-        .describe("Pollen budget cap. null = unlimited"),
+        .describe(
+            "Pollen budget cap. Publishable keys treat null or omission as 0; secret keys use null for unlimited",
+        ),
     accountPermissions: z
         .array(z.string())
         .nullable()

--- a/enter.pollinations.ai/src/routes/api-keys.ts
+++ b/enter.pollinations.ai/src/routes/api-keys.ts
@@ -168,7 +168,9 @@ const CreateApiKeySchema = z.object({
         .number()
         .nullable()
         .optional()
-        .describe("Pollen budget cap for this key. null = unlimited"),
+        .describe(
+            "Pollen budget cap. Publishable keys treat null or omission as 0; secret keys use null for unlimited",
+        ),
     accountPermissions: z
         .array(z.string())
         .nullable()

--- a/enter.pollinations.ai/test/integration/api-keys.test.ts
+++ b/enter.pollinations.ai/test/integration/api-keys.test.ts
@@ -22,6 +22,72 @@ type ApiKeyListResponse = {
 
 describe("API Key Management", () => {
     describe("POST /api/api-keys", () => {
+        test("defaults publishable keys to zero direct-spend budget", async ({
+            sessionToken,
+        }) => {
+            for (const pollenBudget of [undefined, null]) {
+                const response = await SELF.fetch(
+                    "http://localhost:3000/api/api-keys",
+                    {
+                        method: "POST",
+                        headers: {
+                            "Content-Type": "application/json",
+                            Cookie: `better-auth.session_token=${sessionToken}`,
+                        },
+                        body: JSON.stringify({
+                            name: `zero-budget-publishable-${String(pollenBudget)}`,
+                            type: "publishable",
+                            pollenBudget,
+                            metadata: {
+                                redirectUris: [
+                                    "https://zero-budget.example/callback",
+                                ],
+                            },
+                        }),
+                    },
+                );
+
+                expect(response.status).toBe(200);
+                const created = await response.json();
+                expect(created.pollenBudget).toBe(0);
+
+                const db = drizzle(env.DB, { schema });
+                const stored = await db.query.apikey.findFirst({
+                    where: (apikey, { eq }) => eq(apikey.id, created.id),
+                });
+                expect(stored?.pollenBalance).toBe(0);
+            }
+        });
+
+        test("preserves explicit publishable-key budgets", async ({
+            sessionToken,
+        }) => {
+            const response = await SELF.fetch(
+                "http://localhost:3000/api/api-keys",
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                    body: JSON.stringify({
+                        name: "owner-funded-publishable",
+                        type: "publishable",
+                        pollenBudget: 5,
+                        metadata: {
+                            redirectUris: [
+                                "https://owner-funded.example/callback",
+                            ],
+                        },
+                    }),
+                },
+            );
+
+            expect(response.status).toBe(200);
+            const created = await response.json();
+            expect(created.pollenBudget).toBe(5);
+        });
+
         test("should create publishable key metadata in one step", async ({
             sessionToken,
         }) => {

--- a/shared/auth/api-key-creation.ts
+++ b/shared/auth/api-key-creation.ts
@@ -225,6 +225,9 @@ export async function createApiKeyForUser({
     );
 
     const isPublishable = type === "publishable";
+    const effectivePollenBudget = isPublishable
+        ? (pollenBudget ?? 0)
+        : pollenBudget;
     const callerMetadata = pickCallerMetadata(metadata, isPublishable);
     if (Array.isArray(callerMetadata.redirectUris)) {
         for (const uri of callerMetadata.redirectUris as string[]) {
@@ -277,7 +280,9 @@ export async function createApiKeyForUser({
     const d1Updates: Partial<typeof schema.apikey.$inferInsert> = {
         metadata: JSON.stringify(finalMetadata),
     };
-    if (pollenBudget != null) d1Updates.pollenBalance = pollenBudget;
+    if (effectivePollenBudget != null) {
+        d1Updates.pollenBalance = effectivePollenBudget;
+    }
     if (!isPublishable && attribution) {
         d1Updates.byopClientKeyId = attribution.clientId;
     }
@@ -297,7 +302,7 @@ export async function createApiKeyForUser({
         expiresAt: created.expiresAt,
         expiresIn,
         permissions: Object.keys(permissions).length > 0 ? permissions : null,
-        pollenBudget: pollenBudget ?? null,
+        pollenBudget: effectivePollenBudget ?? null,
         byopClientKeyId:
             !isPublishable && attribution ? attribution.clientId : null,
         metadata: finalMetadata,

--- a/shared/test/fixtures/api-keys.ts
+++ b/shared/test/fixtures/api-keys.ts
@@ -64,7 +64,10 @@ export async function createTestApiKey(opts: CreateTestApiKeyOptions = {}) {
         type,
         expiresIn: opts.expiresIn,
         allowedModels: opts.allowedModels,
-        pollenBudget: opts.pollenBudget,
+        pollenBudget:
+            opts.pollenBudget === undefined && type === "publishable"
+                ? 100
+                : opts.pollenBudget,
         accountPermissions: opts.accountPermissions,
         metadata: opts.metadata,
         allowAccountKeysPermission: true,


### PR DESCRIPTION
- Defaults omitted or `null` publishable-key budgets to `0` in the shared server creation path
- Keeps explicitly positive owner-funded budgets and secret-key behavior unchanged
- Updates API schema descriptions and adds regression coverage

Root cause: the dashboard supplied a zero budget, but API callers could omit it and receive an unlimited publishable key.

Checks:
- `npx biome check --write ...`
- `npm run typecheck --workspace enter.pollinations.ai`
- `npm run build:frontend --workspace enter.pollinations.ai`
- `npx vitest run test/integration/api-keys.test.ts` (36 passed)

Related: #13340