### PR TITLE
fix: keep OAuth authorize actions visible on short screens

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/auth/authorize.tsx
+++ b/enter.pollinations.ai/frontend/src/components/auth/authorize.tsx
@@ -806,9 +806,11 @@ export function Authorize() {
                     href="https://pollinations.ai/terms"
                     target="_blank"
                     rel="noopener noreferrer"
+                    aria-label="Terms & Conditions"
                     className="text-xs text-theme-text-soft hover:text-theme-text-strong hover:underline"
                 >
-                    Terms & Conditions
+                    <span className="sm:hidden">Terms</span>
+                    <span className="hidden sm:inline">Terms & Conditions</span>
                 </a>
                 <div className="flex gap-2">
                     <Button

--- a/enter.pollinations.ai/frontend/src/components/auth/authorize.tsx
+++ b/enter.pollinations.ai/frontend/src/components/auth/authorize.tsx
@@ -2,6 +2,7 @@ import {
     Button,
     Collapsible,
     cn,
+    ExternalLinkIcon,
     MailIcon,
     useScrollLock,
 } from "@pollinations/ui";
@@ -807,8 +808,12 @@ export function Authorize() {
                     target="_blank"
                     rel="noopener noreferrer"
                     aria-label="Terms & Conditions"
-                    className="text-xs text-theme-text-soft hover:text-theme-text-strong hover:underline"
+                    className="inline-flex items-center gap-1 text-xs text-theme-text-soft hover:text-theme-text-strong hover:underline"
                 >
+                    <ExternalLinkIcon
+                        aria-hidden="true"
+                        className="h-3.5 w-3.5 shrink-0"
+                    />
                     <span className="sm:hidden">Terms</span>
                     <span className="hidden sm:inline">Terms & Conditions</span>
                 </a>

--- a/enter.pollinations.ai/frontend/src/components/auth/authorize.tsx
+++ b/enter.pollinations.ai/frontend/src/components/auth/authorize.tsx
@@ -4,6 +4,7 @@ import {
     cn,
     ExternalLinkIcon,
     MailIcon,
+    ScrollArea,
     useScrollLock,
 } from "@pollinations/ui";
 import {
@@ -630,7 +631,7 @@ export function Authorize() {
                 </div>
             </AuthModalHeader>
 
-            <div className="min-h-0 overflow-y-auto px-6 py-2 space-y-4">
+            <ScrollArea className="min-h-0 px-6 py-2 space-y-4 overscroll-contain">
                 {error ? (
                     <ErrorBanner>{error}</ErrorBanner>
                 ) : (
@@ -719,7 +720,7 @@ export function Authorize() {
                                     ) : (
                                         <div className="flex items-center gap-2 flex-wrap">
                                             <span>Generate</span>
-                                            <div className="flex items-center gap-1 flex-nowrap">
+                                            <div className="flex flex-wrap items-center gap-1">
                                                 {modalities.map((m) => (
                                                     <ModalityChip
                                                         key={m}
@@ -800,9 +801,9 @@ export function Authorize() {
                         </Collapsible>
                     </div>
                 )}
-            </div>
+            </ScrollArea>
 
-            <div className="flex shrink-0 items-center justify-between border-t border-divider bg-surface-white p-6 pt-4">
+            <div className="flex shrink-0 items-center justify-between border-t border-divider p-6 pt-4">
                 <a
                     href="https://pollinations.ai/terms"
                     target="_blank"
@@ -810,12 +811,12 @@ export function Authorize() {
                     aria-label="Terms & Conditions"
                     className="inline-flex items-center gap-1 text-xs text-theme-text-soft hover:text-theme-text-strong hover:underline"
                 >
-                    <ExternalLinkIcon
-                        aria-hidden="true"
-                        className="h-3.5 w-3.5 shrink-0"
-                    />
                     <span className="sm:hidden">Terms</span>
                     <span className="hidden sm:inline">Terms & Conditions</span>
+                    <ExternalLinkIcon
+                        aria-hidden="true"
+                        className="h-3.5 w-3.5 shrink-0 opacity-65"
+                    />
                 </a>
                 <div className="flex gap-2">
                     <Button

--- a/enter.pollinations.ai/frontend/src/components/auth/authorize.tsx
+++ b/enter.pollinations.ai/frontend/src/components/auth/authorize.tsx
@@ -586,6 +586,7 @@ export function Authorize() {
                     : { labelledBy: "authorize-dialog-title" }
             }
             tone={error ? "error" : undefined}
+            contentClassName="flex max-h-[calc(100dvh-2rem)] flex-col"
         >
             <AuthModalHeader>
                 <div className="flex items-center gap-3 min-w-0">
@@ -628,7 +629,7 @@ export function Authorize() {
                 </div>
             </AuthModalHeader>
 
-            <div className="px-6 py-2 space-y-4">
+            <div className="min-h-0 overflow-y-auto px-6 py-2 space-y-4">
                 {error ? (
                     <ErrorBanner>{error}</ErrorBanner>
                 ) : (
@@ -800,7 +801,7 @@ export function Authorize() {
                 )}
             </div>
 
-            <div className="flex items-center justify-between p-6 pt-4">
+            <div className="flex shrink-0 items-center justify-between border-t border-divider bg-surface-white p-6 pt-4">
                 <a
                     href="https://pollinations.ai/terms"
                     target="_blank"

--- a/packages/ui/src/modules/auth/AuthModal.tsx
+++ b/packages/ui/src/modules/auth/AuthModal.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties, ReactNode } from "react";
 import logoUrl from "../../brand/mark.svg";
+import { cn } from "../../lib/cn.ts";
 import { Dialog } from "../../primitives/Dialog.tsx";
 
 const authLogoMaskUrl = `url('${logoUrl}')`;
@@ -42,7 +43,11 @@ export function AuthModal({
             ariaLabel={dialog?.label}
             labelledBy={dialog?.labelledBy}
             positionerClassName="polli:items-start polli:overflow-y-auto polli:bg-app-bg"
-            contentClassName={`polli:bg-surface-white polli:border-2 ${borderClass} polli:rounded-lg polli:shadow-lg polli:max-w-xl polli:w-full polli:my-auto ${contentClassName ?? ""}`}
+            contentClassName={cn(
+                "polli:bg-surface-white polli:border-2 polli:rounded-lg polli:shadow-lg polli:max-w-xl polli:w-full polli:my-auto",
+                borderClass,
+                contentClassName,
+            )}
         >
             {children}
         </Dialog>

--- a/packages/ui/src/modules/auth/AuthModal.tsx
+++ b/packages/ui/src/modules/auth/AuthModal.tsx
@@ -17,6 +17,7 @@ const authLogoMask: CSSProperties = {
 
 export type AuthModalProps = {
     children: ReactNode;
+    contentClassName?: string;
     dialog?: {
         label?: string;
         labelledBy?: string;
@@ -26,6 +27,7 @@ export type AuthModalProps = {
 
 export function AuthModal({
     children,
+    contentClassName,
     dialog,
     tone = "default",
 }: AuthModalProps) {
@@ -40,7 +42,7 @@ export function AuthModal({
             ariaLabel={dialog?.label}
             labelledBy={dialog?.labelledBy}
             positionerClassName="polli:items-start polli:overflow-y-auto polli:bg-app-bg"
-            contentClassName={`polli:bg-surface-white polli:border-2 ${borderClass} polli:rounded-lg polli:shadow-lg polli:max-w-xl polli:w-full polli:my-auto`}
+            contentClassName={`polli:bg-surface-white polli:border-2 ${borderClass} polli:rounded-lg polli:shadow-lg polli:max-w-xl polli:w-full polli:my-auto ${contentClassName ?? ""}`}
         >
             {children}
         </Dialog>


### PR DESCRIPTION
- Keeps the OAuth consent actions visible by capping the modal to the viewport and scrolling only the consent details.
- Adds opt-in `AuthModal` content classes so other authentication screens keep their current layout.
- Shortens the mobile terms link to `Terms`, retains the full accessible name, and adds the existing external-link cue.
- Validated at 900×529, 375×529, expanded permissions, and 900×720; `npm run typecheck` and `npm run build:frontend` pass.
- Fixes #13451