### PR TITLE
fix: clean up responsive agent cards

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/agent-model-metadata.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/agent-model-metadata.tsx
@@ -21,6 +21,7 @@ export function AgentBasePricingLabel({
                 content={model.baseModel}
                 triggerAs="span"
                 className="min-w-0 max-w-48"
+                displayContents
             >
                 <span className="block max-w-full truncate rounded-md bg-theme-bg-subtle px-2 py-1 font-mono text-[10px] font-medium text-theme-text-muted">
                     {model.baseModel}

--- a/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
@@ -64,7 +64,10 @@ export const ModelId: FC<ModelIdProps> = ({ name }) => (
     </CopyButton>
 );
 
-export const PerPollenEstimate: FC<{ model: ModelPrice }> = ({ model }) => {
+export const PerPollenEstimate: FC<{
+    model: ModelPrice;
+    inline?: boolean;
+}> = ({ model, inline = false }) => {
     const value = calculatePerPollen(model);
     const isFree = value === "∞";
     const isUnavailable = value === "—";
@@ -95,7 +98,12 @@ export const PerPollenEstimate: FC<{ model: ModelPrice }> = ({ model }) => {
 
     return (
         <Tooltip content={tooltip} displayContents>
-            <span className="pointer-events-auto inline-flex flex-col items-center gap-1 whitespace-nowrap">
+            <span
+                className={cn(
+                    "pointer-events-auto inline-flex items-center gap-1 whitespace-nowrap",
+                    !inline && "flex-col",
+                )}
+            >
                 <span className="text-sm font-semibold leading-none tabular-nums text-theme-text-strong">
                     {value}
                 </span>

--- a/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
@@ -50,9 +50,10 @@ export const ModelId: FC<ModelIdProps> = ({ name }) => (
         copiedTooltip="Copied model id"
         aria-label={`Copy model id ${name}`}
         tooltipAlign="start"
+        tooltipClassName="min-w-0 max-w-full"
         className={(copied) =>
             cn(
-                "pointer-events-auto flex min-w-0 cursor-pointer text-left font-mono text-xs font-medium transition-colors",
+                "pointer-events-auto flex min-w-0 max-w-full cursor-pointer text-left font-mono text-xs font-medium transition-colors",
                 copied
                     ? "text-intent-success-text"
                     : "text-theme-text-muted hover:text-theme-text-soft",

--- a/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
@@ -238,14 +238,12 @@ const MobileModelRow: FC<MobileModelRowProps> = ({ model }) => {
                                 alphaTooltip={false}
                                 perUserRpm={model.perUserRpm}
                             />
-                            <span className="inline-flex shrink-0 items-center gap-1">
-                                <BalanceAccessChip
-                                    access={balanceAccess}
-                                    className="whitespace-nowrap"
-                                />
-                                <PerPollenEstimate model={model} />
-                            </span>
+                            <BalanceAccessChip
+                                access={balanceAccess}
+                                className="whitespace-nowrap"
+                            />
                         </div>
+                        <PerPollenEstimate model={model} inline />
                     </div>
                     <ChevronIcon
                         expanded={expanded}

--- a/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
@@ -365,18 +365,6 @@ export const UnifiedModelTable: FC<UnifiedModelTableProps> = ({
 
     return (
         <div ref={containerRef}>
-            {activeTab === "agent" && (
-                <div className="mb-2 flex items-baseline gap-2 rounded-xl border border-divider bg-theme-bg-subtle px-3 py-2 text-xs leading-snug text-theme-text-muted">
-                    <span className="shrink-0 font-medium uppercase tracking-wide text-theme-text-soft">
-                        Agent pricing
-                    </span>
-                    <span>
-                        Rates apply to each base-model call. Agents can make
-                        multiple calls; Pollinations tool calls use the selected
-                        model&apos;s listed price.
-                    </span>
-                </div>
-            )}
             {/* Tab content — the selected modality */}
             {activeSection && isDesktop !== null && (
                 <TabContent

--- a/enter.pollinations.ai/frontend/src/components/models/models.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/models.tsx
@@ -1,5 +1,6 @@
 import {
     Alert,
+    BotIcon,
     Button,
     ChevronIcon,
     Chip,
@@ -496,6 +497,19 @@ export const Models: FC = () => {
                             usage over the last 7 days.
                         </span>
                     </p>
+                    {activeTab === "agent" && (
+                        <p className="flex items-start gap-1.5">
+                            <BotIcon className="mt-0.5 h-3.5 w-3.5 shrink-0 text-theme-text-soft" />
+                            <span>
+                                <strong className="text-theme-text-soft">
+                                    Agent pricing
+                                </strong>{" "}
+                                — Rates apply to each base-model call. Agents
+                                can make multiple calls; Pollinations tool calls
+                                use the selected model&apos;s listed price.
+                            </span>
+                        </p>
+                    )}
                 </div>
             </Section>
         </div>

--- a/enter.pollinations.ai/frontend/src/components/models/models.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/models.tsx
@@ -485,17 +485,17 @@ export const Models: FC = () => {
                     </div>
                 )}
                 <div className="mt-4 space-y-2 border-t border-divider pt-4 text-[13px] leading-snug text-theme-text-muted">
-                    {activeTab === "agent" && (
-                        <p className="flex items-start gap-1.5">
-                            <TokensIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                            <span>
-                                <strong>Agent pricing</strong> — rates apply to
-                                each base-model call. Agents can make multiple
-                                calls; Pollinations tool calls use the selected
-                                model&apos;s listed price.
-                            </span>
-                        </p>
-                    )}
+                    <p className="flex items-start gap-1.5">
+                        <BotIcon className="mt-0.5 h-3.5 w-3.5 shrink-0 text-theme-text-soft" />
+                        <span>
+                            <strong className="text-theme-text-soft">
+                                agent pricing
+                            </strong>{" "}
+                            — Rates apply to each base-model call. Agents can
+                            make multiple calls; Pollinations tool calls use the
+                            selected model&apos;s listed price.
+                        </span>
+                    </p>
                     <p className="flex items-start gap-1.5">
                         <SparklesIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
                         <span>
@@ -523,17 +523,6 @@ export const Models: FC = () => {
                             <strong>gen /pollen</strong> — how many generations
                             you can make with 1 Pollen, estimated from average
                             usage over the last 7 days.
-                        </span>
-                    </p>
-                    <p className="flex items-start gap-1.5">
-                        <BotIcon className="mt-0.5 h-3.5 w-3.5 shrink-0 text-theme-text-soft" />
-                        <span>
-                            <strong className="text-theme-text-soft">
-                                agent pricing
-                            </strong>{" "}
-                            — Rates apply to each base-model call. Agents can
-                            make multiple calls; Pollinations tool calls use the
-                            selected model&apos;s listed price.
                         </span>
                     </p>
                 </div>

--- a/enter.pollinations.ai/frontend/src/components/models/models.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/models.tsx
@@ -501,7 +501,7 @@ export const Models: FC = () => {
                         <BotIcon className="mt-0.5 h-3.5 w-3.5 shrink-0 text-theme-text-soft" />
                         <span>
                             <strong className="text-theme-text-soft">
-                                Agent pricing
+                                agent pricing
                             </strong>{" "}
                             — Rates apply to each base-model call. Agents can
                             make multiple calls; Pollinations tool calls use the

--- a/enter.pollinations.ai/frontend/src/components/models/models.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/models.tsx
@@ -491,9 +491,9 @@ export const Models: FC = () => {
                             <strong className="text-theme-text-soft">
                                 agent pricing
                             </strong>{" "}
-                            — Rates apply to each base-model call. Agents can
-                            make multiple calls; Pollinations tool calls use the
-                            selected model&apos;s listed price.
+                            — rates apply to each base-model call; agents can
+                            make multiple calls, and tool calls use the selected
+                            model&apos;s listed price.
                         </span>
                     </p>
                     <p className="flex items-start gap-1.5">

--- a/enter.pollinations.ai/frontend/src/components/models/models.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/models.tsx
@@ -497,19 +497,17 @@ export const Models: FC = () => {
                             usage over the last 7 days.
                         </span>
                     </p>
-                    {activeTab === "agent" && (
-                        <p className="flex items-start gap-1.5">
-                            <BotIcon className="mt-0.5 h-3.5 w-3.5 shrink-0 text-theme-text-soft" />
-                            <span>
-                                <strong className="text-theme-text-soft">
-                                    Agent pricing
-                                </strong>{" "}
-                                — Rates apply to each base-model call. Agents
-                                can make multiple calls; Pollinations tool calls
-                                use the selected model&apos;s listed price.
-                            </span>
-                        </p>
-                    )}
+                    <p className="flex items-start gap-1.5">
+                        <BotIcon className="mt-0.5 h-3.5 w-3.5 shrink-0 text-theme-text-soft" />
+                        <span>
+                            <strong className="text-theme-text-soft">
+                                Agent pricing
+                            </strong>{" "}
+                            — Rates apply to each base-model call. Agents can
+                            make multiple calls; Pollinations tool calls use the
+                            selected model&apos;s listed price.
+                        </span>
+                    </p>
                 </div>
             </Section>
         </div>

--- a/enter.pollinations.ai/frontend/src/components/models/models.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/models.tsx
@@ -219,6 +219,7 @@ export const Models: FC = () => {
         activeScope === "community"
             ? COMMUNITY_SECTION_ORDER
             : POLLINATIONS_SECTION_ORDER;
+    const hasAgents = scopedModels.some((model) => model.agent);
     const scopeLabel = SCOPE_LABELS[activeScope];
     const searchLabel = SEARCH_LABELS[activeTab];
     const searchTarget =
@@ -360,15 +361,31 @@ export const Models: FC = () => {
                             ))}
                         </div>
                         <div className="flex flex-wrap gap-1.5">
-                            {sectionOrder.map((section) => (
-                                <TabButton
-                                    key={section}
-                                    active={activeTab === section}
-                                    onClick={() => setActiveTab(section)}
-                                >
-                                    {sectionLabels[section]}
-                                </TabButton>
-                            ))}
+                            {sectionOrder.map((section) => {
+                                const showAgentsNew =
+                                    section === "agent" && hasAgents;
+                                return (
+                                    <TabButton
+                                        key={section}
+                                        active={activeTab === section}
+                                        onClick={() => setActiveTab(section)}
+                                        ariaLabel={
+                                            showAgentsNew
+                                                ? "Agents, new"
+                                                : undefined
+                                        }
+                                    >
+                                        <span className="inline-flex items-center gap-1.5">
+                                            {sectionLabels[section]}
+                                            {showAgentsNew && (
+                                                <Chip intent="news" size="sm">
+                                                    New
+                                                </Chip>
+                                            )}
+                                        </span>
+                                    </TabButton>
+                                );
+                            })}
                         </div>
                     </div>
                     <div className="flex w-full items-center justify-between gap-2">


### PR DESCRIPTION
- Keeps long agent and base-model IDs contained and truncated
- Gives mobile cards a fixed three-row header with consistent spacing
- Shows the generation estimate as a one-line third row on mobile
- Moves the agent-pricing explanation into the standard footer legend and keeps it visible across all model views
- Verifies 320px–1440px layouts; passes Biome, TypeScript, and the frontend production build