### PR TITLE
feat: add Qwen3.8 2.4T A95B

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -1524,6 +1524,18 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.000001475,
     },
   },
+  "qwen3.8-2.4t-a95b": {
+    "cost": {
+      "completionTextTokens": 0.000006,
+      "promptCachedTokens": 0.00000025,
+      "promptTextTokens": 0.000002,
+    },
+    "price": {
+      "completionTextTokens": 0.000006,
+      "promptCachedTokens": 0.00000025,
+      "promptTextTokens": 0.000002,
+    },
+  },
   "qwen3.8-max": {
     "cost": {
       "completionTextTokens": 0.000006,

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -124,6 +124,11 @@ const models: ModelDefinition[] = [
         config: portkeyConfig["qwen/qwen3.7-max"],
     },
     {
+        name: "qwen3.8-2.4t-a95b",
+        config: portkeyConfig["accounts/fireworks/models/qwen3p8-2p4t-a95b"],
+        transform: pipe(stripCacheControl, fireworksThinking),
+    },
+    {
         name: "qwen3.8-max",
         config: portkeyConfig["qwen/qwen3.8-max"],
     },

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -277,6 +277,10 @@ export const portkeyConfig: PortkeyConfigMap = {
         createFireworksModelConfig({
             model: "accounts/fireworks/models/kimi-k3",
         }),
+    "accounts/fireworks/models/qwen3p8-2p4t-a95b": () =>
+        createFireworksModelConfig({
+            model: "accounts/fireworks/models/qwen3p8-2p4t-a95b",
+        }),
 
     // -- OpenRouter (Mistral Small 3.2, Mistral Small 4) ---------------------
     // Moved off Azure: Mistral Small was Marketplace SaaS pass-through on

--- a/gen.pollinations.ai/test/text/transforms/createReasoningEffortTransform.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/createReasoningEffortTransform.test.ts
@@ -87,6 +87,7 @@ describe("reasoning_effort model wiring", () => {
         "deepseek",
         "qwen-large",
         "qwen3.7-flash",
+        "qwen3.8-2.4t-a95b",
         "longcat",
         "nemotron",
         "minimax",

--- a/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
+++ b/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
@@ -137,6 +137,21 @@ describe("resolveModelConfig", () => {
         });
     });
 
+    it("routes Qwen3.8 2.4T A95B directly to Fireworks", () => {
+        const result = resolveModelConfig(messages, {
+            model: "qwen3.8-2.4t-a95b",
+        });
+
+        expect(result.options.model).toBe(
+            "accounts/fireworks/models/qwen3p8-2p4t-a95b",
+        );
+        expect(result.options.modelConfig).toMatchObject({
+            provider: "openai",
+            "custom-host": "https://api.fireworks.ai/inference/v1",
+        });
+        expect(result.options.provider).toBeUndefined();
+    });
+
     it("routes Kimi K3 directly to Fireworks without fallback", () => {
         const result = resolveModelConfig(messages, { model: "kimi-k3" });
 

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -1848,6 +1848,30 @@ export const TEXT_SERVICES = {
         contextLength: 1000000,
         isSpecialized: false,
     },
+    "qwen3.8-2.4t-a95b": {
+        aliases: [],
+        provider: "fireworks",
+        brand: "Qwen",
+        category: "text",
+        addedDate: new Date("2026-08-14").getTime(),
+        paidOnly: false,
+        priceMultiplier: 1,
+        cost: {
+            // Fireworks accounts/fireworks/models/qwen3p8-2p4t-a95b rates (2026-08-14).
+            promptTextTokens: perMillion(2),
+            promptCachedTokens: perMillion(0.25),
+            completionTextTokens: perMillion(6),
+        },
+        title: "Qwen3.8 2.4T A95B",
+        description:
+            "Open-weight sparse frontier reasoning for long-horizon coding and autonomous agents",
+        inputModalities: ["text"],
+        outputModalities: ["text"],
+        tools: true,
+        reasoning: true,
+        contextLength: 262144,
+        isSpecialized: false,
+    },
     "qwen3.8-max": {
         aliases: [],
         provider: "openrouter",


### PR DESCRIPTION
- Adds `qwen3.8-2.4t-a95b` as a distinct text-only model through Fireworks route `accounts/fireworks/models/qwen3p8-2p4t-a95b`.
- Keeps `qwen3.8-max` unchanged; adds no aliases, provider fallback, or Pollinations GPU route.
- Sets Quest-Pollen access (`paidOnly: false`), multiplier `1`, and Fireworks rates: $2/M input, $0.25/M cached input, $6/M output.
- Supports tools, reasoning controls, streaming, and 262K context.

Verification:
- Direct Fireworks: basic, tools, reasoning off, streaming, cache read, and 5-request burst.
- Local authenticated E2E: `/v1/models`, basic/tools/reasoning/streaming, output cache, auth, invalid model, malformed request, and 5-request burst.
- Tinybird billing reconciled exact uncached, cached, and completion token rates with `total_cost == total_price`.
- Focused resolver/reasoning/permissions/catalog/pricing tests and both service typechecks pass.

Pricing source: https://fireworks.ai/models/fireworks/qwen3p8-max
