### PR TITLE
fix: require zero budgets for publishable keys

### DIFF
--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -111,7 +111,7 @@ const CreateKeySchema = z.object({
         .nullable()
         .optional()
         .describe(
-            "Pollen budget cap. Ignored for publishable keys, which always use 0; secret keys use null for unlimited",
+            "Pollen budget cap. Publishable keys accept only null, omission, or 0 and always use 0; secret keys use null for unlimited",
         ),
     accountPermissions: z
         .array(z.string())

--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -111,7 +111,7 @@ const CreateKeySchema = z.object({
         .nullable()
         .optional()
         .describe(
-            "Pollen budget cap. Publishable keys treat null or omission as 0; secret keys use null for unlimited",
+            "Pollen budget cap. Ignored for publishable keys, which always use 0; secret keys use null for unlimited",
         ),
     accountPermissions: z
         .array(z.string())

--- a/enter.pollinations.ai/src/routes/api-keys.ts
+++ b/enter.pollinations.ai/src/routes/api-keys.ts
@@ -169,7 +169,7 @@ const CreateApiKeySchema = z.object({
         .nullable()
         .optional()
         .describe(
-            "Pollen budget cap. Publishable keys treat null or omission as 0; secret keys use null for unlimited",
+            "Pollen budget cap. Ignored for publishable keys, which always use 0; secret keys use null for unlimited",
         ),
     accountPermissions: z
         .array(z.string())

--- a/enter.pollinations.ai/src/routes/api-keys.ts
+++ b/enter.pollinations.ai/src/routes/api-keys.ts
@@ -169,7 +169,7 @@ const CreateApiKeySchema = z.object({
         .nullable()
         .optional()
         .describe(
-            "Pollen budget cap. Ignored for publishable keys, which always use 0; secret keys use null for unlimited",
+            "Pollen budget cap. Publishable keys accept only null, omission, or 0 and always use 0; secret keys use null for unlimited",
         ),
     accountPermissions: z
         .array(z.string())

--- a/enter.pollinations.ai/test/integration/api-keys.test.ts
+++ b/enter.pollinations.ai/test/integration/api-keys.test.ts
@@ -22,10 +22,10 @@ type ApiKeyListResponse = {
 
 describe("API Key Management", () => {
     describe("POST /api/api-keys", () => {
-        test("defaults publishable keys to zero direct-spend budget", async ({
+        test("forces publishable keys to zero direct-spend budget", async ({
             sessionToken,
         }) => {
-            for (const pollenBudget of [undefined, null]) {
+            for (const pollenBudget of [undefined, null, 5]) {
                 const response = await SELF.fetch(
                     "http://localhost:3000/api/api-keys",
                     {
@@ -35,7 +35,7 @@ describe("API Key Management", () => {
                             Cookie: `better-auth.session_token=${sessionToken}`,
                         },
                         body: JSON.stringify({
-                            name: `zero-budget-publishable-${String(pollenBudget)}`,
+                            name: `forced-zero-publishable-${String(pollenBudget)}`,
                             type: "publishable",
                             pollenBudget,
                             metadata: {
@@ -57,35 +57,6 @@ describe("API Key Management", () => {
                 });
                 expect(stored?.pollenBalance).toBe(0);
             }
-        });
-
-        test("preserves explicit publishable-key budgets", async ({
-            sessionToken,
-        }) => {
-            const response = await SELF.fetch(
-                "http://localhost:3000/api/api-keys",
-                {
-                    method: "POST",
-                    headers: {
-                        "Content-Type": "application/json",
-                        Cookie: `better-auth.session_token=${sessionToken}`,
-                    },
-                    body: JSON.stringify({
-                        name: "owner-funded-publishable",
-                        type: "publishable",
-                        pollenBudget: 5,
-                        metadata: {
-                            redirectUris: [
-                                "https://owner-funded.example/callback",
-                            ],
-                        },
-                    }),
-                },
-            );
-
-            expect(response.status).toBe(200);
-            const created = await response.json();
-            expect(created.pollenBudget).toBe(5);
         });
 
         test("should create publishable key metadata in one step", async ({

--- a/enter.pollinations.ai/test/integration/api-keys.test.ts
+++ b/enter.pollinations.ai/test/integration/api-keys.test.ts
@@ -25,7 +25,7 @@ describe("API Key Management", () => {
         test("forces publishable keys to zero direct-spend budget", async ({
             sessionToken,
         }) => {
-            for (const pollenBudget of [undefined, null, 5]) {
+            for (const pollenBudget of [undefined, null, 0]) {
                 const response = await SELF.fetch(
                     "http://localhost:3000/api/api-keys",
                     {
@@ -57,6 +57,33 @@ describe("API Key Management", () => {
                 });
                 expect(stored?.pollenBalance).toBe(0);
             }
+        });
+
+        test("rejects non-zero publishable-key budgets", async ({
+            sessionToken,
+        }) => {
+            const response = await SELF.fetch(
+                "http://localhost:3000/api/api-keys",
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Cookie: `better-auth.session_token=${sessionToken}`,
+                    },
+                    body: JSON.stringify({
+                        name: "invalid-budget-publishable",
+                        type: "publishable",
+                        pollenBudget: 5,
+                    }),
+                },
+            );
+
+            expect(response.status).toBe(400);
+            await expect(response.json()).resolves.toMatchObject({
+                error: {
+                    message: "Publishable keys must have a pollen budget of 0",
+                },
+            });
         });
 
         test("should create publishable key metadata in one step", async ({

--- a/shared/auth/api-key-creation.ts
+++ b/shared/auth/api-key-creation.ts
@@ -225,6 +225,11 @@ export async function createApiKeyForUser({
     );
 
     const isPublishable = type === "publishable";
+    if (isPublishable && pollenBudget != null && pollenBudget !== 0) {
+        throw new HTTPException(400, {
+            message: "Publishable keys must have a pollen budget of 0",
+        });
+    }
     const effectivePollenBudget = isPublishable ? 0 : pollenBudget;
     const callerMetadata = pickCallerMetadata(metadata, isPublishable);
     if (Array.isArray(callerMetadata.redirectUris)) {

--- a/shared/auth/api-key-creation.ts
+++ b/shared/auth/api-key-creation.ts
@@ -225,9 +225,7 @@ export async function createApiKeyForUser({
     );
 
     const isPublishable = type === "publishable";
-    const effectivePollenBudget = isPublishable
-        ? (pollenBudget ?? 0)
-        : pollenBudget;
+    const effectivePollenBudget = isPublishable ? 0 : pollenBudget;
     const callerMetadata = pickCallerMetadata(metadata, isPublishable);
     if (Array.isArray(callerMetadata.redirectUris)) {
         for (const uri of callerMetadata.redirectUris as string[]) {

--- a/shared/test/fixtures/api-keys.ts
+++ b/shared/test/fixtures/api-keys.ts
@@ -1,4 +1,5 @@
 import { env } from "cloudflare:test";
+import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { createApiKeyAuth } from "../../auth/api-key.ts";
 import {
@@ -6,7 +7,10 @@ import {
     type CallerMetadata,
     createApiKeyForUser,
 } from "../../auth/api-key-creation.ts";
-import { user as userTable } from "../../db/better-auth.ts";
+import {
+    apikey as apiKeyTable,
+    user as userTable,
+} from "../../db/better-auth.ts";
 
 export type CreateTestUserOptions = {
     id?: string;
@@ -55,6 +59,10 @@ export async function createTestApiKey(opts: CreateTestApiKeyOptions = {}) {
     const userId = opts.userId ?? (await createTestUser(opts.user));
     const authClient = createApiKeyAuth(env);
     const type = opts.type ?? "secret";
+    const testPollenBudget =
+        opts.pollenBudget === undefined && type === "publishable"
+            ? 100
+            : opts.pollenBudget;
 
     const created = await createApiKeyForUser({
         authClient,
@@ -64,18 +72,24 @@ export async function createTestApiKey(opts: CreateTestApiKeyOptions = {}) {
         type,
         expiresIn: opts.expiresIn,
         allowedModels: opts.allowedModels,
-        pollenBudget:
-            opts.pollenBudget === undefined && type === "publishable"
-                ? 100
-                : opts.pollenBudget,
+        pollenBudget: testPollenBudget,
         accountPermissions: opts.accountPermissions,
         metadata: opts.metadata,
         allowAccountKeysPermission: true,
         defaultCreatedVia: "test",
     });
 
+    if (type === "publishable" && testPollenBudget != null) {
+        await drizzle(env.DB)
+            .update(apiKeyTable)
+            .set({ pollenBalance: testPollenBudget })
+            .where(eq(apiKeyTable.id, created.id));
+    }
+
     return {
         ...created,
+        ...(type === "publishable" &&
+            testPollenBudget != null && { pollenBudget: testPollenBudget }),
         userId,
     };
 }

--- a/shared/test/fixtures/api-keys.ts
+++ b/shared/test/fixtures/api-keys.ts
@@ -72,7 +72,7 @@ export async function createTestApiKey(opts: CreateTestApiKeyOptions = {}) {
         type,
         expiresIn: opts.expiresIn,
         allowedModels: opts.allowedModels,
-        pollenBudget: testPollenBudget,
+        pollenBudget: type === "publishable" ? 0 : testPollenBudget,
         accountPermissions: opts.accountPermissions,
         metadata: opts.metadata,
         allowAccountKeysPermission: true,


### PR DESCRIPTION
- Stores a zero Pollen budget for every newly created publishable (`pk_`) key.
- Rejects non-zero publishable-key budgets with HTTP 400 instead of silently ignoring them.
- Accepts omitted, `null`, or explicit `0`; secret-key budget behavior is unchanged.
- Keeps funded publishable-key behavior available only in test fixtures for billing regression coverage.

Checks:
- Biome on changed files
- API-key integration suite: 36 passed
- Focused realtime publishable-key test: passed
- Enter typecheck: passed
- Frontend production build: passed