### PR TITLE
feat: add Grok Imagine Image 2.0

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -658,6 +658,30 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptImageTokens": 0.002,
     },
   },
+  "grok-imagine-image-2.0": {
+    "cost": {
+      "completionImageTokens": 0.06,
+      "promptImageTokens": 0.01,
+    },
+    "costVariants": {
+      "low_1k": {
+        "completionImageTokens": 0.04,
+        "promptImageTokens": 0.01,
+      },
+      "low_2k": {
+        "completionImageTokens": 0.06,
+        "promptImageTokens": 0.01,
+      },
+      "medium_2k": {
+        "completionImageTokens": 0.08,
+        "promptImageTokens": 0.01,
+      },
+    },
+    "price": {
+      "completionImageTokens": 0.06,
+      "promptImageTokens": 0.01,
+    },
+  },
   "grok-imagine-pro": {
     "cost": {
       "completionImageTokens": 0.05,

--- a/enter.pollinations.ai/test/pricing-data.test.ts
+++ b/enter.pollinations.ai/test/pricing-data.test.ts
@@ -492,6 +492,21 @@ test("updated provider prices are reflected for xAI media and OpenRouter text", 
             completionImageTokens: 1,
         }).totalCost,
     ).toBeCloseTo(0.06, 8);
+    for (const [quality, resolution, expected] of [
+        ["low", "1k", 0.05],
+        ["low", "2k", 0.07],
+        ["medium", "1k", 0.07],
+        ["medium", "2k", 0.09],
+    ] as const) {
+        expect(
+            calculatePrice(
+                "grok-imagine-image-2.0",
+                { promptImageTokens: 1, completionImageTokens: 1 },
+                undefined,
+                { quality, resolution },
+            ).totalPrice,
+        ).toBeCloseTo(expected, 8);
+    }
     expect(
         calculateCost("grok-video-pro", {
             promptImageTokens: 1,

--- a/gen.pollinations.ai/src/image/createAndReturnImages.ts
+++ b/gen.pollinations.ai/src/image/createAndReturnImages.ts
@@ -16,6 +16,7 @@ import { callKreaImageAPI } from "./models/kreaModel.ts";
 import { callNovaCanvasAPI } from "./models/novaCanvasModel.ts";
 import {
     callOpenRouterGeminiImageAPI,
+    callOpenRouterGrokImagineImage2API,
     callOpenRouterGrokImagineProAPI,
     callOpenRouterRecraftVectorAPI,
     callOpenRouterSeedreamProAPI,
@@ -789,6 +790,9 @@ const generateImage = async (
 
         case "grok-imagine-pro":
             return await callOpenRouterGrokImagineProAPI(prompt, safeParams);
+
+        case "grok-imagine-image-2.0":
+            return await callOpenRouterGrokImagineImage2API(prompt, safeParams);
 
         case "recraft-v4.1-vector":
             return await callOpenRouterRecraftVectorAPI(prompt, safeParams);

--- a/gen.pollinations.ai/src/image/handler.ts
+++ b/gen.pollinations.ai/src/image/handler.ts
@@ -484,6 +484,7 @@ export async function generateImageOrVideoResponse(
     const safeParams = parseImageParams(c, body);
     c.var.track.setPricingInput({
         resolution: safeParams.resolution,
+        quality: safeParams.quality,
         hasImage: (safeParams.image?.length ?? 0) > 0,
         megapixels: (safeParams.width * safeParams.height) / 1_000_000,
     });

--- a/gen.pollinations.ai/src/image/models/openRouterImageModel.ts
+++ b/gen.pollinations.ai/src/image/models/openRouterImageModel.ts
@@ -24,6 +24,7 @@ const logError = debug("pollinations:openrouter-image:error");
 
 const OPENROUTER_IMAGE_URL = "https://openrouter.ai/api/v1/images";
 const GROK_IMAGINE_QUALITY_MODEL = "x-ai/grok-imagine-image-quality";
+const GROK_IMAGINE_IMAGE_2_MODEL = "x-ai/grok-imagine-image-2.0";
 const RECRAFT_VECTOR_MODEL = "recraft/recraft-v4.1-vector";
 const SEEDREAM_PRO_MODEL = "bytedance-seed/seedream-4.5";
 const SVG_MEDIA_TYPE = "image/svg+xml";
@@ -460,6 +461,75 @@ export async function callOpenRouterGrokImagineProAPI(
             actualModel: "grok-imagine-pro",
             usage: {
                 ...(referenceImage ? { promptImageTokens: 1 } : {}),
+                completionImageTokens: 1,
+            },
+        },
+    };
+}
+
+export async function callOpenRouterGrokImagineImage2API(
+    prompt: string,
+    safeParams: ImageParams,
+): Promise<ImageGenerationResult> {
+    if (safeParams.image.length > 3) {
+        throw new HttpError(
+            "grok-imagine-image-2.0 supports at most 3 reference images",
+            400,
+        );
+    }
+    const apiKey = requireOpenRouterImageApiKey();
+    const inputReferences = safeParams.image.map((url) => ({
+        type: "image_url",
+        image_url: { url },
+    }));
+    const requestBody: Record<string, unknown> = {
+        model: GROK_IMAGINE_IMAGE_2_MODEL,
+        prompt,
+        n: 1,
+        resolution: safeParams.resolution === "2k" ? "2K" : "1K",
+        quality: safeParams.quality,
+        provider: {
+            only: ["xai"],
+            allow_fallbacks: false,
+        },
+    };
+
+    const aspectRatio = closestAspectRatio(safeParams.width, safeParams.height);
+    if (aspectRatio) requestBody.aspect_ratio = aspectRatio;
+    if (inputReferences.length > 0) {
+        requestBody.input_references = inputReferences;
+    }
+
+    const data = await postOpenRouterImage(
+        apiKey,
+        requestBody,
+        "OpenRouter Grok Imagine Image 2.0 request failed",
+    );
+    const encodedImage = data.data?.[0]?.b64_json;
+    if (!encodedImage) {
+        throw new HttpError(
+            "OpenRouter image API returned no image",
+            502,
+            data,
+            OPENROUTER_IMAGE_URL,
+        );
+    }
+
+    logOps("Grok Imagine Image 2.0 generation complete", {
+        referenceImages: inputReferences.length,
+        providerCost: data.usage?.cost,
+    });
+
+    return {
+        buffer: base64ToBuffer(encodedImage),
+        isMature: false,
+        isChild: false,
+        trackingData: {
+            actualModel: "grok-imagine-image-2.0",
+            usage: {
+                ...(inputReferences.length > 0
+                    ? { promptImageTokens: inputReferences.length }
+                    : {}),
                 completionImageTokens: 1,
             },
         },

--- a/gen.pollinations.ai/src/image/models/openRouterImageModel.ts
+++ b/gen.pollinations.ai/src/image/models/openRouterImageModel.ts
@@ -507,12 +507,7 @@ export async function callOpenRouterGrokImagineImage2API(
     );
     const encodedImage = data.data?.[0]?.b64_json;
     if (!encodedImage) {
-        throw new HttpError(
-            "OpenRouter image API returned no image",
-            502,
-            data,
-            OPENROUTER_IMAGE_URL,
-        );
+        throw buildOpenRouterNoImageError(data);
     }
 
     logOps("Grok Imagine Image 2.0 generation complete", {

--- a/gen.pollinations.ai/src/image/models/seedanceReplicateVideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/seedanceReplicateVideoModel.ts
@@ -135,7 +135,11 @@ async function generateSeedanceVideo(
     const input: SeedanceInput = {
         prompt,
         duration,
-        resolution: safeParams.resolution ?? "720p",
+        resolution:
+            safeParams.resolution === "480p" ||
+            safeParams.resolution === "1080p"
+                ? safeParams.resolution
+                : "720p",
         aspect_ratio: resolveSeedanceAspectRatio(safeParams),
         fps: 24,
         camera_fixed: false,

--- a/gen.pollinations.ai/src/image/params.ts
+++ b/gen.pollinations.ai/src/image/params.ts
@@ -58,7 +58,7 @@ export const ImageParamsSchema = z
         seed: sanitizedSeed,
         model: z.enum(allowedModels),
         safe: sanitizedBoolean.catch(false),
-        quality: z.literal(validQualities).catch("medium"),
+        quality: z.string().catch("medium"),
         image: z
             .union([z.array(z.string()), z.string(), z.null(), z.undefined()])
             .transform((value?: string[] | string | null) => {
@@ -147,8 +147,13 @@ export const ImageParamsSchema = z
             data.width,
             data.height,
         );
+        const quality = validQualities.includes(
+            data.quality as (typeof validQualities)[number],
+        )
+            ? (data.quality as (typeof validQualities)[number])
+            : "medium";
 
-        return { ...data, width, height, dimensionsExplicit };
+        return { ...data, quality, width, height, dimensionsExplicit };
     });
 
 export type ImageParams = z.infer<typeof ImageParamsSchema>;

--- a/gen.pollinations.ai/src/image/params.ts
+++ b/gen.pollinations.ai/src/image/params.ts
@@ -86,7 +86,7 @@ export const ImageParamsSchema = z
         // Video-specific parameters - pass through to backend, let provider validate
         duration: z.coerce.number().optional(),
         fps: z.coerce.number().optional(),
-        resolution: z.enum(["480p", "720p", "1080p"]).optional(),
+        resolution: z.enum(["1k", "2k", "480p", "720p", "1080p"]).optional(),
         aspectRatio: z
             .enum([
                 "16:9",
@@ -121,6 +121,17 @@ export const ImageParamsSchema = z
                 path: ["transparent"],
                 message:
                     "Transparent backgrounds are not supported by gpt-image-2.",
+            });
+        }
+        if (
+            data.model === "grok-imagine-image-2.0" &&
+            !["low", "medium"].includes(data.quality)
+        ) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: ["quality"],
+                message:
+                    "grok-imagine-image-2.0 supports low or medium quality.",
             });
         }
     })

--- a/gen.pollinations.ai/src/routes/images.ts
+++ b/gen.pollinations.ai/src/routes/images.ts
@@ -186,6 +186,9 @@ async function parseEditInput(c: Context): Promise<{
                 ...(formData.has("safe")
                     ? { safe: formData.get("safe") as string }
                     : {}),
+                ...(formData.has("resolution")
+                    ? { resolution: formData.get("resolution") as string }
+                    : {}),
             },
         };
     }
@@ -208,7 +211,7 @@ async function parseEditInput(c: Context): Promise<{
             message: "Missing required field: image",
         });
 
-    const extra = collectPassthrough(body, "seed");
+    const extra = collectPassthrough(body, "seed", "resolution");
     const { seed, ...passthrough } = extra as { seed?: number } & Record<
         string,
         unknown

--- a/gen.pollinations.ai/src/schemas/image.ts
+++ b/gen.pollinations.ai/src/schemas/image.ts
@@ -57,7 +57,7 @@ const GenerateImageRequestQueryParamsBaseSchema = z.object({
         .default("medium")
         .meta({
             description:
-                "Image quality level. Only supported by `gptimage`, `gptimage-large`, and `gpt-image-2`.",
+                "Image quality level. Supported by `gptimage`, `gptimage-large`, `gpt-image-2`, and `grok-imagine-image-2.0`.",
         }),
     image: z
         .string()
@@ -92,9 +92,9 @@ const GenerateImageRequestQueryParamsBaseSchema = z.object({
     }),
 
     // Video-specific params
-    resolution: z.enum(["480p", "720p", "1080p"]).optional().meta({
+    resolution: z.enum(["1k", "2k", "480p", "720p", "1080p"]).optional().meta({
         description:
-            "Output resolution for video models that advertise `resolutions` in `/models`. The first advertised resolution is the default; requested tiers bill at their listed rate.",
+            "Output resolution for image and video models that advertise `resolutions` in `/models`. The first advertised resolution is the default; requested tiers bill at their listed rate.",
     }),
     duration: z.coerce.number().int().min(1).max(120).optional().meta({
         description:

--- a/gen.pollinations.ai/test/image/costVariants-e2e.test.ts
+++ b/gen.pollinations.ai/test/image/costVariants-e2e.test.ts
@@ -26,8 +26,32 @@ type ReplicateCall = {
 
 function createBillingVariantMocks() {
     const replicateState: { calls: ReplicateCall[] } = { calls: [] };
+    const openRouterState: { calls: Record<string, unknown>[] } = { calls: [] };
     return createFetchMock({
         tinybird: createMockTinybird(),
+        openrouter: {
+            state: openRouterState,
+            handlerMap: {
+                "openrouter.ai": async (request: Request) => {
+                    openRouterState.calls.push(
+                        (await request.json()) as Record<string, unknown>,
+                    );
+                    return Response.json({
+                        data: [
+                            {
+                                b64_json:
+                                    Buffer.from(PNG_BYTES).toString("base64"),
+                                media_type: "image/png",
+                            },
+                        ],
+                        usage: { cost: 0.06 },
+                    });
+                },
+            },
+            reset: () => {
+                openRouterState.calls = [];
+            },
+        },
         replicate: {
             state: replicateState,
             handlerMap: {
@@ -107,11 +131,15 @@ afterEach(async () => {
     await teardownFetchMock();
 });
 
-async function generate(path: string, apiKey: string) {
+async function generate(path: string, apiKey: string, init?: RequestInit) {
     const ctx = createExecutionContext();
     const response = await worker.fetch(
         new Request(`https://gen.pollinations.ai${path}`, {
-            headers: { authorization: `Bearer ${apiKey}` },
+            ...init,
+            headers: {
+                ...init?.headers,
+                authorization: `Bearer ${apiKey}`,
+            },
         }),
         withInlineGenerationCoordinator(env),
         ctx,
@@ -189,5 +217,56 @@ test("p-video sends the selected resolution upstream and bills its variant", asy
         tokenPriceCompletionVideoSeconds: 0.04,
         totalCost: 0.2,
         totalPrice: 0.2,
+    });
+});
+
+test("Grok Imagine Image 2.0 forwards and bills its quality-resolution tier", async ({
+    paidApiKey,
+    mocks,
+}) => {
+    await mocks.enable("tinybird", "openrouter");
+    syncImageEnv(
+        { OPENROUTER_API_KEY: "openrouter-test-key" } as CloudflareBindings,
+        ["OPENROUTER_API_KEY"],
+    );
+
+    await generate("/v1/images/edits", paidApiKey, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+            model: "grok-imagine-image-2.0",
+            prompt: "billing-grok-image-2",
+            image: INPUT_IMAGE_URL,
+            quality: "low",
+            resolution: "2k",
+            seed: 104,
+        }),
+    });
+
+    expect(mocks.openrouter.state.calls).toEqual([
+        expect.objectContaining({
+            model: "x-ai/grok-imagine-image-2.0",
+            quality: "low",
+            resolution: "2K",
+            provider: { only: ["xai"], allow_fallbacks: false },
+            input_references: [
+                {
+                    type: "image_url",
+                    image_url: { url: INPUT_IMAGE_URL },
+                },
+            ],
+        }),
+    ]);
+    expect(mocks.tinybird.state.events).toHaveLength(1);
+    expect(mocks.tinybird.state.events[0]).toMatchObject({
+        modelRequested: "grok-imagine-image-2.0",
+        modelUsed: "grok-imagine-image-2.0",
+        costVariant: "low_2k",
+        tokenCountPromptImage: 1,
+        tokenPricePromptImage: 0.01,
+        tokenCountCompletionImage: 1,
+        tokenPriceCompletionImage: 0.06,
+        totalCost: expect.closeTo(0.07, 8),
+        totalPrice: 0.07,
     });
 });

--- a/gen.pollinations.ai/test/image/openRouterImageModel.test.ts
+++ b/gen.pollinations.ai/test/image/openRouterImageModel.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { syncImageEnv } from "../../src/image/env.ts";
 import {
     callOpenRouterGeminiImageAPI,
+    callOpenRouterGrokImagineImage2API,
     callOpenRouterGrokImagineProAPI,
     callOpenRouterRecraftVectorAPI,
     callOpenRouterSeedreamProAPI,
@@ -150,6 +151,84 @@ describe("OpenRouter Grok Imagine Pro", () => {
         ).rejects.toMatchObject({
             status: 502,
             upstreamUrl: OPENROUTER_IMAGE_URL,
+        });
+    });
+});
+
+describe("OpenRouter Grok Imagine Image 2.0", () => {
+    it.each([
+        ["low", undefined, "1K"],
+        ["low", "2k", "2K"],
+        ["medium", undefined, "1K"],
+        ["medium", "2k", "2K"],
+    ] as const)("forwards %s quality at %s resolution", async (quality, resolution, expectedResolution) => {
+        syncImageEnv(
+            {
+                OPENROUTER_API_KEY: "openrouter-test-key",
+            } as CloudflareBindings,
+            ["OPENROUTER_API_KEY"],
+        );
+        const requests: Record<string, unknown>[] = [];
+        mockOpenRouterFetch(requests);
+
+        const result = await callOpenRouterGrokImagineImage2API("test prompt", {
+            ...baseParams,
+            model: "grok-imagine-image-2.0",
+            quality,
+            resolution,
+            image: [
+                "https://example.com/one.png",
+                "https://example.com/two.png",
+                "https://example.com/three.png",
+            ],
+        });
+
+        expect(requests[0]).toEqual({
+            model: "x-ai/grok-imagine-image-2.0",
+            prompt: "test prompt",
+            n: 1,
+            resolution: expectedResolution,
+            quality,
+            provider: {
+                only: ["xai"],
+                allow_fallbacks: false,
+            },
+            aspect_ratio: "1:1",
+            input_references: [
+                {
+                    type: "image_url",
+                    image_url: { url: "https://example.com/one.png" },
+                },
+                {
+                    type: "image_url",
+                    image_url: { url: "https://example.com/two.png" },
+                },
+                {
+                    type: "image_url",
+                    image_url: { url: "https://example.com/three.png" },
+                },
+            ],
+        });
+        expect(result.trackingData).toEqual({
+            actualModel: "grok-imagine-image-2.0",
+            usage: {
+                promptImageTokens: 3,
+                completionImageTokens: 1,
+            },
+        });
+    });
+
+    it("rejects more than three reference images", async () => {
+        await expect(
+            callOpenRouterGrokImagineImage2API("test prompt", {
+                ...baseParams,
+                model: "grok-imagine-image-2.0",
+                image: ["one", "two", "three", "four"],
+            }),
+        ).rejects.toMatchObject({
+            status: 400,
+            message:
+                "grok-imagine-image-2.0 supports at most 3 reference images",
         });
     });
 });

--- a/gen.pollinations.ai/test/image/openRouterImageModel.test.ts
+++ b/gen.pollinations.ai/test/image/openRouterImageModel.test.ts
@@ -231,6 +231,32 @@ describe("OpenRouter Grok Imagine Image 2.0", () => {
                 "grok-imagine-image-2.0 supports at most 3 reference images",
         });
     });
+
+    it("returns content-policy refusals as client errors", async () => {
+        syncImageEnv(
+            { OPENROUTER_API_KEY: "openrouter-test-key" } as CloudflareBindings,
+            ["OPENROUTER_API_KEY"],
+        );
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+            Response.json({
+                data: [],
+                error: {
+                    message: "Request refused by content policy",
+                    metadata: { error_type: "content_policy_violation" },
+                },
+            }),
+        );
+
+        await expect(
+            callOpenRouterGrokImagineImage2API("test prompt", {
+                ...baseParams,
+                model: "grok-imagine-image-2.0",
+            }),
+        ).rejects.toMatchObject({
+            status: 400,
+            message: "Request refused by content policy",
+        });
+    });
 });
 
 const geminiUsage = {

--- a/gen.pollinations.ai/test/image/params.test.ts
+++ b/gen.pollinations.ai/test/image/params.test.ts
@@ -48,6 +48,29 @@ describe("ImageParamsSchema", () => {
                 resolution: "480p",
             }).success,
         ).toBe(true);
+        expect(
+            ImageParamsSchema.safeParse({
+                model: "grok-imagine-image-2.0",
+                resolution: "2k",
+                quality: "low",
+            }).success,
+        ).toBe(true);
+    });
+
+    it("rejects unsupported Grok Imagine Image 2.0 quality", () => {
+        const result = ImageParamsSchema.safeParse({
+            model: "grok-imagine-image-2.0",
+            quality: "high",
+        });
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+            expect(result.error.issues[0]).toMatchObject({
+                path: ["quality"],
+                message:
+                    "grok-imagine-image-2.0 supports low or medium quality.",
+            });
+        }
     });
 
     it("rejects an unsupported resolution", () => {

--- a/gen.pollinations.ai/test/image/params.test.ts
+++ b/gen.pollinations.ai/test/image/params.test.ts
@@ -73,6 +73,18 @@ describe("ImageParamsSchema", () => {
         }
     });
 
+    it("does not silently upgrade invalid Grok Imagine Image 2.0 quality", () => {
+        expect(
+            ImageParamsSchema.safeParse({
+                model: "grok-imagine-image-2.0",
+                quality: "LOW",
+            }).success,
+        ).toBe(false);
+        expect(
+            ImageParamsSchema.parse({ model: "flux", quality: "LOW" }).quality,
+        ).toBe("medium");
+    });
+
     it("rejects an unsupported resolution", () => {
         const result = ImageParamsSchema.safeParse({
             model: "veo",

--- a/shared/registry/cost-variants.ts
+++ b/shared/registry/cost-variants.ts
@@ -17,6 +17,7 @@ import type {
 // live model prices on it.
 export type PricingInput = {
     resolution?: string;
+    quality?: string;
     hasImage?: boolean;
     megapixels?: number;
     searchContextSize?: "low" | "high";

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -833,6 +833,64 @@ export const IMAGE_SERVICES = {
         outputModalities: ["image"],
         maxReferenceImages: 1, // OpenRouter image edit route forwards one input image.
     },
+    "grok-imagine-image-2.0": {
+        aliases: [],
+        provider: "openrouter",
+        brand: "xAI",
+        category: "image",
+        addedDate: new Date("2026-08-14").getTime(),
+        priceMultiplier: 1,
+        paidOnly: true,
+        // OpenRouter x-ai/grok-imagine-image-2.0 pricing, verified 2026-08-14.
+        cost: {
+            promptImageTokens: 0.01,
+            completionImageTokens: 0.06, // medium, 1K
+        },
+        ...defineCostVariants(
+            {
+                low_1k: {
+                    promptImageTokens: 0.01,
+                    completionImageTokens: 0.04,
+                },
+                low_2k: {
+                    promptImageTokens: 0.01,
+                    completionImageTokens: 0.06,
+                },
+                medium_2k: {
+                    promptImageTokens: 0.01,
+                    completionImageTokens: 0.08,
+                },
+            },
+            ({ input }) => {
+                if (input?.quality === "low") {
+                    return input.resolution === "2k" ? "low_2k" : "low_1k";
+                }
+                return input?.resolution === "2k" ? "medium_2k" : undefined;
+            },
+            {
+                low_1k: {
+                    label: "Low · 1K",
+                    description: "Applies to low-quality 1K requests.",
+                },
+                low_2k: {
+                    label: "Low · 2K",
+                    description: "Applies to low-quality 2K requests.",
+                },
+                medium_2k: {
+                    label: "Medium · 2K",
+                    description: "Applies to medium-quality 2K requests.",
+                },
+            },
+            "Medium · 1K",
+        ),
+        resolutions: ["1k", "2k"],
+        title: "Grok Imagine Image 2.0",
+        description:
+            "Creates and edits high-detail images at 1K or 2K with up to three references",
+        inputModalities: ["text", "image"],
+        outputModalities: ["image"],
+        maxReferenceImages: 3,
+    },
     "recraft-v4.1-vector": {
         aliases: ["recraft-vector", "recraft-svg", "recraft-v4.1-svg"],
         provider: "openrouter",

--- a/shared/schemas/openai.ts
+++ b/shared/schemas/openai.ts
@@ -565,6 +565,13 @@ const imageQualityField = z
         description:
             "Image quality. OpenAI 'standard'/'hd' mapped to Pollinations equivalents",
     });
+const imageResolutionField = z
+    .enum(["1k", "2k", "480p", "720p", "1080p"])
+    .optional()
+    .meta({
+        description:
+            "Output resolution for resolution-priced image and video models (Pollinations extension)",
+    });
 
 export const CreateImageRequestSchema = z
     .object({
@@ -593,10 +600,7 @@ export const CreateImageRequestSchema = z
                 description:
                     "Reference image URL(s) for image-to-image generation (Pollinations extension)",
             }),
-        resolution: z.enum(["480p", "720p", "1080p"]).optional().meta({
-            description:
-                "Output resolution for resolution-priced video models (Pollinations extension)",
-        }),
+        resolution: imageResolutionField,
         safe: SafeSchema,
     })
     .passthrough() // Allow Pollinations extensions: seed, safe, etc.
@@ -658,6 +662,7 @@ export const CreateImageEditRequestSchema = z
         n: imageNField,
         size: imageSizeField,
         quality: imageQualityField,
+        resolution: imageResolutionField,
         safe: SafeSchema,
     })
     .passthrough()


### PR DESCRIPTION
- Adds `grok-imagine-image-2.0` as a new paid-only model; no aliases and no changes to existing Grok image models.
- Routes the exact `x-ai/grok-imagine-image-2.0` ID through OpenRouter, pinned to xAI with provider fallback disabled.
- Supports low/medium quality, 1K/2K output, and up to three reference images across simple, OpenAI JSON, and multipart routes.
- Bills OpenRouter's exact output tiers ($0.04/$0.06/$0.06/$0.08) plus $0.01 per input image using request-selected cost variants.
- Widens the shared resolution schema for 1K/2K while retaining per-model validation; the adjacent Seedance edit is type-only.
- Verified direct provider calls and full local E2E: every tier, editing via `media.pollinations.ai`, `b64_json`/URL formats, permissions, billing, caching, validation errors, and concurrent burst. All measured generations finished within 67 seconds. Gen: 111 focused/invariant tests + typecheck. Enter: 81 pricing/invariant tests + typecheck.