### PR TITLE
fix: authenticate GitHub reads with the App installation token

### DIFF
--- a/enter.pollinations.ai/src/auth.ts
+++ b/enter.pollinations.ai/src/auth.ts
@@ -6,6 +6,10 @@ import {
 } from "@shared/auth/api-key.ts";
 import * as betterAuthSchema from "@shared/db/better-auth.ts";
 import { user as userTable } from "@shared/db/better-auth.ts";
+import {
+    getInstallationToken,
+    githubAppCredentialsFromEnv,
+} from "@shared/github/app-auth.ts";
 import { AUTH_TRUSTED_ORIGINS } from "@shared/public-urls.ts";
 import {
     type BetterAuthOptions,
@@ -150,14 +154,21 @@ function onAfterSessionCreate(
                     const githubId = user?.githubId;
                     if (!githubId) return;
 
+                    // OAuth client_id/secret Basic auth is rejected by GitHub
+                    // (401); the App installation token is the authenticated path.
                     const headers: Record<string, string> = {
                         Accept: "application/vnd.github+json",
                         "User-Agent": "pollinations-enter",
+                        "X-GitHub-Api-Version": "2022-11-28",
+                        Authorization: `token ${
+                            env.ENVIRONMENT === "test"
+                                ? "mock_github_auth_token"
+                                : await getInstallationToken(
+                                      githubAppCredentialsFromEnv(env),
+                                      "pollinations",
+                                  )
+                        }`,
                     };
-                    // Use OAuth app credentials for 5,000 req/hr (vs 60 unauthenticated)
-                    if (env.GITHUB_CLIENT_ID && env.GITHUB_CLIENT_SECRET) {
-                        headers.Authorization = `Basic ${btoa(`${env.GITHUB_CLIENT_ID}:${env.GITHUB_CLIENT_SECRET}`)}`;
-                    }
                     const res = await fetch(
                         `https://api.github.com/user/${githubId}`,
                         { headers },

--- a/enter.pollinations.ai/src/services/quests/groups/github-profile.ts
+++ b/enter.pollinations.ai/src/services/quests/groups/github-profile.ts
@@ -1,5 +1,9 @@
 import { getLogger } from "@logtape/logtape";
 import * as schema from "@shared/db/better-auth.ts";
+import {
+    getInstallationToken,
+    githubAppCredentialsFromEnv,
+} from "@shared/github/app-auth.ts";
 import { eq } from "drizzle-orm";
 import { type QuestDefinition, rewardableQuests } from "../definitions.ts";
 import type {
@@ -20,6 +24,7 @@ const log = getLogger(["enter", "quest", "github-profile"]);
 const GITHUB_ACCOUNT_AGE_DAYS = 730;
 const PUBLIC_REPO_STAR_THRESHOLD = 20;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const REPO_OWNER = "pollinations";
 
 type GitHubProfileResponse = {
     login?: string;
@@ -32,15 +37,25 @@ type GitHubRepoResponse = {
     stargazers_count?: number;
 };
 
-function githubApiHeaders(env: CloudflareBindings): Record<string, string> {
-    const headers: Record<string, string> = {
+// GitHub removed OAuth client_id/client_secret Basic auth for API requests: it
+// now answers 401 Bad credentials, so the App installation token is the only
+// authenticated path (15,000 req/hr, against 60 unauthenticated).
+async function githubApiHeaders(
+    env: CloudflareBindings,
+): Promise<Record<string, string>> {
+    const token =
+        env.ENVIRONMENT === "test"
+            ? "mock_github_auth_token"
+            : await getInstallationToken(
+                  githubAppCredentialsFromEnv(env),
+                  REPO_OWNER,
+              );
+    return {
         Accept: "application/vnd.github+json",
         "User-Agent": "pollinations-enter",
+        "X-GitHub-Api-Version": "2022-11-28",
+        Authorization: `token ${token}`,
     };
-    if (env.GITHUB_CLIENT_ID && env.GITHUB_CLIENT_SECRET) {
-        headers.Authorization = `Basic ${btoa(`${env.GITHUB_CLIENT_ID}:${env.GITHUB_CLIENT_SECRET}`)}`;
-    }
-    return headers;
 }
 
 async function fetchGitHubProfile(
@@ -49,7 +64,7 @@ async function fetchGitHubProfile(
 ): Promise<{ login: string | null; createdAt: Date | null } | null> {
     log.info("GITHUB_PROFILE_FETCH_START: githubId={githubId}", { githubId });
     const response = await fetch(`https://api.github.com/user/${githubId}`, {
-        headers: githubApiHeaders(env),
+        headers: await githubApiHeaders(env),
     });
     const rateLimitRemaining = response.headers.get("x-ratelimit-remaining");
     const rateLimitReset = response.headers.get("x-ratelimit-reset");
@@ -103,7 +118,7 @@ async function fetchPublicRepoStars(
         });
         const response = await fetch(
             `https://api.github.com/users/${encodeURIComponent(login)}/repos?type=owner&per_page=100&page=${page}`,
-            { headers: githubApiHeaders(env) },
+            { headers: await githubApiHeaders(env) },
         );
         const rateLimitRemaining = response.headers.get(
             "x-ratelimit-remaining",

--- a/enter.pollinations.ai/test/mocks/github.ts
+++ b/enter.pollinations.ai/test/mocks/github.ts
@@ -65,9 +65,10 @@ export function createMockGithub(): MockAPI<MockGithubState> {
 
     const githubAuth = createMiddleware(async (c, next) => {
         const authHeader = c.req.header("Authorization");
+        // Real GitHub rejects OAuth client_id/secret Basic auth with 401, so the
+        // mock must too — accepting it hid a live 401 behind green tests.
         const isUserToken = authHeader?.includes("mock_github_auth_token");
-        const isAppCredentials = authHeader?.startsWith("Basic ");
-        if (!isUserToken && !isAppCredentials) {
+        if (!isUserToken) {
             return c.json({ message: "Bad credentials" }, 401);
         }
         return await next();


### PR DESCRIPTION
`github_established` ("Senior dev") shipped today and cannot be earned by anyone. Root cause: GitHub rejects OAuth `client_id`/`client_secret` Basic auth with **401 Bad credentials**, so `fetchGitHubProfile` always returned `null`.

Verified against production credentials:
```
Authorization: Basic base64(client_id:client_secret)  -> HTTP 401 "Bad credentials"
Authorization: token <installation token>             -> HTTP 200, 15,000 req/hr
(no Authorization header)                             -> HTTP 200, 60 req/hr
```

- Switches to `getInstallationToken`, the pattern `github-contributions` already uses.
- Fixes the same broken auth in the `auth.ts` username sync, which had been failing silently.
- Stops the GitHub test mock accepting `Basic ` — it accepted exactly what real GitHub rejects, which is why this shipped green. Reverting the source now fails 3 tests.

Confirmed no `github_established` reward exists for any user in production D1.

Checks: `npx vitest run test/quests.test.ts` — 30 passed.