### PR TITLE
Promote main to production

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
@@ -203,17 +203,6 @@ export const ModelRow: FC<ModelRowProps> = ({ model }) => {
                         />
                     </div>
                     <ModelId name={model.name} />
-                    {model.agent && modelDescription && (
-                        <Tooltip
-                            content={modelDescription}
-                            triggerAs="span"
-                            className="min-w-0 max-w-full"
-                        >
-                            <span className="block min-w-0 max-w-full truncate text-xs text-theme-text-soft">
-                                {modelDescription}
-                            </span>
-                        </Tooltip>
-                    )}
                     {model.brandUrl && model.brand && (
                         <a
                             href={model.brandUrl}


### PR DESCRIPTION
- Promotes #13445
- Uses the shared model-name tooltip for agent descriptions