### PR TITLE
fix: spell out RPM in model tooltip

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/model-status-chips.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-status-chips.tsx
@@ -31,7 +31,7 @@ export const ModelStatusChips: FC<ModelStatusChipsProps> = ({
             ? undefined
             : {
                   label: `${perUserRpm} RPM/user`,
-                  tooltip: `Per-user rate limit: ${perUserRpm} RPM.`,
+                  tooltip: `Per-user rate limit: ${perUserRpm} requests per minute.`,
               };
 
     return (


### PR DESCRIPTION
- Writes out “requests per minute” in the per-user rate-limit tooltip.
- Keeps the compact `RPM/user` chip label unchanged.

Checks:
- Biome
- `git diff --check`