### PR TITLE
fix: use Pollinations contact addresses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,6 +222,12 @@ Preserve during compaction: modified files + line numbers, all code/diffs/impl d
 
 Be concise. PRs/comments/issues: bullets, <200 words, no fluff.
 
+### Pollinations identity
+
+- Use `hello@pollinations.ai` for public support, privacy, legal, and customer-facing contact. Do not introduce `@myceli.ai` customer contact addresses or present Myceli as the product brand.
+- `Myceli.AI OÜ` may remain where the registered legal entity or data controller must be named.
+- Existing `myceli.ai` infrastructure hostnames and provider-account identifiers are legacy migration targets. Do not rename or remove them piecemeal; migrate each service with routing, deployment, and rollback verification.
+
 - PRs: "- Adds X", "- Fix Y"; 3-5 bullets; titles "fix:"/"feat:"/"Add"; no marketing.
 - Issue comments: bullets only; facts not opinions; link code; be direct (no "I think"/"maybe").
 - Code reviews: focus on what needs improving; link specific lines; don't praise fine code or repeat obvious things.

--- a/enter.pollinations.ai/frontend/src/components/layout/dashboard-shell.tsx
+++ b/enter.pollinations.ai/frontend/src/components/layout/dashboard-shell.tsx
@@ -440,7 +440,10 @@ const DashboardRail: FC<DashboardRailProps> = ({
         <div className="flex shrink-0 flex-col gap-2 border-t border-theme-text-strong/10 pt-4">
             {walletArea && <div className="px-1">{walletArea}</div>}
             {accountArea}
-            <DashboardFooter links={footerLinks} note="© 2026 Myceli.AI" />
+            <DashboardFooter
+                links={footerLinks}
+                note="© 2026 Pollinations.AI"
+            />
         </div>
     </aside>
 );

--- a/enter.pollinations.ai/wrangler.toml
+++ b/enter.pollinations.ai/wrangler.toml
@@ -196,7 +196,7 @@ id = "84512601e2a44679a4d3b0f7415d90ec"
 
 [env.dev.vars]
 ENVIRONMENT = "dev"
-USAGE_DEBUG_USER_ID = "ds1EIz1ELXSNZzzRKJ0jrCsGgLeiVfRh" # pollen@myceli.ai; dev dashboard usage data
+USAGE_DEBUG_USER_ID = "ds1EIz1ELXSNZzzRKJ0jrCsGgLeiVfRh" # dev dashboard usage data
 CLOUDFLARE_ACCOUNT_ID = "b6ec751c0862027ba269faf7029b2501"
 LOG_LEVEL = "debug"
 LOG_FORMAT = "json"

--- a/operations/kpi/README.md
+++ b/operations/kpi/README.md
@@ -54,7 +54,7 @@ npm run dev
 
 ## Deployment
 
-**Cloudflare account:** Myceli (`b6ec751c0862027ba269faf7029b2501` / Elliot@myceli.ai)
+**Cloudflare account:** Myceli (`b6ec751c0862027ba269faf7029b2501`; contact: hello@pollinations.ai)
 
 This is NOT on the Pollinations account. You must be logged into the myceli Cloudflare account.
 
@@ -63,7 +63,7 @@ cd operations/kpi
 
 # 1. Login to the myceli account (opens browser)
 npx wrangler login
-# Verify: npx wrangler whoami → should show "Elliot@myceli.ai's Account"
+# Verify: npx wrangler whoami → should show account ID b6ec751c0862027ba269faf7029b2501
 
 # 2. Build frontend
 npm run build

--- a/operations/observability/docker-compose.prod.yml
+++ b/operations/observability/docker-compose.prod.yml
@@ -6,7 +6,7 @@ services:
     environment:
       - GF_SECURITY_ADMIN_USER=${GF_ADMIN_USER:-admin}
       - GF_SECURITY_ADMIN_PASSWORD=${GF_ADMIN_PASSWORD}
-      - GF_SECURITY_ADMIN_EMAIL=${GF_ADMIN_EMAIL:-hi@myceli.ai}
+      - GF_SECURITY_ADMIN_EMAIL=${GF_ADMIN_EMAIL:-hello@pollinations.ai}
       - GF_SERVER_ROOT_URL=https://observability.pollinations.ai
       - GF_SERVER_DOMAIN=observability.pollinations.ai
       - GF_USERS_ALLOW_SIGN_UP=false

--- a/operations/observability/src/index.js
+++ b/operations/observability/src/index.js
@@ -47,7 +47,8 @@ export class ObservabilityGrafana extends Container {
     envVars = {
         GF_SECURITY_ADMIN_USER: workerEnv.GF_ADMIN_USER || "admin",
         GF_SECURITY_ADMIN_PASSWORD: requiredSecret("GF_ADMIN_PASSWORD"),
-        GF_SECURITY_ADMIN_EMAIL: workerEnv.GF_ADMIN_EMAIL || "hi@myceli.ai",
+        GF_SECURITY_ADMIN_EMAIL:
+            workerEnv.GF_ADMIN_EMAIL || "hello@pollinations.ai",
         GF_SERVER_ROOT_URL: ROOT_URL,
         GF_SERVER_DOMAIN: DOMAIN,
         GF_USERS_ALLOW_SIGN_UP: "false",

--- a/operations/observability/wrangler.toml
+++ b/operations/observability/wrangler.toml
@@ -32,7 +32,7 @@ crons = ["*/5 * * * *"]
 [vars]
 GF_SERVER_ROOT_URL = "https://observability.pollinations.ai"
 GF_ADMIN_USER = "admin"
-GF_ADMIN_EMAIL = "hi@myceli.ai"
+GF_ADMIN_EMAIL = "hello@pollinations.ai"
 
 # Secrets:
 # - GF_ADMIN_PASSWORD

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -33,11 +33,11 @@
     "contributors": [
         {
             "name": "Circuit-Overtime",
-            "email": "ayushman@myceli.ai"
+            "email": "hello@pollinations.ai"
         },
         {
             "name": "ElliotEtag",
-            "email": "elliot@myceli.ai"
+            "email": "hello@pollinations.ai"
         }
     ],
     "license": "MIT",

--- a/packages/polli-cli/package.json
+++ b/packages/polli-cli/package.json
@@ -32,17 +32,17 @@
   "contributors": [
     {
       "name": "Thomas Haferlach",
-      "email": "thomash@myceli.ai",
+      "email": "hello@pollinations.ai",
       "url": "https://github.com/voodoohop"
     },
     {
       "name": "Ayushman",
-      "email": "ayushman@myceli.ai",
+      "email": "hello@pollinations.ai",
       "url": "https://github.com/Circuit-Overtime"
     },
     {
       "name": "Itachi",
-      "email": "itachi@myceli.ai",
+      "email": "hello@pollinations.ai",
       "url": "https://github.com/Itachi-1824"
     }
   ],

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -56,15 +56,15 @@
   "contributors": [
     {
       "name": "Itachi-1824",
-      "email": "itachi@myceli.ai"
+      "email": "hello@pollinations.ai"
     },
     {
       "name": "Circuit-Overtime",
-      "email": "ayushman@myceli.ai"
+      "email": "hello@pollinations.ai"
     },
     {
       "name": "ElliotEtag",
-      "email": "elliot@myceli.ai"
+      "email": "hello@pollinations.ai"
     }
   ],
   "license": "MIT",

--- a/pollinations.ai/public/legal/PRIVACY_POLICY.md
+++ b/pollinations.ai/public/legal/PRIVACY_POLICY.md
@@ -78,7 +78,7 @@ Where data leaves the EEA, we use approved safeguards (e.g., EU Standard Contrac
 
 Access, correction, deletion, restriction, portability, objection to legitimate-interest processing, and withdrawal of consent where applicable.
 
-You can complain to your local authority or the Estonian Data Protection Inspectorate (AKI). **Contact:** hello@myceli.ai.
+You can complain to your local authority or the Estonian Data Protection Inspectorate (AKI). **Contact:** hello@pollinations.ai.
 
 ## 11) Security
 
@@ -103,4 +103,4 @@ Myceli.AI OÜ
 Registry code: 17186693  
 VAT number: EE102877908  
 Registered address: Harju maakond, Tallinn, Kesklinna linnaosa, Tornimäe tn 5, 10145, Estonia  
-Email: hello@myceli.ai
+Email: hello@pollinations.ai

--- a/pollinations.ai/public/legal/TERMS_OF_SERVICE.md
+++ b/pollinations.ai/public/legal/TERMS_OF_SERVICE.md
@@ -6,7 +6,7 @@ _2026-07-02 — Pollen purchases now include a service fee shown before payment,
 
 _2026-05-11 — Wallet now expires after 12 months of account inactivity. Effective 2026-06-01; the inactivity clock starts on that date for all existing balances._
 
-## What Myceli.AI Is
+## What Pollinations Is
 
 We operate commercial, hosted services (dashboard & APIs) built on the open-source pollinations.ai codebase. We handle billing and support; the OSS remains under its repository licences.
 
@@ -15,7 +15,7 @@ Myceli.AI OÜ
 Registry code: 17186693  
 VAT number: EE102877908  
 Registered address: Harju maakond, Tallinn, Kesklinna linnaosa, Tornimäe tn 5, 10145, Estonia  
-Email: hello@myceli.ai
+Email: hello@pollinations.ai
 
 ---
 

--- a/pollinations.ai/src/copy/content/layout.ts
+++ b/pollinations.ai/src/copy/content/layout.ts
@@ -25,6 +25,6 @@ export const LAYOUT = {
     termsLink: "Terms",
     privacyLink: "Privacy",
     refundsLink: "Refunds",
-    footerBranding: "Pollinations.AI © 2026 Myceli AI OÜ",
+    footerBranding: "Pollinations.AI © 2026",
     footerTagline: "Open source AI innovation",
 };


### PR DESCRIPTION
- Replaces legacy Myceli email addresses with `hello@pollinations.ai` across legal pages, package metadata, observability defaults, and operational documentation.
- Updates customer-facing branding to Pollinations while preserving the registered legal entity and infrastructure hostnames.
- Adds repository guidance preventing legacy customer-contact addresses from being reintroduced.
- Validated with Biome, JSON parsing, `git diff --check`, and a repository-wide scan confirming no concrete `@myceli.ai` email addresses remain.