### PR TITLE
fix: move agent pricing note to legend

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
@@ -367,18 +367,6 @@ export const UnifiedModelTable: FC<UnifiedModelTableProps> = ({
 
     return (
         <div ref={containerRef}>
-            {activeTab === "agent" && (
-                <div className="mb-2 flex items-baseline gap-2 rounded-xl border border-divider bg-theme-bg-subtle px-3 py-2 text-xs leading-snug text-theme-text-muted">
-                    <span className="shrink-0 font-medium uppercase tracking-wide text-theme-text-soft">
-                        Agent pricing
-                    </span>
-                    <span>
-                        Rates apply to each base-model call. Agents can make
-                        multiple calls; Pollinations tool calls use the selected
-                        model&apos;s listed price.
-                    </span>
-                </div>
-            )}
             {/* Tab content — the selected modality */}
             {activeSection && isDesktop !== null && (
                 <TabContent

--- a/enter.pollinations.ai/frontend/src/components/models/models.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/models.tsx
@@ -467,6 +467,17 @@ export const Models: FC = () => {
                     </div>
                 )}
                 <div className="mt-4 space-y-2 border-t border-divider pt-4 text-[13px] leading-snug text-theme-text-muted">
+                    {activeTab === "agent" && (
+                        <p className="flex items-start gap-1.5">
+                            <TokensIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                            <span>
+                                <strong>Agent pricing</strong> — rates apply to
+                                each base-model call. Agents can make multiple
+                                calls; Pollinations tool calls use the selected
+                                model&apos;s listed price.
+                            </span>
+                        </p>
+                    )}
                     <p className="flex items-start gap-1.5">
                         <SparklesIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
                         <span>


### PR DESCRIPTION
- Moves the agent-specific pricing explanation below the model list.
- Reuses the existing pricing legend styling and keeps the note visible only on the Agents tab.
- Removes the large pricing notice above the agent rows.

Checks: `npm --prefix enter.pollinations.ai run typecheck`