### PR TITLE
feat: add /v1/moderations endpoint (OpenAI-compatible moderation API)

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/model-search.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-search.ts
@@ -7,6 +7,7 @@ export const MODEL_CATEGORIES = [
     "realtime",
     "text",
     "embedding",
+    "moderation",
 ] as const;
 
 export type ModelCategory = (typeof MODEL_CATEGORIES)[number];

--- a/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
@@ -51,6 +51,7 @@ export const sectionLabels: Record<SectionType, string> = {
     realtime: "Realtime",
     text: "Text",
     embedding: "Embedding",
+    moderation: "Moderation",
 };
 
 // --- Tab content ---

--- a/enter.pollinations.ai/frontend/src/components/models/models.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/models.tsx
@@ -103,6 +103,7 @@ const SEARCH_LABELS: Record<SectionType, string> = {
     realtime: "realtime",
     text: "text",
     embedding: "embedding",
+    moderation: "moderation",
 };
 
 function matchesQuery(model: ModelPrice, query: string): boolean {
@@ -124,6 +125,7 @@ function categorizeModels(
         realtime: [],
         text: [],
         embedding: [],
+        moderation: [],
     };
 
     for (const model of models) {

--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -44,6 +44,7 @@ import { DEFAULT_AUDIO_MODEL } from "@shared/registry/audio.ts";
 import { DEFAULT_EMBEDDING_MODEL } from "@shared/registry/embeddings.ts";
 import { DEFAULT_IMAGE_MODEL } from "@shared/registry/image.ts";
 import { DEFAULT_3D_MODEL } from "@shared/registry/model3d.ts";
+import { DEFAULT_MODERATION_MODEL } from "@shared/registry/moderation.ts";
 import { DEFAULT_REALTIME_MODEL } from "@shared/registry/realtime.ts";
 import {
     calculateUsageBilling,
@@ -1746,6 +1747,7 @@ fixtureTest(
             "audio",
             "realtime",
             "embedding",
+            "moderation",
         ];
         expect([
             ...new Set(officialModels.map((model) => model.category)),
@@ -1762,6 +1764,7 @@ fixtureTest(
             audio: DEFAULT_AUDIO_MODEL,
             realtime: DEFAULT_REALTIME_MODEL,
             embedding: DEFAULT_EMBEDDING_MODEL,
+            moderation: DEFAULT_MODERATION_MODEL,
         };
         for (const category of categoryOrder) {
             const models = officialModels.filter(

--- a/gen.pollinations.ai/src/middleware/model.ts
+++ b/gen.pollinations.ai/src/middleware/model.ts
@@ -2,6 +2,7 @@ import type { CommunityEndpointRuntime } from "@shared/community-endpoints.ts";
 import { DEFAULT_AUDIO_MODEL } from "@shared/registry/audio.ts";
 import { DEFAULT_EMBEDDING_MODEL } from "@shared/registry/embeddings.ts";
 import { DEFAULT_IMAGE_MODEL } from "@shared/registry/image.ts";
+import { DEFAULT_MODERATION_MODEL } from "@shared/registry/moderation.ts";
 import { DEFAULT_REALTIME_MODEL } from "@shared/registry/realtime.ts";
 import type { ModelDefinition } from "@shared/registry/registry.ts";
 import { DEFAULT_TEXT_MODEL } from "@shared/registry/text.ts";
@@ -19,6 +20,7 @@ const ENDPOINT_LABEL: Record<EventType, string> = {
     "generate.image": "image",
     "generate.audio": "audio",
     "generate.embedding": "embeddings",
+    "generate.moderation": "moderations",
     "generate.realtime": "realtime",
 };
 
@@ -177,9 +179,11 @@ export function resolveModel(
                   ? DEFAULT_AUDIO_MODEL
                   : eventType === "generate.embedding"
                     ? DEFAULT_EMBEDDING_MODEL
-                    : eventType === "generate.realtime"
-                      ? DEFAULT_REALTIME_MODEL
-                      : DEFAULT_IMAGE_MODEL);
+                    : eventType === "generate.moderation"
+                      ? DEFAULT_MODERATION_MODEL
+                      : eventType === "generate.realtime"
+                        ? DEFAULT_REALTIME_MODEL
+                        : DEFAULT_IMAGE_MODEL);
         const model = rawModel || defaultModel;
         // auth() runs before resolveModel on the authenticated generation
         // routes, so the caller identity is available to gate private

--- a/gen.pollinations.ai/src/model-registry.ts
+++ b/gen.pollinations.ai/src/model-registry.ts
@@ -7,6 +7,7 @@ import {
     modelInfoFromDefinition,
 } from "@shared/registry/model-info.ts";
 import { DEFAULT_3D_MODEL } from "@shared/registry/model3d.ts";
+import { DEFAULT_MODERATION_MODEL } from "@shared/registry/moderation.ts";
 import { DEFAULT_REALTIME_MODEL } from "@shared/registry/realtime.ts";
 import {
     type Category,
@@ -43,6 +44,7 @@ const CATEGORY_ORDER: Record<Category, number> = {
     audio: 4,
     realtime: 5,
     embedding: 6,
+    moderation: 7,
 };
 const DEFAULT_MODEL_BY_CATEGORY: Partial<Record<Category, string>> = {
     text: DEFAULT_TEXT_MODEL,
@@ -51,6 +53,7 @@ const DEFAULT_MODEL_BY_CATEGORY: Partial<Record<Category, string>> = {
     audio: DEFAULT_AUDIO_MODEL,
     realtime: DEFAULT_REALTIME_MODEL,
     embedding: DEFAULT_EMBEDDING_MODEL,
+    moderation: DEFAULT_MODERATION_MODEL,
 };
 
 export type GenerationModelEntry = {
@@ -83,6 +86,7 @@ let cachedRegistry: CachedRegistry | null = null;
 function eventTypeForCategory(category: Category): EventType {
     if (category === "audio") return "generate.audio";
     if (category === "embedding") return "generate.embedding";
+    if (category === "moderation") return "generate.moderation";
     if (category === "realtime") return "generate.realtime";
     if (category === "text") return "generate.text";
     return "generate.image";
@@ -94,6 +98,7 @@ function supportedEndpointsForEventType(eventType: EventType): string[] {
         return ["/audio/{text}", "/v1/audio/speech"];
     }
     if (eventType === "generate.embedding") return ["/v1/embeddings"];
+    if (eventType === "generate.moderation") return ["/v1/moderations"];
     if (eventType === "generate.realtime") {
         return ["/realtime", "/v1/realtime"];
     }
@@ -129,7 +134,9 @@ function communityEntryToGenerationEntry(
                 ? communityImageSupportedEndpoints(
                       entry.definition.inputModalities,
                   )
-                : communityTextSupportedEndpoints(),
+                : eventType === "generate.moderation"
+                  ? ["/v1/moderations"]
+                  : communityTextSupportedEndpoints(),
         definition: entry.definition,
         info: entry.info,
         communityEndpoint: entry.communityEndpoint,

--- a/gen.pollinations.ai/src/moderations/handler.ts
+++ b/gen.pollinations.ai/src/moderations/handler.ts
@@ -1,0 +1,201 @@
+import { UpstreamError } from "@shared/error.ts";
+import type { Usage } from "@shared/registry/registry.ts";
+import {
+    buildUsageHeaders,
+    FALLBACK_TARGET_HEADER,
+    openaiUsageToUsage,
+} from "@shared/registry/usage-headers.ts";
+import type { Context } from "hono";
+import type { Env } from "@/env.ts";
+import { fallbackCandidates, withModelFallback } from "../fallback.ts";
+import {
+    type CreateModerationRequest,
+    MODERATION_CATEGORIES,
+} from "../schemas/moderations.ts";
+import { generateTextPortkey } from "../text/generateTextPortkey.ts";
+import { syncTextEnvironment } from "../text/handler.ts";
+import type { ChatMessage } from "../text/types.ts";
+
+type ModerationContext = Context<Env>;
+
+type ModerationResult = {
+    flagged: boolean;
+    categories: Record<(typeof MODERATION_CATEGORIES)[number], boolean>;
+    category_scores: Record<(typeof MODERATION_CATEGORIES)[number], number>;
+};
+
+const MODERATION_SYSTEM_PROMPT = [
+    "You are a content moderation classifier. Classify the user input for harmful content.",
+    "Respond with ONLY a JSON object, no markdown, no commentary, matching exactly this schema:",
+    `{"flagged": boolean, "is_safe": boolean, "categories": {${MODERATION_CATEGORIES.map(
+        (c) => `"${c}": boolean`,
+    ).join(", ")}}, "category_scores": {${MODERATION_CATEGORIES.map(
+        (c) => `"${c}": number`,
+    ).join(", ")}}}`,
+    '"flagged" must be true whenever any category applies. "category_scores" holds 0-1 confidence per category.',
+].join("\n");
+
+function addUsage(target: Usage, usage: Usage): void {
+    for (const [key, value] of Object.entries(usage) as [
+        keyof Usage,
+        number,
+    ][]) {
+        target[key] = (target[key] ?? 0) + value;
+    }
+}
+
+/**
+ * Best-effort JSON extraction from a model answer: strips markdown fences and
+ * takes the first `{...}` span. Returns null when nothing parseable exists.
+ */
+function extractJson(text: string): string | null {
+    const noFences = text.replace(/```(?:json)?/gi, "").trim();
+    const start = noFences.indexOf("{");
+    const end = noFences.lastIndexOf("}");
+    if (start === -1 || end <= start) return null;
+    return noFences.slice(start, end + 1);
+}
+
+function parseVerdict(content: string | undefined | null): ModerationResult {
+    const unparseable = (): UpstreamError =>
+        new UpstreamError(502, {
+            message: "Moderation model returned an unparseable verdict",
+        });
+    if (!content) {
+        throw new UpstreamError(502, {
+            message: "Moderation model returned an empty verdict",
+        });
+    }
+    const jsonText = extractJson(content);
+    if (!jsonText) throw unparseable();
+    let data: Record<string, unknown>;
+    try {
+        data = JSON.parse(jsonText) as Record<string, unknown>;
+    } catch {
+        throw unparseable();
+    }
+
+    const categories = Object.fromEntries(
+        MODERATION_CATEGORIES.map((category) => [
+            category,
+            Boolean(
+                (data.categories as Record<string, unknown> | undefined)?.[
+                    category
+                ],
+            ),
+        ]),
+    ) as ModerationResult["categories"];
+    const category_scores = Object.fromEntries(
+        MODERATION_CATEGORIES.map((category) => [
+            category,
+            Number(
+                (data.category_scores as Record<string, unknown> | undefined)?.[
+                    category
+                ] ?? 0,
+            ),
+        ]),
+    ) as ModerationResult["category_scores"];
+
+    const flagged =
+        data.flagged === true ||
+        data.is_safe === false ||
+        MODERATION_CATEGORIES.some((category) => categories[category]) ||
+        MODERATION_CATEGORIES.some(
+            (category) => category_scores[category] >= 0.5,
+        );
+
+    return { flagged, categories, category_scores };
+}
+
+function moderationResponse(
+    responseModel: string,
+    results: ModerationResult[],
+    usage: Usage,
+): Response {
+    return new Response(
+        JSON.stringify({
+            id: `modr_${crypto.randomUUID()}`,
+            model: responseModel,
+            results,
+        }),
+        {
+            headers: {
+                "Content-Type": "application/json",
+                ...buildUsageHeaders(responseModel, usage),
+            },
+        },
+    );
+}
+
+export async function generateModeration(
+    c: ModerationContext,
+    request: CreateModerationRequest,
+): Promise<Response> {
+    syncTextEnvironment(c.env);
+    const inputs = Array.isArray(request.input)
+        ? request.input
+        : [request.input];
+    const portkey = c.env.PORTKEY;
+    const fetcher = portkey
+        ? (input: string, init?: RequestInit) => portkey.fetch(input, init)
+        : undefined;
+
+    const messagesFor = (input: string): ChatMessage[] => [
+        { role: "system", content: MODERATION_SYSTEM_PROMPT },
+        { role: "user", content: input },
+    ];
+
+    const aggregatedUsage: Usage = {};
+
+    const { result, candidate, index } = await withModelFallback(
+        fallbackCandidates(c.var.model),
+        async (attempt) => {
+            const perInputResults: ModerationResult[] = [];
+            for (const input of inputs) {
+                const completion = await generateTextPortkey(
+                    messagesFor(input),
+                    {
+                        model: attempt.id,
+                        temperature: 0,
+                        max_tokens: 1024,
+                        portkeyGatewayUrl: c.env.PORTKEY_GATEWAY_URL,
+                    },
+                    fetcher,
+                );
+                if (completion.usage) {
+                    addUsage(
+                        aggregatedUsage,
+                        openaiUsageToUsage(
+                            completion.usage as Parameters<
+                                typeof openaiUsageToUsage
+                            >[0],
+                        ),
+                    );
+                }
+                perInputResults.push(
+                    parseVerdict(
+                        completion.choices?.[0]?.message?.content as
+                            | string
+                            | undefined,
+                    ),
+                );
+            }
+            return perInputResults;
+        },
+        c.var.track?.failedCalls,
+    );
+    if (candidate.entry) c.set("servedModelEntry", candidate.entry);
+
+    const response = moderationResponse(
+        c.var.model.resolved,
+        result,
+        aggregatedUsage,
+    );
+    if (index > 0) {
+        response.headers.set(
+            FALLBACK_TARGET_HEADER,
+            `config.targets[${index}]`,
+        );
+    }
+    return response;
+}

--- a/gen.pollinations.ai/src/routes/generation-executor.ts
+++ b/gen.pollinations.ai/src/routes/generation-executor.ts
@@ -27,6 +27,7 @@ import {
     Generate3dRequestBodySchema,
     Generate3dRequestQueryParamsSchema,
 } from "@/schemas/model3d.ts";
+import { CreateModerationRequestSchema } from "@/schemas/moderations.ts";
 import { GenerateTextRequestQueryParamsSchema } from "@/schemas/text.ts";
 import {
     handleSimpleAudio,
@@ -41,6 +42,7 @@ import {
     generateEmbeddingsResponse,
     generateImageVideo,
     generateModel3d,
+    generateModerationResponse,
     generateSimpleText,
     generateTextContent,
     simpleAudioQuerySchema,
@@ -89,6 +91,17 @@ generationExecutorRoutes.post(
     prepareGenerationRequest,
     textExecutionCache,
     generateEmbeddingsResponse,
+);
+
+generationExecutorRoutes.post(
+    "/v1/moderations",
+    textBodyLimit,
+    validator("json", CreateModerationRequestSchema),
+    resolveModel("generate.moderation"),
+    track("generate.moderation"),
+    prepareGenerationRequest,
+    textExecutionCache,
+    generateModerationResponse,
 );
 
 generationExecutorRoutes.post(

--- a/gen.pollinations.ai/src/routes/generation-handlers.ts
+++ b/gen.pollinations.ai/src/routes/generation-handlers.ts
@@ -21,7 +21,9 @@ import {
     withSafetyHeaders,
 } from "@/middleware/safety.ts";
 import { handle3dPrompt } from "@/model3d/handler.ts";
+import { generateModeration } from "@/moderations/handler.ts";
 import type { CreateEmbeddingRequestSchema } from "@/schemas/embeddings.ts";
+import type { CreateModerationRequestSchema } from "@/schemas/moderations.ts";
 import {
     handleChatCompletionLocal,
     handleSimpleTextLocal,
@@ -162,6 +164,15 @@ export async function generateEmbeddingsResponse(
     );
     if (servedEntry) c.set("servedModelEntry", servedEntry);
     return response;
+}
+
+export async function generateModerationResponse(
+    c: Context<Env>,
+): Promise<Response> {
+    const requestBody = c.req.valid("json" as never) as z.infer<
+        typeof CreateModerationRequestSchema
+    >;
+    return generateModeration(c, requestBody);
 }
 
 export async function generateChatCompletion(

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -71,6 +71,10 @@ import {
     type ModelListQueryParams,
     ModelListQueryParamsSchema,
 } from "@/schemas/models.ts";
+import {
+    CreateModerationRequestSchema,
+    CreateModerationResponseSchema,
+} from "@/schemas/moderations.ts";
 import { RealtimeRequestQueryParamsSchema } from "@/schemas/realtime.ts";
 import { GenerateTextRequestQueryParamsSchema } from "@/schemas/text.ts";
 import { generationAccess } from "@/utils/generation-access.ts";
@@ -84,6 +88,7 @@ import {
     generateEmbeddingsResponse,
     generateImageVideo,
     generateModel3d,
+    generateModerationResponse,
     generateSimpleText,
     generateTextContent,
     simpleAudioQuerySchema,
@@ -531,6 +536,34 @@ export const proxyRoutes = new Hono<Env>()
             getVisibleModelEntriesForEventType(c, "generate.embedding"),
         ),
     )
+    .get(
+        "/moderations/models",
+        describeRoute({
+            tags: ["🛡️ Moderations"],
+            summary: "List Moderation Models",
+            description:
+                "Returns available moderation models with pricing, capabilities, and supported input modalities. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
+            responses: {
+                200: {
+                    description: "Success",
+                    content: {
+                        "application/json": {
+                            schema: resolver(
+                                z.array(z.any()).meta({
+                                    description:
+                                        "List of moderation models with pricing and metadata",
+                                }),
+                            ),
+                        },
+                    },
+                },
+                ...errorResponseDescriptions(400, 500),
+            },
+        }),
+        ...modelsListHandler((c) =>
+            getVisibleModelEntriesForEventType(c, "generate.moderation"),
+        ),
+    )
     .post("/register", handleRegisterServer)
     .get("/register", handleRegisterServer)
     // Auth required for all endpoints below (API key only - no session cookies)
@@ -622,6 +655,42 @@ export const proxyRoutes = new Hono<Env>()
         generationAccess,
         deduplicateGeneration,
         generateEmbeddingsResponse,
+    )
+    .post(
+        "/v1/moderations",
+        describeRoute({
+            tags: ["🛡️ Moderations"],
+            summary: "Create Moderation",
+            description: [
+                "Classify text for harmful content with an OpenAI-compatible moderation response format.",
+                "",
+                "**Models:** `qwen-safety` (Qwen3Guard 8B) flags unsafe content across hate, harassment, self-harm, sexual, and violence categories.",
+                "",
+                "**Input:** Pass a string or an array of up to 32 strings in the `input` field. Each input gets its own moderation result.",
+                "",
+                "**Billing:** Billed per request at the model's per-token rate (prompt and completion tokens).",
+            ].join("\n"),
+            responses: {
+                200: {
+                    description: "Success",
+                    content: {
+                        "application/json": {
+                            schema: resolver(CreateModerationResponseSchema),
+                        },
+                    },
+                },
+                ...errorResponseDescriptions(400, 401, 402, 403, 429, 500),
+            },
+        }),
+        textBodyLimit,
+        validator("json", CreateModerationRequestSchema),
+        resolveModel("generate.moderation"),
+        track("generate.moderation"),
+        prepareGenerationRequest,
+        textCache,
+        generationAccess,
+        deduplicateGeneration,
+        generateModerationResponse,
     )
     .post(
         "/text",

--- a/gen.pollinations.ai/src/schemas/moderations.ts
+++ b/gen.pollinations.ai/src/schemas/moderations.ts
@@ -1,0 +1,68 @@
+import { DEFAULT_MODERATION_MODEL } from "@shared/registry/moderation.ts";
+import { z } from "zod";
+
+export const MODERATION_CATEGORIES = [
+    "harassment",
+    "harassment/threatening",
+    "hate",
+    "hate/threatening",
+    "self-harm",
+    "self-harm/instructions",
+    "self-harm/intent",
+    "sexual",
+    "sexual/minors",
+    "violence",
+    "violence/graphic",
+    "illicit",
+    "illicit/violent",
+] as const;
+
+export const MAX_MODERATION_BATCH_SIZE = 32;
+
+export const CreateModerationRequestSchema = z
+    .object({
+        model: z.string().default(DEFAULT_MODERATION_MODEL).meta({
+            description: "Moderation model to use",
+            example: "qwen-safety",
+        }),
+        input: z
+            .union([
+                z.string(),
+                z.array(z.string()).min(1).max(MAX_MODERATION_BATCH_SIZE),
+            ])
+            .meta({
+                description: `Text to classify. Pass a string or an array of up to ${MAX_MODERATION_BATCH_SIZE} strings — each input gets its own moderation result.`,
+                example: "I want to hurt myself",
+            }),
+    })
+    .meta({ $id: "CreateModerationRequest" });
+
+export const ModerationCategoriesSchema = z.object(
+    Object.fromEntries(
+        MODERATION_CATEGORIES.map((category) => [category, z.boolean()]),
+    ) as Record<(typeof MODERATION_CATEGORIES)[number], z.ZodBoolean>,
+);
+
+export const ModerationCategoryScoresSchema = z.object(
+    Object.fromEntries(
+        MODERATION_CATEGORIES.map((category) => [category, z.number()]),
+    ) as Record<(typeof MODERATION_CATEGORIES)[number], z.ZodNumber>,
+);
+
+export const ModerationResultSchema = z.object({
+    flagged: z.boolean(),
+    categories: ModerationCategoriesSchema,
+    category_scores: ModerationCategoryScoresSchema,
+});
+
+export const CreateModerationResponseSchema = z
+    .object({
+        id: z.string(),
+        model: z.string(),
+        results: z.array(ModerationResultSchema),
+    })
+    .meta({ $id: "CreateModerationResponse" });
+
+export type CreateModerationRequest = z.infer<
+    typeof CreateModerationRequestSchema
+>;

--- a/gen.pollinations.ai/src/text/handler.ts
+++ b/gen.pollinations.ai/src/text/handler.ts
@@ -49,7 +49,7 @@ const TEXT_ENV_KEYS = [
     "PORTKEY_GATEWAY_URL",
 ] as const satisfies readonly (keyof CloudflareBindings)[];
 
-function syncTextEnvironment(env: CloudflareBindings): void {
+export function syncTextEnvironment(env: CloudflareBindings): void {
     // Text provider config still reads process.env. In Workers all bindings are
     // stable per deployment, so copying known string bindings before generation
     // is deterministic across concurrent requests in the same isolate.

--- a/gen.pollinations.ai/test/moderations/moderations.test.ts
+++ b/gen.pollinations.ai/test/moderations/moderations.test.ts
@@ -1,0 +1,306 @@
+import {
+    createExecutionContext,
+    env,
+    waitOnExecutionContext,
+} from "cloudflare:test";
+import { test as baseTest } from "@shared/test/fixtures/index.ts";
+import {
+    createFetchMock,
+    teardownFetchMock,
+} from "@shared/test/mocks/fetch.ts";
+import { createMockTinybird } from "@shared/test/mocks/tinybird.ts";
+import { afterEach, describe, expect } from "vitest";
+import worker from "../../src/index.ts";
+import { resetGenerationModelRegistryCache } from "../../src/model-registry.ts";
+import { MODERATION_CATEGORIES } from "../../src/schemas/moderations.ts";
+import { withInlineGenerationCoordinator } from "../helpers/inline-generation-coordinator.ts";
+
+const TEST_MODERATION_MODEL = "qwen-safety";
+const PORTKEY_HOST = "portkey.test";
+const TINYBIRD_STATS_HOST = "api.europe-west2.gcp.tinybird.co";
+
+function buildVerdict(flagged: boolean) {
+    const categories = Object.fromEntries(
+        MODERATION_CATEGORIES.map((category) => [
+            category,
+            flagged && category === "violence",
+        ]),
+    );
+    const category_scores = Object.fromEntries(
+        MODERATION_CATEGORIES.map((category) => [
+            category,
+            flagged && category === "violence" ? 0.9 : 0,
+        ]),
+    );
+    return { flagged, is_safe: !flagged, categories, category_scores };
+}
+
+function createModerationMocks() {
+    env.PORTKEY_GATEWAY_URL = `https://${PORTKEY_HOST}`;
+    env.OVHCLOUD_API_KEY = "test-ovhcloud-key";
+    process.env.OVHCLOUD_API_KEY = env.OVHCLOUD_API_KEY;
+
+    const requests: Array<Record<string, unknown>> = [];
+    return createFetchMock({
+        tinybird: createMockTinybird(),
+        tinybirdStats: {
+            state: {},
+            handlerMap: {
+                [TINYBIRD_STATS_HOST]: async () => Response.json({ data: [] }),
+            },
+            reset: () => {},
+        },
+        portkey: {
+            state: { requests },
+            handlerMap: {
+                [PORTKEY_HOST]: async (request) => {
+                    const body = (await request.clone().json()) as {
+                        model?: string;
+                        messages?: Array<{ role?: string; content?: string }>;
+                    };
+                    requests.push(body);
+                    const userContent =
+                        body.messages?.find((m) => m.role === "user")
+                            ?.content ?? "";
+                    const flagged = userContent.includes("kill");
+                    return Response.json({
+                        id: "chatcmpl_moderation_test",
+                        object: "chat.completion",
+                        created: 1,
+                        model: body.model,
+                        choices: [
+                            {
+                                index: 0,
+                                message: {
+                                    role: "assistant",
+                                    content: JSON.stringify(
+                                        buildVerdict(flagged),
+                                    ),
+                                },
+                                finish_reason: "stop",
+                            },
+                        ],
+                        usage: {
+                            prompt_tokens: 10,
+                            completion_tokens: 5,
+                            total_tokens: 15,
+                        },
+                    });
+                },
+            },
+            reset: () => {
+                requests.length = 0;
+            },
+        },
+    });
+}
+
+const test = baseTest.extend<{
+    mocks: ReturnType<typeof createModerationMocks>;
+}>({
+    // biome-ignore lint/correctness/noEmptyPattern: vitest fixture pattern requires object destructuring
+    mocks: async ({}, use) => {
+        const mocks = createModerationMocks();
+        await use(mocks);
+    },
+});
+
+afterEach(async () => {
+    await teardownFetchMock();
+    resetGenerationModelRegistryCache();
+});
+
+async function fetchWorker(path: string, init: RequestInit) {
+    const ctx = createExecutionContext();
+    const response = await worker.fetch(
+        new Request(`https://gen.pollinations.ai${path}`, init),
+        withInlineGenerationCoordinator(env),
+        ctx,
+    );
+    return {
+        response,
+        wait: () => waitOnExecutionContext(ctx),
+    };
+}
+
+function buildModerationBody(extra: Record<string, unknown> = {}) {
+    return JSON.stringify({
+        model: TEST_MODERATION_MODEL,
+        input: "Just a normal message",
+        ...extra,
+    });
+}
+
+describe("/v1/moderations", () => {
+    test("classifies a safe input with an OpenAI-compatible response", async ({
+        paidApiKey: apiKey,
+        mocks,
+    }) => {
+        await mocks.enable("tinybird", "tinybirdStats", "portkey");
+        const { response, wait } = await fetchWorker("/v1/moderations", {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                authorization: `Bearer ${apiKey}`,
+            },
+            body: buildModerationBody(),
+        });
+
+        const body = await response.text();
+        expect(response.status, body).toBe(200);
+        const data = JSON.parse(body) as {
+            id: string;
+            model: string;
+            results: Array<{
+                flagged: boolean;
+                categories: Record<string, boolean>;
+            }>;
+        };
+        expect(data.id).toMatch(/^modr_/);
+        expect(data.model).toBe(TEST_MODERATION_MODEL);
+        expect(data.results).toHaveLength(1);
+        expect(data.results[0].flagged).toBe(false);
+        expect(data.results[0].categories).toMatchObject(
+            Object.fromEntries(MODERATION_CATEGORIES.map((c) => [c, false])),
+        );
+        expect(response.headers.get("x-model-used")).toBe(
+            TEST_MODERATION_MODEL,
+        );
+        expect(response.headers.get("x-usage-prompt-text-tokens")).toBe("10");
+        expect(response.headers.get("x-usage-completion-text-tokens")).toBe(
+            "5",
+        );
+
+        await wait();
+        const events = mocks.tinybird.state.events;
+        expect(events).toHaveLength(1);
+        expect(events[0]).toMatchObject({
+            eventType: "generate.moderation",
+            modelRequested: TEST_MODERATION_MODEL,
+            resolvedModelRequested: TEST_MODERATION_MODEL,
+            modelUsed: TEST_MODERATION_MODEL,
+            tokenCountPromptText: 10,
+            tokenCountCompletionText: 5,
+            isBilledUsage: true,
+        });
+        expect(events[0].totalPrice).toBeGreaterThan(0);
+    });
+
+    test("flags a harmful input with per-category verdicts", async ({
+        paidApiKey: apiKey,
+        mocks,
+    }) => {
+        await mocks.enable("tinybird", "tinybirdStats", "portkey");
+        const { response, wait } = await fetchWorker("/v1/moderations", {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                authorization: `Bearer ${apiKey}`,
+            },
+            body: buildModerationBody({ input: "I want to kill everyone" }),
+        });
+
+        expect(response.status).toBe(200);
+        const data = (await response.json()) as {
+            results: Array<{
+                flagged: boolean;
+                categories: Record<string, boolean>;
+                category_scores: Record<string, number>;
+            }>;
+        };
+        expect(data.results[0].flagged).toBe(true);
+        expect(data.results[0].categories.violence).toBe(true);
+        expect(data.results[0].categories.hate).toBe(false);
+        expect(data.results[0].category_scores.violence).toBe(0.9);
+        await wait();
+    });
+
+    test("returns one result per array input", async ({
+        paidApiKey: apiKey,
+        mocks,
+    }) => {
+        await mocks.enable("tinybird", "tinybirdStats", "portkey");
+        const { response, wait } = await fetchWorker("/v1/moderations", {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                authorization: `Bearer ${apiKey}`,
+            },
+            body: buildModerationBody({
+                input: ["Just a normal message", "I will kill you"],
+            }),
+        });
+
+        expect(response.status).toBe(200);
+        const data = (await response.json()) as {
+            results: Array<{ flagged: boolean }>;
+        };
+        expect(data.results).toHaveLength(2);
+        expect(data.results[0].flagged).toBe(false);
+        expect(data.results[1].flagged).toBe(true);
+        expect(response.headers.get("x-usage-prompt-text-tokens")).toBe("20");
+        await wait();
+    });
+
+    test("defaults to the moderation model when none is given", async ({
+        paidApiKey: apiKey,
+        mocks,
+    }) => {
+        await mocks.enable("tinybird", "tinybirdStats", "portkey");
+        const { response, wait } = await fetchWorker("/v1/moderations", {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                authorization: `Bearer ${apiKey}`,
+            },
+            body: JSON.stringify({ input: "Just a normal message" }),
+        });
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("x-model-used")).toBe(
+            TEST_MODERATION_MODEL,
+        );
+        await response.arrayBuffer();
+        await wait();
+    });
+
+    test("rejects a text model on the moderation endpoint", async ({
+        paidApiKey: apiKey,
+        mocks,
+    }) => {
+        await mocks.enable("tinybird", "tinybirdStats", "portkey");
+        const { response, wait } = await fetchWorker("/v1/moderations", {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                authorization: `Bearer ${apiKey}`,
+            },
+            body: buildModerationBody({ model: "openai-fast" }),
+        });
+
+        expect(response.status).toBe(400);
+        const data = (await response.json()) as {
+            error?: { message?: string };
+        };
+        expect(data.error?.message).toContain("text model");
+        await wait();
+    });
+});
+
+describe("GET /moderations/models", () => {
+    test("lists moderation models", async ({ paidApiKey: apiKey, mocks }) => {
+        await mocks.enable("tinybird", "tinybirdStats", "portkey");
+        const { response, wait } = await fetchWorker("/moderations/models", {
+            headers: {
+                authorization: `Bearer ${apiKey}`,
+            },
+        });
+
+        expect(response.status).toBe(200);
+        const data = (await response.json()) as Array<{ name: string }>;
+        expect(data.some((model) => model.name === TEST_MODERATION_MODEL)).toBe(
+            true,
+        );
+        await wait();
+    });
+});

--- a/gen.pollinations.ai/vitest.config.ts
+++ b/gen.pollinations.ai/vitest.config.ts
@@ -38,6 +38,7 @@ const genAliases = [
     "schemas/image.ts",
     "schemas/model3d.ts",
     "schemas/models.ts",
+    "schemas/moderations.ts",
     "schemas/realtime.ts",
     "schemas/text.ts",
     "userImage.ts",
@@ -76,6 +77,10 @@ const baseConfig = defineConfig({
             {
                 find: /^@\/model3d\/(.*)$/,
                 replacement: `${genSrc}model3d/$1`,
+            },
+            {
+                find: /^@\/moderations\/(.*)$/,
+                replacement: `${genSrc}moderations/$1`,
             },
             {
                 find: /^@shared\/(.*)$/,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -769,6 +769,7 @@ export const MODEL_CATEGORIES = [
     "audio",
     "embedding",
     "realtime",
+    "moderation",
 ] as const;
 
 /** Model category */

--- a/packages/ui/src/modules/gen/ModelSelector.tsx
+++ b/packages/ui/src/modules/gen/ModelSelector.tsx
@@ -23,6 +23,7 @@ const CATEGORY_LABELS: Record<ModelSelectorCategory, string> = {
     audio: "Audio",
     embedding: "Embeddings",
     realtime: "Realtime",
+    moderation: "Moderation",
 };
 
 /** Human-readable label for a model category, e.g. "embedding" -> "Embeddings". */

--- a/shared/registry/model-info.ts
+++ b/shared/registry/model-info.ts
@@ -38,6 +38,7 @@ export const ModelInfoSchema = z.object({
         "video",
         "3d",
         "embedding",
+        "moderation",
         "realtime",
     ]),
     brand: z.string(),

--- a/shared/registry/moderation.ts
+++ b/shared/registry/moderation.ts
@@ -1,0 +1,27 @@
+import { perMillion } from "./price-helpers";
+import type { ModelDefinition } from "./registry";
+
+export type ModerationModelName = keyof typeof MODERATION_SERVICES;
+
+export const DEFAULT_MODERATION_MODEL: ModerationModelName = "qwen-safety";
+
+export const MODERATION_SERVICES = {
+    "qwen-safety": {
+        aliases: ["qwen3guard-gen-8b"],
+        provider: "ovhcloud",
+        brand: "Qwen",
+        category: "moderation",
+        addedDate: new Date("2026-02-15").getTime(),
+        priceMultiplier: 1,
+        cost: {
+            promptTextTokens: perMillion(0.01),
+            completionTextTokens: perMillion(0.01),
+        },
+        title: "Qwen3Guard 8B",
+        description:
+            "Flags unsafe content — a moderation filter, not a chat companion",
+        inputModalities: ["text"],
+        outputModalities: ["text"],
+        isSpecialized: true,
+    },
+} as const satisfies Record<string, ModelDefinition>;

--- a/shared/registry/registry.ts
+++ b/shared/registry/registry.ts
@@ -17,6 +17,7 @@ export {
 import { EMBEDDING_SERVICES, type EmbeddingServiceId } from "./embeddings";
 import { IMAGE_SERVICES, type ImageModelName } from "./image";
 import { MODEL3D_SERVICES, type Model3dName } from "./model3d";
+import { MODERATION_SERVICES, type ModerationModelName } from "./moderation";
 import { REALTIME_SERVICES, type RealtimeModelName } from "./realtime";
 import { TEXT_SERVICES, type TextModelName } from "./text";
 
@@ -27,6 +28,7 @@ export type Category =
     | "video"
     | "3d"
     | "embedding"
+    | "moderation"
     | "realtime";
 
 export const MODEL_INPUT_MODALITIES = [
@@ -84,7 +86,8 @@ export type ModelName =
     | AudioModelName
     | EmbeddingServiceId
     | RealtimeModelName
-    | Model3dName;
+    | Model3dName
+    | ModerationModelName;
 
 export type VideoCapability =
     | "start_frame"
@@ -498,6 +501,7 @@ const MODEL_REGISTRY = {
     ...EMBEDDING_SERVICES,
     ...REALTIME_SERVICES,
     ...MODEL3D_SERVICES,
+    ...MODERATION_SERVICES,
 } as Record<ModelName, ModelDefinition>;
 
 /**

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -2077,22 +2077,4 @@ export const TEXT_SERVICES = {
         contextLength: 262144,
         isSpecialized: false,
     },
-    "qwen-safety": {
-        aliases: ["qwen3guard-gen-8b"],
-        provider: "ovhcloud",
-        brand: "Qwen",
-        category: "text",
-        addedDate: new Date("2026-02-15").getTime(),
-        priceMultiplier: 1,
-        cost: {
-            promptTextTokens: perMillion(0.01),
-            completionTextTokens: perMillion(0.01),
-        },
-        title: "Qwen3Guard 8B",
-        description:
-            "Flags unsafe content — a moderation filter, not a chat companion",
-        inputModalities: ["text"],
-        outputModalities: ["text"],
-        isSpecialized: true,
-    },
 } as const satisfies Record<string, ModelDefinition>;

--- a/shared/schemas/generation-event.ts
+++ b/shared/schemas/generation-event.ts
@@ -7,6 +7,7 @@ export type EventType =
     | "generate.image"
     | "generate.audio"
     | "generate.embedding"
+    | "generate.moderation"
     | "generate.realtime";
 
 // Plain TypeScript type for Tinybird events (no D1 table - events sent directly to Tinybird)


### PR DESCRIPTION
Closes #13325

Adds an OpenAI-compatible `/v1/moderations` endpoint, exposing content moderation as a dedicated route instead of forcing it through chat.

- Adds `moderation` model category + `generate.moderation` event type
- Moves `qwen-safety` (Qwen3Guard 8B) from text to the moderation registry
- `POST /v1/moderations`: string or array-of-strings input, OpenAI response shape (`id`, `model`, `results[].flagged/categories/category_scores`)
- `GET /moderations/models`: moderation model catalog
- Handler calls qwen-safety and maps its JSON verdict to the 13 OpenAI moderation categories; bills real provider token usage via usage headers (per-provider, like text/embeddings)
- Registers `moderation` in SDK `MODEL_CATEGORIES` and the enter frontend model lists

Tests: `test/moderations/moderations.test.ts` (request/response shape, flagged verdicts, array input, default model, wrong-model rejection, models list, usage headers + billing). Full gen suite green.