### PR TITLE
feat: update Muse Spark to 1.2

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -1037,7 +1037,7 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.00000035,
     },
   },
-  "muse-spark-1.1": {
+  "muse-spark-1.2": {
     "cost": {
       "completionTextTokens": 0.00000425,
       "promptCachedTokens": 0.00000015,

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -414,8 +414,8 @@ const models: ModelDefinition[] = [
         transform: fireworksThinking,
     },
     {
-        name: "muse-spark-1.1",
-        config: portkeyConfig["meta/muse-spark-1.1"],
+        name: "muse-spark-1.2",
+        config: portkeyConfig["meta/muse-spark-1.2"],
     },
     {
         name: "llama",

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -398,9 +398,9 @@ export const portkeyConfig: PortkeyConfigMap = {
         }),
 
     // -- Vercel AI Gateway (Meta) --------------------------------------------
-    "meta/muse-spark-1.1": () =>
+    "meta/muse-spark-1.2": () =>
         createVercelAIGatewayModelConfig({
-            model: "meta/muse-spark-1.1",
+            model: "meta/muse-spark-1.2",
         }),
 
     // -- Azure (Myceli Prod — eastus, Meta Llama) ----------------------------

--- a/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
+++ b/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
@@ -161,6 +161,19 @@ describe("resolveModelConfig", () => {
         expect(result.options.provider).toBeUndefined();
     });
 
+    it("routes Muse Spark 1.2 directly through Vercel without fallback", () => {
+        const result = resolveModelConfig(messages, {
+            model: "muse-spark-1.2",
+        });
+
+        expect(result.options.model).toBe("meta/muse-spark-1.2");
+        expect(result.options.modelConfig).toMatchObject({
+            provider: "openai",
+            "custom-host": "https://ai-gateway.vercel.sh/v1",
+        });
+        expect(result.options.provider).toBeUndefined();
+    });
+
     it("routes DeepSeek to the exact Fireworks 0731 checkpoint", () => {
         const result = resolveModelConfig(messages, { model: "deepseek" });
 

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -1702,12 +1702,12 @@ export const TEXT_SERVICES = {
         contextLength: 131072,
         isSpecialized: false,
     },
-    "muse-spark-1.1": {
-        aliases: ["muse-spark", "spark", "spark-1.1"],
+    "muse-spark-1.2": {
+        aliases: ["muse-spark-1.1", "muse-spark", "spark", "spark-1.1"],
         provider: "vercel",
         brand: "Meta",
         category: "text",
-        addedDate: new Date("2026-07-12").getTime(),
+        addedDate: new Date("2026-08-14").getTime(),
         paidOnly: true,
         priceMultiplier: 1,
         cost: {
@@ -1715,7 +1715,7 @@ export const TEXT_SERVICES = {
             promptCachedTokens: perMillion(0.15),
             completionTextTokens: perMillion(4.25),
         },
-        title: "Muse Spark 1.1",
+        title: "Muse Spark 1.2",
         description: "Agentic coding and tool-use model with 1M context",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],


### PR DESCRIPTION
- Replaces the existing `muse-spark-1.1` service with canonical `muse-spark-1.2` through Vercel's exact `meta/muse-spark-1.2` route.
- Keeps `muse-spark-1.1` and every existing shorthand as compatibility aliases.
- Preserves paid-only access, multiplier 1, capabilities, 1M context, prices, and no-fallback behavior.
- Adds one focused resolver test and updates the required effective-price snapshot.

Validation:
- Direct Vercel probes: text, streaming, vision, reasoning, tools, invalid media, exact usage cost, and 10 concurrent requests.
- Local Gen E2E: canonical and all aliases, `/v1/chat/completions`, `/text`, `/text/{prompt}`, catalogs, permissions, billing, cache replay, errors, and 10 concurrent requests.
- Gen focused suites: 69 tests; Enter focused suites: 378 tests; Gen and Enter typechecks pass.
