### PR TITLE
fix: request reasoning summaries from Azure Responses API

### DIFF
--- a/gen.pollinations.ai/src/text/azureResponsesClient.ts
+++ b/gen.pollinations.ai/src/text/azureResponsesClient.ts
@@ -186,7 +186,7 @@ function buildBody(messages: ChatMessage[], options: TransformOptions): Json {
         typeof options.reasoning_effort === "string" &&
         REASONING_EFFORTS.has(options.reasoning_effort)
     ) {
-        body.reasoning = { effort: options.reasoning_effort };
+        body.reasoning = { effort: options.reasoning_effort, summary: "auto" };
     }
     if (Array.isArray(options.tools) && options.tools.length) {
         body.tools = options.tools.flatMap((raw) => {

--- a/gen.pollinations.ai/test/text/azureResponsesClient.test.ts
+++ b/gen.pollinations.ai/test/text/azureResponsesClient.test.ts
@@ -207,7 +207,10 @@ describe("callAzureResponses", () => {
                 },
             ],
         });
-        expect(bodies[1].reasoning).toEqual({ effort: "none" });
+        expect(bodies[1].reasoning).toEqual({
+            effort: "none",
+            summary: "auto",
+        });
     });
 
     it("maps output, tool calls, finish reason, and every billable usage field", async () => {


### PR DESCRIPTION
## Summary

- body.reasoning previously set only effort, so Azure Responses did not generate reasoning-summary text even though the model produced billed reasoning tokens.
- Adds summary: auto to the reasoning request field so the existing streaming and non-streaming relay can expose the summary as reasoning_content.
- Current Microsoft Azure documentation supports auto for GPT-5 reasoning summaries. GPT-5 models do not support concise, so auto is intentional and no fallback is needed.
- Enabling summaries can add output tokens and latency for callers that explicitly set reasoning_effort.

## Validation

- npx vitest run test/text/azureResponsesClient.test.ts — 12/12 passed
- npm run typecheck — passed
- npx biome check on both changed files — passed
- GitHub checks — passed