### PR TITLE
Deploy: MCP root endpoint

### DIFF
--- a/.github/workflows/deploy-gen-cloudflare.yml
+++ b/.github/workflows/deploy-gen-cloudflare.yml
@@ -6,6 +6,7 @@ on:
       - production
     paths:
       - 'gen.pollinations.ai/**'
+      - 'packages/mcp/**'
       - 'shared/**'
       - 'package.json'
       - 'package-lock.json'

--- a/apps/mcp/worker.js
+++ b/apps/mcp/worker.js
@@ -41,16 +41,16 @@ export default {
     async fetch(request) {
         const url = new URL(request.url);
 
-        if (url.pathname === "/" && request.method === "GET") {
+        if (url.pathname === "/health" && request.method === "GET") {
             return Response.json({
                 name: "pollinations-mcp",
                 transport: "streamable-http",
-                endpoint: "/mcp",
+                endpoint: "/",
                 stateless: true,
             });
         }
 
-        if (url.pathname !== "/mcp") {
+        if (url.pathname !== "/") {
             return new Response("Not found", { status: 404 });
         }
 

--- a/apps/mcp/worker.test.js
+++ b/apps/mcp/worker.test.js
@@ -30,7 +30,7 @@ async function connectClient(options = {}, token = TOKEN) {
         { capabilities: {}, ...options },
     );
     const transport = new StreamableHTTPClientTransport(
-        new URL("https://mcp.pollinations.ai/mcp"),
+        new URL("https://mcp.pollinations.ai"),
         {
             fetch: localFetch,
             requestInit: {
@@ -44,13 +44,13 @@ async function connectClient(options = {}, token = TOKEN) {
 
 test("serves health and requires bearer auth", async () => {
     const health = await worker.fetch(
-        new Request("https://mcp.pollinations.ai/"),
+        new Request("https://mcp.pollinations.ai/health"),
     );
     assert.equal(health.status, 200);
-    assert.equal((await health.json()).endpoint, "/mcp");
+    assert.equal((await health.json()).endpoint, "/");
 
     const unauthorized = await worker.fetch(
-        new Request("https://mcp.pollinations.ai/mcp", {
+        new Request("https://mcp.pollinations.ai", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: "{}",
@@ -61,6 +61,11 @@ test("serves health and requires bearer auth", async () => {
         unauthorized.headers.get("www-authenticate"),
         'Bearer realm="mcp.pollinations.ai"',
     );
+
+    const oldEndpoint = await worker.fetch(
+        new Request("https://mcp.pollinations.ai/mcp"),
+    );
+    assert.equal(oldEndpoint.status, 404);
 });
 
 test("serves modern and legacy clients without sessions", async () => {

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/prompt-agent-fields.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/prompt-agent-fields.tsx
@@ -100,7 +100,7 @@ export function PromptAgentFields({
                             </div>
                             <div className="flex min-w-0 items-center gap-2">
                                 <span className="min-w-0 flex-1 break-all font-mono text-xs text-theme-text-muted">
-                                    https://mcp.pollinations.ai/mcp
+                                    https://mcp.pollinations.ai
                                 </span>
                                 <Switch
                                     checked={form.pollinationsTools}

--- a/enter.pollinations.ai/src/routes/agent-runtime.ts
+++ b/enter.pollinations.ai/src/routes/agent-runtime.ts
@@ -16,9 +16,8 @@ import {
     PromptAgentRuntimeRequestSchema,
 } from "../services/prompt-agent-runtime.ts";
 
-// Must include /mcp: the MCP worker serves the Streamable HTTP transport only
-// at that path and returns 404 for every other pathname (apps/mcp/worker.js).
-export const POLLINATIONS_MCP_URL = "https://mcp.pollinations.ai/mcp";
+// The MCP worker serves Streamable HTTP directly at the root URL.
+export const POLLINATIONS_MCP_URL = "https://mcp.pollinations.ai";
 
 function genBaseUrl(env: Env["Bindings"]): string {
     return (

--- a/enter.pollinations.ai/test/prompt-agent-runtime.test.ts
+++ b/enter.pollinations.ai/test/prompt-agent-runtime.test.ts
@@ -34,13 +34,11 @@ const BASE_RUNTIME: PromptAgentRuntime = {
 };
 
 describe("built-in Pollinations MCP endpoint", () => {
-    // The MCP worker serves Streamable HTTP only at /mcp and 404s every other
-    // pathname (apps/mcp/worker.js). Shipping the bare host broke every managed
-    // agent with Pollinations tools; the runtime tests mock whatever url they are
-    // given, so only asserting the real constant catches it.
-    it("points at the /mcp transport path", () => {
-        expect(POLLINATIONS_MCP_URL).toBe("https://mcp.pollinations.ai/mcp");
-        expect(new URL(POLLINATIONS_MCP_URL).pathname).toBe("/mcp");
+    // Runtime tests mock whichever URL they receive, so assert the real hosted
+    // transport URL directly to keep the agent and MCP Worker in sync.
+    it("points at the root transport URL", () => {
+        expect(POLLINATIONS_MCP_URL).toBe("https://mcp.pollinations.ai");
+        expect(new URL(POLLINATIONS_MCP_URL).pathname).toBe("/");
     });
 });
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -6,6 +6,16 @@ All calls go through `https://gen.pollinations.ai` by default. Set `POLLINATIONS
 
 ## Quick Start
 
+For Streamable HTTP clients, connect to `https://mcp.pollinations.ai` and send
+your API key as `Authorization: Bearer YOUR_KEY`.
+
+The server can only use models and account features allowed by that key's
+permissions, and it cannot spend beyond the key's budget. Configure both in
+[API key settings](https://enter.pollinations.ai/keys); see
+[Authentication](https://gen.pollinations.ai/docs#tag/-authentication).
+
+Or run the server locally over stdio:
+
 ```bash
 # Run directly with npx (no installation required)
 npx @pollinations/mcp
@@ -27,7 +37,8 @@ Get your API key at [enter.pollinations.ai](https://enter.pollinations.ai/keys),
 - `pk_` (publishable) — client-safe, rate-limited (1 pollen per IP per hour)
 - `sk_` (secret) — server-side only, no rate limits, can spend Pollen
 
-Set your key via environment variable or the `setApiKey` tool:
+For the local server, set your key via environment variable or the `setApiKey`
+tool:
 
 ```bash
 export POLLINATIONS_API_KEY=sk_your_key_here

--- a/packages/mcp/src/server.js
+++ b/packages/mcp/src/server.js
@@ -33,15 +33,6 @@ function createServerInstructions(apiBaseUrl, includeAuthTools, version) {
 
 The credential is forwarded to the Pollinations API for that request only.`;
 
-    const authenticationTools = includeAuthTools
-        ? `
-### Authentication
-- **setApiKey** - Set your API key
-- **getKeyInfo** - Check current key status (local)
-- **clearApiKey** - Remove stored key
-`
-        : "";
-
     return `# Pollinations MCP Server v${version}
 
 ## Authentication
@@ -49,31 +40,18 @@ ${authentication}
 
 Get your API key at: https://enter.pollinations.ai/keys
 
-## Available Tools
+## Model discovery and generation
 
-### Image & Video Generation
-- **generateImage** - Generate or edit an image; edits accept reference image URLs
-- **generateVideo** - Generate a video as an unlisted media resource link
-- **generate3D** - Generate a GLB model as an unlisted media resource link
+Pollinations is a live multi-model gateway. Never decide that a requested model is unavailable based on prior knowledge.
 
-### Text Generation
-- **generateText** - OpenAI-compatible text, search, multimodal, and tool-calling API
-- **createEmbeddings** - Create text or multimodal embeddings
-
-### Audio
-- **generateAudio** - Generate speech, music, or sound as an unlisted media resource link
-
-### Discovery
-- **listModels** - List models by modality
-- **getModelStatus** - Get recent model health and latency
-${authenticationTools}
-### Account
-- **getBalance** - Get the authenticated key's Pollen balance
+- When the user names a model or provider, or asks about availability, capabilities, aliases, voices, or pricing, call listModels with the relevant modality first.
+- Match the request against both model names and aliases, then pass the canonical model name to the generation tool.
+- generateText can invoke any listed text model; generateImage can invoke any listed image model.
+- For pricing, quote the returned pricing fields and currency; do not estimate.
+- Use getModelStatus for recent health and latency, not model discovery.
 
 ## API Endpoint
-All requests go through: ${apiBaseUrl}
-
-Model listing results include the current capabilities, voices, and pricing.`;
+All requests go through: ${apiBaseUrl}`;
 }
 
 export function buildServer({
@@ -85,13 +63,13 @@ export function buildServer({
         {
             name: "pollinations-mcp",
             version,
+        },
+        {
             instructions: createServerInstructions(
                 apiBaseUrl,
                 includeAuthTools,
                 version,
             ),
-        },
-        {
             capabilities: {
                 tools: {},
             },

--- a/packages/mcp/src/services/discoveryService.js
+++ b/packages/mcp/src/services/discoveryService.js
@@ -28,7 +28,7 @@ async function getModelStatus(params, context) {
 export const discoveryTools = [
     [
         "listModels",
-        "List live models with capabilities, pricing, and metadata. Filter by modality or community ownership.",
+        "Call before claiming that a named model is unavailable. Returns live canonical names, aliases, modalities, capabilities, voices, supported endpoints, and pricing in Pollen. Filter by modality or community ownership.",
         {
             type: z
                 .enum([

--- a/packages/mcp/src/services/imageService.js
+++ b/packages/mcp/src/services/imageService.js
@@ -142,7 +142,9 @@ const imageParamsSchema = {
     model: z
         .string()
         .optional()
-        .describe("Image model. Use listModels with type=image"),
+        .describe(
+            "Canonical image model name or alias returned by listModels with type=image",
+        ),
     n: z
         .literal(1)
         .optional()
@@ -204,7 +206,7 @@ const videoParamsSchema = {
 export const imageTools = [
     [
         "generateImage",
-        "Generate or edit one image and return an unlisted media.pollinations.ai resource link. To edit, provide an HTTP(S) reference in image.",
+        "Generate or edit one image using any image model in the live Pollinations registry and return an unlisted media.pollinations.ai resource link. If the user requests a named model or provider, call listModels with type=image first and pass the matched canonical model name. To edit, provide an HTTP(S) reference in image.",
         imageParamsSchema,
         generateImage,
     ],

--- a/packages/mcp/src/services/textService.js
+++ b/packages/mcp/src/services/textService.js
@@ -266,7 +266,7 @@ const chatParamsSchema = {
         .string()
         .optional()
         .describe(
-            "Text model (default: 'openai'). Use listModels with type=text",
+            "Canonical text model name or alias returned by listModels with type=text",
         ),
     temperature: z
         .number()
@@ -406,7 +406,7 @@ const chatParamsSchema = {
 export const textTools = [
     [
         "generateText",
-        "Call POST /v1/chat/completions for text, search, multimodal input, tool calling, structured output, reasoning, or audio output.",
+        "Run a completion through any text model in the live Pollinations registry. If the user requests a named model or provider, call listModels with type=text first and pass the matched canonical model name. Supports search, multimodal input, tool calling, structured output, reasoning, and audio output.",
         chatParamsSchema,
         generateText,
     ],

--- a/packages/mcp/test-mcp-client.js
+++ b/packages/mcp/test-mcp-client.js
@@ -119,6 +119,41 @@ await step("modern listTools", async () => {
     return `${tools.length} tools`;
 });
 
+await step("model discovery guidance", () => {
+    const instructions = client.getInstructions();
+    assert.match(
+        instructions,
+        /Never decide that a requested model is unavailable based on prior knowledge/,
+    );
+    assert.match(
+        instructions,
+        /call listModels with the relevant modality first/,
+    );
+
+    const tools = new Map(modernTools.map((tool) => [tool.name, tool]));
+    assert.match(
+        tools.get("listModels").description,
+        /before claiming that a named model is unavailable/,
+    );
+    assert.match(
+        tools.get("generateText").description,
+        /any text model in the live Pollinations registry/,
+    );
+    assert.match(
+        tools.get("generateImage").description,
+        /any image model in the live Pollinations registry/,
+    );
+    assert.match(
+        tools.get("generateText").inputSchema.properties.model.description,
+        /Canonical text model name or alias returned by listModels/,
+    );
+    assert.match(
+        tools.get("generateImage").inputSchema.properties.model.description,
+        /Canonical image model name or alias returned by listModels/,
+    );
+    return "instructions and tool descriptions";
+});
+
 await step("listModels (unauthenticated)", () =>
     call("listModels", { type: "text" }),
 );
@@ -176,6 +211,9 @@ if (!KEY) {
                 size: "256x256",
             },
         });
+        if (result.isError) {
+            throw new Error(result.content?.[0]?.text || "tool error");
+        }
         const link = result.content?.find(
             (part) => part.type === "resource_link",
         );


### PR DESCRIPTION
- Serves the hosted MCP Streamable HTTP transport at `https://mcp.pollinations.ai` only.
- Moves health checks to `/health`; `/mcp` returns 404.
- Aligns managed agents and the dashboard with the root endpoint.
- Improves live model-discovery guidance and resource-link validation.

Promotes #13407 through the guarded production workflows.