### PR TITLE
fix: split permission migration per alias to fit D1 CPU limit

### DIFF
--- a/.claude/skills/model-management/SKILL.md
+++ b/.claude/skills/model-management/SKILL.md
@@ -113,6 +113,10 @@ Present the mandatory row and obtain explicit confirmation before editing. If a 
   one D1 migration PR. Replace old IDs, preserve unrelated permission fields
   and array order, deduplicate old/new pairs, prove idempotence, and verify all
   audited old-ID counts are zero after deployment.
+- Keep every migration statement within D1's per-query CPU limit: one statement
+  per alias, and prefilter with `instr()` inside `CASE` so JSON functions never
+  run on non-matching rows. A single whole-table JSON scan fails with error
+  7429 at production scale (~150k apikey rows).
 - API-key create and update paths must store recognized aliases as canonical
   IDs, while preserving unknown and community IDs, so migrations do not need to
   repair newly written aliases again.

--- a/enter.pollinations.ai/drizzle/0046_canonicalize-model-permission-aliases.sql
+++ b/enter.pollinations.ai/drizzle/0046_canonicalize-model-permission-aliases.sql
@@ -2,95 +2,772 @@
 -- registry ID. Canonicalize every alias currently present in production model
 -- allowlists while preserving unrelated permission data and array order.
 -- Read-only audit on 2026-08-14: 21 current aliases plus two pending canonical
--- renames across 1,863 production allowlists; staging contained none. This
+-- renames across 1,863 production allowlists. Staging contained none. This
 -- migration must deploy with the Muse Spark 1.2 and Grok 4.6 registry changes,
 -- not before.
-WITH alias_map(alias, canonical) AS (
-    VALUES
-        ('gemini-flash-lite-3.1', 'gemini-flash-lite-3.5'),
-        ('universal-3-pro', 'universal-3.5-pro'),
-        ('sana', 'dreamshaper'),
-        ('grok-reasoning', 'grok-large'),
-        ('kimi-k2.7-code', 'kimi-code'),
-        ('nova-micro', 'nova-fast'),
-        ('kimi-k2.6', 'kimi'),
-        ('gemini-3.5-flash', 'gemini'),
-        ('qwen3-tts', 'qwen-tts'),
-        ('gpt-5.5', 'openai-large'),
-        ('mistral-4', 'mistral'),
-        ('stable-audio-2.5', 'stable-audio-3-medium'),
-        ('grok-4.3', 'grok-large'),
-        ('claude-opus-4.8', 'claude-large'),
-        ('minimax-m3', 'minimax'),
-        ('nanobanana2', 'nanobanana-2'),
-        ('deepseek-v4-pro', 'deepseek-pro'),
-        ('nemotron-3-ultra', 'nemotron'),
-        ('trellis-2-high', 'trellis-2'),
-        ('trellis-2-low', 'trellis-2'),
-        ('trellis-2-medium', 'trellis-2'),
-        ('muse-spark-1.1', 'muse-spark-1.2'),
-        ('grok-4.5', 'grok-4.6')
-),
-candidate_keys AS MATERIALIZED (
-    SELECT id, permissions
-    FROM apikey
-    WHERE json_valid(permissions)
-      AND json_type(permissions, '$.models') = 'array'
-      AND (
-           instr(permissions, '"gemini-flash-lite-3.1"') > 0
-        OR instr(permissions, '"universal-3-pro"') > 0
-        OR instr(permissions, '"sana"') > 0
-        OR instr(permissions, '"grok-reasoning"') > 0
-        OR instr(permissions, '"kimi-k2.7-code"') > 0
-        OR instr(permissions, '"nova-micro"') > 0
-        OR instr(permissions, '"kimi-k2.6"') > 0
-        OR instr(permissions, '"gemini-3.5-flash"') > 0
-        OR instr(permissions, '"qwen3-tts"') > 0
-        OR instr(permissions, '"gpt-5.5"') > 0
-        OR instr(permissions, '"mistral-4"') > 0
-        OR instr(permissions, '"stable-audio-2.5"') > 0
-        OR instr(permissions, '"grok-4.3"') > 0
-        OR instr(permissions, '"claude-opus-4.8"') > 0
-        OR instr(permissions, '"minimax-m3"') > 0
-        OR instr(permissions, '"nanobanana2"') > 0
-        OR instr(permissions, '"deepseek-v4-pro"') > 0
-        OR instr(permissions, '"nemotron-3-ultra"') > 0
-        OR instr(permissions, '"trellis-2-high"') > 0
-        OR instr(permissions, '"trellis-2-low"') > 0
-        OR instr(permissions, '"trellis-2-medium"') > 0
-        OR instr(permissions, '"muse-spark-1.1"') > 0
-        OR instr(permissions, '"grok-4.5"') > 0
-      )
-),
-canonicalized AS (
-    SELECT
-        candidate_keys.id,
-        CAST(model.key AS integer) AS position,
-        COALESCE(alias_map.canonical, model.value) AS model_id,
-        alias_map.canonical IS NOT NULL AS changed
-    FROM candidate_keys
-    JOIN json_each(candidate_keys.permissions, '$.models') AS model
-    LEFT JOIN alias_map
-        ON model.type = 'text' AND model.value = alias_map.alias
-),
-deduplicated AS (
-    SELECT id, model_id, MIN(position) AS position
-    FROM canonicalized
-    GROUP BY id, model_id
-),
-migrated AS (
-    SELECT id, json_group_array(model_id) AS models
-    FROM (
-        SELECT id, model_id
-        FROM deduplicated
-        ORDER BY id, position
-    )
-    GROUP BY id
-)
+--
+-- One statement per alias: a single-statement version exceeded D1's per-query
+-- CPU limit (code 7429) on the ~153k-row production apikey table because
+-- json_valid() ran on every row. Each statement below prefilters with a cheap
+-- instr() inside CASE (guaranteed evaluation order), so JSON functions only
+-- touch rows whose permissions text contains the alias.
+
 UPDATE apikey
 SET permissions = json_set(
     permissions,
     '$.models',
-    json((SELECT models FROM migrated WHERE migrated.id = apikey.id))
+    (
+        SELECT json_group_array(model_id)
+        FROM (
+            SELECT model_id
+            FROM (
+                SELECT
+                    CASE
+                        WHEN model.type = 'text' AND model.value = 'gemini-flash-lite-3.1'
+                            THEN 'gemini-flash-lite-3.5'
+                        ELSE model.value
+                    END AS model_id,
+                    CAST(model.key AS integer) AS position
+                FROM json_each(apikey.permissions, '$.models') AS model
+            )
+            GROUP BY model_id
+            ORDER BY MIN(position)
+        )
+    )
 )
-WHERE id IN (SELECT id FROM canonicalized WHERE changed);
+WHERE CASE
+    WHEN instr(permissions, '"gemini-flash-lite-3.1"') = 0 THEN 0
+    WHEN NOT json_valid(permissions) THEN 0
+    WHEN json_type(permissions, '$.models') != 'array' THEN 0
+    ELSE EXISTS (
+        SELECT 1
+        FROM json_each(permissions, '$.models') AS model
+        WHERE model.type = 'text' AND model.value = 'gemini-flash-lite-3.1'
+    )
+END;
+UPDATE apikey
+SET permissions = json_set(
+    permissions,
+    '$.models',
+    (
+        SELECT json_group_array(model_id)
+        FROM (
+            SELECT model_id
+            FROM (
+                SELECT
+                    CASE
+                        WHEN model.type = 'text' AND model.value = 'universal-3-pro'
+                            THEN 'universal-3.5-pro'
+                        ELSE model.value
+                    END AS model_id,
+                    CAST(model.key AS integer) AS position
+                FROM json_each(apikey.permissions, '$.models') AS model
+            )
+            GROUP BY model_id
+            ORDER BY MIN(position)
+        )
+    )
+)
+WHERE CASE
+    WHEN instr(permissions, '"universal-3-pro"') = 0 THEN 0
+    WHEN NOT json_valid(permissions) THEN 0
+    WHEN json_type(permissions, '$.models') != 'array' THEN 0
+    ELSE EXISTS (
+        SELECT 1
+        FROM json_each(permissions, '$.models') AS model
+        WHERE model.type = 'text' AND model.value = 'universal-3-pro'
+    )
+END;
+UPDATE apikey
+SET permissions = json_set(
+    permissions,
+    '$.models',
+    (
+        SELECT json_group_array(model_id)
+        FROM (
+            SELECT model_id
+            FROM (
+                SELECT
+                    CASE
+                        WHEN model.type = 'text' AND model.value = 'sana'
+                            THEN 'dreamshaper'
+                        ELSE model.value
+                    END AS model_id,
+                    CAST(model.key AS integer) AS position
+                FROM json_each(apikey.permissions, '$.models') AS model
+            )
+            GROUP BY model_id
+            ORDER BY MIN(position)
+        )
+    )
+)
+WHERE CASE
+    WHEN instr(permissions, '"sana"') = 0 THEN 0
+    WHEN NOT json_valid(permissions) THEN 0
+    WHEN json_type(permissions, '$.models') != 'array' THEN 0
+    ELSE EXISTS (
+        SELECT 1
+        FROM json_each(permissions, '$.models') AS model
+        WHERE model.type = 'text' AND model.value = 'sana'
+    )
+END;
+UPDATE apikey
+SET permissions = json_set(
+    permissions,
+    '$.models',
+    (
+        SELECT json_group_array(model_id)
+        FROM (
+            SELECT model_id
+            FROM (
+                SELECT
+                    CASE
+                        WHEN model.type = 'text' AND model.value = 'grok-reasoning'
+                            THEN 'grok-large'
+                        ELSE model.value
+                    END AS model_id,
+                    CAST(model.key AS integer) AS position
+                FROM json_each(apikey.permissions, '$.models') AS model
+            )
+            GROUP BY model_id
+            ORDER BY MIN(position)
+        )
+    )
+)
+WHERE CASE
+    WHEN instr(permissions, '"grok-reasoning"') = 0 THEN 0
+    WHEN NOT json_valid(permissions) THEN 0
+    WHEN json_type(permissions, '$.models') != 'array' THEN 0
+    ELSE EXISTS (
+        SELECT 1
+        FROM json_each(permissions, '$.models') AS model
+        WHERE model.type = 'text' AND model.value = 'grok-reasoning'
+    )
+END;
+UPDATE apikey
+SET permissions = json_set(
+    permissions,
+    '$.models',
+    (
+        SELECT json_group_array(model_id)
+        FROM (
+            SELECT model_id
+            FROM (
+                SELECT
+                    CASE
+                        WHEN model.type = 'text' AND model.value = 'kimi-k2.7-code'
+                            THEN 'kimi-code'
+                        ELSE model.value
+                    END AS model_id,
+                    CAST(model.key AS integer) AS position
+                FROM json_each(apikey.permissions, '$.models') AS model
+            )
+            GROUP BY model_id
+            ORDER BY MIN(position)
+        )
+    )
+)
+WHERE CASE
+    WHEN instr(permissions, '"kimi-k2.7-code"') = 0 THEN 0
+    WHEN NOT json_valid(permissions) THEN 0
+    WHEN json_type(permissions, '$.models') != 'array' THEN 0
+    ELSE EXISTS (
+        SELECT 1
+        FROM json_each(permissions, '$.models') AS model
+        WHERE model.type = 'text' AND model.value = 'kimi-k2.7-code'
+    )
+END;
+UPDATE apikey
+SET permissions = json_set(
+    permissions,
+    '$.models',
+    (
+        SELECT json_group_array(model_id)
+        FROM (
+            SELECT model_id
+            FROM (
+                SELECT
+                    CASE
+                        WHEN model.type = 'text' AND model.value = 'nova-micro'
+                            THEN 'nova-fast'
+                        ELSE model.value
+                    END AS model_id,
+                    CAST(model.key AS integer) AS position
+                FROM json_each(apikey.permissions, '$.models') AS model
+            )
+            GROUP BY model_id
+            ORDER BY MIN(position)
+        )
+    )
+)
+WHERE CASE
+    WHEN instr(permissions, '"nova-micro"') = 0 THEN 0
+    WHEN NOT json_valid(permissions) THEN 0
+    WHEN json_type(permissions, '$.models') != 'array' THEN 0
+    ELSE EXISTS (
+        SELECT 1
+        FROM json_each(permissions, '$.models') AS model
+        WHERE model.type = 'text' AND model.value = 'nova-micro'
+    )
+END;
+UPDATE apikey
+SET permissions = json_set(
+    permissions,
+    '$.models',
+    (
+        SELECT json_group_array(model_id)
+        FROM (
+            SELECT model_id
+            FROM (
+                SELECT
+                    CASE
+                        WHEN model.type = 'text' AND model.value = 'kimi-k2.6'
+                            THEN 'kimi'
+                        ELSE model.value
+                    END AS model_id,
+                    CAST(model.key AS integer) AS position
+                FROM json_each(apikey.permissions, '$.models') AS model
+            )
+            GROUP BY model_id
+            ORDER BY MIN(position)
+        )
+    )
+)
+WHERE CASE
+    WHEN instr(permissions, '"kimi-k2.6"') = 0 THEN 0
+    WHEN NOT json_valid(permissions) THEN 0
+    WHEN json_type(permissions, '$.models') != 'array' THEN 0
+    ELSE EXISTS (
+        SELECT 1
+        FROM json_each(permissions, '$.models') AS model
+        WHERE model.type = 'text' AND model.value = 'kimi-k2.6'
+    )
+END;
+UPDATE apikey
+SET permissions = json_set(
+    permissions,
+    '$.models',
+    (
+        SELECT json_group_array(model_id)
+        FROM (
+            SELECT model_id
+            FROM (
+                SELECT
+                    CASE
+                        WHEN model.type = 'text' AND model.value = 'gemini-3.5-flash'
+                            THEN 'gemini'
+                        ELSE model.value
+                    END AS model_id,
+                    CAST(model.key AS integer) AS position
+                FROM json_each(apikey.permissions, '$.models') AS model
+            )
+            GROUP BY model_id
+            ORDER BY MIN(position)
+        )
+    )
+)
+WHERE CASE
+    WHEN instr(permissions, '"gemini-3.5-flash"') = 0 THEN 0
+    WHEN NOT json_valid(permissions) THEN 0
+    WHEN json_type(permissions, '$.models') != 'array' THEN 0
+    ELSE EXISTS (
+        SELECT 1
+        FROM json_each(permissions, '$.models') AS model
+        WHERE model.type = 'text' AND model.value = 'gemini-3.5-flash'
+    )
+END;
+UPDATE apikey
+SET permissions = json_set(
+    permissions,
+    '$.models',
+    (
+        SELECT json_group_array(model_id)
+        FROM (
+            SELECT model_id
+            FROM (
+                SELECT
+                    CASE
+                        WHEN model.type = 'text' AND model.value = 'qwen3-tts'
+                            THEN 'qwen-tts'
+                        ELSE model.value
+                    END AS model_id,
+                    CAST(model.key AS integer) AS position
+                FROM json_each(apikey.permissions, '$.models') AS model
+            )
+            GROUP BY model_id
+            ORDER BY MIN(position)
+        )
+    )
+)
+WHERE CASE
+    WHEN instr(permissions, '"qwen3-tts"') = 0 THEN 0
+    WHEN NOT json_valid(permissions) THEN 0
+    WHEN json_type(permissions, '$.models') != 'array' THEN 0
+    ELSE EXISTS (
+        SELECT 1
+        FROM json_each(permissions, '$.models') AS model
+        WHERE model.type = 'text' AND model.value = 'qwen3-tts'
+    )
+END;
+UPDATE apikey
+SET permissions = json_set(
+    permissions,
+    '$.models',
+    (
+        SELECT json_group_array(model_id)
+        FROM (
+            SELECT model_id
+            FROM (
+                SELECT
+                    CASE
+                        WHEN model.type = 'text' AND model.value = 'gpt-5.5'
+                            THEN 'openai-large'
+                        ELSE model.value
+                    END AS model_id,
+                    CAST(model.key AS integer) AS position
+                FROM json_each(apikey.permissions, '$.models') AS model
+            )
+            GROUP BY model_id
+            ORDER BY MIN(position)
+        )
+    )
+)
+WHERE CASE
+    WHEN instr(permissions, '"gpt-5.5"') = 0 THEN 0
+    WHEN NOT json_valid(permissions) THEN 0
+    WHEN json_type(permissions, '$.models') != 'array' THEN 0
+    ELSE EXISTS (
+        SELECT 1
+        FROM json_each(permissions, '$.models') AS model
+        WHERE model.type = 'text' AND model.value = 'gpt-5.5'
+    )
+END;
+UPDATE apikey
+SET permissions = json_set(
+    permissions,
+    '$.models',
+    (
+        SELECT json_group_array(model_id)
+        FROM (
+            SELECT model_id
+            FROM (
+                SELECT
+                    CASE
+                        WHEN model.type = 'text' AND model.value = 'mistral-4'
+                            THEN 'mistral'
+                        ELSE model.value
+                    END AS model_id,
+                    CAST(model.key AS integer) AS position
+                FROM json_each(apikey.permissions, '$.models') AS model
+            )
+            GROUP BY model_id
+            ORDER BY MIN(position)
+        )
+    )
+)
+WHERE CASE
+    WHEN instr(permissions, '"mistral-4"') = 0 THEN 0
+    WHEN NOT json_valid(permissions) THEN 0
+    WHEN json_type(permissions, '$.models') != 'array' THEN 0
+    ELSE EXISTS (
+        SELECT 1
+        FROM json_each(permissions, '$.models') AS model
+        WHERE model.type = 'text' AND model.value = 'mistral-4'
+    )
+END;
+UPDATE apikey
+SET permissions = json_set(
+    permissions,
+    '$.models',
+    (
+        SELECT json_group_array(model_id)
+        FROM (
+            SELECT model_id
+            FROM (
+                SELECT
+                    CASE
+                        WHEN model.type = 'text' AND model.value = 'stable-audio-2.5'
+                            THEN 'stable-audio-3-medium'
+                        ELSE model.value
+                    END AS model_id,
+                    CAST(model.key AS integer) AS position
+                FROM json_each(apikey.permissions, '$.models') AS model
+            )
+            GROUP BY model_id
+            ORDER BY MIN(position)
+        )
+    )
+)
+WHERE CASE
+    WHEN instr(permissions, '"stable-audio-2.5"') = 0 THEN 0
+    WHEN NOT json_valid(permissions) THEN 0
+    WHEN json_type(permissions, '$.models') != 'array' THEN 0
+    ELSE EXISTS (
+        SELECT 1
+        FROM json_each(permissions, '$.models') AS model
+        WHERE model.type = 'text' AND model.value = 'stable-audio-2.5'
+    )
+END;
+UPDATE apikey
+SET permissions = json_set(
+    permissions,
+    '$.models',
+    (
+        SELECT json_group_array(model_id)
+        FROM (
+            SELECT model_id
+            FROM (
+                SELECT
+                    CASE
+                        WHEN model.type = 'text' AND model.value = 'grok-4.3'
+                            THEN 'grok-large'
+                        ELSE model.value
+                    END AS model_id,
+                    CAST(model.key AS integer) AS position
+                FROM json_each(apikey.permissions, '$.models') AS model
+            )
+            GROUP BY model_id
+            ORDER BY MIN(position)
+        )
+    )
+)
+WHERE CASE
+    WHEN instr(permissions, '"grok-4.3"') = 0 THEN 0
+    WHEN NOT json_valid(permissions) THEN 0
+    WHEN json_type(permissions, '$.models') != 'array' THEN 0
+    ELSE EXISTS (
+        SELECT 1
+        FROM json_each(permissions, '$.models') AS model
+        WHERE model.type = 'text' AND model.value = 'grok-4.3'
+    )
+END;
+UPDATE apikey
+SET permissions = json_set(
+    permissions,
+    '$.models',
+    (
+        SELECT json_group_array(model_id)
+        FROM (
+            SELECT model_id
+            FROM (
+                SELECT
+                    CASE
+                        WHEN model.type = 'text' AND model.value = 'claude-opus-4.8'
+                            THEN 'claude-large'
+                        ELSE model.value
+                    END AS model_id,
+                    CAST(model.key AS integer) AS position
+                FROM json_each(apikey.permissions, '$.models') AS model
+            )
+            GROUP BY model_id
+            ORDER BY MIN(position)
+        )
+    )
+)
+WHERE CASE
+    WHEN instr(permissions, '"claude-opus-4.8"') = 0 THEN 0
+    WHEN NOT json_valid(permissions) THEN 0
+    WHEN json_type(permissions, '$.models') != 'array' THEN 0
+    ELSE EXISTS (
+        SELECT 1
+        FROM json_each(permissions, '$.models') AS model
+        WHERE model.type = 'text' AND model.value = 'claude-opus-4.8'
+    )
+END;
+UPDATE apikey
+SET permissions = json_set(
+    permissions,
+    '$.models',
+    (
+        SELECT json_group_array(model_id)
+        FROM (
+            SELECT model_id
+            FROM (
+                SELECT
+                    CASE
+                        WHEN model.type = 'text' AND model.value = 'minimax-m3'
+                            THEN 'minimax'
+                        ELSE model.value
+                    END AS model_id,
+                    CAST(model.key AS integer) AS position
+                FROM json_each(apikey.permissions, '$.models') AS model
+            )
+            GROUP BY model_id
+            ORDER BY MIN(position)
+        )
+    )
+)
+WHERE CASE
+    WHEN instr(permissions, '"minimax-m3"') = 0 THEN 0
+    WHEN NOT json_valid(permissions) THEN 0
+    WHEN json_type(permissions, '$.models') != 'array' THEN 0
+    ELSE EXISTS (
+        SELECT 1
+        FROM json_each(permissions, '$.models') AS model
+        WHERE model.type = 'text' AND model.value = 'minimax-m3'
+    )
+END;
+UPDATE apikey
+SET permissions = json_set(
+    permissions,
+    '$.models',
+    (
+        SELECT json_group_array(model_id)
+        FROM (
+            SELECT model_id
+            FROM (
+                SELECT
+                    CASE
+                        WHEN model.type = 'text' AND model.value = 'nanobanana2'
+                            THEN 'nanobanana-2'
+                        ELSE model.value
+                    END AS model_id,
+                    CAST(model.key AS integer) AS position
+                FROM json_each(apikey.permissions, '$.models') AS model
+            )
+            GROUP BY model_id
+            ORDER BY MIN(position)
+        )
+    )
+)
+WHERE CASE
+    WHEN instr(permissions, '"nanobanana2"') = 0 THEN 0
+    WHEN NOT json_valid(permissions) THEN 0
+    WHEN json_type(permissions, '$.models') != 'array' THEN 0
+    ELSE EXISTS (
+        SELECT 1
+        FROM json_each(permissions, '$.models') AS model
+        WHERE model.type = 'text' AND model.value = 'nanobanana2'
+    )
+END;
+UPDATE apikey
+SET permissions = json_set(
+    permissions,
+    '$.models',
+    (
+        SELECT json_group_array(model_id)
+        FROM (
+            SELECT model_id
+            FROM (
+                SELECT
+                    CASE
+                        WHEN model.type = 'text' AND model.value = 'deepseek-v4-pro'
+                            THEN 'deepseek-pro'
+                        ELSE model.value
+                    END AS model_id,
+                    CAST(model.key AS integer) AS position
+                FROM json_each(apikey.permissions, '$.models') AS model
+            )
+            GROUP BY model_id
+            ORDER BY MIN(position)
+        )
+    )
+)
+WHERE CASE
+    WHEN instr(permissions, '"deepseek-v4-pro"') = 0 THEN 0
+    WHEN NOT json_valid(permissions) THEN 0
+    WHEN json_type(permissions, '$.models') != 'array' THEN 0
+    ELSE EXISTS (
+        SELECT 1
+        FROM json_each(permissions, '$.models') AS model
+        WHERE model.type = 'text' AND model.value = 'deepseek-v4-pro'
+    )
+END;
+UPDATE apikey
+SET permissions = json_set(
+    permissions,
+    '$.models',
+    (
+        SELECT json_group_array(model_id)
+        FROM (
+            SELECT model_id
+            FROM (
+                SELECT
+                    CASE
+                        WHEN model.type = 'text' AND model.value = 'nemotron-3-ultra'
+                            THEN 'nemotron'
+                        ELSE model.value
+                    END AS model_id,
+                    CAST(model.key AS integer) AS position
+                FROM json_each(apikey.permissions, '$.models') AS model
+            )
+            GROUP BY model_id
+            ORDER BY MIN(position)
+        )
+    )
+)
+WHERE CASE
+    WHEN instr(permissions, '"nemotron-3-ultra"') = 0 THEN 0
+    WHEN NOT json_valid(permissions) THEN 0
+    WHEN json_type(permissions, '$.models') != 'array' THEN 0
+    ELSE EXISTS (
+        SELECT 1
+        FROM json_each(permissions, '$.models') AS model
+        WHERE model.type = 'text' AND model.value = 'nemotron-3-ultra'
+    )
+END;
+UPDATE apikey
+SET permissions = json_set(
+    permissions,
+    '$.models',
+    (
+        SELECT json_group_array(model_id)
+        FROM (
+            SELECT model_id
+            FROM (
+                SELECT
+                    CASE
+                        WHEN model.type = 'text' AND model.value = 'trellis-2-high'
+                            THEN 'trellis-2'
+                        ELSE model.value
+                    END AS model_id,
+                    CAST(model.key AS integer) AS position
+                FROM json_each(apikey.permissions, '$.models') AS model
+            )
+            GROUP BY model_id
+            ORDER BY MIN(position)
+        )
+    )
+)
+WHERE CASE
+    WHEN instr(permissions, '"trellis-2-high"') = 0 THEN 0
+    WHEN NOT json_valid(permissions) THEN 0
+    WHEN json_type(permissions, '$.models') != 'array' THEN 0
+    ELSE EXISTS (
+        SELECT 1
+        FROM json_each(permissions, '$.models') AS model
+        WHERE model.type = 'text' AND model.value = 'trellis-2-high'
+    )
+END;
+UPDATE apikey
+SET permissions = json_set(
+    permissions,
+    '$.models',
+    (
+        SELECT json_group_array(model_id)
+        FROM (
+            SELECT model_id
+            FROM (
+                SELECT
+                    CASE
+                        WHEN model.type = 'text' AND model.value = 'trellis-2-low'
+                            THEN 'trellis-2'
+                        ELSE model.value
+                    END AS model_id,
+                    CAST(model.key AS integer) AS position
+                FROM json_each(apikey.permissions, '$.models') AS model
+            )
+            GROUP BY model_id
+            ORDER BY MIN(position)
+        )
+    )
+)
+WHERE CASE
+    WHEN instr(permissions, '"trellis-2-low"') = 0 THEN 0
+    WHEN NOT json_valid(permissions) THEN 0
+    WHEN json_type(permissions, '$.models') != 'array' THEN 0
+    ELSE EXISTS (
+        SELECT 1
+        FROM json_each(permissions, '$.models') AS model
+        WHERE model.type = 'text' AND model.value = 'trellis-2-low'
+    )
+END;
+UPDATE apikey
+SET permissions = json_set(
+    permissions,
+    '$.models',
+    (
+        SELECT json_group_array(model_id)
+        FROM (
+            SELECT model_id
+            FROM (
+                SELECT
+                    CASE
+                        WHEN model.type = 'text' AND model.value = 'trellis-2-medium'
+                            THEN 'trellis-2'
+                        ELSE model.value
+                    END AS model_id,
+                    CAST(model.key AS integer) AS position
+                FROM json_each(apikey.permissions, '$.models') AS model
+            )
+            GROUP BY model_id
+            ORDER BY MIN(position)
+        )
+    )
+)
+WHERE CASE
+    WHEN instr(permissions, '"trellis-2-medium"') = 0 THEN 0
+    WHEN NOT json_valid(permissions) THEN 0
+    WHEN json_type(permissions, '$.models') != 'array' THEN 0
+    ELSE EXISTS (
+        SELECT 1
+        FROM json_each(permissions, '$.models') AS model
+        WHERE model.type = 'text' AND model.value = 'trellis-2-medium'
+    )
+END;
+UPDATE apikey
+SET permissions = json_set(
+    permissions,
+    '$.models',
+    (
+        SELECT json_group_array(model_id)
+        FROM (
+            SELECT model_id
+            FROM (
+                SELECT
+                    CASE
+                        WHEN model.type = 'text' AND model.value = 'muse-spark-1.1'
+                            THEN 'muse-spark-1.2'
+                        ELSE model.value
+                    END AS model_id,
+                    CAST(model.key AS integer) AS position
+                FROM json_each(apikey.permissions, '$.models') AS model
+            )
+            GROUP BY model_id
+            ORDER BY MIN(position)
+        )
+    )
+)
+WHERE CASE
+    WHEN instr(permissions, '"muse-spark-1.1"') = 0 THEN 0
+    WHEN NOT json_valid(permissions) THEN 0
+    WHEN json_type(permissions, '$.models') != 'array' THEN 0
+    ELSE EXISTS (
+        SELECT 1
+        FROM json_each(permissions, '$.models') AS model
+        WHERE model.type = 'text' AND model.value = 'muse-spark-1.1'
+    )
+END;
+UPDATE apikey
+SET permissions = json_set(
+    permissions,
+    '$.models',
+    (
+        SELECT json_group_array(model_id)
+        FROM (
+            SELECT model_id
+            FROM (
+                SELECT
+                    CASE
+                        WHEN model.type = 'text' AND model.value = 'grok-4.5'
+                            THEN 'grok-4.6'
+                        ELSE model.value
+                    END AS model_id,
+                    CAST(model.key AS integer) AS position
+                FROM json_each(apikey.permissions, '$.models') AS model
+            )
+            GROUP BY model_id
+            ORDER BY MIN(position)
+        )
+    )
+)
+WHERE CASE
+    WHEN instr(permissions, '"grok-4.5"') = 0 THEN 0
+    WHEN NOT json_valid(permissions) THEN 0
+    WHEN json_type(permissions, '$.models') != 'array' THEN 0
+    ELSE EXISTS (
+        SELECT 1
+        FROM json_each(permissions, '$.models') AS model
+        WHERE model.type = 'text' AND model.value = 'grok-4.5'
+    )
+END;

--- a/enter.pollinations.ai/test/canonicalize-model-permission-aliases-migration.test.ts
+++ b/enter.pollinations.ai/test/canonicalize-model-permission-aliases-migration.test.ts
@@ -47,7 +47,6 @@ const countAliasesSql = `
 
 describe("canonicalize model permission aliases migration", () => {
     it("migrates every audited alias and preserves permission data", async () => {
-        expect(migrationSql).toContain("candidate_keys AS MATERIALIZED");
         for (const alias of aliases) {
             expect(migrationSql).toContain(`instr(permissions, '"${alias}"')`);
         }
@@ -124,11 +123,23 @@ describe("canonicalize model permission aliases migration", () => {
             .first<{ count: number }>();
         expect(aliasesBefore?.count).toBe(aliasMappings.length + 3);
 
-        const migrationForTest = migrationSql.replace(
-            /\bapikey\b/g,
-            "model_alias_migration_apikey",
-        );
-        await env.DB.prepare(migrationForTest).run();
+        const migrationStatements = migrationSql
+            .replace(/\bapikey\b/g, "model_alias_migration_apikey")
+            .split(";")
+            .map((statement) => statement.trim())
+            .filter((statement) =>
+                statement
+                    .split("\n")
+                    .map((line) => line.trim())
+                    .some((line) => line !== "" && !line.startsWith("--")),
+            );
+        expect(migrationStatements).toHaveLength(aliasMappings.length);
+        const runMigration = async () => {
+            for (const statement of migrationStatements) {
+                await env.DB.prepare(statement).run();
+            }
+        };
+        await runMigration();
 
         const migratedRows = await env.DB.prepare(`
             SELECT id, permissions
@@ -193,7 +204,7 @@ describe("canonicalize model permission aliases migration", () => {
             CREATE TABLE model_alias_migration_snapshot AS
             SELECT id, permissions FROM model_alias_migration_apikey
         `).run();
-        await env.DB.prepare(migrationForTest).run();
+        await runMigration();
         const changedOnSecondRun = await env.DB.prepare(`
             SELECT count(*) AS count
             FROM model_alias_migration_apikey AS current


### PR DESCRIPTION
- Migration 0046 failed on production deploy: single whole-table UPDATE ran json_valid() on all ~153k apikey rows and exceeded D1's per-query CPU limit (error 7429), rolled back cleanly (verified: 0046 unrecorded, alias counts unchanged, no partial writes).
- Rewrites 0046 as one UPDATE per alias with an instr() prefilter inside CASE so JSON functions only run on matching rows. Semantics unchanged: array order preserved, old/new pairs deduplicated, only rows whose models array contains the alias are touched.
- Migration test now runs the statements sequentially and asserts the statement count; full suite (order, dedup, edge cases, idempotence) passes unchanged.
- Adds the D1 CPU constraint to the model-management skill.