### PR TITLE
docs: update durable media guidance

### DIFF
--- a/.claude/skills/model-management/SKILL.md
+++ b/.claude/skills/model-management/SKILL.md
@@ -31,6 +31,11 @@ Read [operating-policy.md](references/operating-policy.md) before recommending a
 
 ## Mandatory confirmation gate
 
+Apply this gate only to a proposed tracked model mutation. Do not turn a
+read-only status confirmation, an approval of an already-documented planning
+decision, or a correction of an operational fact into a different mutation.
+Treat a generic “confirm” as approval only for the exact contract just shown.
+
 Do not edit any model until the user confirms its complete business and inference contract. Inspect the code and provider first; do not ask the user to discover values for you.
 
 Show one complete row per model:
@@ -134,7 +139,7 @@ Present the mandatory row and obtain explicit confirmation before editing. If a 
 - Run the relevant rows in [change-and-test-matrix.md](references/change-and-test-matrix.md).
 - For new models and provider/model-ID changes, run the full declared-modality matrix and [billing-verification.md](references/billing-verification.md).
 - Test aliases, permissions, errors, caching, capacity, and `/models` metadata.
-- Verify all media is fully returned within the supported synchronous time budget.
+- Verify all media is fully returned within the supported request-lifetime budget, including the durable-media checks when applicable.
 - Record exact evidence and uncertainty in the PR.
 
 ### 6. Open the PR

--- a/.claude/skills/model-management/references/change-and-test-matrix.md
+++ b/.claude/skills/model-management/references/change-and-test-matrix.md
@@ -52,6 +52,16 @@ Do not advertise a capability because the base model supports it if the selected
 - Run repeated generations to measure typical and slow-tail latency; require completion within the supported synchronous budget.
 - Verify resolution/duration-specific billing rather than assuming one flat media price.
 
+## Durable long-running media
+
+For any media route that may exceed 120 seconds:
+
+- Disconnect the original client and retry the byte-identical request. The retry must join the running job rather than start a second upstream execution.
+- After completion, retry again and verify retrieval from the completed R2 cache with an intact response.
+- Verify exactly one wallet debit and one billed Tinybird event across the original request, running-job join, and completed-cache retrieval.
+- Exercise durations just below, at, and above 300 seconds. Requests within the boundary must complete; requests beyond it must terminate clearly unless a separately approved asynchronous public contract exists.
+- Keep provider polling internal. Do not expose provider job IDs or require user polling under the synchronous public contract.
+
 ## Audio, speech, and music
 
 - TTS through every advertised public endpoint, with every declared voice and format.
@@ -76,7 +86,7 @@ Do not advertise a capability because the base model supports it if the selected
 - For OCR, test PDF and image inputs, page selection, structured blocks, and large-payload behavior when exposed.
 - For SVG/vector output, validate parseability and render the result.
 - For 3D, inspect the actual asset type and any preview; do not label PLY, splats, or point clouds as GLB meshes.
-- Run multiple timed media jobs; do not add a specialist model that routinely exceeds the synchronous budget.
+- Run multiple timed media jobs; do not add a specialist model that routinely exceeds the supported request-lifetime budget.
 
 ## Errors, permissions, cache, and capacity
 

--- a/.claude/skills/model-management/references/operating-policy.md
+++ b/.claude/skills/model-management/references/operating-policy.md
@@ -31,7 +31,9 @@ These are strategic defaults. The user's explicit, confirmed contract for a spec
 
 - Pollinations-operated GPUs require a separately proven popularity, utilization, reliability, and margin case. Being open-weight is not enough.
 - Prefer provider APIs for niche or uncertain-demand models.
-- Media should normally finish and be returned within **120 seconds** because Pollinations does not have a durable asynchronous completion path for users.
+- Media requests may run for up to **300 seconds** through the durable generation coordinator. Internally polling an asynchronous provider is allowed behind the synchronous public request contract.
+- Verify identical-request disconnect/rejoin, one upstream execution, completed R2 cache retrieval, and once-only wallet and Tinybird settlement.
+- A route expected to exceed 300 seconds requires a separately approved asynchronous public contract.
 - Do not add slow 3D, video, audio, or specialist media merely for catalog breadth. Test repeated real generations and the slow tail, not one successful request.
 
 ## Public catalog contract

--- a/.claude/skills/model-management/references/repository-and-local-testing.md
+++ b/.claude/skills/model-management/references/repository-and-local-testing.md
@@ -10,6 +10,7 @@ Read live code before relying on this map; paths evolve.
 | Registry conversion and prices | `shared/registry/registry.ts`, `shared/registry/price-helpers.ts`, `shared/registry/usage-headers.ts` |
 | Text routing | `gen.pollinations.ai/src/text/configs/modelConfigs.ts`, `providerConfigs.ts`, `availableModels.ts` |
 | Image and video | `gen.pollinations.ai/src/image/`, especially dispatch, params, models, and provider handlers |
+| Durable media coordination | `gen.pollinations.ai/src/durable-objects/GenerationCoordinator.ts`, `gen.pollinations.ai/src/middleware/generation-deduplication.ts`, `gen.pollinations.ai/src/routes/generation-executor.ts`, `gen.pollinations.ai/src/utils/execute-generation.ts` |
 | Audio and speech | `gen.pollinations.ai/src/routes/audio.ts` and transcription/realtime routes |
 | Embeddings | `gen.pollinations.ai/src/embeddings/` |
 | Billing and observability | `gen.pollinations.ai/src/middleware/track.ts`, `enter.pollinations.ai/observability/` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,16 @@ curl "http://localhost:8788/v1/chat/completions" -H "Authorization: Bearer $TOKE
 - Models: `/image/models`, `/v1/models`
 - See `./APIDOCS.md`, `.claude/skills/enter-services/SKILL.md`
 
+## Durable Media Requests
+
+- Media generation uses the durable generation coordinator and supports request
+  lifetimes up to 300 seconds. Do not reject a route solely because it exceeds
+  120 seconds or polls an asynchronous provider internally.
+- Prove identical-request disconnect/rejoin, one upstream execution, completed
+  R2 cache retrieval, one wallet debit, and one billed Tinybird event.
+- Test behavior just below, at, and above 300 seconds. A route expected to exceed
+  300 seconds requires a separately approved asynchronous public contract.
+
 ## ⚠️ YAGNI — You Aren't Gonna Need It (CRITICAL)
 
 **Follow YAGNI religiously:**


### PR DESCRIPTION
- Documents the working 300-second durable media request boundary in `AGENTS.md` and the model-management operating policy.
- Replaces the stale 120-second rejection rule while keeping 120 seconds as the threshold for durable-path verification.
- Adds disconnect/rejoin, single upstream execution, completed R2 cache, once-only wallet/Tinybird settlement, and 300-second boundary checks.
- Clarifies that model confirmation applies only to the exact tracked mutation shown.
- Validated with the skill package validator and `git diff --check`; Biome correctly ignores Markdown.