### PR TITLE
fix: follow MCP server redirects

### DIFF
--- a/enter.pollinations.ai/src/services/prompt-agent-runtime.ts
+++ b/enter.pollinations.ai/src/services/prompt-agent-runtime.ts
@@ -124,20 +124,18 @@ async function loadMcpTools(
                     type: "http",
                     url: server.url,
                     headers: server.headers,
-                    fetch: async (input, init) => {
-                        const response = await globalThis.fetch.call(
-                            globalThis,
-                            input,
-                            { ...init, redirect: "manual" },
-                        );
-                        if (response.status >= 300 && response.status < 400) {
-                            await response.body?.cancel();
-                            throw new Error(
-                                "MCP server redirects are not allowed",
-                            );
-                        }
-                        return response;
-                    },
+                    // The redirect override is required, not optional: the MCP
+                    // client asks for redirect "error", which workerd rejects
+                    // outright ("must be one of follow or manual"). We follow
+                    // them — refusing bought little, since a hostile server can
+                    // proxy anywhere without a redirect and the config-time host
+                    // blocklist is the real SSRF control, while redirects are
+                    // ordinary (trailing slashes, http->https, moved paths).
+                    fetch: async (input, init) =>
+                        globalThis.fetch.call(globalThis, input, {
+                            ...init,
+                            redirect: "follow",
+                        }),
                 },
             });
             clients.push(client);

--- a/enter.pollinations.ai/test/prompt-agent-runtime.test.ts
+++ b/enter.pollinations.ai/test/prompt-agent-runtime.test.ts
@@ -295,7 +295,7 @@ describe("prompt-agent runtime", () => {
         });
     });
 
-    it("refuses MCP redirects without forwarding credentials, and keeps serving", async () => {
+    it("keeps serving when a redirect response cannot be used", async () => {
         const requests: { url: string; authorization: string | null }[] = [];
         vi.stubGlobal(
             "fetch",
@@ -344,9 +344,10 @@ describe("prompt-agent runtime", () => {
             },
         );
 
-        // The redirect is refused before it is followed, so the MCP credential
-        // never reaches the attacker host. That guarantee is independent of how
-        // the failure is handled.
+        // Redirects are followed in production (redirect: "follow"); this stub
+        // returns the 302 itself, so the transport simply cannot use it. The
+        // credential still goes only to the configured host, never to the
+        // redirect target, because nothing here follows the hop.
         // Compare the parsed hostname rather than a url prefix: a prefix match
         // also accepts attacker.example.evil.com, so it is not a sound host check.
         expect(requests.map((r) => new URL(r.url).hostname)).not.toContain(


### PR DESCRIPTION
Drops the redirect restriction on user-configured MCP servers.

The rationale for refusing them was weak: a hostile server can proxy anywhere without a redirect, and the user supplies both the URL and the headers, so a redirect adds nothing they could not do directly. The real SSRF control is the config-time host blocklist (`isBlockedHostname` rejects localhost, RFC1918, `169.254.*`, CGNAT, multicast), and on Workers there is little internal surface to reach anyway.

Meanwhile redirects are ordinary — trailing-slash normalisation, `http`→`https`, load balancers, moved paths. Our own `/mcp` → `/` endpoint move would have been served as a redirect if this restriction had not made that unusable.

**The override itself has to stay.** Removing the custom `fetch` breaks all MCP loading: the AI SDK asks for `redirect: "error"`, which workerd rejects with `TypeError: Invalid redirect value, must be one of "follow" or "manual"`. So the wrapper is a Workers compatibility shim as much as a policy — it now passes `"follow"` instead of `"manual"` plus a throw. The comment records this so it is not removed again.

The redirect test is kept but renamed: it no longer describes refusal, since the stub returns the 302 itself and nothing follows the hop. It still asserts credentials reach only the configured host and that an unusable response degrades rather than 502s.

If you later want redirects bounded, the sound version is to follow them manually and re-run `isBlockedHostname` on each hop — that keeps the only property worth keeping without the compatibility cost.

Checks: `npx vitest run test/prompt-agent-runtime.test.ts` — 21 passed.