### PR TITLE
fix: verify MCP deployment health endpoint

### DIFF
--- a/apps/mcp/deploy.json
+++ b/apps/mcp/deploy.json
@@ -1,9 +1,12 @@
 {
   "target": "worker",
   "credentials": "myceli",
-  "subdomain": "mcp",
   "install": "npm ci && npm ci --prefix ../../packages/mcp",
   "build": "npm run test",
   "deploy": "npm run deploy",
-  "watch": ["packages/mcp/"]
+  "watch": ["packages/mcp/"],
+  "verify": [
+    "https://mcp.myceli.ai/health",
+    "https://mcp.pollinations.ai/health"
+  ]
 }


### PR DESCRIPTION
- Stops the generic Worker verifier from polling the authenticated MCP root for HTTP 200.
- Verifies `/health` on both `mcp.myceli.ai` and `mcp.pollinations.ai` after deployment.
- Keeps the root MCP transport authenticated and `/mcp` removed.

Checks:
- Deployment discovery tests: 2/2
- Hosted MCP Worker tests: 5/5
- Biome and diff checks