### PR TITLE
chore: sync main into production

### DIFF
--- a/APIDOCS.md
+++ b/APIDOCS.md
@@ -237,7 +237,7 @@ Each upload gets its own unique id — re-uploading the same bytes yields a new 
 
 - **Use `pk_` keys in browsers.** Anywhere a `sk_` key could be read off the wire, use a publishable key with a tight budget and an allow-list of models.
 - **One key per app.** Child keys scope budget and permissions independently — easier to audit, easier to revoke without touching production.
-- **Image/audio `GET` URLs are cache-friendly.** They're idempotent on `(prompt, model, seed)` — cache them on a CDN if you serve the same generations to many users.
+- **Retry the same request after a timeout.** Keep the endpoint, body, query parameters, and seed unchanged. Your retry waits for the generation already in progress or receives the completed cached result instead of starting another generation.
 - **Watch `429` and `503`.** A `Retry-After` header tells you how long to back off. `502` from us means upstream provider — usually transient.
 
 ## 🛠️ Endpoints
@@ -273,7 +273,9 @@ Supports streaming, function calling, vision (image input), structured outputs, 
 | `stream` | `boolean` \| `null` | default: `false` |
 | `stream_options` | `object` \| `null` | — |
 | `safe` | `string` \| `boolean` | Safety features: comma-separated list of privacy, secrets, sexual, violence, shield, true, nsfw. true enables privacy,secrets; nsfw enables sexual,violence. Also accepted in the Pollinations-Safe header. Defaults to off; false and 0 are accepted as off. |
-| `reasoning_effort` | enum (6) — `"none"`, `"minimal"`, `"low"`, … | Requests reasoning depth for models that support adjustable reasoning. "none" requests no reasoning. |
+| `reasoning_effort` | enum (7) — `"none"`, `"minimal"`, `"low"`, … | Requests reasoning depth for models that support adjustable reasoning. "none" requests no reasoning. |
+| `web_search_options` | `object` | Controls Perplexity Sonar search context. Pollinations currently supports low and high. |
+| `web_search_options.search_context_size` * | `"low"` \| `"medium"` \| `"high"` | — |
 | `temperature` | `number` \| `null` | — |
 | `top_p` | `number` \| `null` | — |
 | `tools` | `object`[] | — |
@@ -373,7 +375,9 @@ Use `/v1/chat/completions` when you need the full OpenAI-compatible JSON respons
 | `stream` | `boolean` \| `null` | default: `false` |
 | `stream_options` | `object` \| `null` | — |
 | `safe` | `string` \| `boolean` | Safety features: comma-separated list of privacy, secrets, sexual, violence, shield, true, nsfw. true enables privacy,secrets; nsfw enables sexual,violence. Also accepted in the Pollinations-Safe header. Defaults to off; false and 0 are accepted as off. |
-| `reasoning_effort` | enum (6) — `"none"`, `"minimal"`, `"low"`, … | Requests reasoning depth for models that support adjustable reasoning. "none" requests no reasoning. |
+| `reasoning_effort` | enum (7) — `"none"`, `"minimal"`, `"low"`, … | Requests reasoning depth for models that support adjustable reasoning. "none" requests no reasoning. |
+| `web_search_options` | `object` | Controls Perplexity Sonar search context. Pollinations currently supports low and high. |
+| `web_search_options.search_context_size` * | `"low"` \| `"medium"` \| `"high"` | — |
 | `temperature` | `number` \| `null` | — |
 | `top_p` | `number` \| `null` | — |
 | `tools` | `object`[] | — |
@@ -413,7 +417,7 @@ This is a simplified alternative to the OpenAI-compatible `/v1/chat/completions`
 |---|---|---|---|
 | `prompt` * | `path` | `string` | Text prompt for generation |
 | `model` | `query` | `string` | Text model to use. See /v1/models or /text/models for the full list of available models. · default: `"openai"` |
-| `seed` | `query` | `integer` | Seed for reproducible results. Use -1 for random. · default: `0` · min: `-1` |
+| `seed` | `query` | `integer` | Seed for reproducible results. · default: `0` · min: `-1` |
 | `system` | `query` | `string` | System prompt to set the model's behavior and context. Acts as initial instructions before the user prompt. |
 | `json` | `query` | `boolean` | When true, the model returns valid JSON. Useful for structured data extraction. |
 | `temperature` | `query` | `number` | Controls randomness. Lower values (e.g. 0.2) produce more focused output, higher values (e.g. 1.5) produce more creative output. Range: 0.0 to 2.0. |
@@ -437,7 +441,7 @@ curl "https://gen.pollinations.ai/text/Write%20a%20haiku%20about%20coding?model=
 
 Generate an image from a text prompt. Returns JPEG, PNG, or SVG depending on the selected model.
 
-**Available models:** `sana`, `kontext`, `nanobanana`, `nanobanana-2`, `nanobanana-2-lite`, `nanobanana-pro`, `seedream5`, `seedream5-pro`, `seedream`, `seedream-pro`, `ideogram-v4-turbo`, `ideogram-v4-balanced`, `ideogram-v4-quality`, `gptimage`, `gptimage-large`, `gpt-image-2`, `flux`, `zimage`, `wan-image`, `wan-image-pro`, `qwen-image`, `grok-imagine`, `grok-imagine-pro`, `recraft-v4.1-vector`, `klein`, `p-image`, `p-image-edit`, `nova-canvas`. `zimage` is the default.
+**Available models:** `krea`, `dreamshaper`, `kontext`, `nanobanana`, `nanobanana-2`, `nanobanana-2-lite`, `nanobanana-pro`, `seedream5`, `seedream5-pro`, `seedream`, `seedream-pro`, `ideogram-v4-turbo`, `ideogram-v4-balanced`, `ideogram-v4-quality`, `gptimage`, `gptimage-large`, `gpt-image-2`, `flux`, `zimage`, `zimage-fal`, `wan-image`, `wan-image-pro`, `qwen-image`, `qwen-image-3`, `grok-imagine`, `grok-imagine-pro`, `grok-imagine-image-2.0`, `recraft-v4.1-vector`, `klein`, `p-image`, `p-image-edit`, `nova-canvas`. `zimage` is the default.
 
 Browse all available models and their capabilities at [`/image/models`](https://gen.pollinations.ai/image/models).
 
@@ -446,14 +450,15 @@ Browse all available models and their capabilities at [`/image/models`](https://
 | Param | In | Type | Description |
 |---|---|---|---|
 | `prompt` * | `path` | `string` | Text description of the image to generate |
-| `model` * | `query` | `string` | Model to use. **Image:** flux, zimage, gptimage, kontext, seedream5, seedream5-pro, nanobanana, nanobanana-pro, klein. **Video:** veo, veo-1080p, seedance, seedance-pro, wan, nova-reel. See /image/models for full list. · default: `"zimage"` |
-| `width` | `query` | `integer` | Width in pixels. For images, exact pixels. For video models, used for aspect ratio and, unless the model name fixes a tier, mapped to the nearest resolution. · default: `1024` |
-| `height` | `query` | `integer` | Height in pixels. For images, exact pixels. For video models, used for aspect ratio and, unless the model name fixes a tier, mapped to the nearest resolution. · default: `1024` |
-| `seed` | `query` | `integer` | Seed for reproducible results. Use -1 for random. Supported by: flux, zimage, seedream, klein, seedance, nova-reel. Other models ignore this parameter. · default: `0` · range: `-1…2147483647` |
+| `model` * | `query` | `string` | Model to use. **Image:** flux, zimage, gptimage, kontext, seedream5, seedream5-pro, nanobanana, nanobanana-pro, klein. **Video:** veo, seedance-pro, wan, wan-pro, p-video, nova-reel. See /image/models for full list. · default: `"zimage"` |
+| `width` | `query` | `integer` | Width in pixels. For images, exact pixels. For video models, used for aspect ratio; use `resolution` to select a resolution tier. · default: `1024` |
+| `height` | `query` | `integer` | Height in pixels. For images, exact pixels. For video models, used for aspect ratio; use `resolution` to select a resolution tier. · default: `1024` |
+| `seed` | `query` | `integer` | Seed for reproducible results. Supported by: flux, zimage, seedream, klein, seedance, nova-reel. Other models ignore this parameter. · default: `0` · range: `-1…2147483647` |
 | `safe` | `query` | `string` \| `boolean` | Safety features: comma-separated list of privacy, secrets, sexual, violence, shield, true, nsfw. true enables privacy,secrets; nsfw enables sexual,violence. Also accepted in the Pollinations-Safe header. Defaults to off; false and 0 are accepted as off. |
-| `quality` | `query` | `"low"` \| `"medium"` \| `"high"` \| `"hd"` | Image quality level. Only supported by `gptimage`, `gptimage-large`, and `gpt-image-2`. · default: `"medium"` |
-| `image` | `query` | `string` | Reference image URL(s) for image editing or video generation. Separate multiple URLs with `\|` or `,`. **Image models:** Used for editing/style reference (kontext, gptimage, seedream, klein, nanobanana). **Video models:** `image[0]` = starting frame (I2V); `image[1]` = ending frame for first+last-frame interpolation. End-frame supported by `veo`, `veo-1080p`, `seedance`, `seedance-2.0`, and `wan-fast`; other video models silently drop `image[1]`. See `video_capabilities` on `/image/models` or `/models` for per-model support. |
+| `quality` | `query` | `"low"` \| `"medium"` \| `"high"` \| `"hd"` | Image quality level. Supported by `gptimage`, `gptimage-large`, `gpt-image-2`, and `grok-imagine-image-2.0`. · default: `"medium"` |
+| `image` | `query` | `string` | Reference image URL(s) for image editing or video generation. Separate multiple URLs with `\|` or `,`. **Image models:** Used for editing/style reference (kontext, gptimage, seedream, klein, nanobanana). **Video models:** `image[0]` = starting frame (I2V); `image[1]` = ending frame for first+last-frame interpolation. End-frame supported by `veo`, the `seedance-2.0` family, `seedance-2.5`, `wan-fast`, and `wan-pro`; other video models silently drop `image[1]`. See `video_capabilities` on `/image/models` or `/models` for per-model support. |
 | `transparent` | `query` | `boolean` | Generate image with transparent background. Only supported by `gptimage` and `gptimage-large`. · default: `false` |
+| `resolution` | `query` | enum (6) — `"1k"`, `"2k"`, `"480p"`, … | Output resolution for image and video models that advertise `resolutions` in `/models`. The first advertised resolution is the default; requested tiers bill at their listed rate. |
 
 <sub>`*` = required parameter</sub>
 
@@ -472,7 +477,7 @@ curl "https://gen.pollinations.ai/image/a%20beautiful%20sunset%20over%20mountain
 
 OpenAI-compatible image generation endpoint.
 
-Generate images from text prompts. Supports `response_format: "url"` (returns a pollinations.ai URL) or `"b64_json"` (returns base64-encoded image data, default). Community image models are text-to-image only and support `"b64_json"` only.
+Generate images from text prompts. Supports `response_format: "url"` (returns a pollinations.ai URL) or `"b64_json"` (returns base64-encoded image data, default). Community image models support `"b64_json"` only.
 
 **Authentication:** Include your API key as `Authorization: Bearer YOUR_API_KEY`.
 
@@ -488,6 +493,7 @@ Generate images from text prompts. Supports `response_format: "url"` (returns a 
 | `response_format` | `"url"` \| `"b64_json"` | Return format. "url" returns a pollinations.ai URL, "b64_json" returns base64-encoded image data · default: `"b64_json"` |
 | `user` | `string` | End-user identifier for abuse tracking |
 | `image` | `string` \| `string`[] | Reference image URL(s) for image-to-image generation (Pollinations extension) |
+| `resolution` | enum (6) — `"1k"`, `"2k"`, `"480p"`, … | Output resolution for resolution-priced image and video models (Pollinations extension) |
 | `safe` | `string` \| `boolean` | Safety features: comma-separated list of privacy, secrets, sexual, violence, shield, true, nsfw. true enables privacy,secrets; nsfw enables sexual,violence. Also accepted in the Pollinations-Safe header. Defaults to off; false and 0 are accepted as off. |
 
 <sub>`*` = required field</sub>
@@ -513,7 +519,7 @@ OpenAI-compatible image editing endpoint.
 
 Edit images using a text prompt and one or more source images.
 Accepts JSON with image URLs or multipart/form-data with file uploads.
-Community image models do not support edits yet.
+Community image models forward edits to the registrant's OpenAI-compatible endpoint as multipart form data.
 
 **Authentication:** Include your API key as `Authorization: Bearer YOUR_API_KEY`.
 
@@ -537,7 +543,7 @@ curl -X POST "https://gen.pollinations.ai/v1/images/edits" \
 
 Generate a video from a text prompt. Returns MP4.
 
-**Available models:** `veo`, `veo-1080p`, `seedance-pro`, `seedance-2.0`, `wan`, `wan-fast`, `wan-pro`, `wan-pro-1080p`, `grok-video-pro`, `happyhorse-1.1`, `p-video-720p`, `p-video-1080p`, `nova-reel`.
+**Available models:** `veo`, `seedance-pro`, `seedance-2.0`, `seedance-2.0-mini`, `seedance-2.0-fast`, `wan`, `wan-fast`, `wan-pro`, `grok-video-pro`, `grok-imagine-video-1.5`, `seedance-2.5`, `happyhorse-1.1`, `minimax-h3`, `p-video`, `nova-reel`.
 
 Use `duration` to set video length, `aspectRatio` for orientation, and `audio` where the selected model supports audio output.
 
@@ -550,15 +556,16 @@ Browse all available models and their `video_capabilities` at [`/image/models`](
 | Param | In | Type | Description |
 |---|---|---|---|
 | `prompt` * | `path` | `string` | Text description of the video to generate |
-| `model` * | `query` | `string` | Model to use. **Image:** flux, zimage, gptimage, kontext, seedream5, seedream5-pro, nanobanana, nanobanana-pro, klein. **Video:** veo, veo-1080p, seedance, seedance-pro, wan, nova-reel. See /image/models for full list. · default: `"zimage"` |
-| `width` | `query` | `integer` | Width in pixels. For images, exact pixels. For video models, used for aspect ratio and, unless the model name fixes a tier, mapped to the nearest resolution. · default: `1024` |
-| `height` | `query` | `integer` | Height in pixels. For images, exact pixels. For video models, used for aspect ratio and, unless the model name fixes a tier, mapped to the nearest resolution. · default: `1024` |
-| `seed` | `query` | `integer` | Seed for reproducible results. Use -1 for random. Supported by: flux, zimage, seedream, klein, seedance, nova-reel. Other models ignore this parameter. · default: `0` · range: `-1…2147483647` |
+| `model` * | `query` | `string` | Model to use. **Image:** flux, zimage, gptimage, kontext, seedream5, seedream5-pro, nanobanana, nanobanana-pro, klein. **Video:** veo, seedance-pro, wan, wan-pro, p-video, nova-reel. See /image/models for full list. · default: `"veo"` |
+| `width` | `query` | `integer` | Width in pixels. For images, exact pixels. For video models, used for aspect ratio; use `resolution` to select a resolution tier. · default: `1024` |
+| `height` | `query` | `integer` | Height in pixels. For images, exact pixels. For video models, used for aspect ratio; use `resolution` to select a resolution tier. · default: `1024` |
+| `seed` | `query` | `integer` | Seed for reproducible results. Supported by: flux, zimage, seedream, klein, seedance, nova-reel. Other models ignore this parameter. · default: `0` · range: `-1…2147483647` |
 | `safe` | `query` | `string` \| `boolean` | Safety features: comma-separated list of privacy, secrets, sexual, violence, shield, true, nsfw. true enables privacy,secrets; nsfw enables sexual,violence. Also accepted in the Pollinations-Safe header. Defaults to off; false and 0 are accepted as off. |
-| `image` | `query` | `string` | Reference image URL(s) for image editing or video generation. Separate multiple URLs with `\|` or `,`. **Image models:** Used for editing/style reference (kontext, gptimage, seedream, klein, nanobanana). **Video models:** `image[0]` = starting frame (I2V); `image[1]` = ending frame for first+last-frame interpolation. End-frame supported by `veo`, `veo-1080p`, `seedance`, `seedance-2.0`, and `wan-fast`; other video models silently drop `image[1]`. See `video_capabilities` on `/image/models` or `/models` for per-model support. |
-| `duration` | `query` | `integer` | Video duration in seconds. Only applies to video models. `veo` and `veo-1080p`: 4, 6, or 8s. `seedance`: 2-10s. `seedance-2.0`: 4-15s. `wan`: 2-15s. `nova-reel`: 6-120s (multiples of 6). · range: `1…120` |
-| `aspectRatio` | `query` | `string` | Video aspect ratio (`16:9` or `9:16`). Only applies to video models. If not set, determined by width/height. |
-| `audio` | `query` | `boolean` | Generate audio for the video. Only applies to video models. Note: `wan` generates audio regardless of this flag. For `veo` and `veo-1080p`, set to `true` to enable audio. · default: `false` |
+| `image` | `query` | `string` | Reference image URL(s) for image editing or video generation. Separate multiple URLs with `\|` or `,`. **Image models:** Used for editing/style reference (kontext, gptimage, seedream, klein, nanobanana). **Video models:** `image[0]` = starting frame (I2V); `image[1]` = ending frame for first+last-frame interpolation. End-frame supported by `veo`, the `seedance-2.0` family, `seedance-2.5`, `wan-fast`, and `wan-pro`; other video models silently drop `image[1]`. See `video_capabilities` on `/image/models` or `/models` for per-model support. |
+| `resolution` | `query` | enum (6) — `"1k"`, `"2k"`, `"480p"`, … | Output resolution for image and video models that advertise `resolutions` in `/models`. The first advertised resolution is the default; requested tiers bill at their listed rate. |
+| `duration` | `query` | `integer` | Video duration in seconds. Only applies to video models. `veo`: 4, 6, or 8s. `seedance-pro`: 2-10s. `seedance-2.0`: 4-15s; Mini: 4-10s; Fast: 4-5s. `seedance-2.5`: exactly 4s. `minimax-h3`: exactly 5s. `wan`: 2-15s. `nova-reel`: 6-120s (multiples of 6). · range: `1…120` |
+| `aspectRatio` | `query` | `string` | Video aspect ratio (`16:9` or `9:16`). Only applies to video models. If not set, determined by explicit width/height; `seedance-2.5` otherwise defaults to `16:9`. `minimax-h3` supports only `16:9`. |
+| `audio` | `query` | `boolean` | Generate audio for the video. Only applies to video models. `wan` and `minimax-h3` always generate audio regardless of this flag. For `veo`, set to `true` to enable audio. · default: `false` |
 
 <sub>`*` = required parameter</sub>
 
@@ -573,47 +580,94 @@ curl "https://gen.pollinations.ai/video/a%20sunset%20timelapse%20over%20the%20oc
 
 ### Audio
 
-#### `POST` `/v1/audio/music/upload` — Upload Music Reference
+#### `POST` `/v1/audio/voice-changer` — Transform a Voice
 
-Upload an audio file to ElevenLabs Music and receive a `song_id` for reference conditioning or inpainting. Set `extract_composition_plan=true` to return a music_v2 composition plan derived from the track.
+Transform the speaker identity in an audio file while preserving its words, timing, emotion, and delivery. Accepts preset voice names or custom ElevenLabs voice IDs.
 
 📥 **Request body** · `multipart/form-data`
 
 | Field | Type | Description |
 |---|---|---|
-| `file` * | `string · binary` | Music file to upload. |
-| `extract_composition_plan` | `boolean` | Return a music_v2 composition plan extracted from the uploaded track. · default: `false` |
+| `model` | `string` | default: `"eleven-voice-changer"` |
+| `audio` * | `string · binary` | Source audio, up to 50 MB. ElevenLabs supports clips up to five minutes. |
+| `voice` | `string` | Target preset voice name or custom ElevenLabs voice ID. · default: `"alloy"` |
+| `response_format` | `"mp3"` \| `"opus"` \| `"aac"` \| `"wav"` \| `"pcm"` | default: `"mp3"` |
 
 <sub>`*` = required field</sub>
 
-📤 **Response** · `200` · `application/json` — Success - Returns ElevenLabs song_id and optional composition_plan
-
-| Field | Type | Description |
-|---|---|---|
-| `song_id` | `string` | — |
-| `composition_plan` | `object` | — |
-
-<sub>`*` = required field</sub>
+📤 **Response** · `200` · `audio/mpeg`, `audio/opus`, `audio/aac`, `audio/wav`, `audio/pcm` — Success - Returns transformed speech
 
 💻 **Example**
 
 ```bash
-curl -X POST "https://gen.pollinations.ai/v1/audio/music/upload" \
+curl -X POST "https://gen.pollinations.ai/v1/audio/voice-changer" \
   -H "Authorization: Bearer $POLLINATIONS_KEY" \
-  -F "file=@./input.bin"
+  -F "audio=@./input.mp3"
 ```
 
 ---
 
-#### `POST` `/v1/audio/speech` — Text to Speech (OpenAI-compatible)
+#### `POST` `/v1/audio/voice-isolator` — Isolate Speech
 
-Generate speech or music from text. Compatible with the OpenAI TTS API for JSON requests.
+Remove music, ambient sound, and other background noise from an audio or video file while preserving spoken audio.
 
-Set `model` to `elevenmusic`, `lyria-3-clip`, `stable-audio-3-medium`, or `stable-audio-3-large` to generate music. Lyria returns one fixed 30-second MP3 clip. Send multipart/form-data with `reference_audio` plus `input` to run audio-to-audio (style transfer) on `stable-audio-3-medium` or `stable-audio-3-large`, or reference-audio conditioning on `elevenmusic`; for ElevenLabs inpainting, pass a `composition_plan`.
+📥 **Request body** · `multipart/form-data`
 
-**Available voices:** alloy, echo, fable, onyx, nova, shimmer, ash, ballad, coral, sage, verse, rachel, domi, bella, elli, charlotte, dorothy, sarah, emily, lily, matilda, adam, antoni, arnold, josh, sam, daniel, charlie, james, fin, callum, liam, george, brian, bill, conversational_a, conversational_b, read_speech_a, read_speech_b, read_speech_c, read_speech_d
+| Field | Type | Description |
+|---|---|---|
+| `model` | `string` | default: `"eleven-voice-isolator"` |
+| `audio` * | `string · binary` | Source audio or video, up to 50 MB and at least 4.6 seconds long. |
+
+<sub>`*` = required field</sub>
+
+📤 **Response** · `200` · `audio/mpeg` — Success - Returns isolated speech as MP3 audio
+
+💻 **Example**
+
+```bash
+curl -X POST "https://gen.pollinations.ai/v1/audio/voice-isolator" \
+  -H "Authorization: Bearer $POLLINATIONS_KEY" \
+  -F "audio=@./input.mp3"
+```
+
+---
+
+#### `POST` `/v1/audio/speech` — Generate Audio (OpenAI-compatible)
+
+Generate speech, music, sound effects, or dialogue from text. Compatible with the OpenAI TTS API for JSON requests.
+
+Set `model` to `elevenmusic`, `lyria-3-clip`, `stable-audio-3-medium`, or `stable-audio-3-large` to generate music. Lyria returns one fixed 30-second MP3 clip. Pass any publicly accessible audio URL as `reference_audio` to run audio-to-audio (style transfer) on `stable-audio-3-medium` or `stable-audio-3-large`, or reference-audio conditioning on `elevenmusic`; for ElevenLabs inpainting, pass a `composition_plan`.
+
+For multi-speaker audio, set `model` to `eleven-dialogue` and put one turn per line in `input` as `<voice>: <text>`. Voice labels may be preset names or ElevenLabs voice IDs; the top-level `voice` field is ignored for this model. Dialogue supports up to 10 unique voices and 2,000 total text characters.
+
+**Available voices:** alloy, echo, fable, onyx, nova, shimmer, ash, ballad, coral, sage, verse, rachel, domi, bella, elli, charlotte, dorothy, sarah, emily, lily, matilda, adam, antoni, arnold, josh, sam, daniel, charlie, james, fin, callum, liam, george, brian, bill, conversational_a, conversational_b, read_speech_a, read_speech_b, read_speech_c, read_speech_d, af_alloy, af_aoede, af_bella, af_heart, af_jessica, af_kore, af_nicole, af_nova, af_river, af_sarah, af_sky, am_adam, am_echo, am_eric, am_fenrir, am_liam, am_michael, am_onyx, am_puck, am_santa, bf_alice, bf_emma, bf_isabella, bf_lily, bm_daniel, bm_fable, bm_george, bm_lewis, ef_dora, em_alex, em_santa, ff_siwis, hf_alpha, hf_beta, hm_omega, hm_psi, if_sara, im_nicola, jf_alpha, jf_gongitsune, jf_nezumi, jf_tebukuro, jm_kumo, pf_dora, pm_alex, pm_santa, zf_xiaobei, zf_xiaoni, zf_xiaoxiao, zf_xiaoyi, zm_yunjian, zm_yunxi, zm_yunxia, zm_yunyang
 
 **Output formats:** mp3 (default), opus, aac, flac, wav, pcm
+
+📥 **Request body** · `application/json`
+
+| Field | Type | Description |
+|---|---|---|
+| `model` | `string` | — |
+| `input` * | `string` | Text or prompt to generate. For eleven-dialogue, use one `voice: text` turn per line. · length: `1…10000` |
+| `safe` | `string` \| `boolean` | Optional safety features; accepts a comma-separated string or boolean shorthand. |
+| `voice` | `string` | default: `"alloy"` |
+| `response_format` | enum (6) — `"mp3"`, `"opus"`, `"aac"`, … | default: `"mp3"` |
+| `duration` | `number` | range: `0.5…300` |
+| `seconds` | `number` | range: `1…380` |
+| `steps` | `integer` | range: `1…100` |
+| `negative_prompt` | `string` | — |
+| `instrumental` | `boolean` | — |
+| `store_for_inpainting` | `boolean` | — |
+| `reference_audio` | `string · uri` | Public HTTP(S) URL for reference-audio conditioning or audio-to-audio generation. |
+| `conditioning_ref` | `object` | — |
+| `composition_plan` | `object` | — |
+| `seed` | `integer` | max: `4294967295` |
+| `instructions` | `string` | — |
+| `loop` | `boolean` | — |
+| `prompt_influence` | `number` | max: `1` |
+
+<sub>`*` = required field</sub>
 
 📤 **Response** · `200` · `audio/mpeg`, `audio/opus`, `audio/aac`, `audio/flac`, `audio/wav`, `audio/pcm` — Success - Returns audio data
 
@@ -621,6 +675,49 @@ Set `model` to `elevenmusic`, `lyria-3-clip`, `stable-audio-3-medium`, or `stabl
 
 ```bash
 curl -X POST "https://gen.pollinations.ai/v1/audio/speech" \
+  -H "Authorization: Bearer $POLLINATIONS_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"input":"Hello world","voice":"nova"}'
+```
+
+---
+
+#### `POST` `/v1/audio/speech/with-timestamps` — Generate Speech with Timestamps
+
+Generate base64-encoded speech with character-level timing for the original and normalized text. Supports the elevenlabs, elevenflash, and eleven-multilingual-v2 models.
+
+📥 **Request body** · `application/json`
+
+| Field | Type | Description |
+|---|---|---|
+| `model` | `"elevenlabs"` \| `"elevenflash"` \| `"eleven-multilingual-v2"` | default: `"elevenlabs"` |
+| `input` * | `string` | Text to synthesize and align. · max length: `10000` |
+| `voice` | `string` | Preset voice name or custom ElevenLabs voice ID. · default: `"alloy"` |
+| `response_format` | `"mp3"` \| `"opus"` \| `"aac"` \| `"wav"` \| `"pcm"` | Encoding used for audio_base64. · default: `"mp3"` |
+| `seed` | `integer` | max: `4294967295` |
+
+<sub>`*` = required field</sub>
+
+📤 **Response** · `200` · `application/json` — Success - Returns base64 audio and character timings
+
+| Field | Type | Description |
+|---|---|---|
+| `audio_base64` * | `string` | — |
+| `alignment` * | `object` | — |
+| `alignment.characters` | `string`[] | — |
+| `alignment.character_start_times_seconds` | `number`[] | — |
+| `alignment.character_end_times_seconds` | `number`[] | — |
+| `normalized_alignment` * | `object` | — |
+| `normalized_alignment.characters` | `string`[] | — |
+| `normalized_alignment.character_start_times_seconds` | `number`[] | — |
+| `normalized_alignment.character_end_times_seconds` | `number`[] | — |
+
+<sub>`*` = required field</sub>
+
+💻 **Example**
+
+```bash
+curl -X POST "https://gen.pollinations.ai/v1/audio/speech/with-timestamps" \
   -H "Authorization: Bearer $POLLINATIONS_KEY" \
   -H "Content-Type: application/json" \
   -d '{"input":"Hello world","voice":"nova"}'
@@ -638,15 +735,16 @@ Transcribe audio files to text. Compatible with the OpenAI Whisper API.
 - `whisper-large-v3` (default) — OpenAI Whisper via OVHcloud
 - `whisper-1` — Alias for whisper-large-v3
 - `scribe` — ElevenLabs Scribe (90+ languages, word-level timestamps)
+- `grok-transcribe` — xAI speech recognition with word timestamps, speaker labels, and text formatting
 - `universal-2` — AssemblyAI Universal-2 (99 languages)
-- `universal-3-pro` — AssemblyAI Universal-3 Pro (highest accuracy, prompting)
+- `universal-3.5-pro` — AssemblyAI Universal-3.5 Pro (18 languages, code switching, prompting)
 
 📥 **Request body** · `multipart/form-data`
 
 | Field | Type | Description |
 |---|---|---|
 | `file` * | `string · binary` | The audio file to transcribe. Supported formats: mp3, mp4, mpeg, mpga, m4a, wav, webm. |
-| `model` | `string` | The model to use. Options: `whisper-large-v3`, `whisper-1`, `scribe`, `universal-2`, `universal-3-pro`. · default: `"whisper-large-v3"` |
+| `model` | `string` | The model to use. Options: `whisper-large-v3`, `whisper-1`, `scribe`, `grok-transcribe`, `universal-2`, `universal-3.5-pro`. · default: `"whisper-large-v3"` |
 | `language` | `string` | Language of the audio in ISO-639-1 format (e.g. `en`, `fr`). Improves accuracy. |
 | `prompt` | `string` | Optional text to guide the model's style or continue a previous segment. |
 | `response_format` | enum (6) — `"json"`, `"text"`, `"srt"`, … | The format of the transcript output. Use `diarized_json` for OpenAI-compatible speaker segments on diarization-capable models. · default: `"json"` |
@@ -687,11 +785,11 @@ Generate speech or music from text via a simple GET request.
 
 **Text-to-speech (default):** Returns spoken audio in the selected voice and format.
 
-**Available voices:** alloy, echo, fable, onyx, nova, shimmer, ash, ballad, coral, sage, verse, rachel, domi, bella, elli, charlotte, dorothy, sarah, emily, lily, matilda, adam, antoni, arnold, josh, sam, daniel, charlie, james, fin, callum, liam, george, brian, bill, conversational_a, conversational_b, read_speech_a, read_speech_b, read_speech_c, read_speech_d
+**Available voices:** alloy, echo, fable, onyx, nova, shimmer, ash, ballad, coral, sage, verse, rachel, domi, bella, elli, charlotte, dorothy, sarah, emily, lily, matilda, adam, antoni, arnold, josh, sam, daniel, charlie, james, fin, callum, liam, george, brian, bill, conversational_a, conversational_b, read_speech_a, read_speech_b, read_speech_c, read_speech_d, af_alloy, af_aoede, af_bella, af_heart, af_jessica, af_kore, af_nicole, af_nova, af_river, af_sarah, af_sky, am_adam, am_echo, am_eric, am_fenrir, am_liam, am_michael, am_onyx, am_puck, am_santa, bf_alice, bf_emma, bf_isabella, bf_lily, bm_daniel, bm_fable, bm_george, bm_lewis, ef_dora, em_alex, em_santa, ff_siwis, hf_alpha, hf_beta, hm_omega, hm_psi, if_sara, im_nicola, jf_alpha, jf_gongitsune, jf_nezumi, jf_tebukuro, jm_kumo, pf_dora, pm_alex, pm_santa, zf_xiaobei, zf_xiaoni, zf_xiaoxiao, zf_xiaoyi, zm_yunjian, zm_yunxi, zm_yunxia, zm_yunyang
 
 **Output formats:** mp3 (default), opus, aac, flac, wav, pcm
 
-**Music generation:** Set `model=elevenmusic`, `lyria-3-clip`, `stable-audio-3-medium`, or `stable-audio-3-large` to generate music instead of speech. `lyria-3-clip` returns a fixed 30-second MP3 clip; `elevenmusic` supports `duration` (3-300 seconds) and `instrumental` mode; `stable-audio-3-medium`/`stable-audio-3-large` support `seconds` (1-380), `steps`, `seed`, and `negative_prompt`. Use `POST /v1/audio/speech` with multipart `reference_audio` for style transfer (medium/large), or `POST /v1/audio/music/upload` to register a source track for inpainting.
+**Music generation:** Set `model=elevenmusic`, `lyria-3-clip`, `stable-audio-3-medium`, or `stable-audio-3-large` to generate music instead of speech. `lyria-3-clip` returns a fixed 30-second MP3 clip; `elevenmusic` supports `duration` (3-300 seconds) and `instrumental` mode; `stable-audio-3-medium`/`stable-audio-3-large` support `seconds` (1-380), `steps`, `seed`, and `negative_prompt`. Pass any publicly accessible audio URL as `reference_audio` to `POST /v1/audio/speech`.
 
 ⚙️ **Parameters**
 
@@ -699,17 +797,17 @@ Generate speech or music from text via a simple GET request.
 |---|---|---|---|
 | `text` * | `path` | `string` | Text to convert to speech, or a music description for a music-generation model |
 | `voice` | `query` | `string` | Voice to use for speech generation (TTS only) · default: `"alloy"` |
-| `response_format` | `query` | enum (6) — `"mp3"`, `"opus"`, `"aac"`, … | Audio output format. CSM supports mp3, opus, flac, wav, and pcm; Qwen TTS currently returns WAV regardless of this setting; lyria-3-clip and eleven-sfx support mp3 only. · default: `"mp3"` |
+| `response_format` | `query` | enum (6) — `"mp3"`, `"opus"`, `"aac"`, … | Audio output format. CSM and Kokoro support mp3, opus, flac, wav, and pcm; Qwen TTS currently returns WAV regardless of this setting; lyria-3-clip and eleven-sfx support mp3 only. · default: `"mp3"` |
 | `model` | `query` | `string` | Audio model: TTS (default) or a music-generation model such as lyria-3-clip |
 | `duration` | `query` | `string` | Music duration in seconds (elevenmusic 3-300; lyria-3-clip fixed at 30) |
 | `seconds` | `query` | `number` | Audio duration in seconds for stable-audio-3-medium/large, 1-380 · range: `1…380` |
 | `steps` | `query` | `integer` | Sampling steps (stable-audio-3-medium 1-100, stable-audio-3-large 4-8) · range: `1…100` |
 | `negative_prompt` | `query` | `string` | Negative prompt for stable-audio-3-large |
 | `instrumental` | `query` | `"true"` \| `"false"` | If true, guarantees instrumental output (elevenmusic only) · default: `"false"` |
-| `instruct` | `query` | `string` | Emotion/style instruction (qwen-tts-instruct only) |
+| `instructions` | `query` | `string` | Emotion/style instruction (qwen-tts-instruct only) |
 | `loop` | `query` | `"true"` \| `"false"` | Loop the generated sound effect (eleven-sfx only) |
 | `prompt_influence` | `query` | `string` | How strictly to follow the prompt, 0-1 (eleven-sfx only) |
-| `seed` | `query` | `integer` | Seed for deterministic output (0-4294967295). Same seed + params = best-effort return of the same cached result. Omit for random. · range: `-1…4294967295` |
+| `seed` | `query` | `integer` | Seed passed to the model. Same seed + parameters return the same cached result while available. · range: `-1…4294967295` |
 | `key` | `query` | `string` | API key (alternative to Authorization header) |
 | `safe` | `query` | `string` \| `boolean` | Safety features: comma-separated list of privacy, secrets, sexual, violence, shield, true, nsfw. true enables privacy,secrets; nsfw enables sexual,violence. Also accepted in the Pollinations-Safe header. Defaults to off; false and 0 are accepted as off. |
 
@@ -726,22 +824,51 @@ curl "https://gen.pollinations.ai/audio/Hello%2C%20welcome%20to%20Pollinations!?
 
 ### Realtime
 
-#### `GET` `/v1/realtime` — Realtime WebSocket
+#### `GET` `/realtime` — Realtime WebSocket
 
-OpenAI-compatible Realtime WebSocket proxy.
+OpenAI-compatible Realtime WebSocket for voice, multimodal, and transcription sessions.
 
-Connect with `wss://gen.pollinations.ai/v1/realtime?model=gpt-realtime-2.1` and send/receive Realtime JSON events over the socket.
+Connect with `wss://gen.pollinations.ai/realtime?model=gpt-realtime-2.1` and send/receive OpenAI Realtime JSON events over the socket. Selecting `scribe-realtime` creates a transcription session automatically.
 Server clients can authenticate with `Authorization: Bearer <key>`. Browser WebSocket clients can use `?key=pk_...` because they cannot set custom authorization headers.
 
-**Models:** `gpt-realtime-2.1`, `gpt-realtime-2`.
+**Models:** `gpt-realtime-2.1`, `gpt-realtime-2.1-mini`, `gpt-realtime-2`, `scribe-realtime`.
 
-**Billing:** requires a positive balance. Gen proxies the WebSocket, aggregates observed `response.done` usage, and deducts one session total when the socket closes. Input transcription sessions are not supported yet.
+**Billing:** requires a positive balance and settles one session total when the socket closes.
 
 ⚙️ **Parameters**
 
 | Param | In | Type | Description |
 |---|---|---|---|
-| `model` | `query` | `"gpt-realtime-2.1"` \| `"gpt-realtime-2"` | Realtime model to use. Supported models: gpt-realtime-2.1, gpt-realtime-2. · default: `"gpt-realtime-2.1"` |
+| `model` | `query` | `"gpt-realtime-2.1"` \| `"gpt-realtime-2.1-mini"` \| `"gpt-realtime-2"` \| `"scribe-realtime"` | Realtime model to use. Supported models: gpt-realtime-2.1, gpt-realtime-2.1-mini, gpt-realtime-2, scribe-realtime. · default: `"gpt-realtime-2.1"` |
+| `key` | `query` | `string` | Pollinations API key. Useful for browser WebSocket clients that cannot set custom Authorization headers. |
+
+<sub>`*` = required parameter</sub>
+
+💻 **Example**
+
+```bash
+curl "https://gen.pollinations.ai/realtime?model=gpt-realtime-2.1&key=:key" \
+  -H "Authorization: Bearer $POLLINATIONS_KEY"
+```
+
+---
+
+#### `GET` `/v1/realtime` — Realtime WebSocket
+
+OpenAI-compatible Realtime WebSocket for voice, multimodal, and transcription sessions.
+
+Connect with `wss://gen.pollinations.ai/v1/realtime?model=gpt-realtime-2.1` and send/receive OpenAI Realtime JSON events over the socket. Selecting `scribe-realtime` creates a transcription session automatically.
+Server clients can authenticate with `Authorization: Bearer <key>`. Browser WebSocket clients can use `?key=pk_...` because they cannot set custom authorization headers.
+
+**Models:** `gpt-realtime-2.1`, `gpt-realtime-2.1-mini`, `gpt-realtime-2`, `scribe-realtime`.
+
+**Billing:** requires a positive balance and settles one session total when the socket closes.
+
+⚙️ **Parameters**
+
+| Param | In | Type | Description |
+|---|---|---|---|
+| `model` | `query` | `"gpt-realtime-2.1"` \| `"gpt-realtime-2.1-mini"` \| `"gpt-realtime-2"` \| `"scribe-realtime"` | Realtime model to use. Supported models: gpt-realtime-2.1, gpt-realtime-2.1-mini, gpt-realtime-2, scribe-realtime. · default: `"gpt-realtime-2.1"` |
 | `key` | `query` | `string` | Pollinations API key. Useful for browser WebSocket clients that cannot set custom Authorization headers. |
 
 <sub>`*` = required parameter</sub>
@@ -816,7 +943,7 @@ curl -X POST "https://gen.pollinations.ai/v1/embeddings" \
 
 #### `GET` `/v1/models` — List Models (OpenAI-compatible)
 
-Returns available models (text, community text/image, image, realtime, audio, embeddings) in the OpenAI-compatible format (`{object: "list", data: [...]}`). Use this endpoint if you're using an OpenAI SDK. For richer metadata including pricing and capabilities, use `/models`, `/text/models`, `/image/models`, `/audio/models`, or `/embeddings/models` instead. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance.
+Returns available models in the OpenAI-compatible format (`{object: "list", data: [...]}`). Official models are ordered by modality (text, image, video, 3D, audio, realtime, embedding), with each configured default first, followed by stable and then alpha/preview models from newest to oldest. Community models follow from newest to oldest. Use this endpoint if you're using an OpenAI SDK. For richer metadata including pricing and capabilities, use `/models`, `/text/models`, `/image/models`, `/audio/models`, or `/embeddings/models` instead. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance.
 
 📤 **Response** · `200` · `application/json` — Success
 
@@ -833,6 +960,7 @@ Returns available models (text, community text/image, image, realtime, audio, em
 | `data[].tools` | `boolean` | — |
 | `data[].reasoning` | `boolean` | — |
 | `data[].context_length` | `number` | — |
+| `data[].per_user_rpm` | `number` \| `null` | — |
 
 <sub>`*` = required field</sub>
 
@@ -873,7 +1001,7 @@ curl "https://gen.pollinations.ai/v1/models" \
 
 #### `GET` `/models` — List Models
 
-Returns all available text, community text/image, image, video, 3D, realtime, audio, and embedding models with pricing, capabilities, and metadata. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance.
+Returns all available models with pricing, capabilities, and metadata. Official models are ordered by modality (text, image, video, 3D, audio, realtime, embedding), with each configured default first, followed by stable and then alpha/preview models from newest to oldest. Community models follow from newest to oldest. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance.
 
 📤 **Response** · `200` · `application/json` — Success
 
@@ -1159,11 +1287,14 @@ List private and public community models owned by the authenticated account. API
 | `data[].name` * | `string` | — |
 | `data[].title` * | `string` | — |
 | `data[].description` * | `string` \| `null` | — |
-| `data[].modality` * | `"text"` \| `"image"` | Upstream API family. "text" uses `/v1/chat/completions`; "image" uses `/v1/images/generations` and currently supports text-to-image generation only. |
+| `data[].modality` * | `"text"` \| `"image"` | Upstream API family. "text" uses `/v1/chat/completions`; "image" uses `/v1/images/generations` and optionally `/v1/images/edits` when the endpoint test succeeds. |
 | `data[].imagePricing` * | `"request"` \| `"tokens"` | Image models only. "request": the generated-image price is charged once per generation. "tokens": provider-returned OpenAI image token usage is charged against per-token prices. Detected by the endpoint test. |
+| `data[].inputModalities` * | `"text"` \| `"image"` \| `"audio"`[] | — |
 | `data[].baseUrl` * | `string` | — |
 | `data[].upstreamModel` * | `string` | — |
 | `data[].visibility` * | `"private"` \| `"public"` | "private": owner-only, shown only to the owner, with no owner-set price. "public": anyone and listed in the catalog; it may be free or priced. Publishing requires an allowlisted account. |
+| `data[].perUserRpm` * | `number` \| `null` | Maximum requests per minute for each Pollinations user. Decimals are supported; 0.5 means one request every two minutes. Null means no Pollinations-side limit. |
+| `data[].fallbackModelIds` * | `string`[] | — |
 | `data[].promptTextPrice` * | `number` | — |
 | `data[].promptCachedPrice` * | `number` | — |
 | `data[].promptCacheWritePrice` * | `number` | — |
@@ -1178,6 +1309,9 @@ List private and public community models owned by the authenticated account. API
 | `data[].disabledAt` * | `string` \| `null` | — |
 | `data[].createdAt` * | `string` | — |
 | `data[].updatedAt` * | `string` | — |
+| `provider` * | `object` | — |
+| `provider.name` * | `string` \| `null` | — |
+| `provider.url` * | `string · uri` \| `null` | — |
 
 <sub>`*` = required field</sub>
 
@@ -1201,12 +1335,15 @@ Register a private or public community text or image model. Private is the defau
 | `name` * | `string` | length: `1…120` |
 | `title` * | `string` | Display name shown in the model catalog. · length: `1…42` |
 | `description` | `string` | max length: `160` |
-| `baseUrl` * | `string · uri` | OpenAI-compatible `/v1` base URL or full `/chat/completions` or `/images/generations` URL. |
+| `baseUrl` * | `string · uri` | OpenAI-compatible `/v1` base URL or full chat, image generation, or image edit URL. |
 | `upstreamModel` | `string` | length: `1…253` |
 | `bearerToken` * | `string` | — |
-| `modality` | `"text"` \| `"image"` | Upstream API family. "text" uses `/v1/chat/completions`; "image" uses `/v1/images/generations` and currently supports text-to-image generation only. · default: `"text"` |
+| `modality` | `"text"` \| `"image"` | Upstream API family. "text" uses `/v1/chat/completions`; "image" uses `/v1/images/generations` and optionally `/v1/images/edits` when the endpoint test succeeds. · default: `"text"` |
 | `imagePricing` | `"request"` \| `"tokens"` | Image models only. "request": the generated-image price is charged once per generation. "tokens": provider-returned OpenAI image token usage is charged against per-token prices. Detected by the endpoint test. · default: `"request"` |
+| `inputModalities` | `"text"` \| `"image"` \| `"audio"`[] | Input types accepted by the model. Select every supported modality so the model catalog can advertise them accurately. · default: `["text"]` |
 | `visibility` | `"private"` \| `"public"` | "private": owner-only, shown only to the owner, with no owner-set price. "public": anyone and listed in the catalog; it may be free or priced. Publishing requires an allowlisted account. · default: `"private"` |
+| `perUserRpm` | `number` \| `null` | Maximum requests per minute for each Pollinations user. Decimals are supported; 0.5 means one request every two minutes. Null means no Pollinations-side limit. |
+| `fallbackModelIds` | `string`[] | Community model ids ("<owner>/<name>") tried in order when this model's upstream fails, or an empty array to clear them. Each must be another active community model of the same modality, public or owned by you, and priced at or below this model on every price field. |
 | `promptTextPrice` | `number` | Pollen price. Token rates are per token internally (the dashboard displays per 1M); `completionImagePrice` is per generated image when `imagePricing` is "request". |
 | `promptCachedPrice` | `number` | Pollen price. Token rates are per token internally (the dashboard displays per 1M); `completionImagePrice` is per generated image when `imagePricing` is "request". |
 | `promptCacheWritePrice` | `number` | Pollen price. Token rates are per token internally (the dashboard displays per 1M); `completionImagePrice` is per generated image when `imagePricing` is "request". |
@@ -1228,11 +1365,14 @@ Register a private or public community text or image model. Private is the defau
 | `name` * | `string` | — |
 | `title` * | `string` | — |
 | `description` * | `string` \| `null` | — |
-| `modality` * | `"text"` \| `"image"` | Upstream API family. "text" uses `/v1/chat/completions`; "image" uses `/v1/images/generations` and currently supports text-to-image generation only. |
+| `modality` * | `"text"` \| `"image"` | Upstream API family. "text" uses `/v1/chat/completions`; "image" uses `/v1/images/generations` and optionally `/v1/images/edits` when the endpoint test succeeds. |
 | `imagePricing` * | `"request"` \| `"tokens"` | Image models only. "request": the generated-image price is charged once per generation. "tokens": provider-returned OpenAI image token usage is charged against per-token prices. Detected by the endpoint test. |
+| `inputModalities` * | `"text"` \| `"image"` \| `"audio"`[] | — |
 | `baseUrl` * | `string` | — |
 | `upstreamModel` * | `string` | — |
 | `visibility` * | `"private"` \| `"public"` | "private": owner-only, shown only to the owner, with no owner-set price. "public": anyone and listed in the catalog; it may be free or priced. Publishing requires an allowlisted account. |
+| `perUserRpm` * | `number` \| `null` | Maximum requests per minute for each Pollinations user. Decimals are supported; 0.5 means one request every two minutes. Null means no Pollinations-side limit. |
+| `fallbackModelIds` * | `string`[] | — |
 | `promptTextPrice` * | `number` | — |
 | `promptCachedPrice` * | `number` | — |
 | `promptCacheWritePrice` * | `number` | — |
@@ -1263,8 +1403,73 @@ curl -X POST "https://gen.pollinations.ai/account/my-models" \
 {
   "modality": "text",
   "imagePricing": "request",
+  "inputModalities": [
+    "text"
+  ],
   "visibility": "private"
 }
+```
+
+---
+
+#### `POST` `/account/my-models/provider` — Update Community Provider Profile
+
+Set the public provider name and HTTPS service link shared by all community models owned by the authenticated account. Send both fields empty to clear the profile. Publishing approval and `account:keys` are required.
+
+📥 **Request body** · `application/json`
+
+| Field | Type | Description |
+|---|---|---|
+| `name` * | `string` | max length: `42` |
+| `url` * | `string` | max length: `2048` |
+
+<sub>`*` = required field</sub>
+
+📤 **Response** · `200` · `application/json` — Updated community provider profile
+
+| Field | Type | Description |
+|---|---|---|
+| `name` * | `string` \| `null` | — |
+| `url` * | `string · uri` \| `null` | — |
+
+<sub>`*` = required field</sub>
+
+💻 **Example**
+
+```bash
+curl -X POST "https://gen.pollinations.ai/account/my-models/provider" \
+  -H "Authorization: Bearer $POLLINATIONS_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"My Provider","url":"https://api.example.com"}'
+```
+
+---
+
+#### `GET` `/account/my-models/{id}/fallback-candidates` — List Fallback Candidates
+
+Community models this model may declare as fallbacks: active, public or owned by you, same modality, and priced at or below it on every price field. Computed with the same rule the update endpoint validates against, so every id listed here is accepted. Eligibility is re-checked when a request is routed, so a target repriced above this model afterwards stops serving without changing the stored list.
+
+⚙️ **Parameters**
+
+| Param | In | Type | Description |
+|---|---|---|---|
+| `id` * | `path` | `string` | — |
+
+<sub>`*` = required parameter</sub>
+
+📤 **Response** · `200` · `application/json` — Eligible fallback model ids
+
+| Field | Type | Description |
+|---|---|---|
+| `data` * | `string`[] | — |
+
+<sub>`*` = required field</sub>
+
+💻 **Example**
+
+```bash
+curl "https://gen.pollinations.ai/account/my-models/key_abc123/fallback-candidates" \
+  -H "Authorization: Bearer $POLLINATIONS_KEY"
 ```
 
 ---
@@ -1303,7 +1508,7 @@ curl -X POST "https://gen.pollinations.ai/account/my-models/models" \
 
 #### `POST` `/account/my-models/test` — Test My Model Endpoint
 
-Test an OpenAI-compatible upstream model before publishing it. Image tests also detect token pricing when valid OpenAI image usage is returned; otherwise they select fixed per-image pricing. Requires community model publishing approval; API keys also require `account:keys`.
+Test an OpenAI-compatible upstream model before publishing it. Image tests detect token pricing and probe the derived `/images/edits` endpoint. Requires community model publishing approval; API keys also require `account:keys`.
 
 📥 **Request body** · `application/json`
 
@@ -1312,7 +1517,7 @@ Test an OpenAI-compatible upstream model before publishing it. Image tests also 
 | `baseUrl` * | `string · uri` | — |
 | `bearerToken` * | `string` | — |
 | `model` * | `string` | length: `1…253` |
-| `modality` | `"text"` \| `"image"` | Upstream API family. "text" uses `/v1/chat/completions`; "image" uses `/v1/images/generations` and currently supports text-to-image generation only. · default: `"text"` |
+| `modality` | `"text"` \| `"image"` | Upstream API family. "text" uses `/v1/chat/completions`; "image" uses `/v1/images/generations` and optionally `/v1/images/edits` when the endpoint test succeeds. · default: `"text"` |
 
 <sub>`*` = required field</sub>
 
@@ -1325,6 +1530,7 @@ Test an OpenAI-compatible upstream model before publishing it. Image tests also 
 | `usage` * | `object` | Raw provider usage, or `{ images: 1 }` when an image provider returns no token usage. |
 | `billableUsage` * | `object` | Normalized billable usage fields used to reveal applicable prices. |
 | `imagePricing` | `"request"` \| `"tokens"` | Image tests only: pricing mode detected from the provider response. |
+| `inputModalities` | `"text"` \| `"image"` \| `"audio"`[] | Image tests only: input types detected from generation and edit probes. |
 
 <sub>`*` = required field</sub>
 
@@ -1358,11 +1564,14 @@ Update a community model owned by the authenticated account. Changing visibility
 | `name` | `string` | length: `1…120` |
 | `title` | `string` | Display name shown in the model catalog. · length: `1…42` |
 | `description` | `string` | max length: `160` |
-| `baseUrl` | `string · uri` | OpenAI-compatible `/v1` base URL or full `/chat/completions` or `/images/generations` URL. |
+| `baseUrl` | `string · uri` | OpenAI-compatible `/v1` base URL or full chat, image generation, or image edit URL. |
 | `upstreamModel` | `string` | length: `1…253` |
 | `bearerToken` | `string` | — |
 | `visibility` | `"private"` \| `"public"` | "private": owner-only, shown only to the owner, with no owner-set price. "public": anyone and listed in the catalog; it may be free or priced. Publishing requires an allowlisted account. |
+| `perUserRpm` | `number` \| `null` | Maximum requests per minute for each Pollinations user. Decimals are supported; 0.5 means one request every two minutes. Null means no Pollinations-side limit. |
 | `imagePricing` | `"request"` \| `"tokens"` | Image models only. "request": the generated-image price is charged once per generation. "tokens": provider-returned OpenAI image token usage is charged against per-token prices. Detected by the endpoint test. |
+| `inputModalities` | `"text"` \| `"image"` \| `"audio"`[] | Input types accepted by the model. Select every supported modality so the model catalog can advertise them accurately. |
+| `fallbackModelIds` | `string`[] | Community model ids ("<owner>/<name>") tried in order when this model's upstream fails, or an empty array to clear them. Each must be another active community model of the same modality, public or owned by you, and priced at or below this model on every price field. |
 | `active` | `boolean` | — |
 | `promptTextPrice` | `number` | Pollen price. Token rates are per token internally (the dashboard displays per 1M); `completionImagePrice` is per generated image when `imagePricing` is "request". |
 | `promptCachedPrice` | `number` | Pollen price. Token rates are per token internally (the dashboard displays per 1M); `completionImagePrice` is per generated image when `imagePricing` is "request". |
@@ -1385,11 +1594,14 @@ Update a community model owned by the authenticated account. Changing visibility
 | `name` * | `string` | — |
 | `title` * | `string` | — |
 | `description` * | `string` \| `null` | — |
-| `modality` * | `"text"` \| `"image"` | Upstream API family. "text" uses `/v1/chat/completions`; "image" uses `/v1/images/generations` and currently supports text-to-image generation only. |
+| `modality` * | `"text"` \| `"image"` | Upstream API family. "text" uses `/v1/chat/completions`; "image" uses `/v1/images/generations` and optionally `/v1/images/edits` when the endpoint test succeeds. |
 | `imagePricing` * | `"request"` \| `"tokens"` | Image models only. "request": the generated-image price is charged once per generation. "tokens": provider-returned OpenAI image token usage is charged against per-token prices. Detected by the endpoint test. |
+| `inputModalities` * | `"text"` \| `"image"` \| `"audio"`[] | — |
 | `baseUrl` * | `string` | — |
 | `upstreamModel` * | `string` | — |
 | `visibility` * | `"private"` \| `"public"` | "private": owner-only, shown only to the owner, with no owner-set price. "public": anyone and listed in the catalog; it may be free or priced. Publishing requires an allowlisted account. |
+| `perUserRpm` * | `number` \| `null` | Maximum requests per minute for each Pollinations user. Decimals are supported; 0.5 means one request every two minutes. Null means no Pollinations-side limit. |
+| `fallbackModelIds` * | `string`[] | — |
 | `promptTextPrice` * | `number` | — |
 | `promptCachedPrice` * | `number` | — |
 | `promptCacheWritePrice` * | `number` | — |
@@ -1420,6 +1632,9 @@ curl -X POST "https://gen.pollinations.ai/account/my-models/key_abc123/update" \
 {
   "modality": "text",
   "imagePricing": "request",
+  "inputModalities": [
+    "text"
+  ],
   "visibility": "private"
 }
 ```
@@ -1782,7 +1997,7 @@ Create a new API key. To create an app key, use `type: "publishable"` with `redi
 | `type` | `"secret"` \| `"publishable"` | Key type: secret (sk_) or publishable app key (pk_). Use publishable to create an app key. · default: `"secret"` |
 | `expiresIn` | `integer` | Expiry in seconds from now (max 365 days) · max: `31536000` |
 | `allowedModels` | `string`[] \| `null` | Model IDs this key can access. null = all models |
-| `pollenBudget` | `number` \| `null` | Pollen budget cap. null = unlimited |
+| `pollenBudget` | `number` \| `null` | Pollen budget cap. Publishable keys accept only null, omission, or 0 and always use 0; secret keys use null for unlimited |
 | `accountPermissions` | `string`[] \| `null` | Account permissions (e.g. ["usage"]). "keys" is auto-stripped. |
 | `redirectUris` | `string`[] | Allowed OAuth redirect URIs for publishable app keys. Required for OAuth app flows. Must be https:// except http:// loopback URIs for local apps. Matching pins scheme, host, port, and path; one trailing slash is ignored. If the registered URI has no query, incoming query params are allowed; if it has a query, the query must match exactly. Loopback ports are matched port-agnostically. |
 | `earningsEnabled` | `boolean` | Enable developer earnings for publishable app keys. Defaults to false; send true to opt in. |
@@ -1984,9 +2199,9 @@ curl "https://gen.pollinations.ai/v1/models/status" \
 
 Generate a 3D model from a text prompt or reference image(s). Returns GLB by default.
 
-**Available models:** `trellis-2-low`, `trellis-2-medium`, `trellis-2-high`, `hyper3d-rodin`. `trellis-2-low` is the default.
+**Available models:** `trellis-2`, `hyper3d-rodin`. `trellis-2` is the default.
 
-Pass reference image URL(s) via the `image` parameter for image-to-3D models (`trellis-2-*`). Separate multiple URLs with `|` or `,`. `hyper3d-rodin` accepts both images and a text prompt.
+Pass reference image URL(s) via the `image` parameter for image-to-3D models (`trellis-2`). Separate multiple URLs with `|` or `,`. `hyper3d-rodin` accepts both images and a text prompt.
 
 Browse all available models and their input requirements at [`/3d/models`](https://gen.pollinations.ai/3d/models).
 
@@ -1994,8 +2209,9 @@ Browse all available models and their input requirements at [`/3d/models`](https
 
 | Param | In | Type | Description |
 |---|---|---|---|
-| `prompt` * | `path` | `string` | Text description of the 3D model to generate (required for text-to-3D models; ignored by image-only models) |
-| `model` * | `query` | `"trellis-2-low"` \| `"trellis-2-medium"` \| `"trellis-2-high"` \| `"hyper3d-rodin"` \| `"rodin"` | Model to use. See /3d/models for the full list and per-model input requirements. · default: `"trellis-2-low"` |
+| `prompt` * | `path` | `string` | Text description of the 3D model to generate (required for text-to-3D models such as Hyper3D Rodin; ignored by image-only models such as Trellis 2) |
+| `model` * | `query` | enum (6) — `"trellis-2"`, `"hyper3d-rodin"`, `"trellis-2-low"`, … | Model to use. See /3d/models for the full list and per-model input requirements. · default: `"trellis-2"` |
+| `resolution` | `query` | `"low"` \| `"medium"` \| `"high"` | Output detail for `trellis-2`. Defaults to `low`. |
 | `image` | `query` | `string` | Reference image URL(s) for image-to-3D generation. Separate multiple URLs with `\|` or `,`. Required for image-only models (e.g. `trellis`, `triposr`, `sf3d`). |
 | `seed` | `query` | `integer` | Seed for varied generations. Passed through to models that support it (`hyper3d-rodin`); otherwise only affects the media-cache key, so a new seed forces a fresh generation for the same prompt/image. |
 | `safe` | `query` | `string` \| `boolean` | Safety features: comma-separated list of privacy, secrets, sexual, violence, shield, true, nsfw. true enables privacy,secrets; nsfw enables sexual,violence. Also accepted in the Pollinations-Safe header. Defaults to off; false and 0 are accepted as off. |
@@ -2007,8 +2223,46 @@ Browse all available models and their input requirements at [`/3d/models`](https
 💻 **Example**
 
 ```bash
-curl "https://gen.pollinations.ai/3d/a%20low-poly%20treasure%20chest?model=trellis-2-low&image=:image" \
+curl "https://gen.pollinations.ai/3d/a%20low-poly%20treasure%20chest?model=trellis-2&resolution=low" \
   -H "Authorization: Bearer $POLLINATIONS_KEY"
+```
+
+---
+
+#### `POST` `/3d/{prompt}` — Generate 3D Model With JSON
+
+Generate a 3D model from a text prompt or reference image using JSON parameters. `trellis-2` supports `low`, `medium`, and `high` resolution with variable pricing.
+
+⚙️ **Parameters**
+
+| Param | In | Type | Description |
+|---|---|---|---|
+| `prompt` * | `path` | `string` | Text description of the 3D model to generate (required for text-to-3D models; ignored by image-only models) |
+| `key` | `query` | `string` | API key (alternative to Authorization header) |
+| `safe` | `query` | `string` \| `boolean` | Safety features: comma-separated list of privacy, secrets, sexual, violence, shield, true, nsfw. true enables privacy,secrets; nsfw enables sexual,violence. Also accepted in the Pollinations-Safe header. Defaults to off; false and 0 are accepted as off. |
+
+<sub>`*` = required parameter</sub>
+
+📥 **Request body** · `application/json`
+
+| Field | Type | Description |
+|---|---|---|
+| `model` | enum (6) — `"trellis-2"`, `"hyper3d-rodin"`, `"trellis-2-low"`, … | Model to use for 3D generation. See /3d/models for the full list and per-model input requirements. · default: `"trellis-2"` |
+| `image` | `string` \| `string`[] | Reference image URL or array of URLs for image-to-3D generation, optionally guided by the path prompt on supported models. A string is treated as one complete URL. |
+| `resolution` | `"low"` \| `"medium"` \| `"high"` | Output voxel-grid resolution for `trellis-2`: `low` (512³), `medium` (1024³), or `high` (1536³). Higher resolutions add detail, take longer, and cost more. · default: `"low"` |
+| `seed` | `integer` | Seed for varied generations. Passed to models that support it. |
+
+<sub>`*` = required field</sub>
+
+📤 **Response** · `200` · `model/gltf-binary` — Success - Returns the generated 3D model
+
+💻 **Example**
+
+```bash
+curl -X POST "https://gen.pollinations.ai/3d/a%20low-poly%20treasure%20chest?key=:key&safe=:safe" \
+  -H "Authorization: Bearer $POLLINATIONS_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"hyper3d-rodin"}'
 ```
 
 ## ⚠️ Error Responses
@@ -2032,6 +2286,10 @@ All endpoints return errors in this envelope:
 | Status | Code | Description |
 |---|---|---|
 | `400` | `BAD_REQUEST` | Invalid input. `details` includes `formErrors` and `fieldErrors` for validation failures. |
+| `400` | `invalid_image_url` | A supplied image URL is malformed, not HTTP(S), points at a private or credentialed host, or redirects. Provide a direct public image URL. |
+| `400` | `failed_to_download_image` | A supplied image URL could not be downloaded — host unreachable, DNS failure, a non-2xx response from the image host, or a body that ended mid-read. The host's status is reported in `details.upstreamStatus`. |
+| `400` | `image_too_large` | A supplied image exceeds the per-image size cap, or the request exceeds the per-request image size or count cap. |
+| `400` | `unsupported_image_media_type` | A supplied image declares no media type and could not be recognized from its content. A declared media type is forwarded to the provider as-is, so whether a given format is usable is answered by the provider, not here. |
 | `401` | `UNAUTHORIZED` | Missing or invalid API key. Provide via `Authorization: Bearer <key>` header or `?key=<key>` query param. |
 | `402` | `PAYMENT_REQUIRED` | Insufficient pollen balance or API key budget exhausted. |
 | `403` | `FORBIDDEN` | Access denied — insufficient permissions or paid-model access for this model. |
@@ -2148,6 +2406,7 @@ Marks the end of a static prompt prefix to cache (Gemini, Claude, and Nova model
 | `response_format` | `"url"` \| `"b64_json"` | Return format. "url" returns a pollinations.ai URL, "b64_json" returns base64-encoded image data · default: `"b64_json"` |
 | `user` | `string` | End-user identifier for abuse tracking |
 | `image` | `string` \| `string`[] | Reference image URL(s) for image-to-image generation (Pollinations extension) |
+| `resolution` | enum (6) — `"1k"`, `"2k"`, `"480p"`, … | Output resolution for resolution-priced image and video models (Pollinations extension) |
 | `safe` | `string` \| `boolean` | Safety features: comma-separated list of privacy, secrets, sexual, violence, shield, true, nsfw. true enables privacy,secrets; nsfw enables sexual,violence. Also accepted in the Pollinations-Safe header. Defaults to off; false and 0 are accepted as off. |
 
 <sub>`*` = required field</sub>

--- a/apps/floret/.env.example
+++ b/apps/floret/.env.example
@@ -1,8 +1,8 @@
 PYTHONPATH=src
 OPENAI_BASE_URL=https://gen.pollinations.ai
-# Local/dev only. Hosted deployments get a per-request credential from the
-# gateway instead — leave this unset there, and leave the flag below off, so a
-# request without one fails rather than spending the operator's own key.
+# Local/dev only. Users call gen with pk_/sk_; hosted Floret receives the
+# gateway's short-lived ag_ token instead. Leave this and the flag below unset
+# in production so Floret never spends an operator key.
 OPENAI_API_KEY=sk_your_key_here
 POLLI_ALLOW_OPERATOR_KEY=true
 

--- a/apps/floret/README.md
+++ b/apps/floret/README.md
@@ -29,6 +29,35 @@ docker run -p 8000:8000 --env-file .env floret
 
 The container needs no baked-in secrets. Hosted calls pass a short-lived agent run token via `Authorization: Bearer ag_…`; `OPENAI_API_KEY` is available only for local/dev use when `POLLI_ALLOW_OPERATOR_KEY=true`.
 
+## API
+
+```bash
+curl https://gen.pollinations.ai/v1/chat/completions \
+  -H "Authorization: Bearer $POLLINATIONS_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "floret",
+    "messages": [{"role": "user", "content": "Create a narrated launch concept"}],
+    "stream": true,
+    "routing": {
+      "text": "auto",
+      "web_search": "gemini-search",
+      "image_generation": "flux",
+      "image_editing": "nanobanana",
+      "video": "wan-fast",
+      "audio": "openai-audio"
+    }
+  }'
+```
+
+Users authenticate to `gen.pollinations.ai` with their normal `pk_` or `sk_` key. The gateway calls Floret with a short-lived internal `ag_` token; Floret's direct endpoint rejects user keys.
+
+- Every field is optional.
+- Omitted/`auto` lets Floret select; an explicitly supplied JSON `null` is invalid.
+- Explicit selections override any tool model proposed by the brain.
+- `audio` is TTS/audio generation, not transcription.
+- Invalid/incompatible IDs return 422 before work begins.
+
 ## Configuration
 
 See `.env.example`. Settings are read via `pydantic-settings`; most are `POLLI_`-prefixed (`POLLI_BRAIN_MODEL`, `POLLI_MAX_CONCURRENCY`, ...), while `OPENAI_API_KEY`/`OPENAI_BASE_URL` follow the OpenAI SDK's own convention.

--- a/apps/floret/src/floret/agent.py
+++ b/apps/floret/src/floret/agent.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
-from typing import Any
+from typing import Any, cast
 
 from openai import AsyncOpenAI
+from openai.types.chat import ChatCompletionMessageParam, ChatCompletionToolParam
 
 from floret.config import resolve_api_key, settings
 from floret.knowledge import build_system_prompt
+from floret.routing import RoutingPreferences
 from floret.toolset import TOOL_SCHEMAS, dispatch, parse_args
 
 logger = logging.getLogger(__name__)
@@ -51,19 +53,22 @@ async def run_agent_events(
     *,
     model: str | None = None,
     max_iters: int | None = None,
+    routing: RoutingPreferences | None = None,
 ):
     """Run the tool-calling loop, yielding progress events as they happen.
 
     Yields {"type": "tool_start", "name"} per tool call, then exactly one
     {"type": "final", "text", "artifacts", "iterations"}.
     """
-    model = model or settings.brain_model
+    routing = routing or RoutingPreferences()
+    model = routing.text or model or settings.brain_model
     max_iters = max_iters or settings.max_iters
     client = _client()
     semaphore = asyncio.Semaphore(settings.max_concurrency)
+    system_prompt = build_system_prompt() + routing.prompt_block()
 
     convo: list[dict[str, Any]] = [
-        {"role": "system", "content": build_system_prompt()},
+        {"role": "system", "content": system_prompt},
         *messages,
     ]
     artifacts: list[dict[str, Any]] = []
@@ -74,12 +79,12 @@ async def run_agent_events(
     for iteration in range(max_iters):
         completion = await client.chat.completions.create(
             model=model,
-            messages=convo,
-            tools=TOOL_SCHEMAS,
+            messages=cast(list[ChatCompletionMessageParam], convo),
+            tools=cast(list[ChatCompletionToolParam], TOOL_SCHEMAS),
             tool_choice="auto",
         )
         msg = completion.choices[0].message
-        tool_calls = msg.tool_calls or []
+        tool_calls = cast(list[Any], msg.tool_calls or [])
 
         # Record the assistant turn (with any tool_calls) verbatim.
         assistant_entry: dict[str, Any] = {
@@ -144,7 +149,7 @@ async def run_agent_events(
         async def _run(call: Any) -> tuple[str, Any]:
             call_id, name, raw_args = _tool_call_fields(call)
             async with semaphore:
-                result = await dispatch(name, parse_args(raw_args))
+                result = await dispatch(name, parse_args(raw_args), routing)
             return call_id, result
 
         keys = ["{}:{}".format(*_tool_call_fields(tc)[1:]) for tc in tool_calls]
@@ -186,7 +191,10 @@ async def run_agent_events(
             "content": "Iteration limit reached. Write your final answer now using what you have.",
         }
     )
-    final = await client.chat.completions.create(model=model, messages=convo)
+    final = await client.chat.completions.create(
+        model=model,
+        messages=cast(list[ChatCompletionMessageParam], convo),
+    )
     yield {
         "type": "final",
         "text": final.choices[0].message.content or "",
@@ -200,12 +208,15 @@ async def run_agent(
     *,
     model: str | None = None,
     max_iters: int | None = None,
+    routing: RoutingPreferences | None = None,
 ) -> dict[str, Any]:
     """Run the tool-calling loop over `messages` (OpenAI chat format).
 
     Returns {"text", "artifacts", "iterations"}.
     """
-    async for event in run_agent_events(messages, model=model, max_iters=max_iters):
+    async for event in run_agent_events(
+        messages, model=model, max_iters=max_iters, routing=routing
+    ):
         if event["type"] == "final":
             return {
                 "text": event["text"],

--- a/apps/floret/src/floret/api.py
+++ b/apps/floret/src/floret/api.py
@@ -19,6 +19,13 @@ from pydantic import BaseModel
 
 from floret.agent import run_agent, run_agent_events
 from floret.config import _api_key_override, settings
+from floret.routing import (
+    RoutingInput,
+    RoutingPreferences,
+    RoutingRegistryUnavailable,
+    RoutingValidationError,
+    validate_routing,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +63,7 @@ class ChatRequest(BaseModel):
     model: str
     messages: list[ChatMessage]
     stream: bool = False
+    routing: RoutingInput | None = None
 
 
 def _files_dir() -> str:
@@ -185,7 +193,10 @@ _STREAM_DONE = object()
 
 
 async def _sse_events(
-    messages: list[dict[str, Any]], model: str, api_key: str | None
+    messages: list[dict[str, Any]],
+    model: str,
+    api_key: str | None,
+    routing: RoutingPreferences,
 ) -> AsyncIterator[str]:
     """Translate agent events into OpenAI chat.completion.chunk SSE frames.
 
@@ -203,7 +214,7 @@ async def _sse_events(
 
     async def _pump() -> None:
         try:
-            async for event in run_agent_events(messages):
+            async for event in run_agent_events(messages, routing=routing):
                 await queue.put(event)
         except Exception as exc:
             await queue.put(exc)
@@ -248,42 +259,58 @@ async def _sse_events(
     yield "data: [DONE]\n\n"
 
 
-def _spendable_credential(http_request: Request) -> str | None:
-    """The Pollinations key this request may spend, if any.
-
-    Whatever the caller sent as a bearer. For a delegating community model the
-    gateway makes that a short-lived `ag_` run token in place of the endpoint's
-    saved secret, but the agent does not care which kind of key it holds — it
-    just spends the one it was given.
-    """
+def _agent_run_token(http_request: Request) -> str | None:
+    """Return the gateway-minted run token; reject direct user credentials."""
     header = http_request.headers.get("Authorization", "")
-    key = header[7:].strip() if header[:7].lower() == "bearer " else ""
-    return key or None
+    if not header:
+        return None
+    token = header[7:].strip() if header[:7].lower() == "bearer " else ""
+    if not token.startswith("ag_"):
+        raise HTTPException(
+            status_code=401,
+            detail="Floret requires an agent run token.",
+        )
+    return token
 
 
 @app.post("/v1/chat/completions")
 async def chat_completions(request: ChatRequest, http_request: Request) -> Any:
-    api_key = _spendable_credential(http_request)
+    api_key = _agent_run_token(http_request)
     # Fail here rather than part-way through a run: without a credential every
     # downstream generation 401s anyway, after the caller has already waited.
     if not api_key and not settings.allow_operator_key:
         raise HTTPException(
             status_code=401,
-            detail="Missing API key. Pass it as Authorization: Bearer <key>.",
+            detail="Missing agent run token.",
         )
+
+    token = _api_key_override.set(api_key or None)
+    try:
+        routing = await validate_routing(request.routing)
+    except RoutingValidationError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={"field": exc.field, "model": exc.model, "reason": exc.reason},
+        ) from exc
+    except RoutingRegistryUnavailable as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    finally:
+        _api_key_override.reset(token)
+
     if request.stream:
         return StreamingResponse(
             _sse_events(
                 _to_openai_messages(request.messages),
                 request.model,
                 api_key or None,
+                routing,
             ),
             media_type="text/event-stream",
             headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
         )
     token = _api_key_override.set(api_key or None)
     try:
-        result = await run_agent(_to_openai_messages(request.messages))
+        result = await run_agent(_to_openai_messages(request.messages), routing=routing)
         markdown, content_parts = await _build_content(
             result["text"], result["artifacts"]
         )
@@ -336,6 +363,14 @@ async def chat_completions_get() -> dict[str, Any]:
                 "model": "floret",
                 "messages": [{"role": "user", "content": "Hi!"}],
                 "stream": True,
+                "routing": {
+                    "text": "auto",
+                    "web_search": "auto",
+                    "image_generation": "auto",
+                    "image_editing": "auto",
+                    "video": "auto",
+                    "audio": "auto",
+                },
             },
         },
     }

--- a/apps/floret/src/floret/registry.py
+++ b/apps/floret/src/floret/registry.py
@@ -240,6 +240,43 @@ def _normalize(raw: dict[str, Any]) -> dict[str, Any]:
     return {"models": models, "by_modality": by_modality}
 
 
+def _adapt_rich_catalog(raw: object) -> dict[str, dict[str, Any]]:
+    if not isinstance(raw, list):
+        raise ValueError("Model catalog endpoint /models returned a non-array response")
+
+    models: dict[str, dict[str, Any]] = {}
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        model_id = item.get("id") or item.get("name")
+        if isinstance(model_id, str) and model_id:
+            models[model_id] = dict(item)
+    return models
+
+
+async def _fetch_models(path: str) -> object:
+    key = await _resolve_api_key()
+    base = settings.openai_base_url.rstrip("/")
+    headers = {"Authorization": f"Bearer {key}"} if key else {}
+    async with httpx.AsyncClient(timeout=10) as client:
+        response = await client.get(f"{base}{path}", headers=headers)
+        response.raise_for_status()
+        return response.json()
+
+
+async def fetch_model_catalog() -> dict[str, dict[str, Any]]:
+    return _adapt_rich_catalog(await _fetch_models("/models"))
+
+
+async def refresh_registry() -> dict[str, Any]:
+    global _registry_cache
+    raw = await _fetch_models("/v1/models")
+    if not isinstance(raw, dict):
+        raise ValueError("Model endpoint /v1/models returned a non-object response")
+    _registry_cache = _normalize(raw)
+    return _registry_cache
+
+
 async def get_registry() -> dict[str, Any]:
     global _registry_cache
     if _registry_cache is not None:
@@ -247,19 +284,12 @@ async def get_registry() -> dict[str, Any]:
     async with _lock:
         if _registry_cache is not None:
             return _registry_cache
-        key = await _resolve_api_key()
-        base = settings.openai_base_url.rstrip("/")
-        headers = {"Authorization": f"Bearer {key}"} if key else {}
         try:
-            async with httpx.AsyncClient(timeout=30) as client:
-                r = await client.get(f"{base}/v1/models", headers=headers)
-                r.raise_for_status()
-                raw = r.json()
+            return await refresh_registry()
         except Exception as exc:
             logger.warning("Failed to fetch /v1/models: %s", exc)
-            raw = {"data": []}
-        _registry_cache = _normalize(raw)
-        return _registry_cache
+            _registry_cache = _normalize({"data": []})
+            return _registry_cache
 
 
 def get_model_catalog() -> dict[str, dict[str, Any]]:

--- a/apps/floret/src/floret/routing.py
+++ b/apps/floret/src/floret/routing.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+from typing import Annotated, Any
+
+from pydantic import BaseModel, ConfigDict, StringConstraints, model_validator
+
+from floret.registry import fetch_model_catalog
+
+ModelPreference = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+
+@dataclass(frozen=True)
+class CapabilityRequirement:
+    category: str | None = None
+    capability: str | None = None
+    required_input: str | None = None
+    required_output: str | None = None
+    endpoint_when_present: str | None = None
+
+
+_TOOL_FIELDS = {
+    "generate_image": "image_generation",
+    "edit_image": "image_editing",
+    "generate_video": "video",
+    "text_to_speech": "audio",
+    "web_search": "web_search",
+}
+
+_FIELD_LABELS = {
+    "text": "text reasoning",
+    "web_search": "web search",
+    "image_generation": "image generation",
+    "image_editing": "image editing",
+    "video": "video generation",
+    "audio": "audio generation",
+}
+
+_REQUIREMENTS = {
+    "text": CapabilityRequirement(
+        category="text",
+        required_output="text",
+        endpoint_when_present="/v1/chat/completions",
+    ),
+    "web_search": CapabilityRequirement(
+        category="text",
+        capability="web_search",
+        endpoint_when_present="/v1/chat/completions",
+    ),
+    "image_generation": CapabilityRequirement(
+        category="image",
+        required_input="text",
+        required_output="image",
+        endpoint_when_present="/image/{prompt}",
+    ),
+    "image_editing": CapabilityRequirement(
+        category="image",
+        required_input="image",
+        required_output="image",
+    ),
+    "video": CapabilityRequirement(
+        category="video",
+        required_output="video",
+        endpoint_when_present="/video/{prompt}",
+    ),
+    "audio": CapabilityRequirement(
+        required_input="text",
+        required_output="audio",
+        endpoint_when_present="/v1/chat/completions",
+    ),
+}
+
+
+@dataclass(frozen=True)
+class RoutingPreferences:
+    text: str | None = None
+    web_search: str | None = None
+    image_generation: str | None = None
+    image_editing: str | None = None
+    video: str | None = None
+    audio: str | None = None
+
+    def explicit(self) -> dict[str, str]:
+        return {
+            field.name: value
+            for field in fields(self)
+            if (value := getattr(self, field.name)) is not None
+        }
+
+    def model_for_tool(self, tool_name: str) -> str | None:
+        field = _TOOL_FIELDS.get(tool_name)
+        return getattr(self, field) if field is not None else None
+
+    def prompt_block(self) -> str:
+        explicit = self.explicit()
+        if not explicit:
+            return ""
+        constraints = ", ".join(
+            f"{_FIELD_LABELS[field]}={model}" for field, model in explicit.items()
+        )
+        return f"\nFixed models: {constraints}. Use them; do not claim otherwise."
+
+
+class RoutingInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    text: ModelPreference | None = None
+    web_search: ModelPreference | None = None
+    image_generation: ModelPreference | None = None
+    image_editing: ModelPreference | None = None
+    video: ModelPreference | None = None
+    audio: ModelPreference | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def reject_explicit_nulls(cls, value: Any) -> Any:
+        if isinstance(value, dict):
+            null_fields = [field for field, item in value.items() if item is None]
+            if null_fields:
+                raise ValueError(
+                    f"routing fields cannot be null: {', '.join(null_fields)}"
+                )
+        return value
+
+    def to_preferences(self) -> RoutingPreferences:
+        return RoutingPreferences(
+            text=None if self.text == "auto" else self.text,
+            web_search=None if self.web_search == "auto" else self.web_search,
+            image_generation=(
+                None if self.image_generation == "auto" else self.image_generation
+            ),
+            image_editing=None if self.image_editing == "auto" else self.image_editing,
+            video=None if self.video == "auto" else self.video,
+            audio=None if self.audio == "auto" else self.audio,
+        )
+
+
+class RoutingValidationError(ValueError):
+    def __init__(self, field: str, model: str, reason: str) -> None:
+        self.field = field
+        self.model = model
+        self.reason = reason
+        super().__init__(
+            f"Invalid routing preference for '{field}' model '{model}': {reason}"
+        )
+
+
+class RoutingRegistryUnavailable(RuntimeError):
+    pass
+
+
+def _has_capability(meta: dict[str, object], capability: str) -> bool:
+    capabilities = meta.get("capabilities") or {}
+    if isinstance(capabilities, dict):
+        return bool(capabilities.get(capability))
+    if isinstance(capabilities, list):
+        return capability in capabilities
+    return False
+
+
+def _string_values(meta: dict[str, object], key: str) -> list[str]:
+    value = meta.get(key)
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _validation_reason(
+    meta: dict[str, object], requirement: CapabilityRequirement
+) -> str | None:
+    category = meta.get("category")
+    categories = (
+        [category] if isinstance(category, str) else _string_values(meta, "modalities")
+    )
+    if requirement.category and requirement.category not in categories:
+        return f"requires category '{requirement.category}'"
+
+    input_modalities = _string_values(meta, "input_modalities")
+    if (
+        requirement.required_input
+        and requirement.required_input not in input_modalities
+    ):
+        return f"requires input modality '{requirement.required_input}'"
+
+    output_modalities = _string_values(meta, "output_modalities")
+    if (
+        requirement.required_output
+        and requirement.required_output not in output_modalities
+    ):
+        return f"requires output modality '{requirement.required_output}'"
+
+    if requirement.capability and not _has_capability(meta, requirement.capability):
+        return f"requires capability '{requirement.capability}'"
+
+    endpoints = _string_values(meta, "supported_endpoints")
+    if (
+        endpoints
+        and requirement.endpoint_when_present
+        and requirement.endpoint_when_present not in endpoints
+    ):
+        return f"requires endpoint '{requirement.endpoint_when_present}'"
+    return None
+
+
+async def validate_routing(value: RoutingInput | None) -> RoutingPreferences:
+    preferences = value.to_preferences() if value is not None else RoutingPreferences()
+    explicit = preferences.explicit()
+    if not explicit:
+        return preferences
+
+    try:
+        catalog = await fetch_model_catalog()
+    except Exception as exc:
+        raise RoutingRegistryUnavailable("Model registry is unavailable") from exc
+
+    for field, model in explicit.items():
+        meta = catalog.get(model)
+        if meta is None:
+            raise RoutingValidationError(field, model, "unknown model")
+        reason = _validation_reason(meta, _REQUIREMENTS[field])
+        if reason is not None:
+            raise RoutingValidationError(field, model, reason)
+    return preferences

--- a/apps/floret/src/floret/toolset.py
+++ b/apps/floret/src/floret/toolset.py
@@ -11,6 +11,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any
 
+from floret.routing import RoutingPreferences
 from floret.tools import gen, media, shell
 
 logger = logging.getLogger(__name__)
@@ -251,18 +252,27 @@ TOOL_SCHEMAS: list[dict[str, Any]] = [
 # --------------------------------------------------------------------------- #
 # Dispatch
 # --------------------------------------------------------------------------- #
-async def dispatch(name: str, args: dict[str, Any]) -> ToolResult:
+async def dispatch(
+    name: str,
+    args: dict[str, Any],
+    routing: RoutingPreferences | None = None,
+) -> ToolResult:
     """Run one tool call and package brain-text + artifacts."""
+    call_args = dict(args)
+    selected_model = routing.model_for_tool(name) if routing else None
+    if selected_model:
+        call_args["model"] = selected_model
+
     try:
         if name == "generate_image":
-            urls = await gen.generate_image(**args)
+            urls = await gen.generate_image(**call_args)
             arts = [{"type": "image", "url": u} for u in urls]
             return ToolResult(
                 brain="Generated images:\n" + "\n".join(urls), artifacts=arts
             )
 
         if name == "edit_image":
-            url = await gen.edit_image(**args)
+            url = await gen.edit_image(**call_args)
             if url.startswith("data:"):
                 # Hosting fallback: never echo megabytes of base64 into context.
                 brain = (
@@ -274,14 +284,25 @@ async def dispatch(name: str, args: dict[str, Any]) -> ToolResult:
             return ToolResult(brain=brain, artifacts=[{"type": "image", "url": url}])
 
         if name == "generate_video":
-            url = await gen.generate_video(**args)
+            if (
+                selected_model
+                and call_args.get("end_image")
+                and selected_model not in gen.END_FRAME_MODELS
+            ):
+                return ToolResult(
+                    brain=(
+                        f"ERROR: pinned video model {selected_model!r} "
+                        "does not support an end frame"
+                    )
+                )
+            url = await gen.generate_video(**call_args)
             return ToolResult(
                 brain=f"Generated video: {url}",
                 artifacts=[{"type": "video", "url": url}],
             )
 
         if name == "text_to_speech":
-            res = await gen.text_to_speech(**args)
+            res = await gen.text_to_speech(**call_args)
             art = {
                 "type": "audio",
                 "data_uri": res["data_uri"],
@@ -300,7 +321,7 @@ async def dispatch(name: str, args: dict[str, Any]) -> ToolResult:
             return ToolResult(brain=f"Transcript:\n{text}")
 
         if name == "web_search":
-            text = await gen.web_search(**args)
+            text = await gen.web_search(**call_args)
             return ToolResult(brain=text)
 
         if name == "upload_media":

--- a/apps/floret/tests/test_agent_loop.py
+++ b/apps/floret/tests/test_agent_loop.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 
 import pytest
 
 from floret import agent as agent_mod
+from floret.routing import RoutingPreferences
 
 
 def _tool_call(call_id: str, name: str, args: str):
@@ -29,10 +31,12 @@ class _FakeBrain:
         self._sequence = list(sequence)
         self._final = final
         self.calls: list[list[dict]] = []
+        self.kwargs_calls: list[dict] = []
         self.chat = SimpleNamespace(completions=SimpleNamespace(create=self._create))
 
     async def _create(self, **kwargs):
         self.calls.append(kwargs["messages"])
+        self.kwargs_calls.append(kwargs)
         # The post-cap wrap-up call is made WITHOUT tools; serve the final message.
         if "tools" not in kwargs and self._final is not None:
             return self._final
@@ -48,7 +52,7 @@ async def test_two_parallel_tool_calls_both_execute(monkeypatch):
     """A single assistant turn with two tool_calls must run BOTH, not just the first."""
     seen: list[dict] = []
 
-    async def dispatch(name, args):
+    async def dispatch(name, args, routing=None):
         from floret.toolset import ToolResult
 
         seen.append({"name": name, "args": args})
@@ -86,7 +90,7 @@ async def test_two_parallel_tool_calls_both_execute(monkeypatch):
 
 
 async def test_tool_error_is_fed_back_to_brain(monkeypatch):
-    async def dispatch(name, args):
+    async def dispatch(name, args, routing=None):
         from floret.toolset import ToolResult
 
         return ToolResult(brain="ERROR from generate_image: boom", artifacts=[])
@@ -110,7 +114,7 @@ async def test_tool_error_is_fed_back_to_brain(monkeypatch):
 async def test_run_agent_events_yields_tool_starts_then_final(monkeypatch):
     """The event stream must announce each tool call and end with the final result."""
 
-    async def dispatch(name, args):
+    async def dispatch(name, args, routing=None):
         from floret.toolset import ToolResult
 
         return ToolResult(
@@ -153,7 +157,7 @@ async def test_run_agent_events_yields_tool_starts_then_final(monkeypatch):
 async def test_repeated_identical_calls_inject_guidance(monkeypatch):
     """Identical repeated tool calls must trigger corrective guidance, not a kill."""
 
-    async def dispatch(name, args):
+    async def dispatch(name, args, routing=None):
         from floret.toolset import ToolResult
 
         return ToolResult(brain="a video url", artifacts=[])
@@ -184,7 +188,7 @@ async def test_repeated_identical_calls_inject_guidance(monkeypatch):
 
 
 async def test_consecutive_error_turns_inject_guidance(monkeypatch):
-    async def dispatch(name, args):
+    async def dispatch(name, args, routing=None):
         from floret.toolset import ToolResult
 
         return ToolResult(brain="ERROR from generate_video: boom", artifacts=[])
@@ -214,7 +218,7 @@ async def test_consecutive_error_turns_inject_guidance(monkeypatch):
 async def test_unpublished_workspace_file_in_final_answer_triggers_nudge(monkeypatch):
     """A final answer referencing final.mp4 without a hosted URL is not done."""
 
-    async def dispatch(name, args):
+    async def dispatch(name, args, routing=None):
         from floret.toolset import ToolResult
 
         return ToolResult(
@@ -263,7 +267,7 @@ async def test_final_answer_with_hosted_url_is_not_nudged(monkeypatch):
 async def test_no_nudge_when_deliverable_already_attached(monkeypatch):
     """If a hosted av artifact exists, the deliverable reaches the user anyway."""
 
-    async def dispatch(name, args):
+    async def dispatch(name, args, routing=None):
         from floret.toolset import ToolResult
 
         return ToolResult(
@@ -304,7 +308,7 @@ async def test_nudge_emits_visible_stream_event(monkeypatch):
 
 
 async def test_iteration_cap_forces_final_answer(monkeypatch):
-    async def dispatch(name, args):
+    async def dispatch(name, args, routing=None):
         from floret.toolset import ToolResult
 
         return ToolResult(brain="ok", artifacts=[])
@@ -324,3 +328,117 @@ async def test_iteration_cap_forces_final_answer(monkeypatch):
     )
     assert result["iterations"] == 3
     assert result["text"] == "forced final"
+
+
+async def test_routing_object_reaches_dispatch(monkeypatch):
+    seen = []
+
+    async def dispatch(name, args, routing=None):
+        from floret.toolset import ToolResult
+
+        seen.append(routing)
+        return ToolResult(brain="image", artifacts=[])
+
+    monkeypatch.setattr(agent_mod, "dispatch", dispatch)
+    brain = _FakeBrain(
+        [
+            _assistant(
+                "making image",
+                [_tool_call("c1", "generate_image", '{"prompt":"x"}')],
+            ),
+            _assistant("done", None),
+        ]
+    )
+    monkeypatch.setattr(agent_mod, "_client", lambda: brain)
+    routing = RoutingPreferences(image_generation="flux")
+
+    await agent_mod.run_agent([{"role": "user", "content": "image"}], routing=routing)
+
+    assert seen == [routing]
+    assert seen[0] is routing
+
+
+async def test_concurrent_runs_keep_routing_preferences_isolated(monkeypatch):
+    seen = []
+
+    async def dispatch(name, args, routing=None):
+        from floret.toolset import ToolResult
+
+        seen.append((args["prompt"], routing))
+        return ToolResult(brain="image", artifacts=[])
+
+    monkeypatch.setattr(agent_mod, "dispatch", dispatch)
+    brains = iter(
+        [
+            _FakeBrain(
+                [
+                    _assistant(
+                        "first",
+                        [_tool_call("c1", "generate_image", '{"prompt":"first"}')],
+                    ),
+                    _assistant("done", None),
+                ]
+            ),
+            _FakeBrain(
+                [
+                    _assistant(
+                        "second",
+                        [_tool_call("c2", "generate_image", '{"prompt":"second"}')],
+                    ),
+                    _assistant("done", None),
+                ]
+            ),
+        ]
+    )
+    monkeypatch.setattr(agent_mod, "_client", lambda: next(brains))
+    first = RoutingPreferences(image_generation="flux")
+    second = RoutingPreferences(image_generation="nanobanana")
+
+    await asyncio.gather(
+        agent_mod.run_agent([{"role": "user", "content": "first"}], routing=first),
+        agent_mod.run_agent([{"role": "user", "content": "second"}], routing=second),
+    )
+
+    assert set(seen) == {("first", first), ("second", second)}
+
+
+async def test_routing_prompt_lists_only_explicit_preferences(monkeypatch):
+    brain = _FakeBrain([_assistant("done", None)])
+    monkeypatch.setattr(agent_mod, "_client", lambda: brain)
+
+    await agent_mod.run_agent(
+        [{"role": "user", "content": "image"}],
+        routing=RoutingPreferences(image_generation="flux"),
+    )
+
+    system_prompt = brain.calls[0][0]["content"]
+    assert "image generation=flux" in system_prompt
+    assert "video generation=" not in system_prompt
+
+
+async def test_text_routing_model_reaches_every_brain_call(monkeypatch):
+    async def dispatch(name, args, routing=None):
+        from floret.toolset import ToolResult
+
+        return ToolResult(brain="ok", artifacts=[])
+
+    monkeypatch.setattr(agent_mod, "dispatch", dispatch)
+    brain = _FakeBrain(
+        [
+            _assistant("again", [_tool_call("c1", "bash", '{"command":"true"}')]),
+            _assistant("again", [_tool_call("c2", "bash", '{"command":"true"}')]),
+        ],
+        final=_assistant("forced final", None),
+    )
+    monkeypatch.setattr(agent_mod, "_client", lambda: brain)
+    routing = RoutingPreferences(text="openai-large")
+
+    await agent_mod.run_agent(
+        [{"role": "user", "content": "loop"}], max_iters=2, routing=routing
+    )
+
+    assert [call["model"] for call in brain.kwargs_calls] == [
+        "openai-large",
+        "openai-large",
+        "openai-large",
+    ]

--- a/apps/floret/tests/test_api_stream.py
+++ b/apps/floret/tests/test_api_stream.py
@@ -9,6 +9,12 @@ import pytest
 from fastapi.testclient import TestClient
 
 from floret import api as api_mod
+from floret.config import _current_api_key
+from floret.routing import (
+    RoutingPreferences,
+    RoutingRegistryUnavailable,
+    RoutingValidationError,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -30,6 +36,138 @@ def _request_body(stream: bool) -> dict:
 # Every request must carry a credential to spend; the gateway supplies a
 # short-lived run token as the bearer.
 _HEADERS = {"Authorization": "Bearer ag_test-token"}
+
+
+async def _fake_run_agent(messages, **kwargs):
+    return {"text": "unused", "artifacts": [], "iterations": 1}
+
+
+@pytest.mark.parametrize(
+    "routing",
+    [{"image": "flux"}, {"video": " "}, {"text": None}],
+)
+def test_invalid_routing_shape_is_rejected(routing):
+    body = _request_body(stream=False) | {"routing": routing}
+
+    response = TestClient(api_mod.app).post(
+        "/v1/chat/completions", json=body, headers=_HEADERS
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.parametrize("routing", [None, {"text": "auto"}])
+def test_omitted_and_auto_routing_values_remain_allowed(monkeypatch, routing):
+    monkeypatch.setattr(api_mod, "run_agent", _fake_run_agent)
+    body = _request_body(stream=False)
+    if routing is not None:
+        body["routing"] = routing
+
+    response = TestClient(api_mod.app).post(
+        "/v1/chat/completions", json=body, headers=_HEADERS
+    )
+
+    assert response.status_code == 200
+
+
+def test_invalid_routing_preference_returns_stable_422(monkeypatch):
+    async def fake_validate(value):
+        raise RoutingValidationError(
+            field="video",
+            model="flux",
+            reason="model does not support video generation",
+        )
+
+    monkeypatch.setattr(api_mod, "validate_routing", fake_validate, raising=False)
+    monkeypatch.setattr(api_mod, "run_agent", _fake_run_agent)
+    body = _request_body(stream=False) | {"routing": {"video": "flux"}}
+
+    response = TestClient(api_mod.app).post(
+        "/v1/chat/completions", json=body, headers=_HEADERS
+    )
+
+    assert response.status_code == 422
+    assert response.json() == {
+        "detail": {
+            "field": "video",
+            "model": "flux",
+            "reason": "model does not support video generation",
+        }
+    }
+
+
+def test_unavailable_routing_registry_returns_503(monkeypatch):
+    async def fake_validate(value):
+        raise RoutingRegistryUnavailable("model registry unavailable")
+
+    monkeypatch.setattr(api_mod, "validate_routing", fake_validate, raising=False)
+    monkeypatch.setattr(api_mod, "run_agent", _fake_run_agent)
+    body = _request_body(stream=False) | {"routing": {"video": "flux"}}
+
+    response = TestClient(api_mod.app).post(
+        "/v1/chat/completions", json=body, headers=_HEADERS
+    )
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "model registry unavailable"}
+
+
+def test_non_stream_routing_is_validated_once_and_propagated(monkeypatch):
+    preferences = RoutingPreferences(image_generation="flux")
+    calls = []
+
+    async def fake_validate(value):
+        assert value is not None
+        assert value.image_generation == "flux"
+        assert _current_api_key() == "ag_test-token"
+        calls.append("validate")
+        return preferences
+
+    async def fake_run_agent(messages, **kwargs):
+        calls.append("run")
+        assert kwargs["routing"] is preferences
+        return {"text": "plain", "artifacts": [], "iterations": 1}
+
+    monkeypatch.setattr(api_mod, "validate_routing", fake_validate, raising=False)
+    monkeypatch.setattr(api_mod, "run_agent", fake_run_agent)
+    body = _request_body(stream=False) | {"routing": {"image_generation": "flux"}}
+
+    response = TestClient(api_mod.app).post(
+        "/v1/chat/completions", json=body, headers=_HEADERS
+    )
+
+    assert response.status_code == 200
+    assert calls == ["validate", "run"]
+
+
+def test_stream_routing_is_validated_once_and_propagated(monkeypatch):
+    preferences = RoutingPreferences(image_generation="flux")
+    calls = []
+
+    async def fake_validate(value):
+        assert value is not None
+        assert value.image_generation == "flux"
+        assert _current_api_key() == "ag_test-token"
+        calls.append("validate")
+        return preferences
+
+    async def fake_events(messages, **kwargs):
+        calls.append("run")
+        assert kwargs["routing"] is preferences
+        yield {"type": "final", "text": "done", "artifacts": [], "iterations": 1}
+
+    monkeypatch.setattr(api_mod, "validate_routing", fake_validate, raising=False)
+    monkeypatch.setattr(api_mod, "run_agent_events", fake_events)
+    body = _request_body(stream=True) | {"routing": {"image_generation": "flux"}}
+
+    with TestClient(api_mod.app).stream(
+        "POST", "/v1/chat/completions", json=body, headers=_HEADERS
+    ) as response:
+        assert response.status_code == 200
+        response_body = "".join(response.iter_text())
+
+    assert calls == ["validate", "run"]
+    assert response_body.rstrip().endswith("data: [DONE]")
 
 
 def test_stream_true_returns_openai_sse_chunks(monkeypatch):
@@ -203,30 +341,26 @@ def test_stream_false_returns_plain_json(monkeypatch):
     assert resp.json()["choices"][0]["message"]["content"] == "plain"
 
 
-def test_request_without_credential_is_rejected():
+def test_request_without_credential_is_rejected(monkeypatch: pytest.MonkeyPatch):
     """No credential must fail up front, not part-way through a paid run."""
+    monkeypatch.setattr(api_mod.settings, "allow_operator_key", False)
     client = TestClient(api_mod.app)
     resp = client.post("/v1/chat/completions", json=_request_body(stream=False))
     assert resp.status_code == 401
+    assert resp.json() == {"detail": "Missing agent run token."}
 
 
-def test_any_bearer_is_spendable(monkeypatch):
-    """The agent spends whatever key it was handed, whichever kind it is."""
-    from floret.config import _current_api_key
-
-    async def fake_run_agent(messages, **kwargs):
-        assert _current_api_key() == "sk_caller_key"
-        return {"text": "ok", "artifacts": [], "iterations": 1}
-
-    monkeypatch.setattr(api_mod, "run_agent", fake_run_agent)
-
-    client = TestClient(api_mod.app)
-    resp = client.post(
+@pytest.mark.parametrize("key", ["sk_caller_key", "pk_caller_key", "invalid"])
+def test_direct_endpoint_rejects_non_agent_credentials(key):
+    """Users authenticate to gen; only its delegated token reaches Floret."""
+    response = TestClient(api_mod.app).post(
         "/v1/chat/completions",
         json=_request_body(stream=False),
-        headers={"Authorization": "Bearer sk_caller_key"},
+        headers={"Authorization": f"Bearer {key}"},
     )
-    assert resp.status_code == 200
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Floret requires an agent run token."}
 
 
 def test_agent_run_token_reaches_brain_and_tools(monkeypatch):

--- a/apps/floret/tests/test_live.py
+++ b/apps/floret/tests/test_live.py
@@ -102,10 +102,9 @@ async def test_chained_video_via_frame_extraction(tmp_path, monkeypatch):
     )
     clip1 = await media.fetch_media(clip1_url, "clip1.mp4")
 
-    out = await bash(
-        f"ffmpeg -y -sseof -0.5 -i {clip1} -update 1 -q:v 1 last.jpg && ls last.jpg"
-    )
+    out = await bash(f"ffmpeg -y -sseof -0.5 -i {clip1} -update 1 -q:v 1 last.jpg")
     assert "exit_code: 0" in out
+    assert (tmp_path / "workspace" / "last.jpg").is_file()
 
     frame_url = await media.upload_media("last.jpg")
     assert frame_url.startswith("https://media.pollinations.ai/")

--- a/apps/floret/tests/test_media_tools.py
+++ b/apps/floret/tests/test_media_tools.py
@@ -7,6 +7,7 @@ import base64
 import pytest
 
 from floret import toolset
+from floret.routing import RoutingPreferences
 from floret.tools import media
 
 
@@ -122,6 +123,120 @@ async def test_uploaded_video_and_audio_become_artifacts(monkeypatch):
     # Frame images are intermediates — do not spam the reply with them.
     img = await toolset.dispatch("upload_media", {"source": "last1.jpg"})
     assert img.artifacts == []
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "field", "args", "selected"),
+    [
+        (
+            "generate_image",
+            "image_generation",
+            {"prompt": "x", "model": "brain-image"},
+            "flux",
+        ),
+        (
+            "edit_image",
+            "image_editing",
+            {
+                "prompt": "x",
+                "image_url": "https://x/a.jpg",
+                "model": "brain-edit",
+            },
+            "nanobanana",
+        ),
+        (
+            "generate_video",
+            "video",
+            {"prompt": "x", "model": "brain-video"},
+            "wan-fast",
+        ),
+        (
+            "text_to_speech",
+            "audio",
+            {"text": "x", "model": "brain-audio"},
+            "openai-audio",
+        ),
+        (
+            "web_search",
+            "web_search",
+            {"query": "x", "model": "brain-search"},
+            "gemini-search",
+        ),
+    ],
+)
+async def test_dispatch_routing_override_wins_without_mutating_args(
+    monkeypatch, tool_name, field, args, selected
+):
+    calls = []
+
+    async def spy(**kwargs):
+        calls.append(kwargs)
+        if tool_name == "generate_image":
+            return ["https://x/image.jpg"]
+        if tool_name == "text_to_speech":
+            return {
+                "data_uri": "data:audio/mp3;base64,eA==",
+                "b64": "eA==",
+                "format": "mp3",
+                "transcript": "x",
+            }
+        if tool_name == "web_search":
+            return "result"
+        return "https://x/media"
+
+    monkeypatch.setattr(toolset.gen, tool_name, spy)
+    routing = RoutingPreferences(**{field: selected})
+
+    await toolset.dispatch(tool_name, args, routing)
+
+    assert calls[0]["model"] == selected
+    assert args["model"].startswith("brain-")
+
+
+async def test_dispatch_without_override_preserves_brain_model(monkeypatch):
+    calls = []
+
+    async def spy(**kwargs):
+        calls.append(kwargs)
+        return ["https://x/image.jpg"]
+
+    monkeypatch.setattr(toolset.gen, "generate_image", spy)
+
+    await toolset.dispatch(
+        "generate_image",
+        {"prompt": "x", "model": "brain-image"},
+        RoutingPreferences(),
+    )
+
+    assert calls[0]["model"] == "brain-image"
+
+
+async def test_pinned_video_model_rejects_unsupported_end_frame(monkeypatch):
+    called = False
+
+    async def spy(**kwargs):
+        nonlocal called
+        called = True
+        return "https://x/video.mp4"
+
+    monkeypatch.setattr(toolset.gen, "generate_video", spy)
+    routing = RoutingPreferences(video="wan")
+
+    result = await toolset.dispatch(
+        "generate_video",
+        {
+            "prompt": "morph",
+            "image": "https://x/a.jpg",
+            "end_image": "https://x/b.jpg",
+        },
+        routing,
+    )
+
+    assert result.artifacts == []
+    assert result.brain.startswith("ERROR")
+    assert "wan" in result.brain
+    assert "end frame" in result.brain.lower()
+    assert not called
 
 
 async def test_generate_video_rehosts_unfetchable_frames(monkeypatch):

--- a/apps/floret/tests/test_routing.py
+++ b/apps/floret/tests/test_routing.py
@@ -1,0 +1,424 @@
+import asyncio
+
+from pydantic import ValidationError
+import pytest
+
+from floret import registry
+from floret.config import _api_key_override, _current_api_key
+import floret.routing as routing
+from floret.routing import (
+    RoutingInput,
+    RoutingPreferences,
+    RoutingRegistryUnavailable,
+    RoutingValidationError,
+    validate_routing,
+)
+
+_RICH_WIRE_CATALOG = [
+    {
+        "name": "glm",
+        "aliases": [],
+        "category": "text",
+        "brand": "Z.ai",
+        "pricing": {"currency": "pollen"},
+        "title": "GLM",
+        "input_modalities": ["text"],
+        "output_modalities": ["text"],
+        "supported_endpoints": ["/v1/chat/completions"],
+        "capabilities": [],
+    },
+    {
+        "name": "gemini-search",
+        "aliases": ["gemini-search-fast"],
+        "category": "text",
+        "brand": "Google",
+        "pricing": {"currency": "pollen"},
+        "title": "Google Gemini Search",
+        "input_modalities": ["text", "image", "video"],
+        "output_modalities": ["text"],
+        "supported_endpoints": ["/v1/chat/completions"],
+        "capabilities": ["web_search"],
+        "paid_only": True,
+    },
+    {
+        "name": "opaque-image-model-7",
+        "aliases": [],
+        "category": "image",
+        "brand": "Example",
+        "pricing": {"currency": "pollen"},
+        "title": "Opaque Image Model",
+        "input_modalities": ["text"],
+        "output_modalities": ["image"],
+        "supported_endpoints": ["/image/{prompt}"],
+        "capabilities": [],
+    },
+    {
+        "name": "nanobanana",
+        "aliases": [],
+        "category": "image",
+        "brand": "Google",
+        "pricing": {"currency": "pollen"},
+        "title": "Nano Banana",
+        "input_modalities": ["text", "image"],
+        "output_modalities": ["image"],
+        "supported_endpoints": ["/image/{prompt}", "/v1/images/edits"],
+        "capabilities": [],
+    },
+    {
+        "name": "wan-fast",
+        "aliases": [],
+        "category": "video",
+        "brand": "Wan",
+        "pricing": {"currency": "pollen"},
+        "title": "Wan Fast",
+        "input_modalities": ["text", "image"],
+        "output_modalities": ["video"],
+        "supported_endpoints": ["/video/{prompt}"],
+        "capabilities": [],
+    },
+    {
+        "name": "openai-audio",
+        "aliases": [],
+        "category": "text",
+        "brand": "OpenAI",
+        "pricing": {"currency": "pollen"},
+        "title": "OpenAI Audio",
+        "input_modalities": ["text"],
+        "output_modalities": ["text", "audio"],
+        "supported_endpoints": ["/v1/chat/completions"],
+        "capabilities": [],
+    },
+]
+
+_RICH_CATALOG = {item["name"]: item for item in _RICH_WIRE_CATALOG}
+
+
+def _use_catalog(monkeypatch, catalog=None):
+    async def fetch_model_catalog():
+        return _RICH_CATALOG if catalog is None else catalog
+
+    monkeypatch.setattr(routing, "fetch_model_catalog", fetch_model_catalog)
+
+
+def test_omitted_and_auto_values_normalize_to_none():
+    assert RoutingInput().to_preferences() == RoutingPreferences()
+    assert (
+        RoutingInput(
+            text="auto",
+            image_generation="auto",
+            audio="auto",
+        ).to_preferences()
+        == RoutingPreferences()
+    )
+
+
+def test_explicit_values_are_preserved_and_frozen():
+    preferences = RoutingInput(
+        text="glm",
+        image_generation="opaque-image-model-7",
+    ).to_preferences()
+    assert preferences.text == "glm"
+    assert preferences.image_generation == "opaque-image-model-7"
+    with pytest.raises(AttributeError):
+        preferences.text = "openai"
+
+
+def test_uppercase_auto_is_preserved_as_an_explicit_model_id():
+    assert RoutingInput(text="AUTO").to_preferences().text == "AUTO"
+
+
+@pytest.mark.parametrize("value", ["", " ", 123, None])
+def test_explicit_invalid_preference_values_are_rejected(value):
+    with pytest.raises(ValidationError):
+        RoutingInput.model_validate({"text": value})
+
+
+def test_unknown_routing_fields_are_rejected():
+    with pytest.raises(ValidationError):
+        RoutingInput.model_validate({"image": "flux"})
+
+
+def test_rich_catalog_adapter_uses_real_wire_shape_and_search_capability():
+    catalog = registry._adapt_rich_catalog(_RICH_WIRE_CATALOG)
+
+    assert catalog["gemini-search"]["category"] == "text"
+    assert catalog["gemini-search"]["capabilities"] == ["web_search"]
+    assert catalog["gemini-search"]["input_modalities"] == [
+        "text",
+        "image",
+        "video",
+    ]
+
+
+async def test_fetch_model_catalog_uses_authenticated_rich_endpoint(monkeypatch):
+    requests = []
+
+    class Response:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return _RICH_WIRE_CATALOG
+
+    class Client:
+        def __init__(self, *, timeout):
+            assert timeout == 10
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return None
+
+        async def get(self, url, *, headers):
+            requests.append((url, headers))
+            return Response()
+
+    shared_cache = {"models": {"cached": {}}, "by_modality": {}}
+    monkeypatch.setattr(registry, "_registry_cache", shared_cache)
+    monkeypatch.setattr(registry.httpx, "AsyncClient", Client)
+    monkeypatch.setattr(registry.settings, "openai_base_url", "https://example.test/")
+    token = _api_key_override.set("caller-token")
+    try:
+        catalog = await registry.fetch_model_catalog()
+    finally:
+        _api_key_override.reset(token)
+
+    assert requests == [
+        (
+            "https://example.test/models",
+            {"Authorization": "Bearer caller-token"},
+        )
+    ]
+    assert catalog["gemini-search"]["capabilities"] == ["web_search"]
+    assert registry._registry_cache is shared_cache
+
+
+async def test_validate_routing_accepts_all_capability_overrides(monkeypatch):
+    _use_catalog(monkeypatch)
+
+    preferences = await validate_routing(
+        RoutingInput(
+            text="glm",
+            web_search="gemini-search",
+            image_generation="opaque-image-model-7",
+            image_editing="nanobanana",
+            video="wan-fast",
+            audio="openai-audio",
+        )
+    )
+
+    assert preferences == RoutingPreferences(
+        text="glm",
+        web_search="gemini-search",
+        image_generation="opaque-image-model-7",
+        image_editing="nanobanana",
+        video="wan-fast",
+        audio="openai-audio",
+    )
+
+
+async def test_arbitrary_image_id_is_classified_from_authoritative_metadata(
+    monkeypatch,
+):
+    _use_catalog(monkeypatch)
+
+    preferences = await validate_routing(
+        RoutingInput(image_generation="opaque-image-model-7")
+    )
+
+    assert preferences.image_generation == "opaque-image-model-7"
+
+
+@pytest.mark.parametrize("model", ["missing", "AUTO"])
+async def test_validate_routing_rejects_unknown_models(monkeypatch, model):
+    _use_catalog(monkeypatch)
+
+    with pytest.raises(RoutingValidationError) as error:
+        await validate_routing(RoutingInput(text=model))
+
+    assert error.value.field == "text"
+    assert error.value.model == model
+    assert error.value.reason == "unknown model"
+
+
+@pytest.mark.parametrize(
+    ("field", "model", "reason"),
+    [
+        ("text", "opaque-image-model-7", "requires category 'text'"),
+        ("web_search", "glm", "requires capability 'web_search'"),
+        (
+            "image_generation",
+            "nanobanana",
+            "requires endpoint '/image/{prompt}'",
+        ),
+        ("image_editing", "opaque-image-model-7", "requires input modality 'image'"),
+        ("video", "opaque-image-model-7", "requires category 'video'"),
+        ("audio", "glm", "requires output modality 'audio'"),
+    ],
+)
+async def test_validate_routing_rejects_capability_mismatches(
+    monkeypatch, field, model, reason
+):
+    catalog = {
+        key: ({**value, "supported_endpoints": ["/v1/images/edits"]})
+        if key == "nanobanana"
+        else value
+        for key, value in _RICH_CATALOG.items()
+    }
+    _use_catalog(monkeypatch, catalog)
+
+    with pytest.raises(RoutingValidationError) as error:
+        await validate_routing(RoutingInput.model_validate({field: model}))
+
+    assert error.value.field == field
+    assert error.value.model == model
+    assert error.value.reason == reason
+
+
+async def test_explicit_validation_fetches_every_time_and_sees_catalog_changes(
+    monkeypatch,
+):
+    calls = 0
+
+    async def fetch_model_catalog():
+        nonlocal calls
+        calls += 1
+        return _RICH_CATALOG if calls == 1 else {}
+
+    monkeypatch.setattr(routing, "fetch_model_catalog", fetch_model_catalog)
+
+    assert (await validate_routing(RoutingInput(text="glm"))).text == "glm"
+    with pytest.raises(RoutingValidationError, match="unknown model"):
+        await validate_routing(RoutingInput(text="glm"))
+    assert calls == 2
+
+
+async def test_explicit_validation_isolates_caller_catalogs(monkeypatch):
+    caller_catalogs = {
+        "caller-a": {"a-model": {**_RICH_CATALOG["glm"], "name": "a-model"}},
+        "caller-b": {"b-model": {**_RICH_CATALOG["glm"], "name": "b-model"}},
+    }
+
+    async def fetch_model_catalog():
+        await asyncio.sleep(0)
+        return caller_catalogs[_current_api_key()]
+
+    async def validate_for(key, model):
+        token = _api_key_override.set(key)
+        try:
+            return await validate_routing(RoutingInput(text=model))
+        finally:
+            _api_key_override.reset(token)
+
+    monkeypatch.setattr(routing, "fetch_model_catalog", fetch_model_catalog)
+
+    caller_a, caller_b = await asyncio.gather(
+        validate_for("caller-a", "a-model"),
+        validate_for("caller-b", "b-model"),
+    )
+
+    assert caller_a.text == "a-model"
+    assert caller_b.text == "b-model"
+
+
+async def test_explicit_validation_neither_reads_nor_mutates_shared_cache(monkeypatch):
+    shared_cache = {
+        "models": {"wrong-model": {"category": "text"}},
+        "by_modality": {"text": {}},
+    }
+    monkeypatch.setattr(registry, "_registry_cache", shared_cache)
+    _use_catalog(monkeypatch)
+
+    preferences = await validate_routing(RoutingInput(text="glm"))
+
+    assert preferences.text == "glm"
+    assert registry._registry_cache is shared_cache
+
+
+async def test_validate_routing_reports_registry_fetch_failure(monkeypatch):
+    failure = RuntimeError("offline")
+
+    async def fetch_model_catalog():
+        raise failure
+
+    monkeypatch.setattr(routing, "fetch_model_catalog", fetch_model_catalog)
+
+    with pytest.raises(RoutingRegistryUnavailable) as error:
+        await validate_routing(RoutingInput(text="glm"))
+
+    assert error.value.__cause__ is failure
+
+
+@pytest.mark.parametrize("value", [None, RoutingInput(), RoutingInput(text="auto")])
+async def test_validate_routing_skips_registry_without_explicit_preferences(
+    monkeypatch, value
+):
+    async def unexpected_catalog_access():
+        pytest.fail("registry should not be fetched")
+
+    monkeypatch.setattr(routing, "fetch_model_catalog", unexpected_catalog_access)
+
+    assert await validate_routing(value) == RoutingPreferences()
+
+
+@pytest.mark.parametrize("supported_endpoints", [None, []])
+async def test_validate_routing_allows_omitted_endpoint_metadata(
+    monkeypatch, supported_endpoints
+):
+    catalog = {
+        "text-without-endpoints": {
+            **_RICH_CATALOG["glm"],
+            "name": "text-without-endpoints",
+            "supported_endpoints": supported_endpoints,
+        }
+    }
+    _use_catalog(monkeypatch, catalog)
+
+    preferences = await validate_routing(RoutingInput(text="text-without-endpoints"))
+
+    assert preferences.text == "text-without-endpoints"
+
+
+def test_routing_preferences_expose_explicit_values_and_tool_models():
+    preferences = RoutingPreferences(
+        text="glm",
+        web_search="gemini-search",
+        image_generation="opaque-image-model-7",
+        image_editing="nanobanana",
+        video="wan-fast",
+        audio="openai-audio",
+    )
+
+    assert preferences.explicit() == {
+        "text": "glm",
+        "web_search": "gemini-search",
+        "image_generation": "opaque-image-model-7",
+        "image_editing": "nanobanana",
+        "video": "wan-fast",
+        "audio": "openai-audio",
+    }
+    assert preferences.model_for_tool("generate_image") == "opaque-image-model-7"
+    assert preferences.model_for_tool("edit_image") == "nanobanana"
+    assert preferences.model_for_tool("generate_video") == "wan-fast"
+    assert preferences.model_for_tool("text_to_speech") == "openai-audio"
+    assert preferences.model_for_tool("web_search") == "gemini-search"
+    assert preferences.model_for_tool("unknown") is None
+
+
+def test_prompt_block_is_empty_without_explicit_preferences():
+    assert RoutingPreferences().prompt_block() == ""
+
+
+def test_prompt_block_has_exact_required_guidance_suffix():
+    preferences = RoutingPreferences(
+        text="glm",
+        image_generation="opaque-image-model-7",
+        audio="openai-audio",
+    )
+
+    assert preferences.prompt_block() == (
+        "\nFixed models: text reasoning=glm, "
+        "image generation=opaque-image-model-7, audio generation=openai-audio. "
+        "Use them; do not claim otherwise."
+    )

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-toggle-confirmation.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-toggle-confirmation.tsx
@@ -1,0 +1,44 @@
+import { Button, Dialog } from "@pollinations/ui";
+import type { CommunityEndpoint } from "./types.ts";
+
+type CommunityEndpointToggleConfirmationProps = {
+    endpoint: CommunityEndpoint | null;
+    onConfirm: () => void;
+    onCancel: () => void;
+};
+
+export function CommunityEndpointToggleConfirmation({
+    endpoint,
+    onConfirm,
+    onCancel,
+}: CommunityEndpointToggleConfirmationProps) {
+    return (
+        <Dialog
+            open={!!endpoint}
+            onOpenChange={(open) => !open && onCancel()}
+            title={endpoint?.disabled ? "Reactivate Model" : "Deactivate Model"}
+            size="sm"
+            contentClassName="p-6"
+        >
+            <p className="mb-6 mt-4">
+                {endpoint?.disabled ? "Reactivate" : "Deactivate"}{" "}
+                <span className="font-mono text-sm">{endpoint?.modelId}</span>?
+                {endpoint?.disabled
+                    ? "It will be callable by users again."
+                    : "It will stop responding but stays configured."}
+            </p>
+            <div className="flex justify-end gap-2">
+                <Button type="button" onClick={onCancel}>
+                    Cancel
+                </Button>
+                <Button
+                    type="button"
+                    intent={endpoint?.disabled ? "info" : "danger"}
+                    onClick={onConfirm}
+                >
+                    {endpoint?.disabled ? "Reactivate" : "Deactivate"}
+                </Button>
+            </div>
+        </Dialog>
+    );
+}

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoints.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoints.tsx
@@ -17,6 +17,7 @@ import { apiClient } from "../../api.ts";
 import { CommunityEndpointCard } from "./community-endpoint-card.tsx";
 import { CommunityEndpointDeleteConfirmation } from "./community-endpoint-delete-confirmation.tsx";
 import { CommunityEndpointDialog } from "./community-endpoint-dialog.tsx";
+import { CommunityEndpointToggleConfirmation } from "./community-endpoint-toggle-confirmation.tsx";
 import {
     type CommunityEndpoint,
     type CommunityProviderProfile,
@@ -53,6 +54,7 @@ export function CommunityEndpoints({
     const [createOpen, setCreateOpen] = useState(false);
     const [editing, setEditing] = useState<CommunityEndpoint | null>(null);
     const [deleting, setDeleting] = useState<CommunityEndpoint | null>(null);
+    const [toggling, setToggling] = useState<CommunityEndpoint | null>(null);
     const [togglingId, setTogglingId] = useState<string | null>(null);
 
     const loadEndpoints = useCallback(async (): Promise<void> => {
@@ -324,7 +326,7 @@ export function CommunityEndpoints({
                                 key={endpoint.id}
                                 endpoint={endpoint}
                                 isToggling={togglingId === endpoint.id}
-                                onToggle={() => void handleToggle(endpoint)}
+                                onToggle={() => setToggling(endpoint)}
                                 onEdit={() => setEditing(endpoint)}
                                 onDelete={() => setDeleting(endpoint)}
                             />
@@ -365,6 +367,15 @@ export function CommunityEndpoints({
                 endpoint={deleting}
                 onConfirm={() => void handleDelete()}
                 onCancel={() => setDeleting(null)}
+            />
+            <CommunityEndpointToggleConfirmation
+                endpoint={toggling}
+                onConfirm={() => {
+                    if (!toggling) return;
+                    void handleToggle(toggling);
+                    setToggling(null);
+                }}
+                onCancel={() => setToggling(null)}
             />
         </>
     );

--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -1524,6 +1524,18 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.000001475,
     },
   },
+  "qwen3.8-2.4t-a95b": {
+    "cost": {
+      "completionTextTokens": 0.000006,
+      "promptCachedTokens": 0.00000025,
+      "promptTextTokens": 0.000002,
+    },
+    "price": {
+      "completionTextTokens": 0.000006,
+      "promptCachedTokens": 0.00000025,
+      "promptTextTokens": 0.000002,
+    },
+  },
   "qwen3.8-max": {
     "cost": {
       "completionTextTokens": 0.000006,

--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -1,6 +1,7 @@
 import {
     createExecutionContext,
     env,
+    SELF,
     waitOnExecutionContext,
 } from "cloudflare:test";
 import type { Logger } from "@logtape/logtape";
@@ -1864,6 +1865,186 @@ fixtureTest(
         expect(
             openaiModels.data.find((model) => model.id === modelId),
         ).toBeUndefined();
+    },
+);
+
+fixtureTest(
+    "filters model catalogs with ?community query parameter",
+    async () => {
+        const suffix = crypto.randomUUID().slice(0, 8);
+        const textOwner = `filter-text-${suffix}`;
+        const imageOwner = `filter-img-${suffix}`;
+        const textName = `qp-text-${suffix}`;
+        const imageName = `qp-img-${suffix}`;
+        const textModelId = communityModelId(textOwner, textName);
+        const imageModelId = communityModelId(imageOwner, imageName);
+
+        const textUserId = await createTestUser({
+            githubId: COMMUNITY_ENDPOINT_ALLOWED_TEST_GITHUB_ID,
+            githubUsername: textOwner,
+        });
+        const imageUserId = await createTestUser({
+            githubId: COMMUNITY_ENDPOINT_ALLOWED_TEST_GITHUB_ID,
+            githubUsername: imageOwner,
+        });
+
+        await db.insert(communityEndpointTable).values([
+            {
+                id: `endpoint-${crypto.randomUUID()}`,
+                ownerUserId: textUserId,
+                visibility: "public",
+                name: textName,
+                description: "Community text filter test model",
+                baseUrl: "https://api.example.com/v1",
+                upstreamModel: "gpt-4.1-mini",
+                bearerTokenCiphertext: await encryptSecret(
+                    "sk_saved_token",
+                    env.BETTER_AUTH_SECRET,
+                ),
+                promptTextPrice: 0,
+                completionTextPrice: 0,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            },
+            {
+                id: `endpoint-${crypto.randomUUID()}`,
+                ownerUserId: imageUserId,
+                visibility: "public",
+                name: imageName,
+                description: "Community image filter test model",
+                modality: "image",
+                baseUrl: "https://img.example.com/v1",
+                upstreamModel: "flux-1",
+                bearerTokenCiphertext: await encryptSecret(
+                    "sk_saved_token",
+                    env.BETTER_AUTH_SECRET,
+                ),
+                promptTextPrice: 0,
+                completionTextPrice: 0,
+                completionImagePrice: 0.01,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            },
+        ]);
+
+        type ListedModel = { name: string; community?: boolean };
+
+        const [
+            allDefault,
+            allExclude,
+            allOnly,
+            textExclude,
+            textOnly,
+            openaiExclude,
+            openaiOnly,
+            imageExclude,
+            imageOnly,
+            allExcludeNumeric,
+            allOnlyNumeric,
+        ] = await Promise.all([
+            SELF.fetch("https://gen.pollinations.ai/models"),
+            SELF.fetch("https://gen.pollinations.ai/models?community=false"),
+            SELF.fetch("https://gen.pollinations.ai/models?community=true"),
+            SELF.fetch(
+                "https://gen.pollinations.ai/text/models?community=false",
+            ),
+            SELF.fetch(
+                "https://gen.pollinations.ai/text/models?community=true",
+            ),
+            SELF.fetch("https://gen.pollinations.ai/v1/models?community=false"),
+            SELF.fetch("https://gen.pollinations.ai/v1/models?community=true"),
+            SELF.fetch(
+                "https://gen.pollinations.ai/image/models?community=false",
+            ),
+            SELF.fetch(
+                "https://gen.pollinations.ai/image/models?community=true",
+            ),
+            SELF.fetch("https://gen.pollinations.ai/models?community=0"),
+            SELF.fetch("https://gen.pollinations.ai/models?community=1"),
+        ]);
+
+        for (const r of [
+            allDefault,
+            allExclude,
+            allOnly,
+            textExclude,
+            textOnly,
+            openaiExclude,
+            openaiOnly,
+            imageExclude,
+            imageOnly,
+            allExcludeNumeric,
+            allOnlyNumeric,
+        ]) {
+            expect(r.status).toBe(200);
+        }
+
+        const defaultModels = (await allDefault.json()) as ListedModel[];
+        const excludeModels = (await allExclude.json()) as ListedModel[];
+        const onlyModels = (await allOnly.json()) as ListedModel[];
+        const textExcludeModels = (await textExclude.json()) as ListedModel[];
+        const textOnlyModels = (await textOnly.json()) as ListedModel[];
+        const openaiExcludeData = (await openaiExclude.json()) as {
+            data: { id: string }[];
+        };
+        const openaiOnlyData = (await openaiOnly.json()) as {
+            data: { id: string }[];
+        };
+        const imageExcludeModels = (await imageExclude.json()) as ListedModel[];
+        const imageOnlyModels = (await imageOnly.json()) as ListedModel[];
+        const excludeNumeric =
+            (await allExcludeNumeric.json()) as ListedModel[];
+        const onlyNumeric = (await allOnlyNumeric.json()) as ListedModel[];
+
+        expect(defaultModels.some((m) => m.community)).toBe(true);
+        expect(defaultModels.some((m) => !m.community)).toBe(true);
+
+        expect(excludeModels.every((m) => !m.community)).toBe(true);
+        expect(
+            excludeModels.find((m) => m.name === textModelId),
+        ).toBeUndefined();
+
+        expect(onlyModels.every((m) => m.community === true)).toBe(true);
+        expect(onlyModels.find((m) => m.name === textModelId)).toBeDefined();
+
+        expect(textExcludeModels.every((m) => !m.community)).toBe(true);
+        expect(textOnlyModels.every((m) => m.community === true)).toBe(true);
+
+        expect(
+            openaiExcludeData.data.find((m) => m.id === textModelId),
+        ).toBeUndefined();
+        expect(
+            openaiOnlyData.data.find((m) => m.id === textModelId),
+        ).toBeDefined();
+
+        expect(imageExcludeModels.every((m) => !m.community)).toBe(true);
+        expect(
+            imageExcludeModels.find((m) => m.name === imageModelId),
+        ).toBeUndefined();
+
+        expect(imageOnlyModels.every((m) => m.community === true)).toBe(true);
+        expect(
+            imageOnlyModels.find((m) => m.name === imageModelId),
+        ).toBeDefined();
+
+        expect(excludeNumeric.map((m) => m.name)).toEqual(
+            excludeModels.map((m) => m.name),
+        );
+        expect(onlyNumeric.map((m) => m.name)).toEqual(
+            onlyModels.map((m) => m.name),
+        );
+
+        const invalidResponses = await Promise.all([
+            SELF.fetch("https://gen.pollinations.ai/models?community=tru"),
+            SELF.fetch("https://gen.pollinations.ai/models?community=yes"),
+            SELF.fetch("https://gen.pollinations.ai/v1/models?community=2"),
+            SELF.fetch(
+                "https://gen.pollinations.ai/image/models?community=nope",
+            ),
+        ]);
+        for (const r of invalidResponses) {
+            expect(r.status).toBe(400);
+        }
     },
 );
 

--- a/gen.pollinations.ai/src/docs/models.md
+++ b/gen.pollinations.ai/src/docs/models.md
@@ -8,9 +8,24 @@ Discover available models with pricing, capabilities, and metadata. No authentic
 | `GET /v1/models` | All models in OpenAI-compatible format (`{object: "list", data: [...]}`) |
 | `GET /text/models` | Text models with pricing, context window, tool support |
 | `GET /image/models` | Image & video models with capabilities and pricing |
+| `GET /video/models` | Video models with capabilities and pricing |
 | `GET /audio/models` | Audio models with supported voices |
 | `GET /embeddings/models` | Embedding models with supported modalities |
 | `GET /3d/models` | 3D Generation models with supported modalities |
+
+### Query Parameters
+
+All model discovery endpoints accept an optional `community` query parameter:
+
+| Parameter | Values | Behaviour |
+|-----------|--------|-----------|
+| *(omitted)* | | Returns all models (default, backward-compatible) |
+| `community=false` | `false`, `0` | Excludes community models — returns official models only |
+| `community=true` | `true`, `1` | Returns community models only |
+
+Any other value (e.g. `tru`, `yes`, `2`) returns **400 Bad Request**.
+
+Example: `GET /models?community=false`
 
 Rich model endpoints include `capabilities` for agentic/model traits:
 `tool_calling`, `reasoning`, `web_search`, and `code_execution`.

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -13,7 +13,7 @@ import {
     createAudioTokenUsage,
     createCompletionAudioSecondsUsage,
 } from "@shared/registry/usage-headers.ts";
-import { SafeSchema, type SafeValue } from "@shared/schemas/safety.ts";
+import { SafeSchema } from "@shared/schemas/safety.ts";
 import { errorResponseDescriptions } from "@shared/utils/api-docs.ts";
 import { type Context, Hono } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
@@ -45,6 +45,7 @@ import {
 import { readResponseBytes } from "../utils/response-bytes.ts";
 import { validateUserMediaUrl } from "../utils/user-media-url.ts";
 import { transcribeWithAssemblyAi } from "./assemblyai-transcription.ts";
+import type { SimpleAudioQuery } from "./generation-handlers.ts";
 import {
     buildTranscriptionResponse,
     type NormalizedDiarizedSegment,
@@ -155,21 +156,6 @@ async function withAudioFallback(
     if (servedEntry) c.set("servedModelEntry", servedEntry);
     return response;
 }
-type SimpleAudioQuery = {
-    safe?: SafeValue;
-    duration?: number;
-    seconds?: number;
-    steps?: number;
-    negative_prompt?: string;
-    instrumental?: boolean;
-    seed?: number;
-    voice: string;
-    response_format: string;
-    instructions?: string;
-    loop?: boolean;
-    prompt_influence?: number;
-};
-
 type AudioRefChunk = {
     song_id: string;
     range: {
@@ -2490,6 +2476,92 @@ async function dispatchAudioGeneration(
     }
 }
 
+async function generateAudioFromSpeechRequest(
+    c: AudioContext,
+    request: CreateSpeechRequest,
+    log: Logger,
+): Promise<Response> {
+    const {
+        input,
+        safe,
+        voice,
+        response_format,
+        duration,
+        seconds,
+        steps,
+        negative_prompt,
+        instrumental,
+        store_for_inpainting,
+        conditioning_ref,
+        composition_plan,
+        reference_audio,
+        seed,
+        instructions,
+        loop,
+        prompt_influence,
+    } = request;
+
+    requireElevenMusicOptions(c.var.model.resolved, {
+        referenceAudio: reference_audio,
+        compositionPlan: composition_plan,
+        conditioningRef: conditioning_ref,
+        storeForInpainting: store_for_inpainting,
+    });
+
+    if (c.var.model.resolved === "eleven-dialogue") {
+        const inputs = parseDialogueInput(input);
+        const safeTexts = await applySafetyToTexts(
+            c,
+            inputs.map((turn) => turn.text),
+            safe,
+        );
+        const safeInputs = inputs.map((turn, index) => ({
+            ...turn,
+            text: safeTexts[index],
+        }));
+        const response = await generateElevenLabsDialogue({
+            inputs: safeInputs,
+            responseFormat: response_format,
+            seed,
+            apiKey: c.env.ELEVENLABS_API_KEY,
+            log,
+        });
+        return withSafetyHeaders(c, response);
+    }
+
+    const safeInput = await applySafety(c, input, safe);
+    const referenceAudio = reference_audio
+        ? await fetchReferenceAudio(reference_audio)
+        : undefined;
+
+    return withAudioFallback(c, (candidate) =>
+        dispatchAudioGeneration(c, candidate.id, {
+            text: safeInput,
+            voice,
+            responseFormat: response_format,
+            seed,
+            duration,
+            seconds,
+            steps,
+            negativePrompt: negative_prompt,
+            instrumental,
+            storeForInpainting: store_for_inpainting,
+            conditioningRef: conditioning_ref,
+            compositionPlan: composition_plan,
+            referenceAudio,
+            instructions,
+            loop,
+            promptInfluence: prompt_influence,
+            apiKey: c.env.ELEVENLABS_API_KEY,
+            dashScopeApiKey: c.env.DASHSCOPE_API_KEY,
+            deepInfraApiKey: c.env.DEEPINFRA_API_KEY,
+            falKey: c.env.FAL_KEY,
+            stabilityApiKey: c.env.STABILITY_API_KEY,
+            log,
+        }),
+    );
+}
+
 export async function handleSimpleAudio(c: AudioContext): Promise<Response> {
     const log = c.get("log").getChild("generate");
 
@@ -2505,32 +2577,24 @@ export async function handleSimpleAudio(c: AudioContext): Promise<Response> {
     }
 
     const query = c.req.valid("query" as never) as SimpleAudioQuery;
-    text = await applySafety(c, text, query.safe);
-
-    const apiKey = (c.env as unknown as { ELEVENLABS_API_KEY: string })
-        .ELEVENLABS_API_KEY;
-
-    return withAudioFallback(c, (candidate) =>
-        dispatchAudioGeneration(c, candidate.id, {
-            text,
+    return await generateAudioFromSpeechRequest(
+        c,
+        {
+            input: text,
+            safe: query.safe,
             voice: query.voice,
-            responseFormat: query.response_format,
+            response_format: query.response_format,
             seed: normalizeSeed(query.seed),
             duration: query.duration,
             seconds: query.seconds,
             steps: query.steps,
-            negativePrompt: query.negative_prompt,
+            negative_prompt: query.negative_prompt,
             instrumental: query.instrumental,
             instructions: query.instructions,
             loop: query.loop,
-            promptInfluence: query.prompt_influence,
-            apiKey,
-            dashScopeApiKey: c.env.DASHSCOPE_API_KEY,
-            deepInfraApiKey: c.env.DEEPINFRA_API_KEY,
-            falKey: c.env.FAL_KEY,
-            stabilityApiKey: c.env.STABILITY_API_KEY,
-            log,
-        }),
+            prompt_influence: query.prompt_influence,
+        },
+        log,
     );
 }
 
@@ -2593,83 +2657,10 @@ export async function handleVoiceIsolator(c: AudioContext): Promise<Response> {
 
 export async function handleSpeech(c: AudioContext): Promise<Response> {
     const log = c.get("log").getChild("tts");
-    const {
-        input,
-        safe,
-        voice,
-        response_format,
-        duration,
-        seconds,
-        steps,
-        negative_prompt,
-        instrumental,
-        store_for_inpainting,
-        conditioning_ref,
-        composition_plan,
-        reference_audio,
-        seed,
-        instructions,
-        loop,
-        prompt_influence,
-    } = await parseSpeechRequest(c);
-    requireElevenMusicOptions(c.var.model.resolved, {
-        referenceAudio: reference_audio,
-        compositionPlan: composition_plan,
-        conditioningRef: conditioning_ref,
-        storeForInpainting: store_for_inpainting,
-    });
-
-    if (c.var.model.resolved === "eleven-dialogue") {
-        const inputs = parseDialogueInput(input);
-        const safeTexts = await applySafetyToTexts(
-            c,
-            inputs.map((turn) => turn.text),
-            safe,
-        );
-        const safeInputs = inputs.map((turn, index) => ({
-            ...turn,
-            text: safeTexts[index],
-        }));
-        const response = await generateElevenLabsDialogue({
-            inputs: safeInputs,
-            responseFormat: response_format,
-            seed,
-            apiKey: c.env.ELEVENLABS_API_KEY,
-            log,
-        });
-        return withSafetyHeaders(c, response);
-    }
-
-    const safeInput = await applySafety(c, input, safe);
-    const referenceAudio = reference_audio
-        ? await fetchReferenceAudio(reference_audio)
-        : undefined;
-
-    return withAudioFallback(c, (candidate) =>
-        dispatchAudioGeneration(c, candidate.id, {
-            text: safeInput,
-            voice,
-            responseFormat: response_format,
-            seed,
-            duration,
-            seconds,
-            steps,
-            negativePrompt: negative_prompt,
-            instrumental,
-            storeForInpainting: store_for_inpainting,
-            conditioningRef: conditioning_ref,
-            compositionPlan: composition_plan,
-            referenceAudio,
-            instructions,
-            loop,
-            promptInfluence: prompt_influence,
-            apiKey: c.env.ELEVENLABS_API_KEY,
-            dashScopeApiKey: c.env.DASHSCOPE_API_KEY,
-            deepInfraApiKey: c.env.DEEPINFRA_API_KEY,
-            falKey: c.env.FAL_KEY,
-            stabilityApiKey: c.env.STABILITY_API_KEY,
-            log,
-        }),
+    return await generateAudioFromSpeechRequest(
+        c,
+        await parseSpeechRequest(c),
+        log,
     );
 }
 
@@ -2988,7 +2979,7 @@ export const audioRoutes = new Hono<Env>()
                                     minLength: 1,
                                     maxLength: 10000,
                                     description:
-                                        "Text or prompt to generate. For eleven-dialogue, use one `voice: text` turn per line.",
+                                        "Text or prompt to generate. The `eleven-dialogue` model expects one `voice: text` turn per line.",
                                 },
                                 safe: {
                                     oneOf: [

--- a/gen.pollinations.ai/src/routes/generation-handlers.ts
+++ b/gen.pollinations.ai/src/routes/generation-handlers.ts
@@ -1,5 +1,4 @@
 import { UpstreamError } from "@shared/error.ts";
-import { AUDIO_VOICES } from "@shared/registry/audio.ts";
 import {
     type CreateChatCompletionRequest,
     type CreateChatCompletionResponse,
@@ -35,13 +34,11 @@ export const textBodyLimit = bodyLimit({
 });
 
 export const simpleAudioQuerySchema = z.object({
-    voice: z
-        .enum(AUDIO_VOICES as unknown as [string, ...string[]])
-        .default("alloy")
-        .meta({
-            description: "Voice to use for speech generation (TTS only)",
-            example: "nova",
-        }),
+    voice: z.string().min(1).default("alloy").meta({
+        description:
+            "Voice preset or custom provider voice ID. Dialogue voices come from labels in the text.",
+        example: "nova",
+    }),
     response_format: z
         .enum(["mp3", "opus", "aac", "flac", "wav", "pcm"])
         .default("mp3")
@@ -52,7 +49,7 @@ export const simpleAudioQuerySchema = z.object({
         }),
     model: z.string().optional().meta({
         description:
-            "Audio model: TTS (default) or a music-generation model such as lyria-3-clip",
+            "Audio model for speech, dialogue, music, or sound-effect generation",
         example: "tts-1",
     }),
     duration: z
@@ -120,6 +117,8 @@ export const simpleAudioQuerySchema = z.object({
     }),
     safe: SafeSchema,
 });
+
+export type SimpleAudioQuery = z.infer<typeof simpleAudioQuerySchema>;
 
 export async function generateImageVideo(c: Context<Env>): Promise<Response> {
     const query = c.req.valid("query" as never) as { safe?: SafeValue };

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -888,13 +888,15 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🔊 Audio"],
             summary: "Generate Audio",
             description: [
-                "Generate speech or music from text via a simple GET request.",
+                "Generate speech, dialogue, music, or sound effects from text via a simple GET request.",
                 "",
                 "**Text-to-speech (default):** Returns spoken audio in the selected voice and format.",
                 "",
-                `**Available voices:** ${AUDIO_VOICES.join(", ")}`,
+                `**Known voice presets:** ${AUDIO_VOICES.join(", ")}. ElevenLabs models also accept a custom voice ID.`,
                 "",
                 "**Output formats:** mp3 (default), opus, aac, flac, wav, pcm",
+                "",
+                "**Dialogue:** The `eleven-dialogue` model expects one `<voice>: <text>` turn per line.",
                 "",
                 "**Music generation:** Set `model=elevenmusic`, `lyria-3-clip`, `stable-audio-3-medium`, or `stable-audio-3-large` to generate music instead of speech. `lyria-3-clip` returns a fixed 30-second MP3 clip; `elevenmusic` supports `duration` (3-300 seconds) and `instrumental` mode; `stable-audio-3-medium`/`stable-audio-3-large` support `seconds` (1-380), `steps`, `seed`, and `negative_prompt`. Pass any publicly accessible audio URL as `reference_audio` to `POST /v1/audio/speech`.",
             ].join("\n"),
@@ -915,7 +917,7 @@ export const proxyRoutes = new Hono<Env>()
             z.object({
                 text: z.string().min(1).meta({
                     description:
-                        "Text to convert to speech, or a music description for a music-generation model",
+                        "Text or prompt to generate. The `eleven-dialogue` model expects one `voice: text` turn per line.",
                     example: "Hello, welcome to Pollinations!",
                 }),
             }),

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -67,6 +67,10 @@ import {
     Generate3dRequestBodySchema,
     Generate3dRequestQueryParamsSchema,
 } from "@/schemas/model3d.ts";
+import {
+    type ModelListQueryParams,
+    ModelListQueryParamsSchema,
+} from "@/schemas/models.ts";
 import { RealtimeRequestQueryParamsSchema } from "@/schemas/realtime.ts";
 import { GenerateTextRequestQueryParamsSchema } from "@/schemas/text.ts";
 import { generationAccess } from "@/utils/generation-access.ts";
@@ -187,25 +191,46 @@ function hasPaidBalance(c: any): boolean | undefined {
     return (user.packBalance ?? 0) > 0;
 }
 
-// Factory for model-list endpoints: filters the given models by API key
-// permissions and paid balance, then returns them as JSON.
-const modelsListHandler =
-    (
-        getEntries: (
-            c: Context<Env>,
-        ) => GenerationModelEntry[] | Promise<GenerationModelEntry[]>,
-    ) =>
-    async (c: Context<Env>) => {
-        const allowedModels = c.var.auth?.apiKey?.permissions?.models;
-        const paidBalance = hasPaidBalance(c);
-        return c.json(
-            filterEntriesByPermissions(
-                await getEntries(c),
-                allowedModels,
-                paidBalance,
-            ).map((entry) => entry.info),
-        );
-    };
+// Optionally filter entries by the validated `?community` query parameter.
+function filterEntriesByCommunityParam(
+    entries: GenerationModelEntry[],
+    communityParam: string | undefined,
+): GenerationModelEntry[] {
+    if (communityParam === undefined) return entries;
+    const wantCommunity = communityParam === "true" || communityParam === "1";
+    return entries.filter(
+        (entry) => (entry.communityEndpoint !== undefined) === wantCommunity,
+    );
+}
+
+// Factory for model-list endpoints: validates the community query parameter,
+// filters by API key permissions, paid balance, and community flag,
+// then returns the model list as JSON.
+const modelsListHandler = (
+    getEntries: (
+        c: Context<Env>,
+    ) => GenerationModelEntry[] | Promise<GenerationModelEntry[]>,
+) =>
+    [
+        validator("query", ModelListQueryParamsSchema),
+        async (c: Context<Env>) => {
+            const { community } = c.req.valid(
+                "query" as never,
+            ) as ModelListQueryParams;
+            const allowedModels = c.var.auth?.apiKey?.permissions?.models;
+            const paidBalance = hasPaidBalance(c);
+            return c.json(
+                filterEntriesByCommunityParam(
+                    filterEntriesByPermissions(
+                        await getEntries(c),
+                        allowedModels,
+                        paidBalance,
+                    ),
+                    community,
+                ).map((entry) => entry.info),
+            );
+        },
+    ] as const;
 
 async function getVisibleModelEntries(c: Context<Env>) {
     return (await getGenerationModelRegistry(c.env)).visibleEntries(
@@ -263,7 +288,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Models (OpenAI-compatible)",
             description:
-                "Returns available models in the OpenAI-compatible format (`{object: \"list\", data: [...]}`). Official models are ordered by modality (text, image, video, 3D, audio, realtime, embedding), with each configured default first, followed by stable and then alpha/preview models from newest to oldest. Community models follow from newest to oldest. Use this endpoint if you're using an OpenAI SDK. For richer metadata including pricing and capabilities, use `/models`, `/text/models`, `/image/models`, `/audio/models`, or `/embeddings/models` instead. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance.",
+                "Returns available models in the OpenAI-compatible format (`{object: \"list\", data: [...]}`). Official models are ordered by modality (text, image, video, 3D, audio, realtime, embedding), with each configured default first, followed by stable and then alpha/preview models from newest to oldest. Community models follow from newest to oldest. Use this endpoint if you're using an OpenAI SDK. For richer metadata including pricing and capabilities, use `/models`, `/text/models`, `/image/models`, `/audio/models`, or `/embeddings/models` instead. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
             responses: {
                 200: {
                     description: "Success",
@@ -273,16 +298,23 @@ export const proxyRoutes = new Hono<Env>()
                         },
                     },
                 },
-                ...errorResponseDescriptions(500),
+                ...errorResponseDescriptions(400, 500),
             },
         }),
+        validator("query", ModelListQueryParamsSchema),
         async (c) => {
+            const { community } = c.req.valid(
+                "query" as never,
+            ) as ModelListQueryParams;
             const allowedModels = c.var.auth?.apiKey?.permissions?.models;
             const paidBalance = hasPaidBalance(c);
-            const modelEntries = filterEntriesByPermissions(
-                await getVisibleModelEntries(c),
-                allowedModels,
-                paidBalance,
+            const modelEntries = filterEntriesByCommunityParam(
+                filterEntriesByPermissions(
+                    await getVisibleModelEntries(c),
+                    allowedModels,
+                    paidBalance,
+                ),
+                community,
             );
             const now = Date.now();
 
@@ -317,7 +349,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Models",
             description:
-                "Returns all available models with pricing, capabilities, and metadata. Official models are ordered by modality (text, image, video, 3D, audio, realtime, embedding), with each configured default first, followed by stable and then alpha/preview models from newest to oldest. Community models follow from newest to oldest. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance.",
+                "Returns all available models with pricing, capabilities, and metadata. Official models are ordered by modality (text, image, video, 3D, audio, realtime, embedding), with each configured default first, followed by stable and then alpha/preview models from newest to oldest. Community models follow from newest to oldest. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
             responses: {
                 200: {
                     description: "Success",
@@ -332,10 +364,10 @@ export const proxyRoutes = new Hono<Env>()
                         },
                     },
                 },
-                ...errorResponseDescriptions(500),
+                ...errorResponseDescriptions(400, 500),
             },
         }),
-        modelsListHandler(getVisibleModelEntries),
+        ...modelsListHandler(getVisibleModelEntries),
     )
     .get(
         "/3d/models",
@@ -343,7 +375,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List 3D Models",
             description:
-                "Returns all available 3D model generation models with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance.",
+                "Returns all available 3D model generation models with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
             responses: {
                 200: {
                     description: "Success",
@@ -358,10 +390,10 @@ export const proxyRoutes = new Hono<Env>()
                         },
                     },
                 },
-                ...errorResponseDescriptions(500),
+                ...errorResponseDescriptions(400, 500),
             },
         }),
-        modelsListHandler(getVisibleModel3dEntries),
+        ...modelsListHandler(getVisibleModel3dEntries),
     )
     .get(
         "/image/models",
@@ -369,7 +401,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Image & Video Models",
             description:
-                "Returns all available image and video generation models with pricing, capabilities, and metadata. Video models are included here — check the `outputModalities` field to distinguish image vs video models. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance.",
+                "Returns all available image and video generation models with pricing, capabilities, and metadata. Video models are included here — check the `outputModalities` field to distinguish image vs video models. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
             responses: {
                 200: {
                     description: "Success",
@@ -384,10 +416,10 @@ export const proxyRoutes = new Hono<Env>()
                         },
                     },
                 },
-                ...errorResponseDescriptions(500),
+                ...errorResponseDescriptions(400, 500),
             },
         }),
-        modelsListHandler(getVisibleImageAndVideoEntries),
+        ...modelsListHandler(getVisibleImageAndVideoEntries),
     )
     .get(
         "/video/models",
@@ -395,7 +427,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Video Models",
             description:
-                "Returns all available video generation models with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance.",
+                "Returns all available video generation models with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
             responses: {
                 200: {
                     description: "Success",
@@ -410,10 +442,10 @@ export const proxyRoutes = new Hono<Env>()
                         },
                     },
                 },
-                ...errorResponseDescriptions(500),
+                ...errorResponseDescriptions(400, 500),
             },
         }),
-        modelsListHandler(getVisibleVideoModelEntries),
+        ...modelsListHandler(getVisibleVideoModelEntries),
     )
     .get(
         "/text/models",
@@ -421,7 +453,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Text Models (Detailed)",
             description:
-                "Returns all available text generation and community text models with pricing, capabilities, and metadata including context window size, supported modalities, and tool support. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance.",
+                "Returns all available text generation and community text models with pricing, capabilities, and metadata including context window size, supported modalities, and tool support. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
             responses: {
                 200: {
                     description: "Success",
@@ -436,10 +468,10 @@ export const proxyRoutes = new Hono<Env>()
                         },
                     },
                 },
-                ...errorResponseDescriptions(500),
+                ...errorResponseDescriptions(400, 500),
             },
         }),
-        modelsListHandler((c) =>
+        ...modelsListHandler((c) =>
             getVisibleModelEntriesForEventType(c, "generate.text"),
         ),
     )
@@ -449,7 +481,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Audio Models",
             description:
-                "Returns all available audio models (text-to-speech, music generation, and transcription) with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance.",
+                "Returns all available audio models (text-to-speech, music generation, and transcription) with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
             responses: {
                 200: {
                     description: "Success",
@@ -464,10 +496,10 @@ export const proxyRoutes = new Hono<Env>()
                         },
                     },
                 },
-                ...errorResponseDescriptions(500),
+                ...errorResponseDescriptions(400, 500),
             },
         }),
-        modelsListHandler((c) =>
+        ...modelsListHandler((c) =>
             getVisibleModelEntriesForEventType(c, "generate.audio"),
         ),
     )
@@ -477,7 +509,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🔢 Embeddings"],
             summary: "List Embedding Models",
             description:
-                "Returns available embedding models with pricing, capabilities, and supported input modalities. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance.",
+                "Returns available embedding models with pricing, capabilities, and supported input modalities. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
             responses: {
                 200: {
                     description: "Success",
@@ -492,10 +524,10 @@ export const proxyRoutes = new Hono<Env>()
                         },
                     },
                 },
-                ...errorResponseDescriptions(500),
+                ...errorResponseDescriptions(400, 500),
             },
         }),
-        modelsListHandler((c) =>
+        ...modelsListHandler((c) =>
             getVisibleModelEntriesForEventType(c, "generate.embedding"),
         ),
     )

--- a/gen.pollinations.ai/src/schemas/models.ts
+++ b/gen.pollinations.ai/src/schemas/models.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const ModelListQueryParamsSchema = z.object({
+    community: z.enum(["true", "false", "1", "0"]).optional().meta({
+        description:
+            "Filter by community status: `true`/`1` for community-only, `false`/`0` for official-only. Omit for all models.",
+    }),
+});
+
+export type ModelListQueryParams = z.infer<typeof ModelListQueryParamsSchema>;

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -124,6 +124,11 @@ const models: ModelDefinition[] = [
         config: portkeyConfig["qwen/qwen3.7-max"],
     },
     {
+        name: "qwen3.8-2.4t-a95b",
+        config: portkeyConfig["accounts/fireworks/models/qwen3p8-2p4t-a95b"],
+        transform: pipe(stripCacheControl, fireworksThinking),
+    },
+    {
         name: "qwen3.8-max",
         config: portkeyConfig["qwen/qwen3.8-max"],
     },

--- a/gen.pollinations.ai/src/text/azureResponsesClient.ts
+++ b/gen.pollinations.ai/src/text/azureResponsesClient.ts
@@ -186,7 +186,7 @@ function buildBody(messages: ChatMessage[], options: TransformOptions): Json {
         typeof options.reasoning_effort === "string" &&
         REASONING_EFFORTS.has(options.reasoning_effort)
     ) {
-        body.reasoning = { effort: options.reasoning_effort };
+        body.reasoning = { effort: options.reasoning_effort, summary: "auto" };
     }
     if (Array.isArray(options.tools) && options.tools.length) {
         body.tools = options.tools.flatMap((raw) => {

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -277,6 +277,10 @@ export const portkeyConfig: PortkeyConfigMap = {
         createFireworksModelConfig({
             model: "accounts/fireworks/models/kimi-k3",
         }),
+    "accounts/fireworks/models/qwen3p8-2p4t-a95b": () =>
+        createFireworksModelConfig({
+            model: "accounts/fireworks/models/qwen3p8-2p4t-a95b",
+        }),
 
     // -- OpenRouter (Mistral Small 3.2, Mistral Small 4) ---------------------
     // Moved off Azure: Mistral Small was Marketplace SaaS pass-through on

--- a/gen.pollinations.ai/test/elevenlabs-dialogue.test.ts
+++ b/gen.pollinations.ai/test/elevenlabs-dialogue.test.ts
@@ -101,8 +101,24 @@ describe("ElevenLabs Text to Dialogue", () => {
     });
 });
 
+workerTest("advertises the simple route for every speech model", async () => {
+    const response = await fetchGen("https://gen.pollinations.ai/v1/models");
+    expect(response.status).toBe(200);
+
+    const models = (await response.json()) as {
+        data: { supported_endpoints?: string[] }[];
+    };
+    const speechModels = models.data.filter((model) =>
+        model.supported_endpoints?.includes("/v1/audio/speech"),
+    );
+    expect(speechModels.length).toBeGreaterThan(0);
+    for (const model of speechModels) {
+        expect(model.supported_endpoints).toContain("/audio/{text}");
+    }
+});
+
 workerTest(
-    "translates labelled speech input into ElevenLabs dialogue turns",
+    "translates labelled input through both speech routes",
     async ({ paidApiKey }) => {
         const realFetch = globalThis.fetch.bind(globalThis);
         const fetchMock = vi
@@ -129,8 +145,9 @@ workerTest(
                 }
                 return realFetch(input, init);
             });
-        const ctx = createExecutionContext();
-        const response = await worker.fetch(
+
+        const dialogue = "nova: Hello.\ngeorge: Hi!";
+        const requests = [
             new Request("https://gen.pollinations.ai/v1/audio/speech", {
                 method: "POST",
                 headers: {
@@ -139,44 +156,60 @@ workerTest(
                 },
                 body: JSON.stringify({
                     model: "eleven-dialogue",
-                    input: "nova: Hello.\ngeorge: Hi!",
+                    input: dialogue,
                     voice: "alloy",
                     response_format: "mp3",
                     seed: 42,
                     safe: false,
                 }),
             }),
-            withInlineGenerationCoordinator({
-                ...env,
-                ELEVENLABS_API_KEY: "test-eleven-key",
-            } as unknown as CloudflareBindings),
-            ctx,
-        );
-
-        expect(response.status).toBe(200);
-        const dialogueCall = fetchMock.mock.calls.find(([input]) =>
-            String(input).startsWith(
-                "https://api.elevenlabs.io/v1/text-to-dialogue",
+            new Request(
+                `https://gen.pollinations.ai/audio/${encodeURIComponent(dialogue)}?model=dialogue&response_format=mp3&seed=42&safe=false`,
+                { headers: { Authorization: `Bearer ${paidApiKey}` } },
             ),
-        );
-        expect(dialogueCall).toBeDefined();
-        const upstreamRequest = new Request(
-            dialogueCall?.[0] as RequestInfo,
-            dialogueCall?.[1],
-        );
-        await expect(upstreamRequest.json()).resolves.toEqual({
-            inputs: [
-                { text: "Hello.", voice_id: "MF3mGyEYCl7XYWbV9V6O" },
-                { text: "Hi!", voice_id: "JBFqnCBsd6RMkjVDRZzb" },
-            ],
-            model_id: "eleven_v3",
-            seed: 42,
-        });
-        expect(response.headers.get("x-usage-completion-audio-tokens")).toBe(
-            "9",
-        );
-        expect((await response.arrayBuffer()).byteLength).toBeGreaterThan(0);
-        await waitOnExecutionContext(ctx);
+        ];
+
+        for (const request of requests) {
+            const previousCallCount = fetchMock.mock.calls.length;
+            const ctx = createExecutionContext();
+            const response = await worker.fetch(
+                request,
+                withInlineGenerationCoordinator({
+                    ...env,
+                    ELEVENLABS_API_KEY: "test-eleven-key",
+                } as unknown as CloudflareBindings),
+                ctx,
+            );
+
+            expect(response.status).toBe(200);
+            const dialogueCall = fetchMock.mock.calls
+                .slice(previousCallCount)
+                .find(([input]) =>
+                    String(input).startsWith(
+                        "https://api.elevenlabs.io/v1/text-to-dialogue",
+                    ),
+                );
+            expect(dialogueCall).toBeDefined();
+            const upstreamRequest = new Request(
+                dialogueCall?.[0] as RequestInfo,
+                dialogueCall?.[1],
+            );
+            await expect(upstreamRequest.json()).resolves.toEqual({
+                inputs: [
+                    { text: "Hello.", voice_id: "MF3mGyEYCl7XYWbV9V6O" },
+                    { text: "Hi!", voice_id: "JBFqnCBsd6RMkjVDRZzb" },
+                ],
+                model_id: "eleven_v3",
+                seed: 42,
+            });
+            expect(
+                response.headers.get("x-usage-completion-audio-tokens"),
+            ).toBe("9");
+            expect((await response.arrayBuffer()).byteLength).toBeGreaterThan(
+                0,
+            );
+            await waitOnExecutionContext(ctx);
+        }
     },
 );
 

--- a/gen.pollinations.ai/test/elevenlabs-tts.test.ts
+++ b/gen.pollinations.ai/test/elevenlabs-tts.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { generateElevenLabsSpeech } from "../src/routes/audio.ts";
+import { simpleAudioQuerySchema } from "../src/routes/generation-handlers.ts";
 
 const log = {
     info: vi.fn(),
@@ -38,6 +39,14 @@ describe("ElevenLabs TTS model routing", () => {
         await expect(request.json()).resolves.toMatchObject({
             model_id: expectedModelId,
         });
+    });
+
+    it("accepts custom voice IDs on the simple audio endpoint", () => {
+        const customVoiceId = "custom-elevenlabs-voice-id";
+
+        expect(
+            simpleAudioQuerySchema.parse({ voice: customVoiceId }).voice,
+        ).toBe(customVoiceId);
     });
 
     it("encodes custom voice IDs at the provider URL boundary", async () => {

--- a/gen.pollinations.ai/test/text/azureResponsesClient.test.ts
+++ b/gen.pollinations.ai/test/text/azureResponsesClient.test.ts
@@ -207,7 +207,10 @@ describe("callAzureResponses", () => {
                 },
             ],
         });
-        expect(bodies[1].reasoning).toEqual({ effort: "none" });
+        expect(bodies[1].reasoning).toEqual({
+            effort: "none",
+            summary: "auto",
+        });
     });
 
     it("maps output, tool calls, finish reason, and every billable usage field", async () => {

--- a/gen.pollinations.ai/test/text/transforms/createReasoningEffortTransform.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/createReasoningEffortTransform.test.ts
@@ -87,6 +87,7 @@ describe("reasoning_effort model wiring", () => {
         "deepseek",
         "qwen-large",
         "qwen3.7-flash",
+        "qwen3.8-2.4t-a95b",
         "longcat",
         "nemotron",
         "minimax",

--- a/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
+++ b/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
@@ -137,6 +137,21 @@ describe("resolveModelConfig", () => {
         });
     });
 
+    it("routes Qwen3.8 2.4T A95B directly to Fireworks", () => {
+        const result = resolveModelConfig(messages, {
+            model: "qwen3.8-2.4t-a95b",
+        });
+
+        expect(result.options.model).toBe(
+            "accounts/fireworks/models/qwen3p8-2p4t-a95b",
+        );
+        expect(result.options.modelConfig).toMatchObject({
+            provider: "openai",
+            "custom-host": "https://api.fireworks.ai/inference/v1",
+        });
+        expect(result.options.provider).toBeUndefined();
+    });
+
     it("routes Kimi K3 directly to Fireworks without fallback", () => {
         const result = resolveModelConfig(messages, { model: "kimi-k3" });
 

--- a/gen.pollinations.ai/vitest.config.ts
+++ b/gen.pollinations.ai/vitest.config.ts
@@ -37,6 +37,7 @@ const genAliases = [
     "schemas/embeddings.ts",
     "schemas/image.ts",
     "schemas/model3d.ts",
+    "schemas/models.ts",
     "schemas/realtime.ts",
     "schemas/text.ts",
     "userImage.ts",

--- a/operations/app-management/app.json
+++ b/operations/app-management/app.json
@@ -1012,7 +1012,7 @@
     "platform": "web",
     "githubUsername": "alexander",
     "githubUserId": "6165",
-    "repositoryUrl": "https://github.com/alexander/driftpod-pollinations",
+    "repositoryUrl": null,
     "repositoryStars": null,
     "discordUsername": "lexlexlex --- ## Pollinations integration evidence The Pollinations integration",
     "other": null,

--- a/operations/model-monitor/src/App.jsx
+++ b/operations/model-monitor/src/App.jsx
@@ -9,6 +9,7 @@ import {
     ExternalLinkButton,
     GitHubIcon,
     Heading,
+    IconButton,
     Surface,
     TabButton,
     Table,
@@ -19,8 +20,50 @@ import {
     TableRow,
 } from "@pollinations/ui";
 import { ModalityChip } from "@pollinations/ui/gen";
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useModelMonitor } from "./hooks/useModelMonitor";
+
+const FAVORITES_KEY = "model-monitor-favorites";
+
+function loadFavorites() {
+    try {
+        const raw = localStorage.getItem(FAVORITES_KEY);
+        const parsed = raw ? JSON.parse(raw) : [];
+        return Array.isArray(parsed) ? parsed : [];
+    } catch {
+        return [];
+    }
+}
+
+function saveFavorites(list) {
+    try {
+        localStorage.setItem(FAVORITES_KEY, JSON.stringify(list));
+    } catch {
+        // storage full or blocked — silently ignore
+    }
+}
+
+function modelKey(model) {
+    return `${model.type}-${model.name}`;
+}
+
+function StarIcon({ filled }) {
+    return (
+        <svg
+            viewBox="0 0 24 24"
+            className="h-4 w-4"
+            fill={filled ? "currentColor" : "none"}
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            role="img"
+            aria-label={filled ? "Favorited" : "Not favorited"}
+        >
+            <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+        </svg>
+    );
+}
 
 const WINDOW_OPTIONS = [
     { key: "7d", label: "7d" },
@@ -44,6 +87,31 @@ const MODEL_SCOPES = [
     { key: "official", title: "Official" },
     { key: "community", title: "Community" },
 ];
+
+const FILTER_KEY = "model-monitor-filter";
+
+function loadFilterState() {
+    try {
+        const raw = localStorage.getItem(FILTER_KEY);
+        if (!raw) return null;
+        const { scope, type } = JSON.parse(raw);
+        const validScope = MODEL_SCOPES.some((s) => s.key === scope)
+            ? scope
+            : null;
+        const validType = MODEL_TYPES.some((t) => t.key === type) ? type : null;
+        return { scope: validScope, type: validType };
+    } catch {
+        return null;
+    }
+}
+
+function saveFilterState(filter) {
+    try {
+        localStorage.setItem(FILTER_KEY, JSON.stringify(filter));
+    } catch {
+        // storage full or blocked — silently ignore
+    }
+}
 
 const LOW_SAMPLE_REQUESTS = 10;
 
@@ -107,7 +175,7 @@ function getLatencyColor(latencySec) {
 }
 
 function computeHealthStatus(stats) {
-    if (!stats || !stats.total_requests) return "on";
+    if (!stats?.total_requests) return "on";
     const success = stats.status_2xx || 0;
     const total5xx = stats.errors_5xx || 0;
     // 4xx are client errors and don't count. Judge purely on the 5xx share of
@@ -395,9 +463,32 @@ function App() {
         useModelMonitor(aggregationWindow);
 
     const [sort, setSort] = useState({ key: "requests", asc: false });
-    const [scopeFilter, setScopeFilter] = useState("official");
-    const [typeFilter, setTypeFilter] = useState(null);
+    const [initialFilter] = useState(loadFilterState);
+    const [scopeFilter, setScopeFilter] = useState(
+        initialFilter?.scope ?? "official",
+    );
+    const [typeFilter, setTypeFilter] = useState(initialFilter?.type ?? null);
+    const [favorites, setFavorites] = useState(loadFavorites);
+    const [favoritesOnly, setFavoritesOnly] = useState(false);
     const catalogUnavailable = endpointStatus.catalog === false;
+
+    useEffect(() => {
+        saveFavorites(favorites);
+    }, [favorites]);
+
+    useEffect(() => {
+        saveFilterState({ scope: scopeFilter, type: typeFilter });
+    }, [scopeFilter, typeFilter]);
+
+    const toggleFavorite = useCallback((key) => {
+        setFavorites((prev) => {
+            const next = prev.includes(key)
+                ? prev.filter((k) => k !== key)
+                : [...prev, key];
+            if (next.length === 0) setFavoritesOnly(false);
+            return next;
+        });
+    }, []);
 
     const handleSort = (key) => {
         setSort((prev) => ({
@@ -412,6 +503,10 @@ function App() {
     );
 
     const sortedModels = [...observedModels].sort((a, b) => {
+        const aFav = favorites.includes(modelKey(a));
+        const bFav = favorites.includes(modelKey(b));
+        if (aFav !== bFav) return aFav ? -1 : 1;
+
         const dir = sort.asc ? 1 : -1;
         switch (sort.key) {
             case "type":
@@ -524,9 +619,11 @@ function App() {
     const scopedModels = sortedModels.filter(
         (model) => modelScope(model) === scopeFilter,
     );
-    const filteredModels = typeFilter
-        ? scopedModels.filter((model) => model.type === typeFilter)
-        : scopedModels;
+    const filteredModels = scopedModels
+        .filter((model) => (typeFilter ? model.type === typeFilter : true))
+        .filter((model) =>
+            favoritesOnly ? favorites.includes(modelKey(model)) : true,
+        );
 
     const handleScopeChange = (scope) => {
         setScopeFilter(scope);
@@ -604,10 +701,32 @@ function App() {
                     />
                 </div>
 
+                {favorites.length > 0 && (
+                    <div className="flex items-center gap-2">
+                        <Button
+                            type="button"
+                            size="sm"
+                            intent={favoritesOnly ? "info" : undefined}
+                            aria-pressed={favoritesOnly}
+                            aria-label={`Show favorites only (${favorites.length})`}
+                            onClick={() => setFavoritesOnly((prev) => !prev)}
+                        >
+                            <span className="inline-flex items-center gap-1">
+                                <StarIcon filled={favoritesOnly} />
+                                Favorites
+                                <span className="ml-0.5 tabular-nums opacity-70">
+                                    {favorites.length}
+                                </span>
+                            </span>
+                        </Button>
+                    </div>
+                )}
+
                 <Surface variant="card" className="p-0">
                     <Table>
                         <TableHead>
                             <tr>
+                                <TableHeaderCell className="w-8" />
                                 <SortableTh
                                     label="Type"
                                     sortKey="type"
@@ -697,12 +816,14 @@ function App() {
                             {filteredModels.length === 0 ? (
                                 <TableRow>
                                     <TableCell
-                                        colSpan={adminMode ? 11 : 10}
+                                        colSpan={adminMode ? 12 : 11}
                                         align="center"
                                         className="py-8 text-theme-text-muted"
                                     >
                                         {lastUpdated
-                                            ? "No traffic in this window"
+                                            ? favoritesOnly
+                                                ? "No favorited models match the current filter"
+                                                : "No traffic in this window"
                                             : "Loading models..."}
                                     </TableCell>
                                 </TableRow>
@@ -734,9 +855,31 @@ function App() {
 
                                     return (
                                         <TableRow
-                                            key={`${model.type}-${model.name}`}
+                                            key={modelKey(model)}
                                             intent={rowIntent(health)}
                                         >
+                                            <TableCell className="w-8">
+                                                <IconButton
+                                                    title={
+                                                        favorites.includes(
+                                                            modelKey(model),
+                                                        )
+                                                            ? "Remove from favorites"
+                                                            : "Add to favorites"
+                                                    }
+                                                    onClick={() =>
+                                                        toggleFavorite(
+                                                            modelKey(model),
+                                                        )
+                                                    }
+                                                >
+                                                    <StarIcon
+                                                        filled={favorites.includes(
+                                                            modelKey(model),
+                                                        )}
+                                                    />
+                                                </IconButton>
+                                            </TableCell>
                                             <TableCell>
                                                 <ModalityChip
                                                     modality={model.type}

--- a/shared/registry/audio.ts
+++ b/shared/registry/audio.ts
@@ -217,7 +217,6 @@ export const AUDIO_SERVICES = {
         inputModalities: ["text"],
         outputModalities: ["audio"],
         voices: ELEVENLABS_VOICES as string[],
-        supportedEndpoints: ["/v1/audio/speech"],
     },
     "eleven-voice-changer": {
         aliases: ["voice-changer", "speech-to-speech"],

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -1848,6 +1848,30 @@ export const TEXT_SERVICES = {
         contextLength: 1000000,
         isSpecialized: false,
     },
+    "qwen3.8-2.4t-a95b": {
+        aliases: [],
+        provider: "fireworks",
+        brand: "Qwen",
+        category: "text",
+        addedDate: new Date("2026-08-14").getTime(),
+        paidOnly: false,
+        priceMultiplier: 1,
+        cost: {
+            // Fireworks accounts/fireworks/models/qwen3p8-2p4t-a95b rates (2026-08-14).
+            promptTextTokens: perMillion(2),
+            promptCachedTokens: perMillion(0.25),
+            completionTextTokens: perMillion(6),
+        },
+        title: "Qwen3.8 2.4T A95B",
+        description:
+            "Open-weight sparse frontier reasoning for long-horizon coding and autonomous agents",
+        inputModalities: ["text"],
+        outputModalities: ["text"],
+        tools: true,
+        reasoning: true,
+        contextLength: 262144,
+        isSpecialized: false,
+    },
     "qwen3.8-max": {
         aliases: [],
         provider: "openrouter",


### PR DESCRIPTION
Promote the latest merged changes from `main` to `production`.

Included pull requests:
- [#13383](https://github.com/pollinations/pollinations/pull/13383) — regenerate APIDOCS.md.
- [#12644](https://github.com/pollinations/pollinations/pull/12644) — add model-monitor favorites and persistent filters.
- [#13014](https://github.com/pollinations/pollinations/pull/13014) — add community-model activation confirmation.
- [#13322](https://github.com/pollinations/pollinations/pull/13322) — add the `?community` model-discovery filter.
- [#12847](https://github.com/pollinations/pollinations/pull/12847) — remove the Driftpod.fm repository link.
- [#13377](https://github.com/pollinations/pollinations/pull/13377) — expose speech models through the simple audio route.
- [#13389](https://github.com/pollinations/pollinations/pull/13389) — add Qwen3.8 2.4T A95B.
- [#13387](https://github.com/pollinations/pollinations/pull/13387) — request reasoning summaries from Azure.
- [#13384](https://github.com/pollinations/pollinations/pull/13384) — add Floret model overrides.

Verification:
- Production source guard must confirm this PR comes from `main`.
- CodeQL analysis and merge protection must pass.
- Repository automation and deployment checks must pass.