### PR TITLE
Deploy: MCP health verification

### DIFF
--- a/apps/mcp/deploy.json
+++ b/apps/mcp/deploy.json
@@ -1,9 +1,12 @@
 {
   "target": "worker",
   "credentials": "myceli",
-  "subdomain": "mcp",
   "install": "npm ci && npm ci --prefix ../../packages/mcp",
   "build": "npm run test",
   "deploy": "npm run deploy",
-  "watch": ["packages/mcp/"]
+  "watch": ["packages/mcp/"],
+  "verify": [
+    "https://mcp.myceli.ai/health",
+    "https://mcp.pollinations.ai/health"
+  ]
 }


### PR DESCRIPTION
- Verifies the hosted MCP deployment through `/health` on both production domains.
- Leaves the root transport authenticated and `/mcp` removed.

Promotes #13437 through the guarded production workflow.