### PR TITLE
feat: update Grok 4.5 to 4.6

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -629,22 +629,22 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.000002,
     },
   },
-  "grok-4.5": {
+  "grok-4.6": {
     "cost": {
       "completionTextTokens": 0.000006,
-      "promptCachedTokens": 0.0000003,
+      "promptCachedTokens": 0.0000005,
       "promptTextTokens": 0.000002,
     },
     "costVariants": {
       "long_context": {
         "completionTextTokens": 0.000012,
-        "promptCachedTokens": 0.0000006,
+        "promptCachedTokens": 0.000001,
         "promptTextTokens": 0.000004,
       },
     },
     "price": {
       "completionTextTokens": 0.000006,
-      "promptCachedTokens": 0.0000003,
+      "promptCachedTokens": 0.0000005,
       "promptTextTokens": 0.000002,
     },
   },

--- a/enter.pollinations.ai/test/cost-variants.test.ts
+++ b/enter.pollinations.ai/test/cost-variants.test.ts
@@ -87,17 +87,17 @@ describe("long-context cost variants", () => {
 
     it("Grok uses OpenRouter's inclusive 200K boundary", () => {
         expect(
-            bill("grok-4.5", {
+            bill("grok-4.6", {
                 promptTextTokens: 199_999,
             }).costVariant,
         ).toBeUndefined();
         expect(
-            bill("grok-4.5", {
+            bill("grok-4.6", {
                 promptTextTokens: 200_000,
             }).costVariant,
         ).toBe("long_context");
         expect(
-            bill("grok-4.5", {
+            bill("grok-4.6", {
                 promptTextTokens: 200_001,
             }).costVariant,
         ).toBe("long_context");
@@ -329,12 +329,12 @@ describe("long-context cost variants", () => {
             completionTextTokens: 3.84 / 1e6,
         });
         expect(
-            bill("grok-4.5", {
+            bill("grok-4.6", {
                 promptTextTokens: 200_000,
             }).priceDefinition,
         ).toMatchObject({
             promptTextTokens: 4 / 1e6,
-            promptCachedTokens: 0.6 / 1e6,
+            promptCachedTokens: 1 / 1e6,
             completionTextTokens: 12 / 1e6,
         });
     });

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -199,8 +199,8 @@ const models: ModelDefinition[] = [
         transform: stripCacheControl,
     },
     {
-        name: "grok-4.5",
-        config: portkeyConfig["x-ai/grok-4.5"],
+        name: "grok-4.6",
+        config: portkeyConfig["x-ai/grok-4.6"],
         transform: stripCacheControl,
     },
     {

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -139,10 +139,15 @@ export const portkeyConfig: PortkeyConfigMap = {
         ),
 
     // -- OpenRouter (frontier models) ----------------------------------------
-    "x-ai/grok-4.5": () =>
+    "x-ai/grok-4.6": () =>
         createOpenRouterModelConfig({
-            model: "x-ai/grok-4.5",
-            defaultOptions: { provider: { sort: "price" } },
+            model: "x-ai/grok-4.6",
+            defaultOptions: {
+                provider: {
+                    only: ["xai/zdr"],
+                    allow_fallbacks: false,
+                },
+            },
         }),
     "xiaomi/mimo-v2.5": () =>
         createOpenRouterModelConfig({

--- a/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
+++ b/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
@@ -161,6 +161,20 @@ describe("resolveModelConfig", () => {
         expect(result.options.provider).toBeUndefined();
     });
 
+    it("pins Grok 4.6 to xAI ZDR on OpenRouter without fallback", () => {
+        const result = resolveModelConfig(messages, { model: "grok-4.6" });
+
+        expect(result.options.model).toBe("x-ai/grok-4.6");
+        expect(result.options.modelConfig).toMatchObject({
+            provider: "openai",
+            "custom-host": "https://openrouter.ai/api/v1",
+        });
+        expect(result.options.provider).toEqual({
+            only: ["xai/zdr"],
+            allow_fallbacks: false,
+        });
+    });
+
     it("routes DeepSeek to the exact Fireworks 0731 checkpoint", () => {
         const result = resolveModelConfig(messages, { model: "deepseek" });
 

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -813,8 +813,8 @@ export const TEXT_SERVICES = {
         contextLength: 1048576, // xAI Grok 4.3 context window.
         isSpecialized: false,
     },
-    "grok-4.5": {
-        aliases: ["grok-4-5"],
+    "grok-4.6": {
+        aliases: ["grok-4.5", "grok-4-5"],
         provider: "openrouter",
         brand: "xAI",
         category: "text",
@@ -825,14 +825,14 @@ export const TEXT_SERVICES = {
         // prompt tokens.
         cost: {
             promptTextTokens: perMillion(2),
-            promptCachedTokens: perMillion(0.3),
+            promptCachedTokens: perMillion(0.5),
             completionTextTokens: perMillion(6),
         },
         ...defineCostVariants(
             {
                 long_context: {
                     promptTextTokens: perMillion(4),
-                    promptCachedTokens: perMillion(0.6),
+                    promptCachedTokens: perMillion(1),
                     completionTextTokens: perMillion(12),
                 },
             },
@@ -846,7 +846,7 @@ export const TEXT_SERVICES = {
             },
             "<200K context",
         ),
-        title: "Grok 4.5",
+        title: "Grok 4.6",
         description: "Frontier reasoning for coding and knowledge work",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],


### PR DESCRIPTION
- Replaces canonical `grok-4.5` with `grok-4.6`; preserves `grok-4.5` and `grok-4-5` as compatibility aliases.
- Routes OpenRouter `x-ai/grok-4.6` only through `xai/zdr` with provider fallback disabled; current upstream is `x-ai/grok-4.6-20260810`.
- Updates cached-token pricing to $0.50/M below 200K and $1/M at 200K+, with multiplier 1 and paid-only access unchanged.
- Keeps modalities, endpoints, capabilities, context, description, logo, and Pollinations fallback unchanged.

Verified: direct and local text, vision, streaming, tools, JSON, four reasoning levels, aliases, permissions, cache, exact billing, errors, and a 5-request burst; focused tests and both typechecks pass.