### PR TITLE
feat: add encrypted MCP agent headers

### DIFF
--- a/enter.pollinations.ai/drizzle/0050_bitter_black_bolt.sql
+++ b/enter.pollinations.ai/drizzle/0050_bitter_black_bolt.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `agent` ADD `mcp_headers_ciphertext` text;

--- a/enter.pollinations.ai/drizzle/meta/0050_snapshot.json
+++ b/enter.pollinations.ai/drizzle/meta/0050_snapshot.json
@@ -1,0 +1,1828 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "9d4b577a-b978-4e2c-bf42-51133a08ee27",
+  "prevId": "1ecd4191-02ff-4e9d-9383-7ee74a9019b7",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_account_user_id": {
+          "name": "idx_account_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent": {
+      "name": "agent",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mcp_headers_ciphertext": {
+          "name": "mcp_headers_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_agent_owner_user_id": {
+          "name": "idx_agent_owner_user_id",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_owner_user_id_user_id_fk": {
+          "name": "agent_owner_user_id_user_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 5
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pollen_balance": {
+          "name": "pollen_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "byop_client_key_id": {
+          "name": "byop_client_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_apikey_key": {
+          "name": "idx_apikey_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_expires_at": {
+          "name": "idx_apikey_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_user_id": {
+          "name": "idx_apikey_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_byop_client_key_id": {
+          "name": "idx_apikey_byop_client_key_id",
+          "columns": [
+            "byop_client_key_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apikey_user_id_user_id_fk": {
+          "name": "apikey_user_id_user_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "community_endpoint": {
+      "name": "community_endpoint",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'text'"
+        },
+        "image_pricing": {
+          "name": "image_pricing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'request'"
+        },
+        "supports_image_edits": {
+          "name": "supports_image_edits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "input_modalities": {
+          "name": "input_modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_model": {
+          "name": "upstream_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bearer_token_ciphertext": {
+          "name": "bearer_token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'private'"
+        },
+        "per_user_rpm": {
+          "name": "per_user_rpm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_text_price": {
+          "name": "prompt_text_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_cached_price": {
+          "name": "prompt_cached_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "prompt_cache_write_price": {
+          "name": "prompt_cache_write_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "prompt_audio_price": {
+          "name": "prompt_audio_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "prompt_image_price": {
+          "name": "prompt_image_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "completion_text_price": {
+          "name": "completion_text_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completion_reasoning_price": {
+          "name": "completion_reasoning_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "completion_audio_price": {
+          "name": "completion_audio_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "completion_image_price": {
+          "name": "completion_image_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "delegates_generation": {
+          "name": "delegates_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "fallback_model_ids": {
+          "name": "fallback_model_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_reason": {
+          "name": "disabled_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_by": {
+          "name": "disabled_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_community_endpoint_owner_user_id": {
+          "name": "idx_community_endpoint_owner_user_id",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_community_endpoint_owner_name": {
+          "name": "idx_community_endpoint_owner_name",
+          "columns": [
+            "owner_user_id",
+            "name"
+          ],
+          "isUnique": true
+        },
+        "idx_community_endpoint_agent_id": {
+          "name": "idx_community_endpoint_agent_id",
+          "columns": [
+            "agent_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "community_endpoint_owner_user_id_user_id_fk": {
+          "name": "community_endpoint_owner_user_id_user_id_fk",
+          "tableFrom": "community_endpoint",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_endpoint_agent_id_agent_id_fk": {
+          "name": "community_endpoint_agent_id_agent_id_fk",
+          "tableFrom": "community_endpoint",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "device_code": {
+      "name": "device_code",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_device_code_device_code": {
+          "name": "idx_device_code_device_code",
+          "columns": [
+            "device_code"
+          ],
+          "isUnique": false
+        },
+        "idx_device_code_user_code": {
+          "name": "idx_device_code_user_code",
+          "columns": [
+            "user_code"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "device_code_user_id_user_id_fk": {
+          "name": "device_code_user_id_user_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "polar_checkout_credits": {
+      "name": "polar_checkout_credits",
+      "columns": {
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pollen_credited": {
+          "name": "pollen_credited",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "polar_created_at": {
+          "name": "polar_created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_slug": {
+          "name": "product_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_polar_checkout_credits_user_id": {
+          "name": "idx_polar_checkout_credits_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "polar_checkout_credits_user_id_user_id_fk": {
+          "name": "polar_checkout_credits_user_id_user_id_fk",
+          "tableFrom": "polar_checkout_credits",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rewards": {
+      "name": "rewards",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quest_id": {
+          "name": "quest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pollen_amount": {
+          "name": "pollen_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "balance_bucket": {
+          "name": "balance_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rewards_idempotency_key_unique": {
+          "name": "rewards_idempotency_key_unique",
+          "columns": [
+            "idempotency_key"
+          ],
+          "isUnique": true
+        },
+        "idx_rewards_user_id": {
+          "name": "idx_rewards_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "rewards_user_id_user_id_fk": {
+          "name": "rewards_user_id_user_id_fk",
+          "tableFrom": "rewards",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_session_user_id": {
+          "name": "idx_session_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_auto_top_up_attempt": {
+      "name": "stripe_auto_top_up_attempt",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount_usd": {
+          "name": "amount_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "stripe_auto_top_up_attempt_stripe_invoice_id_unique": {
+          "name": "stripe_auto_top_up_attempt_stripe_invoice_id_unique",
+          "columns": [
+            "stripe_invoice_id"
+          ],
+          "isUnique": true
+        },
+        "idx_stripe_auto_top_up_attempt_user_id": {
+          "name": "idx_stripe_auto_top_up_attempt_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_stripe_auto_top_up_attempt_status": {
+          "name": "idx_stripe_auto_top_up_attempt_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_auto_top_up_attempt_user_id_user_id_fk": {
+          "name": "stripe_auto_top_up_attempt_user_id_user_id_fk",
+          "tableFrom": "stripe_auto_top_up_attempt",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_card_fingerprint_attempt": {
+      "name": "stripe_card_fingerprint_attempt",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "card_fingerprint": {
+          "name": "card_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_stripe_card_fingerprint_attempt_user_created": {
+          "name": "idx_stripe_card_fingerprint_attempt_user_created",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_stripe_card_fingerprint_attempt_user_fingerprint": {
+          "name": "idx_stripe_card_fingerprint_attempt_user_fingerprint",
+          "columns": [
+            "user_id",
+            "card_fingerprint"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_card_fingerprint_attempt_user_id_user_id_fk": {
+          "name": "stripe_card_fingerprint_attempt_user_id_user_id_fk",
+          "tableFrom": "stripe_card_fingerprint_attempt",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_checkout_credits": {
+      "name": "stripe_checkout_credits",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pollen_credited": {
+          "name": "pollen_credited",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_stripe_checkout_credits_user_id": {
+          "name": "idx_stripe_checkout_credits_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_checkout_credits_user_id_user_id_fk": {
+          "name": "stripe_checkout_credits_user_id_user_id_fk",
+          "tableFrom": "stripe_checkout_credits",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "community_provider_name": {
+          "name": "community_provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "community_provider_url": {
+          "name": "community_provider_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'spore'"
+        },
+        "tier_balance": {
+          "name": "tier_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pack_balance": {
+          "name": "pack_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_tier_grant": {
+          "name": "last_tier_grant",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "auto_top_up_amount_usd": {
+          "name": "auto_top_up_amount_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_stripe_customer_id_unique": {
+          "name": "user_stripe_customer_id_unique",
+          "columns": [
+            "stripe_customer_id"
+          ],
+          "isUnique": true
+        },
+        "idx_user_email": {
+          "name": "idx_user_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "idx_user_auto_top_up_enabled": {
+          "name": "idx_user_auto_top_up_enabled",
+          "columns": [
+            "auto_top_up_enabled"
+          ],
+          "isUnique": false
+        },
+        "idx_user_github_id": {
+          "name": "idx_user_github_id",
+          "columns": [
+            "github_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_verification_identifier": {
+          "name": "idx_verification_identifier",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_item": {
+      "name": "media_item",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "app_key_id": {
+          "name": "app_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_media_item_owner_created": {
+          "name": "idx_media_item_owner_created",
+          "columns": [
+            "owner_user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "media_item_owner_user_id_user_id_fk": {
+          "name": "media_item_owner_user_id_user_id_fk",
+          "tableFrom": "media_item",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_tag": {
+      "name": "media_tag",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_media_tag_item_tag": {
+          "name": "idx_media_tag_item_tag",
+          "columns": [
+            "item_id",
+            "tag"
+          ],
+          "isUnique": true
+        },
+        "idx_media_tag_tag_item": {
+          "name": "idx_media_tag_tag_item",
+          "columns": [
+            "tag",
+            "item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "media_tag_item_id_media_item_id_fk": {
+          "name": "media_tag_item_id_media_item_id_fk",
+          "tableFrom": "media_tag",
+          "tableTo": "media_item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/enter.pollinations.ai/drizzle/meta/_journal.json
+++ b/enter.pollinations.ai/drizzle/meta/_journal.json
@@ -351,6 +351,13 @@
       "when": 1786782545630,
       "tag": "0049_legal_the_renegades",
       "breakpoints": true
+    },
+    {
+      "idx": 50,
+      "version": "6",
+      "when": 1786792201937,
+      "tag": "0050_bitter_black_bolt",
+      "breakpoints": true
     }
   ]
 }

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/agent-dialog.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/agent-dialog.tsx
@@ -19,7 +19,6 @@ import {
     isValidMcpRow,
     isValidPerUserRpm,
     type ManagedAgent,
-    type McpServerRow,
     type ModelListingFormState,
     toAgentListingPayload,
     toAgentPayload,
@@ -65,8 +64,15 @@ export function AgentDialog({
                       baseModel: agent.baseModel,
                       pollinationsTools: agent.pollinationsTools,
                       mcpServers: agent.mcpServers.map((server) => ({
-                          ...server,
                           id: crypto.randomUUID(),
+                          name: server.name,
+                          url: server.url,
+                          headers: Object.keys(server.headers).map((name) => ({
+                              id: crypto.randomUUID(),
+                              name,
+                              value: "",
+                              saved: true,
+                          })),
                       })),
                   }
                 : emptyAgentForm),
@@ -84,13 +90,25 @@ export function AgentDialog({
 
     function updateMcpServer(
         index: number,
-        key: keyof Omit<McpServerRow, "id">,
+        key: "name" | "url",
         value: string,
     ): void {
         setForm((current) => ({
             ...current,
             mcpServers: current.mcpServers.map((row, rowIndex) =>
-                rowIndex === index ? { ...row, [key]: value } : row,
+                rowIndex === index
+                    ? {
+                          ...row,
+                          [key]: value,
+                          headers:
+                              key === "name" && value !== row.name
+                                  ? row.headers.map((header) => ({
+                                        ...header,
+                                        saved: false,
+                                    }))
+                                  : row.headers,
+                      }
+                    : row,
             ),
         }));
     }
@@ -100,8 +118,82 @@ export function AgentDialog({
             ...current,
             mcpServers: [
                 ...current.mcpServers,
-                { id: crypto.randomUUID(), name: "", url: "" },
+                {
+                    id: crypto.randomUUID(),
+                    name: "",
+                    url: "",
+                    headers: [],
+                },
             ],
+        }));
+    }
+
+    function addMcpHeader(serverIndex: number): void {
+        setForm((current) => ({
+            ...current,
+            mcpServers: current.mcpServers.map((server, index) =>
+                index === serverIndex
+                    ? {
+                          ...server,
+                          headers: [
+                              ...server.headers,
+                              {
+                                  id: crypto.randomUUID(),
+                                  name: "",
+                                  value: "",
+                                  saved: false,
+                              },
+                          ],
+                      }
+                    : server,
+            ),
+        }));
+    }
+
+    function updateMcpHeader(
+        serverIndex: number,
+        headerIndex: number,
+        key: "name" | "value",
+        value: string,
+    ): void {
+        setForm((current) => ({
+            ...current,
+            mcpServers: current.mcpServers.map((server, index) =>
+                index === serverIndex
+                    ? {
+                          ...server,
+                          headers: server.headers.map((header, index) =>
+                              index === headerIndex
+                                  ? {
+                                        ...header,
+                                        [key]: value,
+                                        saved:
+                                            key === "name" &&
+                                            value !== header.name
+                                                ? false
+                                                : header.saved,
+                                    }
+                                  : header,
+                          ),
+                      }
+                    : server,
+            ),
+        }));
+    }
+
+    function removeMcpHeader(serverIndex: number, headerIndex: number): void {
+        setForm((current) => ({
+            ...current,
+            mcpServers: current.mcpServers.map((server, index) =>
+                index === serverIndex
+                    ? {
+                          ...server,
+                          headers: server.headers.filter(
+                              (_, index) => index !== headerIndex,
+                          ),
+                      }
+                    : server,
+            ),
         }));
     }
 
@@ -224,6 +316,9 @@ export function AgentDialog({
                         onAddMcp={addMcpServer}
                         onUpdateMcp={updateMcpServer}
                         onRemoveMcp={removeMcpServer}
+                        onAddMcpHeader={addMcpHeader}
+                        onUpdateMcpHeader={updateMcpHeader}
+                        onRemoveMcpHeader={removeMcpHeader}
                     />
                 </ScrollArea>
                 <div className="flex shrink-0 justify-end gap-2 border-t border-divider p-6 pt-4">

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/prompt-agent-fields.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/prompt-agent-fields.tsx
@@ -8,7 +8,7 @@ import {
     XIcon,
 } from "@pollinations/ui";
 import { BaseModelInput } from "./base-model-input.tsx";
-import type { AgentFormState, McpServerRow } from "./types.ts";
+import type { AgentFormState } from "./types.ts";
 
 export function PromptAgentFields({
     form,
@@ -17,6 +17,9 @@ export function PromptAgentFields({
     onAddMcp,
     onUpdateMcp,
     onRemoveMcp,
+    onAddMcpHeader,
+    onUpdateMcpHeader,
+    onRemoveMcpHeader,
 }: {
     form: AgentFormState;
     disabled: boolean;
@@ -25,12 +28,16 @@ export function PromptAgentFields({
         value: string | boolean,
     ) => void;
     onAddMcp: () => void;
-    onUpdateMcp: (
-        index: number,
-        key: keyof Omit<McpServerRow, "id">,
+    onUpdateMcp: (index: number, key: "name" | "url", value: string) => void;
+    onRemoveMcp: (index: number) => void;
+    onAddMcpHeader: (serverIndex: number) => void;
+    onUpdateMcpHeader: (
+        serverIndex: number,
+        headerIndex: number,
+        key: "name" | "value",
         value: string,
     ) => void;
-    onRemoveMcp: (index: number) => void;
+    onRemoveMcpHeader: (serverIndex: number, headerIndex: number) => void;
 }) {
     return (
         <div className="space-y-4">
@@ -77,7 +84,7 @@ export function PromptAgentFields({
 
             <FieldStack
                 label="MCP servers"
-                helper="Public Streamable-HTTP MCP servers whose tools the agent can call."
+                helper="Public Streamable-HTTP MCP servers whose tools the agent can call. Optional request headers are stored encrypted."
                 alignLabelRow
                 action={
                     <Button
@@ -97,54 +104,136 @@ export function PromptAgentFields({
                         {form.mcpServers.map((row, index) => (
                             <div
                                 key={row.id}
-                                className="flex items-center gap-2"
+                                className="space-y-2 rounded-md border border-divider p-2"
                             >
-                                <Input
-                                    name={`prompt-agent-mcp-name-${index}`}
-                                    value={row.name}
-                                    placeholder="my-server"
-                                    autoComplete="off"
-                                    autoCapitalize="none"
-                                    spellCheck={false}
-                                    className="w-40 shrink-0"
-                                    disabled={disabled}
-                                    onChange={(e) =>
-                                        onUpdateMcp(
-                                            index,
-                                            "name",
-                                            e.target.value,
-                                        )
-                                    }
-                                />
-                                <Input
-                                    name={`prompt-agent-mcp-url-${index}`}
-                                    type="url"
-                                    inputMode="url"
-                                    value={row.url}
-                                    placeholder="https://mcp.example.com"
-                                    autoComplete="off"
-                                    autoCapitalize="none"
-                                    spellCheck={false}
-                                    className="flex-1"
-                                    disabled={disabled}
-                                    onChange={(e) =>
-                                        onUpdateMcp(
-                                            index,
-                                            "url",
-                                            e.target.value,
-                                        )
-                                    }
-                                />
-                                {!disabled && (
-                                    <IconButton
-                                        intent="danger"
-                                        title="Remove MCP server"
-                                        tooltip="Remove MCP server"
-                                        onClick={() => onRemoveMcp(index)}
+                                <div className="flex items-center gap-2">
+                                    <Input
+                                        name={`prompt-agent-mcp-name-${index}`}
+                                        value={row.name}
+                                        placeholder="my-server"
+                                        autoComplete="off"
+                                        autoCapitalize="none"
+                                        spellCheck={false}
+                                        className="w-40 shrink-0"
+                                        disabled={disabled}
+                                        onChange={(e) =>
+                                            onUpdateMcp(
+                                                index,
+                                                "name",
+                                                e.target.value,
+                                            )
+                                        }
+                                    />
+                                    <Input
+                                        name={`prompt-agent-mcp-url-${index}`}
+                                        type="url"
+                                        inputMode="url"
+                                        value={row.url}
+                                        placeholder="https://mcp.example.com"
+                                        autoComplete="off"
+                                        autoCapitalize="none"
+                                        spellCheck={false}
+                                        className="flex-1"
+                                        disabled={disabled}
+                                        onChange={(e) =>
+                                            onUpdateMcp(
+                                                index,
+                                                "url",
+                                                e.target.value,
+                                            )
+                                        }
+                                    />
+                                    {!disabled && (
+                                        <IconButton
+                                            intent="danger"
+                                            title="Remove MCP server"
+                                            tooltip="Remove MCP server"
+                                            onClick={() => onRemoveMcp(index)}
+                                        >
+                                            <XIcon className="h-4 w-4" />
+                                        </IconButton>
+                                    )}
+                                </div>
+                                <div className="flex items-center justify-between gap-2">
+                                    <span className="text-xs text-theme-text-muted">
+                                        Request headers
+                                    </span>
+                                    <Button
+                                        type="button"
+                                        size="sm"
+                                        disabled={
+                                            disabled || row.headers.length >= 16
+                                        }
+                                        onClick={() => onAddMcpHeader(index)}
                                     >
-                                        <XIcon className="h-4 w-4" />
-                                    </IconButton>
-                                )}
+                                        Add header
+                                    </Button>
+                                </div>
+                                {row.headers.map((header, headerIndex) => (
+                                    <div
+                                        key={header.id}
+                                        className="flex items-center gap-2"
+                                    >
+                                        <Input
+                                            name={`prompt-agent-mcp-header-name-${index}-${headerIndex}`}
+                                            value={header.name}
+                                            placeholder="Authorization"
+                                            autoComplete="off"
+                                            autoCapitalize="none"
+                                            spellCheck={false}
+                                            className="w-48 shrink-0"
+                                            disabled={disabled}
+                                            onChange={(event) =>
+                                                onUpdateMcpHeader(
+                                                    index,
+                                                    headerIndex,
+                                                    "name",
+                                                    event.target.value,
+                                                )
+                                            }
+                                        />
+                                        <Input
+                                            name={`prompt-agent-mcp-header-value-${index}-${headerIndex}`}
+                                            type="password"
+                                            value={header.value}
+                                            placeholder={
+                                                header.saved
+                                                    ? "Saved — leave blank to keep"
+                                                    : "Header value"
+                                            }
+                                            autoComplete="new-password"
+                                            autoCapitalize="none"
+                                            data-lpignore="true"
+                                            data-1p-ignore="true"
+                                            data-bwignore="true"
+                                            className="flex-1"
+                                            disabled={disabled}
+                                            onChange={(event) =>
+                                                onUpdateMcpHeader(
+                                                    index,
+                                                    headerIndex,
+                                                    "value",
+                                                    event.target.value,
+                                                )
+                                            }
+                                        />
+                                        {!disabled && (
+                                            <IconButton
+                                                intent="danger"
+                                                title="Remove header"
+                                                tooltip="Remove header"
+                                                onClick={() =>
+                                                    onRemoveMcpHeader(
+                                                        index,
+                                                        headerIndex,
+                                                    )
+                                                }
+                                            >
+                                                <XIcon className="h-4 w-4" />
+                                            </IconButton>
+                                        )}
+                                    </div>
+                                ))}
                             </div>
                         ))}
                     </div>

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/types.ts
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/types.ts
@@ -17,14 +17,30 @@ import type { ModelInputModality, Usage } from "@shared/registry/registry.ts";
 
 type EndpointFormPrices = Record<CommunityEndpointPriceKey, string>;
 
-export type McpServerRow = { id: string; name: string; url: string };
+export type McpHeaderRow = {
+    id: string;
+    name: string;
+    value: string;
+    saved: boolean;
+};
+
+export type McpServerRow = {
+    id: string;
+    name: string;
+    url: string;
+    headers: McpHeaderRow[];
+};
 
 export type ManagedAgent = {
     id: string;
     systemPrompt: string;
     baseModel: string;
     pollinationsTools: boolean;
-    mcpServers: { name: string; url: string }[];
+    mcpServers: {
+        name: string;
+        url: string;
+        headers: Record<string, null>;
+    }[];
     createdAt: string;
     updatedAt: string;
 };
@@ -37,7 +53,11 @@ type AgentFields = Pick<
 export type AgentFormState = AgentFields & { mcpServers: McpServerRow[] };
 
 export type AgentPayload = AgentFields & {
-    mcpServers: ManagedAgent["mcpServers"];
+    mcpServers: {
+        name: string;
+        url: string;
+        headers: Record<string, string | null>;
+    }[];
 };
 
 export type CommunityProviderProfile = {
@@ -382,23 +402,44 @@ export function observedUsageValue(
 // Mirrors the backend McpServerSchema name pattern (lowercase alphanumeric with
 // _ or -, max 40 chars) so client and server reject the same names.
 export const MCP_SERVER_NAME_PATTERN = /^[a-z0-9][a-z0-9_-]{0,39}$/;
+export const MCP_HEADER_NAME_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]{1,128}$/;
 
 export function isValidMcpRow(row: McpServerRow): boolean {
     const name = row.name.trim();
     const url = row.url.trim();
-    if (!name && !url) return true;
+    const nonEmptyHeaders = row.headers.filter(
+        (header) => header.name.trim() || header.value,
+    );
+    if (!name && !url && nonEmptyHeaders.length === 0) return true;
     try {
         normalizeCommunityEndpointBaseUrl(url);
     } catch {
         return false;
     }
-    return MCP_SERVER_NAME_PATTERN.test(name);
+    if (!MCP_SERVER_NAME_PATTERN.test(name)) return false;
+
+    const headerNames = new Set<string>();
+    for (const header of nonEmptyHeaders) {
+        const headerName = header.name.trim();
+        if (
+            !MCP_HEADER_NAME_PATTERN.test(headerName) ||
+            (!header.saved && !header.value) ||
+            header.value.includes("\r") ||
+            header.value.includes("\n")
+        ) {
+            return false;
+        }
+        const normalized = headerName.toLowerCase();
+        if (headerNames.has(normalized)) return false;
+        headerNames.add(normalized);
+    }
+    return nonEmptyHeaders.length <= 16;
 }
 
 // Validates and trims the MCP server rows, dropping fully-empty rows. Mirrors
 // the backend McpServerSchema so the API rejects the same inputs.
-function mcpServersToPayload(rows: McpServerRow[]): ManagedAgent["mcpServers"] {
-    const servers: ManagedAgent["mcpServers"] = [];
+function mcpServersToPayload(rows: McpServerRow[]): AgentPayload["mcpServers"] {
+    const servers: AgentPayload["mcpServers"] = [];
     for (const row of rows) {
         const name = row.name.trim();
         const url = row.url.trim();
@@ -411,10 +452,27 @@ function mcpServersToPayload(rows: McpServerRow[]): ManagedAgent["mcpServers"] {
         if (!url) {
             throw new Error(`MCP server "${name}" needs a URL`);
         }
+        const headers: Record<string, string | null> = {};
+        for (const header of row.headers) {
+            const headerName = header.name.trim();
+            if (!headerName && !header.value) continue;
+            if (!MCP_HEADER_NAME_PATTERN.test(headerName)) {
+                throw new Error(
+                    `MCP server "${name}" has an invalid header name`,
+                );
+            }
+            if (!header.saved && !header.value) {
+                throw new Error(
+                    `MCP header "${headerName}" for server "${name}" needs a value`,
+                );
+            }
+            headers[headerName] = header.value || null;
+        }
         try {
             servers.push({
                 name,
                 url: normalizeCommunityEndpointBaseUrl(url),
+                headers,
             });
         } catch {
             throw new Error(

--- a/enter.pollinations.ai/src/routes/agent-runtime.ts
+++ b/enter.pollinations.ai/src/routes/agent-runtime.ts
@@ -1,11 +1,15 @@
 import * as schema from "@shared/db/better-auth.ts";
+import { decryptSecret } from "@shared/secret-encryption.ts";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import type { Env } from "../env.ts";
 import { auth } from "../middleware/auth.ts";
-import { parsePromptAgentConfig } from "../services/prompt-agent.ts";
+import {
+    parsePromptAgentConfig,
+    parsePromptAgentMcpHeaders,
+} from "../services/prompt-agent.ts";
 import {
     handlePromptAgentRequest,
     type PromptAgentRequest,
@@ -61,8 +65,20 @@ export const agentRuntimeRoutes = new Hono<Env>()
         if (!config) {
             throw new Error(`Agent ${row.id} has invalid configuration`);
         }
+        const mcpHeaders = row.mcpHeadersCiphertext
+            ? parsePromptAgentMcpHeaders(
+                  await decryptSecret(
+                      row.mcpHeadersCiphertext,
+                      c.env.BETTER_AUTH_SECRET,
+                  ),
+              )
+            : {};
+        if (!mcpHeaders) {
+            throw new Error(`Agent ${row.id} has invalid MCP credentials`);
+        }
         return await handlePromptAgentRequest(body, c.req.raw.signal, {
             config,
+            mcpHeaders,
             apiKey,
             genBaseUrl: genBaseUrl(c.env),
             pollinationsMcpUrl: pollinationsMcpUrl(c.env),

--- a/enter.pollinations.ai/src/routes/agents.ts
+++ b/enter.pollinations.ai/src/routes/agents.ts
@@ -1,5 +1,6 @@
 import * as schema from "@shared/db/better-auth.ts";
 import { validator } from "@shared/middleware/validator.ts";
+import { decryptSecret, encryptSecret } from "@shared/secret-encryption.ts";
 import { and, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { Hono } from "hono";
@@ -9,19 +10,27 @@ import { z } from "zod";
 import type { Env } from "../env.ts";
 import { auth } from "../middleware/auth.ts";
 import {
+    McpServerInputSchema,
+    McpServerResponseSchema,
+    type PromptAgentConfig,
+    type PromptAgentInput,
+    PromptAgentInputSchema,
+    type PromptAgentMcpHeaders,
     PromptAgentSchema,
     parsePromptAgentConfig,
+    parsePromptAgentMcpHeaders,
     serializePromptAgentConfig,
 } from "../services/prompt-agent.ts";
 import { requireAccountPermission } from "./account-permissions.ts";
 
-const CreateAgentSchema = PromptAgentSchema;
+const CreateAgentSchema = PromptAgentInputSchema;
 const UpdateAgentSchema = z
     .object({
-        systemPrompt: PromptAgentSchema.shape.systemPrompt.optional(),
-        baseModel: PromptAgentSchema.shape.baseModel.optional(),
-        pollinationsTools: PromptAgentSchema.shape.pollinationsTools.optional(),
-        mcpServers: PromptAgentSchema.shape.mcpServers.optional(),
+        systemPrompt: PromptAgentInputSchema.shape.systemPrompt.optional(),
+        baseModel: PromptAgentInputSchema.shape.baseModel.optional(),
+        pollinationsTools:
+            PromptAgentInputSchema.shape.pollinationsTools.optional(),
+        mcpServers: z.array(McpServerInputSchema).max(8).optional(),
     })
     .refine(
         (input) => Object.values(input).some((value) => value !== undefined),
@@ -34,7 +43,7 @@ const AgentResponseSchema = z.object({
     systemPrompt: z.string(),
     baseModel: z.string(),
     pollinationsTools: z.boolean(),
-    mcpServers: PromptAgentSchema.shape.mcpServers,
+    mcpServers: z.array(McpServerResponseSchema),
     createdAt: z.string(),
     updatedAt: z.string(),
 });
@@ -52,9 +61,80 @@ function toResponse(row: AgentRow) {
     return {
         id: row.id,
         ...config,
+        mcpServers: config.mcpServers.map((server) => ({
+            name: server.name,
+            url: server.url,
+            headers: Object.fromEntries(
+                server.headers.map((name) => [name, null]),
+            ),
+        })),
         createdAt: row.createdAt,
         updatedAt: row.updatedAt,
     };
+}
+
+function savedHeaderValue(
+    headers: Record<string, string> | undefined,
+    name: string,
+): string | undefined {
+    const normalizedName = name.toLowerCase();
+    return Object.entries(headers ?? {}).find(
+        ([savedName]) => savedName.toLowerCase() === normalizedName,
+    )?.[1];
+}
+
+function resolveMcpServers(
+    servers: PromptAgentInput["mcpServers"],
+    currentHeaders: PromptAgentMcpHeaders = {},
+): {
+    mcpServers: PromptAgentConfig["mcpServers"];
+    mcpHeaders: PromptAgentMcpHeaders;
+} {
+    const mcpHeaders: PromptAgentMcpHeaders = {};
+    const mcpServers = servers.map((server) => {
+        const headers: Record<string, string> = {};
+        for (const [name, value] of Object.entries(server.headers)) {
+            const resolved =
+                value ?? savedHeaderValue(currentHeaders[server.name], name);
+            if (resolved === undefined) {
+                throw new HTTPException(400, {
+                    message: `MCP header "${name}" for server "${server.name}" needs a value`,
+                });
+            }
+            headers[name] = resolved;
+        }
+        if (Object.keys(headers).length > 0) {
+            mcpHeaders[server.name] = headers;
+        }
+        return {
+            name: server.name,
+            url: server.url,
+            headers: Object.keys(headers),
+        };
+    });
+    return { mcpServers, mcpHeaders };
+}
+
+async function encryptedMcpHeaders(
+    headers: PromptAgentMcpHeaders,
+    secret: string,
+): Promise<string | null> {
+    if (Object.keys(headers).length === 0) return null;
+    return encryptSecret(JSON.stringify(headers), secret);
+}
+
+async function storedMcpHeaders(
+    row: AgentRow,
+    secret: string,
+): Promise<PromptAgentMcpHeaders> {
+    if (!row.mcpHeadersCiphertext) return {};
+    const headers = parsePromptAgentMcpHeaders(
+        await decryptSecret(row.mcpHeadersCiphertext, secret),
+    );
+    if (!headers) {
+        throw new Error(`Agent ${row.id} has invalid MCP header credentials`);
+    }
+    return headers;
 }
 
 async function requireOwnedAgent(db: Db, id: string, ownerUserId: string) {
@@ -141,7 +221,7 @@ export const agentsRoutes = new Hono<Env>()
             tags: ["👤 Account"],
             summary: "Create Agent",
             description:
-                "Create an editable prompt agent. The agent can later be registered separately as a community model. API keys require `account:keys`.",
+                "Create an editable prompt agent. MCP header values are encrypted and never returned. The agent can later be registered separately as a community model. API keys require `account:keys`.",
             responses: {
                 200: {
                     description: "Created agent",
@@ -163,13 +243,20 @@ export const agentsRoutes = new Hono<Env>()
             requireAccountPermission(c.var.auth.apiKey, "keys");
             const db = drizzle(c.env.DB, { schema });
             const id = crypto.randomUUID();
-            const config = PromptAgentSchema.parse(input);
+            const { mcpServers, mcpHeaders } = resolveMcpServers(
+                input.mcpServers,
+            );
+            const config = PromptAgentSchema.parse({ ...input, mcpServers });
             const [row] = await db
                 .insert(schema.agent)
                 .values({
                     id,
                     ownerUserId: user.id,
                     config: serializePromptAgentConfig(config),
+                    mcpHeadersCiphertext: await encryptedMcpHeaders(
+                        mcpHeaders,
+                        c.env.BETTER_AUTH_SECRET,
+                    ),
                     createdAt: new Date(),
                     updatedAt: new Date(),
                 })
@@ -183,7 +270,7 @@ export const agentsRoutes = new Hono<Env>()
             tags: ["👤 Account"],
             summary: "Update Agent",
             description:
-                "Update an agent. Existing community model registration is unchanged. API keys require `account:keys`.",
+                "Update an agent. Null MCP header values keep the saved value; omitted headers are removed. Existing community model registration is unchanged. API keys require `account:keys`.",
             responses: {
                 200: {
                     description: "Updated agent",
@@ -213,20 +300,36 @@ export const agentsRoutes = new Hono<Env>()
                     `Agent ${existing.id} has invalid configuration`,
                 );
             }
+            const resolvedMcp = input.mcpServers
+                ? resolveMcpServers(
+                      input.mcpServers,
+                      await storedMcpHeaders(
+                          existing,
+                          c.env.BETTER_AUTH_SECRET,
+                      ),
+                  )
+                : null;
             const config = PromptAgentSchema.parse({
                 systemPrompt: input.systemPrompt ?? currentConfig.systemPrompt,
                 baseModel: input.baseModel ?? currentConfig.baseModel,
                 pollinationsTools:
                     input.pollinationsTools ?? currentConfig.pollinationsTools,
-                mcpServers: input.mcpServers ?? currentConfig.mcpServers,
+                mcpServers: resolvedMcp?.mcpServers ?? currentConfig.mcpServers,
             });
             const serializedConfig = serializePromptAgentConfig(config);
+            const update: Partial<typeof schema.agent.$inferInsert> = {
+                config: serializedConfig,
+                updatedAt: new Date(),
+            };
+            if (resolvedMcp) {
+                update.mcpHeadersCiphertext = await encryptedMcpHeaders(
+                    resolvedMcp.mcpHeaders,
+                    c.env.BETTER_AUTH_SECRET,
+                );
+            }
             const [row] = await db
                 .update(schema.agent)
-                .set({
-                    config: serializedConfig,
-                    updatedAt: new Date(),
-                })
+                .set(update)
                 .where(
                     and(
                         eq(schema.agent.id, id),

--- a/enter.pollinations.ai/src/services/prompt-agent-runtime.ts
+++ b/enter.pollinations.ai/src/services/prompt-agent-runtime.ts
@@ -7,7 +7,10 @@ import {
     stepCountIs,
     ToolLoopAgent,
 } from "ai";
-import type { PromptAgentConfig } from "./prompt-agent.ts";
+import type {
+    PromptAgentConfig,
+    PromptAgentMcpHeaders,
+} from "./prompt-agent.ts";
 
 export type PromptAgentRequest = {
     messages?: ModelMessage[];
@@ -16,6 +19,7 @@ export type PromptAgentRequest = {
 
 type PromptAgentRuntime = {
     config: PromptAgentConfig;
+    mcpHeaders: PromptAgentMcpHeaders;
     apiKey: string;
     genBaseUrl: string;
     pollinationsMcpUrl: string;
@@ -119,7 +123,20 @@ async function loadMcpTools(servers: McpServer[]): Promise<{
 }
 
 async function createAgent(runtime: PromptAgentRuntime) {
-    const servers: McpServer[] = [...runtime.config.mcpServers];
+    const servers: McpServer[] = runtime.config.mcpServers.map((server) => {
+        const storedHeaders = runtime.mcpHeaders[server.name] ?? {};
+        return {
+            name: server.name,
+            url: server.url,
+            headers: Object.fromEntries(
+                server.headers.flatMap((name) =>
+                    storedHeaders[name] === undefined
+                        ? []
+                        : [[name, storedHeaders[name]]],
+                ),
+            ),
+        };
+    });
     if (runtime.config.pollinationsTools) {
         servers.push({
             name: "pollinations",

--- a/enter.pollinations.ai/src/services/prompt-agent.ts
+++ b/enter.pollinations.ai/src/services/prompt-agent.ts
@@ -16,7 +16,40 @@ const McpServerUrlSchema = z
     }, "MCP server URL must use https and target a public host")
     .transform(normalizeCommunityEndpointBaseUrl);
 
-const McpServerSchema = z.object({
+const McpHeaderNameSchema = z
+    .string()
+    .min(1)
+    .max(128)
+    .regex(/^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/, "MCP header name is invalid");
+const McpHeaderValueSchema = z
+    .string()
+    .min(1)
+    .max(8192)
+    .refine((value) => !value.includes("\r") && !value.includes("\n"), {
+        message: "MCP header value cannot contain line breaks",
+    });
+const McpHeadersInputSchema = z
+    .record(McpHeaderNameSchema, McpHeaderValueSchema.nullable())
+    .refine((headers) => Object.keys(headers).length <= 16, {
+        message: "An MCP server can have at most 16 headers",
+    })
+    .superRefine((headers, context) => {
+        const names = new Set<string>();
+        for (const name of Object.keys(headers)) {
+            const normalized = name.toLowerCase();
+            if (!names.has(normalized)) {
+                names.add(normalized);
+                continue;
+            }
+            context.addIssue({
+                code: "custom",
+                path: [name],
+                message: `MCP header name "${name}" is already in use`,
+            });
+        }
+    });
+
+const McpServerBaseSchema = z.object({
     // Namespaces the server's tools (mcp__<name>__<tool>); lowercase to match
     // the community tool-name pattern so its fees can be declared.
     name: z
@@ -29,6 +62,34 @@ const McpServerSchema = z.object({
     url: McpServerUrlSchema,
 });
 
+const McpServerSchema = McpServerBaseSchema.extend({
+    // Header names are safe to return; their encrypted values live separately.
+    headers: z.array(McpHeaderNameSchema).max(16).optional().default([]),
+});
+
+export const McpServerInputSchema = McpServerBaseSchema.extend({
+    // Null means "keep the saved value" on update. Values are never returned.
+    headers: McpHeadersInputSchema.optional().default({}),
+});
+
+function addUniqueMcpServerNameIssues(
+    config: { pollinationsTools?: boolean; mcpServers: { name: string }[] },
+    context: z.RefinementCtx,
+) {
+    const names = new Set(config.pollinationsTools ? ["pollinations"] : []);
+    for (const [index, server] of config.mcpServers.entries()) {
+        if (!names.has(server.name)) {
+            names.add(server.name);
+            continue;
+        }
+        context.addIssue({
+            code: "custom",
+            path: ["mcpServers", index, "name"],
+            message: `MCP server name "${server.name}" is already in use`,
+        });
+    }
+}
+
 export const PromptAgentSchema = z
     .object({
         systemPrompt: z.string().trim().min(1).max(8000),
@@ -36,25 +97,27 @@ export const PromptAgentSchema = z
         pollinationsTools: z.boolean().optional().default(false),
         mcpServers: z.array(McpServerSchema).max(8).optional().default([]),
     })
-    .superRefine((config, context) => {
-        const names = new Set(config.pollinationsTools ? ["pollinations"] : []);
-        for (const [index, server] of config.mcpServers.entries()) {
-            if (!names.has(server.name)) {
-                names.add(server.name);
-                continue;
-            }
-            context.addIssue({
-                code: "custom",
-                path: ["mcpServers", index, "name"],
-                message: `MCP server name "${server.name}" is already in use`,
-            });
-        }
-    })
+    .superRefine(addUniqueMcpServerNameIssues)
     .describe(
         "No-code agent config: a system prompt over a base model, with optional MCP servers. The platform runs it; no worker source or bearerToken is needed.",
     );
 
+export const PromptAgentInputSchema = z
+    .object({
+        systemPrompt: PromptAgentSchema.shape.systemPrompt,
+        baseModel: PromptAgentSchema.shape.baseModel,
+        pollinationsTools: PromptAgentSchema.shape.pollinationsTools,
+        mcpServers: z.array(McpServerInputSchema).max(8).optional().default([]),
+    })
+    .superRefine(addUniqueMcpServerNameIssues);
+
+export const McpServerResponseSchema = McpServerBaseSchema.extend({
+    headers: z.record(McpHeaderNameSchema, z.null()),
+});
+
 export type PromptAgentConfig = z.infer<typeof PromptAgentSchema>;
+export type PromptAgentInput = z.infer<typeof PromptAgentInputSchema>;
+export type PromptAgentMcpHeaders = Record<string, Record<string, string>>;
 
 export function agentRuntimeBaseUrl(env: {
     AGENT_RUNTIME_BASE_URL: string;
@@ -73,4 +136,20 @@ export function parsePromptAgentConfig(raw: string): PromptAgentConfig | null {
 
 export function serializePromptAgentConfig(config: PromptAgentConfig): string {
     return JSON.stringify(config);
+}
+
+export function parsePromptAgentMcpHeaders(
+    raw: string,
+): PromptAgentMcpHeaders | null {
+    try {
+        const parsed = z
+            .record(
+                z.string(),
+                z.record(McpHeaderNameSchema, McpHeaderValueSchema),
+            )
+            .safeParse(JSON.parse(raw));
+        return parsed.success ? parsed.data : null;
+    } catch {
+        return null;
+    }
 }

--- a/enter.pollinations.ai/test/community-endpoint-rpm-input.test.ts
+++ b/enter.pollinations.ai/test/community-endpoint-rpm-input.test.ts
@@ -31,6 +31,7 @@ describe("community endpoint per-user RPM input", () => {
                 id: "1",
                 name: "docs",
                 url: "https://mcp.example.com/rpc/",
+                headers: [],
             }),
         ).toBe(true);
         expect(
@@ -38,6 +39,7 @@ describe("community endpoint per-user RPM input", () => {
                 id: "2",
                 name: "docs",
                 url: "ftp://mcp.example.com/rpc",
+                headers: [],
             }),
         ).toBe(false);
         expect(
@@ -50,10 +52,33 @@ describe("community endpoint per-user RPM input", () => {
                         id: "3",
                         name: "docs",
                         url: "https://mcp.example.com/rpc/",
+                        headers: [
+                            {
+                                id: "header-1",
+                                name: "Authorization",
+                                value: "Bearer secret",
+                                saved: false,
+                            },
+                            {
+                                id: "header-2",
+                                name: "X-Saved",
+                                value: "",
+                                saved: true,
+                            },
+                        ],
                     },
                 ],
             }).mcpServers,
-        ).toEqual([{ name: "docs", url: "https://mcp.example.com/rpc" }]);
+        ).toEqual([
+            {
+                name: "docs",
+                url: "https://mcp.example.com/rpc",
+                headers: {
+                    Authorization: "Bearer secret",
+                    "X-Saved": null,
+                },
+            },
+        ]);
     });
 
     it("rejects duplicate agent MCP names", () => {
@@ -67,11 +92,13 @@ describe("community endpoint per-user RPM input", () => {
                         id: "1",
                         name: "docs",
                         url: "https://one.example.com/mcp",
+                        headers: [],
                     },
                     {
                         id: "2",
                         name: "docs",
                         url: "https://two.example.com/mcp",
+                        headers: [],
                     },
                 ],
             }),

--- a/enter.pollinations.ai/test/prompt-agent-runtime.test.ts
+++ b/enter.pollinations.ai/test/prompt-agent-runtime.test.ts
@@ -23,6 +23,7 @@ const BASE_RUNTIME: PromptAgentRuntime = {
         pollinationsTools: false,
         mcpServers: [],
     },
+    mcpHeaders: {},
     apiKey: "sk_test",
     genBaseUrl: "https://gen.test.example",
     pollinationsMcpUrl: "https://mcp.pollinations.test/mcp",
@@ -63,7 +64,13 @@ describe("prompt-agent config", () => {
                     { name: "docs", url: "https://mcp.example.com/rpc/" },
                 ],
             }).mcpServers,
-        ).toEqual([{ name: "docs", url: "https://mcp.example.com/rpc" }]);
+        ).toEqual([
+            {
+                name: "docs",
+                url: "https://mcp.example.com/rpc",
+                headers: [],
+            },
+        ]);
     });
 
     it("rejects plaintext and private-host MCP servers", () => {
@@ -343,8 +350,18 @@ describe("prompt-agent runtime", () => {
                 config: {
                     ...BASE_RUNTIME.config,
                     mcpServers: [
-                        { name: "docs", url: "https://mcp.example.com/rpc" },
+                        {
+                            name: "docs",
+                            url: "https://mcp.example.com/rpc",
+                            headers: ["Authorization", "X-Tenant"],
+                        },
                     ],
+                },
+                mcpHeaders: {
+                    docs: {
+                        Authorization: "Bearer mcp-secret",
+                        "X-Tenant": "pollinations",
+                    },
                 },
             },
         );
@@ -391,7 +408,10 @@ describe("prompt-agent runtime", () => {
             );
         }
         for (const request of mcpRequests) {
-            expect(request.headers.get("Authorization")).toBeNull();
+            expect(request.headers.get("Authorization")).toBe(
+                "Bearer mcp-secret",
+            );
+            expect(request.headers.get("X-Tenant")).toBe("pollinations");
         }
     });
 
@@ -895,6 +915,7 @@ describe("prompt-agent runtime", () => {
                         {
                             name: "docs",
                             url: "https://mcp.example.com/rpc",
+                            headers: [],
                         },
                     ],
                 },

--- a/enter.pollinations.ai/test/request-inputs.test.ts
+++ b/enter.pollinations.ai/test/request-inputs.test.ts
@@ -1,0 +1,31 @@
+import { collectRequestInputs } from "@shared/observability/request-inputs.ts";
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+
+describe("request input redaction", () => {
+    it("redacts custom header objects from error inputs", async () => {
+        const app = new Hono().post("/", async (c) =>
+            c.json(await collectRequestInputs(c)),
+        );
+        const response = await app.request("/", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+                mcpServers: [
+                    {
+                        name: "docs",
+                        headers: {
+                            "X-Custom-Credential": "must-not-be-logged",
+                        },
+                    },
+                ],
+            }),
+        });
+
+        await expect(response.json()).resolves.toMatchObject({
+            body: {
+                mcpServers: [{ name: "docs", headers: "[redacted]" }],
+            },
+        });
+    });
+});

--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -52,7 +52,7 @@ import {
 } from "@shared/registry/registry.ts";
 import { DEFAULT_TEXT_MODEL } from "@shared/registry/text.ts";
 import { FALLBACK_TARGET_HEADER } from "@shared/registry/usage-headers.ts";
-import { encryptSecret } from "@shared/secret-encryption.ts";
+import { decryptSecret, encryptSecret } from "@shared/secret-encryption.ts";
 import {
     createTestApiKey,
     createTestUser,
@@ -3734,7 +3734,16 @@ fixtureTest(
             systemPrompt: "You are a terse SQL tutor.",
             baseModel: "openai-fast",
             pollinationsTools: true,
-            mcpServers: [{ name: "docs", url: "https://mcp.example.com/rpc" }],
+            mcpServers: [
+                {
+                    name: "docs",
+                    url: "https://mcp.example.com/rpc",
+                    headers: {
+                        Authorization: "Bearer mcp-secret",
+                        "X-Team": "pollinations",
+                    },
+                },
+            ],
         };
         const createAgentResponse = await fetchEnterApi(
             enterApi,
@@ -3759,16 +3768,39 @@ fixtureTest(
             systemPrompt: "You are a terse SQL tutor.",
             baseModel: "openai-fast",
             pollinationsTools: true,
+            mcpServers: [
+                {
+                    name: "docs",
+                    headers: {
+                        Authorization: null,
+                        "X-Team": null,
+                    },
+                },
+            ],
         });
         expect(agent).not.toHaveProperty("apiKeyId");
         expect(agent).not.toHaveProperty("apiKeyCiphertext");
         expect(agent).not.toHaveProperty("bearerTokenCiphertext");
+        expect(agent).not.toHaveProperty("mcpHeadersCiphertext");
         expect(agent).not.toHaveProperty("baseUrl");
         const [storedAgent] = await db
             .select()
             .from(agentTable)
             .where(eq(agentTable.id, agent.id));
         expect(storedAgent.id).toBe(agent.id);
+        expect(storedAgent.config).not.toContain("mcp-secret");
+        expect(storedAgent.mcpHeadersCiphertext).not.toContain("mcp-secret");
+        await expect(
+            decryptSecret(
+                storedAgent.mcpHeadersCiphertext ?? "",
+                env.BETTER_AUTH_SECRET,
+            ).then(JSON.parse),
+        ).resolves.toEqual({
+            docs: {
+                Authorization: "Bearer mcp-secret",
+                "X-Team": "pollinations",
+            },
+        });
         const updateAgentResponse = await fetchEnterApi(
             enterApi,
             new Request(`https://enter.test/api/account/agents/${agent.id}`, {
@@ -3787,6 +3819,60 @@ fixtureTest(
         await expect(updateAgentResponse.json()).resolves.toMatchObject({
             id: agent.id,
             systemPrompt: "You are an editable SQL tutor.",
+        });
+        const [agentAfterPromptUpdate] = await db
+            .select()
+            .from(agentTable)
+            .where(eq(agentTable.id, agent.id));
+        expect(agentAfterPromptUpdate.mcpHeadersCiphertext).toBe(
+            storedAgent.mcpHeadersCiphertext,
+        );
+
+        const updateHeadersResponse = await fetchEnterApi(
+            enterApi,
+            new Request(`https://enter.test/api/account/agents/${agent.id}`, {
+                method: "PATCH",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: cookie,
+                },
+                body: JSON.stringify({
+                    mcpServers: [
+                        {
+                            name: "docs",
+                            url: "https://mcp.example.com/rpc",
+                            headers: {
+                                Authorization: null,
+                                "X-New": "new-secret",
+                            },
+                        },
+                    ],
+                }),
+            }),
+            enterEnv,
+        );
+        expect(updateHeadersResponse.status).toBe(200);
+        await expect(updateHeadersResponse.json()).resolves.toMatchObject({
+            mcpServers: [
+                {
+                    headers: { Authorization: null, "X-New": null },
+                },
+            ],
+        });
+        const [agentAfterHeaderUpdate] = await db
+            .select()
+            .from(agentTable)
+            .where(eq(agentTable.id, agent.id));
+        await expect(
+            decryptSecret(
+                agentAfterHeaderUpdate.mcpHeadersCiphertext ?? "",
+                env.BETTER_AUTH_SECRET,
+            ).then(JSON.parse),
+        ).resolves.toEqual({
+            docs: {
+                Authorization: "Bearer mcp-secret",
+                "X-New": "new-secret",
+            },
         });
         const registerResponse = await fetchEnterApi(
             enterApi,

--- a/shared/db/better-auth.ts
+++ b/shared/db/better-auth.ts
@@ -203,6 +203,7 @@ export const agent = sqliteTable("agent", {
     .notNull()
     .references(() => user.id, { onDelete: "cascade" }),
   config: text("config").notNull(),
+  mcpHeadersCiphertext: text("mcp_headers_ciphertext"),
   createdAt: integer("created_at", { mode: "timestamp" })
     .defaultNow()
     .notNull(),

--- a/shared/observability/request-inputs.ts
+++ b/shared/observability/request-inputs.ts
@@ -15,6 +15,7 @@ const CREDENTIAL_QUERY_PARAMS = new Set([
     "authorization",
     "bearer_token",
     "bearertoken",
+    "headers",
     "key",
     "token",
 ]);


### PR DESCRIPTION
Stacked on #12336.

- Adds optional request headers to each managed-agent MCP server.
- Encrypts header values in the owning agent row and returns only configured header names.
- Preserves unchanged values explicitly, removes omitted headers, and forwards credentials only at MCP runtime.
- Redacts arbitrary header objects from error telemetry and adds a small dashboard editor.
- Verified with Enter/Gen typechecks, 22 focused Enter tests, and the cross-service managed-agent lifecycle test.