### PR TITLE
Promote main to production

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/agent-model-metadata.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/agent-model-metadata.tsx
@@ -1,37 +1,5 @@
-import { cn } from "@pollinations/ui";
+import { cn, Tooltip } from "@pollinations/ui";
 import type { ModelPrice } from "./types.ts";
-
-export function AgentModelMetadata({ model }: { model: ModelPrice }) {
-    const hasPollinationsModelAccess = model.capabilities.includes(
-        "pollinations_models",
-    );
-    if (!model.agent || (!model.baseModel && !hasPollinationsModelAccess)) {
-        return null;
-    }
-
-    return (
-        <div className="flex flex-col gap-1 text-xs text-theme-text-muted">
-            {model.baseModel && (
-                <>
-                    <span>
-                        Base model:{" "}
-                        <span className="font-mono">{model.baseModel}</span>
-                    </span>
-                    <span>
-                        Rates are per base-model call; total usage depends on
-                        the agent&apos;s steps and tools.
-                    </span>
-                </>
-            )}
-            {hasPollinationsModelAccess && (
-                <span>
-                    Can call other Pollinations models on the caller&apos;s
-                    behalf using their API access and balance.
-                </span>
-            )}
-        </div>
-    );
-}
 
 export function AgentBasePricingLabel({
     model,
@@ -42,13 +10,37 @@ export function AgentBasePricingLabel({
 }) {
     if (!model.agent || !model.baseModel) return null;
     return (
-        <p
+        <div
             className={cn(
-                "text-xs font-medium text-theme-text-muted",
+                "flex min-w-0 items-center gap-2 text-xs font-medium text-theme-text-muted",
                 className,
             )}
         >
-            Base model pricing
+            <span className="shrink-0">Base model pricing</span>
+            <Tooltip
+                content={model.baseModel}
+                triggerAs="span"
+                className="min-w-0 max-w-48"
+            >
+                <span className="block max-w-full truncate rounded-md bg-theme-bg-subtle px-2 py-1 font-mono text-[10px] font-medium text-theme-text-muted">
+                    {model.baseModel}
+                </span>
+            </Tooltip>
+        </div>
+    );
+}
+
+export function AgentPricingNote({ model }: { model: ModelPrice }) {
+    if (!model.agent || !model.capabilities.includes("pollinations_models")) {
+        return null;
+    }
+
+    return (
+        <p className="mt-2 border-t border-divider pt-2 text-[11px] leading-snug text-theme-text-muted">
+            <span className="font-medium text-theme-text-soft">
+                Pollinations tools enabled
+            </span>{" "}
+            · additional model calls use the caller&apos;s access and balance.
         </p>
     );
 }

--- a/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
@@ -3,7 +3,7 @@ import { WalletKindIcon } from "@pollinations/ui/wallet";
 import type { FC } from "react";
 import {
     AgentBasePricingLabel,
-    AgentModelMetadata,
+    AgentPricingNote,
 } from "./agent-model-metadata.tsx";
 import { calculatePerPollen, unitLabels } from "./calculations.ts";
 import { CAPABILITY_ICON, MODALITY_ICON } from "./model-icons.tsx";
@@ -203,6 +203,17 @@ export const ModelRow: FC<ModelRowProps> = ({ model }) => {
                         />
                     </div>
                     <ModelId name={model.name} />
+                    {model.agent && modelDescription && (
+                        <Tooltip
+                            content={modelDescription}
+                            triggerAs="span"
+                            className="min-w-0 max-w-full"
+                        >
+                            <span className="block min-w-0 max-w-full truncate text-xs text-theme-text-soft">
+                                {modelDescription}
+                            </span>
+                        </Tooltip>
+                    )}
                     {model.brandUrl && model.brand && (
                         <a
                             href={model.brandUrl}
@@ -213,7 +224,6 @@ export const ModelRow: FC<ModelRowProps> = ({ model }) => {
                             {model.brand}
                         </a>
                     )}
-                    <AgentModelMetadata model={model} />
                     {(inputModalities.length > 0 ||
                         capabilities.length > 0) && (
                         <div className="flex min-w-0 flex-wrap items-center gap-2">
@@ -268,6 +278,7 @@ export const ModelRow: FC<ModelRowProps> = ({ model }) => {
             <div className="w-[clamp(320px,32%,360px)] shrink-0 px-3 py-3">
                 <AgentBasePricingLabel model={model} className="mb-1" />
                 <ModelPricingLedger pricing={pricing} />
+                <AgentPricingNote model={model} />
             </div>
         </Surface>
     );

--- a/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
@@ -2,7 +2,7 @@ import { ChevronIcon, CopyButton, cn } from "@pollinations/ui";
 import { type FC, useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
     AgentBasePricingLabel,
-    AgentModelMetadata,
+    AgentPricingNote,
 } from "./agent-model-metadata.tsx";
 import { CAPABILITY_ICON, MODALITY_ICON } from "./model-icons.tsx";
 import {
@@ -283,13 +283,13 @@ const MobileModelRow: FC<MobileModelRowProps> = ({ model }) => {
                                 {modelDescription}
                             </p>
                         )}
-                        <AgentModelMetadata model={model} />
                         <AgentBasePricingLabel model={model} />
                         <ModelPricingControls model={model} pricing={pricing} />
                         <ModelPricingLedger
                             pricing={pricing}
                             className="w-full"
                         />
+                        <AgentPricingNote model={model} />
                     </div>
                 </div>
             )}
@@ -367,6 +367,18 @@ export const UnifiedModelTable: FC<UnifiedModelTableProps> = ({
 
     return (
         <div ref={containerRef}>
+            {activeTab === "agent" && (
+                <div className="mb-2 flex items-baseline gap-2 rounded-xl border border-divider bg-theme-bg-subtle px-3 py-2 text-xs leading-snug text-theme-text-muted">
+                    <span className="shrink-0 font-medium uppercase tracking-wide text-theme-text-soft">
+                        Agent pricing
+                    </span>
+                    <span>
+                        Rates apply to each base-model call. Agents can make
+                        multiple calls; Pollinations tool calls use the selected
+                        model&apos;s listed price.
+                    </span>
+                </div>
+            )}
             {/* Tab content — the selected modality */}
             {activeSection && isDesktop !== null && (
                 <TabContent


### PR DESCRIPTION
- Promotes the compact managed-agent listing from #13442.
- Shows descriptions without repeating verbose base-model and rate explanations.
- Moves base-model and Pollinations-tool billing details into the pricing column.

Validated with TypeScript, the production frontend build, all PR checks, and visual QA on staging.