### PR TITLE
fix: keep agents serving when an MCP server fails

### DIFF
--- a/enter.pollinations.ai/src/routes/agent-runtime.ts
+++ b/enter.pollinations.ai/src/routes/agent-runtime.ts
@@ -19,6 +19,13 @@ import {
 // The MCP worker serves Streamable HTTP directly at the root URL.
 export const POLLINATIONS_MCP_URL = "https://mcp.pollinations.ai";
 
+function pollinationsMcpUrl(env: Env["Bindings"]): string {
+    return (
+        (env as { POLLINATIONS_MCP_URL?: string }).POLLINATIONS_MCP_URL ??
+        POLLINATIONS_MCP_URL
+    );
+}
+
 function genBaseUrl(env: Env["Bindings"]): string {
     return (
         (env as { GEN_BASE_URL?: string }).GEN_BASE_URL ??
@@ -77,7 +84,7 @@ export const agentRuntimeRoutes = new Hono<Env>()
                 mcpHeaders,
                 apiKey,
                 genBaseUrl: genBaseUrl(c.env),
-                pollinationsMcpUrl: POLLINATIONS_MCP_URL,
+                pollinationsMcpUrl: pollinationsMcpUrl(c.env),
             });
         },
     );

--- a/enter.pollinations.ai/src/services/prompt-agent-runtime.ts
+++ b/enter.pollinations.ai/src/services/prompt-agent-runtime.ts
@@ -1,5 +1,6 @@
 import { type CallToolResult, createMCPClient } from "@ai-sdk/mcp";
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import { getLogger } from "@logtape/logtape";
 import {
     APICallError,
     type FinishReason,
@@ -12,6 +13,8 @@ import type {
     PromptAgentConfig,
     PromptAgentMcpHeaders,
 } from "./prompt-agent.ts";
+
+const log = getLogger(["enter", "prompt-agent-runtime"]);
 
 export const PromptAgentRequestSchema = z
     .object({
@@ -106,8 +109,11 @@ async function loadMcpTools(
         await Promise.all(clients.map((client) => client.close()));
     };
 
-    try {
-        for (const server of servers) {
+    for (const server of servers) {
+        // Isolated per server: a broken MCP endpoint must not take down the whole
+        // agent. A user can save any url, and third-party servers go down; losing
+        // one server's tools is recoverable, losing the request is not.
+        try {
             const client = await createMCPClient({
                 clientName: "pollinations-prompt-agent",
                 initializationOptions: {
@@ -135,17 +141,34 @@ async function loadMcpTools(
                 },
             });
             clients.push(client);
+            let loaded = 0;
             for (const [name, definition] of Object.entries(
                 await client.tools(),
             )) {
                 if (server.includeTools && !server.includeTools.includes(name))
                     continue;
                 tools[`mcp__${server.name}__${name}`] = definition;
+                loaded++;
             }
+            log.info("MCP_SERVER_LOADED: name={name} url={url} tools={tools}", {
+                name: server.name,
+                url: server.url,
+                tools: loaded,
+            });
+        } catch (error) {
+            // The agent route returns a Response rather than throwing, so Hono's
+            // onError never fires and nothing reaches error_event: this log is the
+            // only signal that a server dropped out.
+            log.error(
+                "MCP_SERVER_FAILED: name={name} url={url} error={error}",
+                {
+                    name: server.name,
+                    url: server.url,
+                    error:
+                        error instanceof Error ? error.message : String(error),
+                },
+            );
         }
-    } catch (error) {
-        await close();
-        throw error;
     }
 
     return { tools, close };

--- a/enter.pollinations.ai/test/prompt-agent-runtime.test.ts
+++ b/enter.pollinations.ai/test/prompt-agent-runtime.test.ts
@@ -295,19 +295,31 @@ describe("prompt-agent runtime", () => {
         });
     });
 
-    it("rejects MCP redirects without forwarding credentials", async () => {
+    it("refuses MCP redirects without forwarding credentials, and keeps serving", async () => {
         const requests: { url: string; authorization: string | null }[] = [];
         vi.stubGlobal(
             "fetch",
             vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
                 const request = new Request(input, init);
+                if (request.url.startsWith("https://mcp.example.com/")) {
+                    requests.push({
+                        url: request.url,
+                        authorization: request.headers.get("Authorization"),
+                    });
+                    return new Response(null, {
+                        status: 302,
+                        headers: { Location: "https://attacker.example/mcp" },
+                    });
+                }
                 requests.push({
                     url: request.url,
                     authorization: request.headers.get("Authorization"),
                 });
-                return new Response(null, {
-                    status: 302,
-                    headers: { Location: "https://attacker.example/mcp" },
+                return Response.json({
+                    choices: [
+                        { message: { role: "assistant", content: "no tools" } },
+                    ],
+                    usage: { prompt_tokens: 2, completion_tokens: 2 },
                 });
             }),
         );
@@ -332,14 +344,21 @@ describe("prompt-agent runtime", () => {
             },
         );
 
-        expect(response.status).toBe(502);
-        expect(requests.length).toBeGreaterThan(0);
-        expect(requests).toEqual(
-            requests.map(() => ({
-                url: "https://mcp.example.com/rpc",
-                authorization: "Bearer mcp-secret",
-            })),
-        );
+        // The redirect is refused before it is followed, so the MCP credential
+        // never reaches the attacker host. That guarantee is independent of how
+        // the failure is handled.
+        expect(
+            requests.some((r) => r.url.startsWith("https://attacker.example")),
+        ).toBe(false);
+        expect(
+            requests.filter((r) => r.url === "https://mcp.example.com/rpc")
+                .length,
+        ).toBeGreaterThan(0);
+        // The server drops out rather than failing the request: the agent answers
+        // without its tools.
+        const body = await response.text();
+        expect(response.status, body).toBe(200);
+        expect(JSON.parse(body).choices[0].message.content).toBe("no tools");
     });
 
     it("runs the MCP tool loop and reuses the negotiated session", async () => {
@@ -620,6 +639,55 @@ describe("prompt-agent runtime", () => {
         expect(response.status).toBe(200);
         expect(mcpToolCalls).toBe(16);
         expect(body.usage.tool_call_counts.mcp_call).toBe(17);
+    });
+
+    it("keeps running when an MCP server fails to load", async () => {
+        // A user can save any MCP url and third-party servers go down; losing one
+        // server's tools must not take down the whole agent request.
+        let modelCalls = 0;
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+                const request = new Request(input, init);
+                if (request.url === "https://mcp.broken.example/sse") {
+                    return new Response("Method Not Allowed", { status: 405 });
+                }
+                modelCalls++;
+                return Response.json({
+                    choices: [
+                        {
+                            message: {
+                                role: "assistant",
+                                content: "still here",
+                            },
+                        },
+                    ],
+                    usage: { prompt_tokens: 3, completion_tokens: 2 },
+                });
+            }),
+        );
+
+        const res = await runAgent(
+            { messages: [{ role: "user", content: "hi" }] },
+            {
+                ...BASE_RUNTIME,
+                config: {
+                    ...BASE_RUNTIME.config,
+                    mcpServers: [
+                        {
+                            name: "websearch",
+                            url: "https://mcp.broken.example/sse",
+                            headers: [],
+                        },
+                    ],
+                },
+            },
+        );
+
+        const text = await res.text();
+        expect(res.status, text).toBe(200);
+        expect(modelCalls).toBeGreaterThan(0);
+        expect(JSON.parse(text).choices[0].message.content).toBe("still here");
     });
 
     it("passes the caller token only to the built-in Pollinations MCP", async () => {

--- a/enter.pollinations.ai/test/prompt-agent-runtime.test.ts
+++ b/enter.pollinations.ai/test/prompt-agent-runtime.test.ts
@@ -347,9 +347,11 @@ describe("prompt-agent runtime", () => {
         // The redirect is refused before it is followed, so the MCP credential
         // never reaches the attacker host. That guarantee is independent of how
         // the failure is handled.
-        expect(
-            requests.some((r) => r.url.startsWith("https://attacker.example")),
-        ).toBe(false);
+        // Compare the parsed hostname rather than a url prefix: a prefix match
+        // also accepts attacker.example.evil.com, so it is not a sound host check.
+        expect(requests.map((r) => new URL(r.url).hostname)).not.toContain(
+            "attacker.example",
+        );
         expect(
             requests.filter((r) => r.url === "https://mcp.example.com/rpc")
                 .length,


### PR DESCRIPTION
Follow-ups from the agent MCP outage.

**One bad MCP server 502s the whole agent.** `loadMcpTools` threw and `createAgent()` sits outside any try/catch, so a 404/405 from any server failed every request. This is live: published agent `19e9460d` points at `https://victor-websearch.hf.space/gradio_api/mcp/sse` — POST returns 405 (it is an SSE endpoint; the runtime speaks Streamable HTTP), so that agent returns 502 on every call.

- Isolates each server: a failing one loses its tools, the agent still answers.
- Adds `MCP_SERVER_LOADED` / `MCP_SERVER_FAILED` logs. `handlePromptAgentRequest` returns a Response instead of throwing, so Hono's `onError` never fires and nothing reaches `error_event` — this route emits no telemetry at all, and these logs are the only signal a server dropped out.
- Makes the built-in MCP url env-overridable (`POLLINATIONS_MCP_URL`), matching the existing `genBaseUrl`/`GEN_BASE_URL` pattern, so the endpoint can move without a code change.

**Note on the redirect test:** it keeps its security assertion — credentials never reach the redirect target, which `redirect: "manual"` guarantees independently of failure handling — and now also asserts the agent keeps serving instead of returning 502. Failure semantics are what this PR intentionally changes.

Not included: real telemetry for this route needs the Hono context plumbed into the service, which is bigger than this change.

Checks: `npx vitest run test/prompt-agent-runtime.test.ts` — 21 passed.