### PR TITLE
feat: add Seedance 2.0 Mini and Fast

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -1534,6 +1534,27 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "completionVideoSeconds": 0.18,
     },
   },
+  "seedance-2.0-fast": {
+    "cost": {
+      "completionVideoSeconds": 0.07,
+    },
+    "price": {
+      "completionVideoSeconds": 0.07,
+    },
+  },
+  "seedance-2.0-mini": {
+    "cost": {
+      "completionVideoSeconds": 0.09,
+    },
+    "costVariants": {
+      "480p": {
+        "completionVideoSeconds": 0.04,
+      },
+    },
+    "price": {
+      "completionVideoSeconds": 0.09,
+    },
+  },
   "seedance-2.5": {
     "cost": {
       "completionVideoSeconds": 0.1028,

--- a/gen.pollinations.ai/src/image/createAndReturnVideos.ts
+++ b/gen.pollinations.ai/src/image/createAndReturnVideos.ts
@@ -46,6 +46,8 @@ export async function createAndReturnVideo(
             result = await callSeedanceProAPI(prompt, safeParams);
             break;
         case "seedance-2.0":
+        case "seedance-2.0-mini":
+        case "seedance-2.0-fast":
             result = await callSeedanceV2API(prompt, safeParams);
             break;
         case "wan":

--- a/gen.pollinations.ai/src/image/models/seedanceV2VideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/seedanceV2VideoModel.ts
@@ -1,10 +1,9 @@
 /**
- * ByteDance Seedance 2.0 video generation via Replicate.
+ * ByteDance Seedance 2.0 family video generation via Replicate.
  *
- * v1: 720p locked, T2V/I2V/reference modes via the existing safeParams.image
- * convention. Audio + image input are free; only resolution + reference_videos
- * are price multipliers, and we don't expose reference_videos (would trigger
- * "video_in" tier).
+ * The full model remains 720p locked. All three use the existing
+ * safeParams.image convention for T2V/I2V/reference modes. We don't expose
+ * reference_videos, which would trigger Replicate's "video_in" price tier.
  */
 
 import debug from "debug";
@@ -22,8 +21,30 @@ import {
 const logOps = debug("pollinations:seedance2:ops");
 const logError = debug("pollinations:seedance2:error");
 
-const MODEL = "bytedance/seedance-2.0";
-const TRACKING_LABEL = "seedance-2.0";
+const MODELS = {
+    "seedance-2.0": {
+        upstream: "bytedance/seedance-2.0",
+        title: "Seedance 2.0",
+        resolutions: ["720p"],
+        defaultResolution: "720p",
+        maxDuration: 15,
+    },
+    "seedance-2.0-mini": {
+        upstream: "bytedance/seedance-2.0-mini",
+        title: "Seedance 2.0 Mini",
+        resolutions: ["480p", "720p"],
+        defaultResolution: "720p",
+        maxDuration: 10,
+    },
+    "seedance-2.0-fast": {
+        upstream: "bytedance/seedance-2.0-fast",
+        title: "Seedance 2.0 Fast",
+        resolutions: ["480p"],
+        defaultResolution: "480p",
+        maxDuration: 5,
+    },
+} as const;
+type SeedanceV2ModelName = keyof typeof MODELS;
 
 // Replicate's Seedance 2.0 accepts a narrower set than our shared aspectRatio
 // enum (which also allows 9:21). Validate at the boundary so users get a clear
@@ -55,7 +76,7 @@ export function resolveSeedanceV2AspectRatio(
 interface SeedanceV2Input {
     prompt: string;
     duration: number;
-    resolution: "720p";
+    resolution: "480p" | "720p";
     aspect_ratio: SeedanceV2AspectRatio;
     generate_audio: boolean;
     seed?: number;
@@ -67,11 +88,25 @@ export async function callSeedanceV2API(
     prompt: string,
     safeParams: ImageParams,
 ): Promise<VideoGenerationResult> {
+    const modelName = safeParams.model as SeedanceV2ModelName;
+    const config = MODELS[modelName];
+    const requestedResolution =
+        safeParams.resolution ?? config.defaultResolution;
+    if (
+        !(config.resolutions as readonly string[]).includes(requestedResolution)
+    ) {
+        throw new HttpError(
+            `${config.title} supports ${config.resolutions.join(" or ")} resolution`,
+            400,
+        );
+    }
+    const resolution = requestedResolution as SeedanceV2Input["resolution"];
+
     // Seedance 2.0 requires duration in [4, 15]. The schema enforces min=1
     // so we only need to clamp into the upstream's accepted range.
     const duration = Math.max(
         4,
-        Math.min(15, Math.floor(safeParams.duration ?? 5)),
+        Math.min(config.maxDuration, Math.floor(safeParams.duration ?? 5)),
     );
 
     // Positional image[] contract:
@@ -80,7 +115,7 @@ export async function callSeedanceV2API(
     const images = safeParams.image ?? [];
     if (images.length > 2) {
         throw new HttpError(
-            "Seedance 2.0 supports at most two images: image[0] as first frame and image[1] as last frame.",
+            `${config.title} supports at most two images: image[0] as first frame and image[1] as last frame.`,
             400,
         );
     }
@@ -88,7 +123,7 @@ export async function callSeedanceV2API(
     const input: SeedanceV2Input = {
         prompt,
         duration,
-        resolution: "720p",
+        resolution,
         aspect_ratio: resolveSeedanceV2AspectRatio(safeParams.aspectRatio),
         generate_audio: safeParams.audio,
     };
@@ -98,7 +133,7 @@ export async function callSeedanceV2API(
     if (images.length >= 1) input.image = await toDataUri(images[0]);
     if (images.length >= 2) input.last_frame_image = await toDataUri(images[1]);
 
-    logOps("Seedance 2.0 input:", {
+    logOps(`${config.title} input:`, {
         ...input,
         prompt: prompt.slice(0, 80),
         image: input.image ? "[url]" : undefined,
@@ -109,33 +144,33 @@ export async function callSeedanceV2API(
     let actualDurationSeconds: number | undefined;
     try {
         const result = await runReplicatePrediction<SeedanceV2Input, string>({
-            model: MODEL,
+            model: config.upstream,
             input,
         });
         videoUrl = result.output;
         actualDurationSeconds = result.videoOutputDurationSeconds;
-        logOps("Seedance 2.0 prediction succeeded:", {
+        logOps(`${config.title} prediction succeeded:`, {
             id: result.id,
             predict_time: result.predictTimeSeconds,
             video_output_duration: actualDurationSeconds,
         });
     } catch (err) {
-        logError("Seedance 2.0 prediction call failed:", err);
+        logError(`${config.title} prediction call failed:`, err);
         if (err instanceof ReplicateError) {
             logError("Replicate raw error details:", {
                 message: err.message,
                 status: err.status,
             });
         }
-        throw toReplicateHttpError(err, "Seedance 2.0 generation failed");
+        throw toReplicateHttpError(err, `${config.title} generation failed`);
     }
 
     const videoResponse = await fetchUpstream(videoUrl, {
-        errorLabel: "Failed to download Seedance 2.0 output video",
+        errorLabel: `Failed to download ${config.title} output video`,
     });
     const buffer = Buffer.from(await videoResponse.arrayBuffer());
     logOps(
-        "Seedance 2.0 video downloaded:",
+        `${config.title} video downloaded:`,
         (buffer.length / 1024 / 1024).toFixed(2),
         "MB",
     );
@@ -149,7 +184,7 @@ export async function callSeedanceV2API(
         mimeType: "video/mp4",
         durationSeconds: billedDuration,
         trackingData: {
-            actualModel: TRACKING_LABEL,
+            actualModel: modelName,
             usage: {
                 completionVideoSeconds: billedDuration,
             },

--- a/gen.pollinations.ai/src/image/models/seedanceV2VideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/seedanceV2VideoModel.ts
@@ -6,6 +6,8 @@
  * reference_videos, which would trigger Replicate's "video_in" price tier.
  */
 
+import { IMAGE_SERVICES } from "@shared/registry/image.ts";
+import type { ModelDefinition } from "@shared/registry/registry.ts";
 import debug from "debug";
 import type { VideoGenerationResult } from "../createAndReturnVideos.ts";
 import { HttpError } from "../httpError.ts";
@@ -24,31 +26,21 @@ const logError = debug("pollinations:seedance2:error");
 const MODELS = {
     "seedance-2.0": {
         upstream: "bytedance/seedance-2.0",
-        title: "Seedance 2.0",
-        resolutions: ["720p"],
-        defaultResolution: "720p",
         maxDuration: 15,
     },
     "seedance-2.0-mini": {
         upstream: "bytedance/seedance-2.0-mini",
-        title: "Seedance 2.0 Mini",
-        resolutions: ["480p", "720p"],
-        defaultResolution: "720p",
         maxDuration: 10,
     },
     "seedance-2.0-fast": {
         upstream: "bytedance/seedance-2.0-fast",
-        title: "Seedance 2.0 Fast",
-        resolutions: ["480p"],
-        defaultResolution: "480p",
         maxDuration: 5,
     },
 } as const;
 type SeedanceV2ModelName = keyof typeof MODELS;
 
-// Replicate's Seedance 2.0 accepts a narrower set than our shared aspectRatio
-// enum (which also allows 9:21). Validate at the boundary so users get a clear
-// 400 instead of a Replicate 422 round-trip.
+// Pollinations currently exposes this validated subset. Adding 9:21 requires
+// a separate live probe before expanding the public contract.
 const SEEDANCE_V2_ASPECT_RATIOS = [
     "16:9",
     "4:3",
@@ -62,13 +54,14 @@ type SeedanceV2AspectRatio = (typeof SEEDANCE_V2_ASPECT_RATIOS)[number];
 
 export function resolveSeedanceV2AspectRatio(
     requested: ImageParams["aspectRatio"] | undefined,
+    modelTitle = "Seedance 2.0",
 ): SeedanceV2AspectRatio {
     if (!requested) return "16:9";
     if ((SEEDANCE_V2_ASPECT_RATIOS as readonly string[]).includes(requested)) {
         return requested as SeedanceV2AspectRatio;
     }
     throw new HttpError(
-        `aspectRatio "${requested}" is not supported by Seedance 2.0. Supported: ${SEEDANCE_V2_ASPECT_RATIOS.join(", ")}.`,
+        `aspectRatio "${requested}" is not supported by ${modelTitle}. Supported: ${SEEDANCE_V2_ASPECT_RATIOS.join(", ")}.`,
         400,
     );
 }
@@ -90,20 +83,13 @@ export async function callSeedanceV2API(
 ): Promise<VideoGenerationResult> {
     const modelName = safeParams.model as SeedanceV2ModelName;
     const config = MODELS[modelName];
-    const requestedResolution =
-        safeParams.resolution ?? config.defaultResolution;
-    if (
-        !(config.resolutions as readonly string[]).includes(requestedResolution)
-    ) {
-        throw new HttpError(
-            `${config.title} supports ${config.resolutions.join(" or ")} resolution`,
-            400,
-        );
-    }
-    const resolution = requestedResolution as SeedanceV2Input["resolution"];
+    const definition = IMAGE_SERVICES[modelName] as ModelDefinition;
+    const resolution = (safeParams.resolution ??
+        definition.resolutions?.[0] ??
+        "720p") as SeedanceV2Input["resolution"];
 
-    // Seedance 2.0 requires duration in [4, 15]. The schema enforces min=1
-    // so we only need to clamp into the upstream's accepted range.
+    // Replicate accepts 4–15 seconds. Pollinations caps Mini and Fast at their
+    // empirically verified synchronous latency limits.
     const duration = Math.max(
         4,
         Math.min(config.maxDuration, Math.floor(safeParams.duration ?? 5)),
@@ -115,7 +101,7 @@ export async function callSeedanceV2API(
     const images = safeParams.image ?? [];
     if (images.length > 2) {
         throw new HttpError(
-            `${config.title} supports at most two images: image[0] as first frame and image[1] as last frame.`,
+            `${definition.title} supports at most two images: image[0] as first frame and image[1] as last frame.`,
             400,
         );
     }
@@ -124,7 +110,10 @@ export async function callSeedanceV2API(
         prompt,
         duration,
         resolution,
-        aspect_ratio: resolveSeedanceV2AspectRatio(safeParams.aspectRatio),
+        aspect_ratio: resolveSeedanceV2AspectRatio(
+            safeParams.aspectRatio,
+            definition.title,
+        ),
         generate_audio: safeParams.audio,
     };
     if (safeParams.seed !== undefined) {
@@ -133,7 +122,7 @@ export async function callSeedanceV2API(
     if (images.length >= 1) input.image = await toDataUri(images[0]);
     if (images.length >= 2) input.last_frame_image = await toDataUri(images[1]);
 
-    logOps(`${config.title} input:`, {
+    logOps(`${definition.title} input:`, {
         ...input,
         prompt: prompt.slice(0, 80),
         image: input.image ? "[url]" : undefined,
@@ -149,28 +138,31 @@ export async function callSeedanceV2API(
         });
         videoUrl = result.output;
         actualDurationSeconds = result.videoOutputDurationSeconds;
-        logOps(`${config.title} prediction succeeded:`, {
+        logOps(`${definition.title} prediction succeeded:`, {
             id: result.id,
             predict_time: result.predictTimeSeconds,
             video_output_duration: actualDurationSeconds,
         });
     } catch (err) {
-        logError(`${config.title} prediction call failed:`, err);
+        logError(`${definition.title} prediction call failed:`, err);
         if (err instanceof ReplicateError) {
             logError("Replicate raw error details:", {
                 message: err.message,
                 status: err.status,
             });
         }
-        throw toReplicateHttpError(err, `${config.title} generation failed`);
+        throw toReplicateHttpError(
+            err,
+            `${definition.title} generation failed`,
+        );
     }
 
     const videoResponse = await fetchUpstream(videoUrl, {
-        errorLabel: `Failed to download ${config.title} output video`,
+        errorLabel: `Failed to download ${definition.title} output video`,
     });
     const buffer = Buffer.from(await videoResponse.arrayBuffer());
     logOps(
-        `${config.title} video downloaded:`,
+        `${definition.title} video downloaded:`,
         (buffer.length / 1024 / 1024).toFixed(2),
         "MB",
     );

--- a/gen.pollinations.ai/src/schemas/image.ts
+++ b/gen.pollinations.ai/src/schemas/image.ts
@@ -94,7 +94,7 @@ const GenerateImageRequestQueryParamsBaseSchema = z.object({
     // Video-specific params
     resolution: z.enum(["480p", "720p", "1080p"]).optional().meta({
         description:
-            "Output resolution for resolution-priced video models (`veo`, `wan-pro`, `p-video`, `seedance-pro`). Defaults to 720p. Non-default resolutions bill at the model's rate for that tier.",
+            "Output resolution for video models that advertise `resolutions` in `/models`. The first advertised resolution is the default; requested tiers bill at their listed rate.",
     }),
     duration: z.coerce.number().int().min(1).max(120).optional().meta({
         description:

--- a/gen.pollinations.ai/src/schemas/image.ts
+++ b/gen.pollinations.ai/src/schemas/image.ts
@@ -84,7 +84,7 @@ const GenerateImageRequestQueryParamsBaseSchema = z.object({
         )
         .meta({
             description:
-                "Reference image URL(s) for image editing or video generation. Separate multiple URLs with `|` or `,`. **Image models:** Used for editing/style reference (kontext, gptimage, seedream, klein, nanobanana). **Video models:** `image[0]` = starting frame (I2V); `image[1]` = ending frame for first+last-frame interpolation. End-frame supported by `veo`, `seedance-2.0`, `seedance-2.5`, `wan-fast`, and `wan-pro`; other video models silently drop `image[1]`. See `video_capabilities` on `/image/models` or `/models` for per-model support.",
+                "Reference image URL(s) for image editing or video generation. Separate multiple URLs with `|` or `,`. **Image models:** Used for editing/style reference (kontext, gptimage, seedream, klein, nanobanana). **Video models:** `image[0]` = starting frame (I2V); `image[1]` = ending frame for first+last-frame interpolation. End-frame supported by `veo`, the `seedance-2.0` family, `seedance-2.5`, `wan-fast`, and `wan-pro`; other video models silently drop `image[1]`. See `video_capabilities` on `/image/models` or `/models` for per-model support.",
         }),
     transparent: z.coerce.boolean().optional().default(false).meta({
         description:
@@ -98,7 +98,7 @@ const GenerateImageRequestQueryParamsBaseSchema = z.object({
     }),
     duration: z.coerce.number().int().min(1).max(120).optional().meta({
         description:
-            "Video duration in seconds. Only applies to video models. `veo`: 4, 6, or 8s. `seedance-pro`: 2-10s. `seedance-2.0`: 4-15s. `seedance-2.5`: exactly 4s. `wan`: 2-15s. `nova-reel`: 6-120s (multiples of 6).",
+            "Video duration in seconds. Only applies to video models. `veo`: 4, 6, or 8s. `seedance-pro`: 2-10s. `seedance-2.0`: 4-15s; Mini: 4-10s; Fast: 4-5s. `seedance-2.5`: exactly 4s. `wan`: 2-15s. `nova-reel`: 6-120s (multiples of 6).",
     }),
     aspectRatio: z.string().optional().meta({
         description:

--- a/gen.pollinations.ai/test/image/seedanceV2VideoModel.test.ts
+++ b/gen.pollinations.ai/test/image/seedanceV2VideoModel.test.ts
@@ -107,19 +107,12 @@ describe("Seedance 2.0 Mini and Fast via Replicate", () => {
         });
     });
 
-    it.each([
-        ["seedance-2.0-mini", "1080p"],
-        ["seedance-2.0-fast", "720p"],
-    ] as const)("rejects unsupported %s resolution %s before submitting", async (model, resolution) => {
-        const fetchSpy = vi.spyOn(globalThis, "fetch");
-
+    it("names the selected variant in aspect-ratio errors", async () => {
         await expect(
             callSeedanceV2API("a paper boat", {
                 ...baseParams,
-                model,
-                resolution,
+                aspectRatio: "9:21",
             }),
-        ).rejects.toMatchObject({ status: 400 });
-        expect(fetchSpy).not.toHaveBeenCalled();
+        ).rejects.toThrow("not supported by Seedance 2.0 Mini");
     });
 });

--- a/gen.pollinations.ai/test/image/seedanceV2VideoModel.test.ts
+++ b/gen.pollinations.ai/test/image/seedanceV2VideoModel.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { syncImageEnv } from "../../src/image/env.ts";
+import { callSeedanceV2API } from "../../src/image/models/seedanceV2VideoModel.ts";
+import type { ImageParams } from "../../src/image/params.ts";
+
+const VIDEO_URL = "https://video.example.com/seedance.mp4";
+const IMAGE_URLS = [
+    "https://image.example.com/start.png",
+    "https://image.example.com/end.png",
+];
+const PNG_BYTES = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
+
+const baseParams: ImageParams = {
+    model: "seedance-2.0-mini",
+    width: 1024,
+    height: 768,
+    dimensionsExplicit: false,
+    seed: 42,
+    safe: false,
+    quality: "medium",
+    image: IMAGE_URLS,
+    transparent: false,
+    reasoning: "balanced",
+    audio: true,
+    duration: 4,
+    aspectRatio: "4:3",
+};
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe("Seedance 2.0 Mini and Fast via Replicate", () => {
+    it.each([
+        ["seedance-2.0-mini", undefined, "720p", 15, 10],
+        ["seedance-2.0-mini", "480p", "480p", 4, 4],
+        ["seedance-2.0-fast", undefined, "480p", 15, 5],
+    ] as const)("routes %s resolution %s as %s and caps duration %s at %s", async (model, resolution, expectedResolution, duration, expectedDuration) => {
+        syncImageEnv(
+            { REPLICATE_API_TOKEN: "replicate-test-key" } as CloudflareBindings,
+            ["REPLICATE_API_TOKEN"],
+        );
+        const upstreamModel = `bytedance/${model}`;
+        const predictionUrl = `https://api.replicate.com/v1/models/${upstreamModel}/predictions`;
+        const inputs: Record<string, unknown>[] = [];
+        vi.spyOn(globalThis, "fetch").mockImplementation(async (url, init) => {
+            const href = typeof url === "string" ? url : url.toString();
+            if (IMAGE_URLS.includes(href)) {
+                return new Response(PNG_BYTES, {
+                    headers: { "Content-Type": "image/png" },
+                });
+            }
+            if (href === predictionUrl) {
+                inputs.push(
+                    (
+                        JSON.parse(init?.body as string) as {
+                            input: Record<string, unknown>;
+                        }
+                    ).input,
+                );
+                return new Response(
+                    JSON.stringify({
+                        id: `pred-${model}`,
+                        status: "succeeded",
+                        output: VIDEO_URL,
+                        metrics: { video_output_duration_seconds: 4 },
+                    }),
+                    { status: 201 },
+                );
+            }
+            if (href === VIDEO_URL) {
+                return new Response(new Uint8Array([0, 0, 0, 24]), {
+                    headers: { "Content-Type": "video/mp4" },
+                });
+            }
+            return new Response("unexpected URL", { status: 404 });
+        });
+
+        const result = await callSeedanceV2API("a paper boat", {
+            ...baseParams,
+            model,
+            resolution,
+            duration,
+        });
+
+        expect(inputs).toEqual([
+            {
+                prompt: "a paper boat",
+                duration: expectedDuration,
+                resolution: expectedResolution,
+                aspect_ratio: "4:3",
+                generate_audio: true,
+                seed: 42,
+                image: expect.stringMatching(/^data:image\/png;base64,/),
+                last_frame_image: expect.stringMatching(
+                    /^data:image\/png;base64,/,
+                ),
+            },
+        ]);
+        expect(result).toMatchObject({
+            mimeType: "video/mp4",
+            durationSeconds: 4,
+            trackingData: {
+                actualModel: model,
+                usage: { completionVideoSeconds: 4 },
+            },
+        });
+    });
+
+    it.each([
+        ["seedance-2.0-mini", "1080p"],
+        ["seedance-2.0-fast", "720p"],
+    ] as const)("rejects unsupported %s resolution %s before submitting", async (model, resolution) => {
+        const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+        await expect(
+            callSeedanceV2API("a paper boat", {
+                ...baseParams,
+                model,
+                resolution,
+            }),
+        ).rejects.toMatchObject({ status: 400 });
+        expect(fetchSpy).not.toHaveBeenCalled();
+    });
+});

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -517,6 +517,64 @@ export const IMAGE_SERVICES = {
         videoCapabilities: ["start_frame", "end_frame", "audio_output"],
         maxReferenceImages: 2, // Video keyframe slots: start + end.
     },
+    "seedance-2.0-mini": {
+        aliases: [],
+        provider: "replicate",
+        brand: "ByteDance",
+        category: "video",
+        addedDate: new Date("2026-08-14").getTime(),
+        priceMultiplier: 1,
+        paidOnly: true,
+        // Replicate non_video_in tiers: 480p $0.04/s, 720p $0.09/s.
+        cost: {
+            completionVideoSeconds: 0.09,
+        },
+        ...defineCostVariants(
+            {
+                "480p": {
+                    completionVideoSeconds: 0.04,
+                },
+            },
+            matchResolution("480p"),
+            {
+                "480p": {
+                    label: "480p",
+                    description:
+                        "Applies when the requested video resolution is 480p.",
+                },
+            },
+            "720p",
+        ),
+        resolutions: ["720p", "480p"],
+        title: "Seedance 2.0 Mini",
+        description:
+            "Lower-cost 4–10 second video with synchronized sound and first/last-frame control at 480p or 720p",
+        inputModalities: ["text", "image"],
+        outputModalities: ["video", "audio"],
+        videoCapabilities: ["start_frame", "end_frame", "audio_output"],
+        maxReferenceImages: 2, // Video keyframe slots: start + end.
+    },
+    "seedance-2.0-fast": {
+        aliases: [],
+        provider: "replicate",
+        brand: "ByteDance",
+        category: "video",
+        addedDate: new Date("2026-08-14").getTime(),
+        priceMultiplier: 1,
+        paidOnly: true,
+        // Replicate non_video_in 480p tier; 720p misses the latency limit.
+        cost: {
+            completionVideoSeconds: 0.07,
+        },
+        resolutions: ["480p"],
+        title: "Seedance 2.0 Fast",
+        description:
+            "Short 4–5 second video with synchronized sound and first/last-frame control at 480p",
+        inputModalities: ["text", "image"],
+        outputModalities: ["video", "audio"],
+        videoCapabilities: ["start_frame", "end_frame", "audio_output"],
+        maxReferenceImages: 2, // Video keyframe slots: start + end.
+    },
     "wan": {
         aliases: ["wan2.6", "wan-i2v"],
         provider: "replicate",


### PR DESCRIPTION
- Adds `seedance-2.0-mini` and `seedance-2.0-fast` as distinct paid-only Replicate services with no aliases or fallback.
- Exposes Mini at 480p/720p for 4–10 seconds ($0.04/$0.09 per second) and Fast at 480p for 4–5 seconds ($0.07 per second).
- Reuses the existing Seedance 2.0 handler while preserving the existing full model unchanged.
- Local Gen E2E verified authentication, resolution routing, keyframes through `media.pollinations.ai`, optional audio, MP4 tracks, billing, catalogs, exact cache replay, and burst behavior.
- Fast 720p and longer durations are intentionally excluded after repeated local latency exceeded 120 seconds.

Tests: focused Replicate/Seedance suites, registry and pricing invariants, snapshots, Biome, and Gen/Enter typechecks.