### PR TITLE
Deploy: follow MCP server redirects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,6 +212,7 @@ Preserve during compaction: modified files + line numbers, all code/diffs/impl d
 
 ## Git Workflow
 
+- Feature branches target `main`. Promote `main` to `production` only through a separate promotion PR; never target `production` directly with feature or fix work.
 - "send to git" = git status, diff, branch, commit all, push, PR description.
 - Verify branch: `git branch --show-current` and confirm if unsure (branch mix-ups are a recurring mistake).
 - Avoid force pushes (`--force`, `--force-with-lease`) — prefer follow-up commits.
@@ -221,6 +222,12 @@ Preserve during compaction: modified files + line numbers, all code/diffs/impl d
 ## Communication Style
 
 Be concise. PRs/comments/issues: bullets, <200 words, no fluff.
+
+### Pollinations identity
+
+- Pollinations.ai is the product brand. Use `hello@pollinations.ai` for public support, privacy, legal, and general customer contact, and `billing@pollinations.ai` for billing contact.
+- Myceli.AI OÜ is the registered legal entity and data controller. Preserve its legal name, copyright and ownership attribution, contributor identities, provider-account identities, infrastructure hostnames, and entity-specific operational contacts.
+- Never replace Myceli entity or infrastructure references merely because they differ from the Pollinations product brand. Change them only as part of an explicitly requested legal-entity or infrastructure migration.
 
 - PRs: "- Adds X", "- Fix Y"; 3-5 bullets; titles "fix:"/"feat:"/"Add"; no marketing.
 - Issue comments: bullets only; facts not opinions; link code; be direct (no "I think"/"maybe").

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 
 | Name | Description | Author |
 |------|-------------|--------|
+| [🖼️ NeuralCanvas](https://play.google.com/store/apps/details?id=com.proApps.aiimagegenerator) | NeuralCanvas is a native Android app (Kotlin + Jetpack Compose) that turns a text prompt into an AI-generated image, built entirely on the Pollinations image API. How it uses Pollinations: every gener | [@greysonmiller67-lang](https://github.com/greysonmiller67-lang) |
 | [💼 Vyrsa Academy](https://vyrsa.xyz) | [Vyrsa.xyz](https://vyrsa.xyz/) is a premium digital transformation academy designed to help you break free from imposter syndrome and build unshakable confidence. Through a proven "Grow, Reflect, Tra | [@ariaerendev](https://github.com/ariaerendev) |
 | [💼 Indish Marketer's Voice Agent](https://voice.prototools.in) | An AI voice agent that businesses embed on their own website. Callers speak naturally instead of filling out a contact form; the agent answers from the business's own knowledge base and captures leads | [@indishmarketer](https://github.com/indishmarketer) |
 | [🛠️ FSChart](https://fastnow.github.io/fschart_pollinations) | FSChart converts natural language into 3D models and 2D function plots in the browser. Enter “a rotating red cube” or “plot y=sin(x)” to call Pollinations and render. | [@fastnow](https://github.com/fastnow) |
@@ -30,7 +31,6 @@
 | [🖼️ IMADreamer](https://fastnow.github.io/imadreamer) | IMADreamer is a free AI image generation tool built on the Pollinations API. | [@fastnow](https://github.com/fastnow) |
 | [📚 FlashcardGeneratorAI](https://flashcardgeneratorai-pollinationsai-classic.pages.dev) | With FlashcardGeneratorAI you can use Pollinations AI to generate digital interactive flashcards to enhance memorization and learning (and use card matching games to reinforce concepts by repetition) | [@rpbmultiongh](https://github.com/rpbmultiongh) |
 | [🖼️ INKRUSH](https://inkrush-comic-studio.onrender.com) | Free browser-based AI comic book maker powered by Pollinations.AI. Create multi-panel comic stories with custom speech bubbles, character lock, retro comic styles, and export as PDF books.📖 | [@takiff507](https://github.com/takiff507) |
-| [✍️ Tessera Lumen - Oracle of Sophia Tarot](https://app.963.co.za) | Personalised oracle readings with card draws, guidance, reflection, and daily insight. | [@Jeraque007](https://github.com/Jeraque007) |
 
 [Browse all apps →](https://pollinations.ai/apps)
 <!-- recent-apps:end -->

--- a/enter.pollinations.ai/frontend/src/components/models/agent-model-metadata.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/agent-model-metadata.tsx
@@ -21,6 +21,7 @@ export function AgentBasePricingLabel({
                 content={model.baseModel}
                 triggerAs="span"
                 className="min-w-0 max-w-48"
+                displayContents
             >
                 <span className="block max-w-full truncate rounded-md bg-theme-bg-subtle px-2 py-1 font-mono text-[10px] font-medium text-theme-text-muted">
                     {model.baseModel}

--- a/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
@@ -50,9 +50,10 @@ export const ModelId: FC<ModelIdProps> = ({ name }) => (
         copiedTooltip="Copied model id"
         aria-label={`Copy model id ${name}`}
         tooltipAlign="start"
+        tooltipClassName="min-w-0 max-w-full"
         className={(copied) =>
             cn(
-                "pointer-events-auto flex min-w-0 cursor-pointer text-left font-mono text-xs font-medium transition-colors",
+                "pointer-events-auto flex min-w-0 max-w-full cursor-pointer text-left font-mono text-xs font-medium transition-colors",
                 copied
                     ? "text-intent-success-text"
                     : "text-theme-text-muted hover:text-theme-text-soft",
@@ -63,7 +64,10 @@ export const ModelId: FC<ModelIdProps> = ({ name }) => (
     </CopyButton>
 );
 
-export const PerPollenEstimate: FC<{ model: ModelPrice }> = ({ model }) => {
+export const PerPollenEstimate: FC<{
+    model: ModelPrice;
+    inline?: boolean;
+}> = ({ model, inline = false }) => {
     const value = calculatePerPollen(model);
     const isFree = value === "∞";
     const isUnavailable = value === "—";
@@ -94,7 +98,12 @@ export const PerPollenEstimate: FC<{ model: ModelPrice }> = ({ model }) => {
 
     return (
         <Tooltip content={tooltip} displayContents>
-            <span className="pointer-events-auto inline-flex flex-col items-center gap-1 whitespace-nowrap">
+            <span
+                className={cn(
+                    "pointer-events-auto inline-flex items-center gap-1 whitespace-nowrap",
+                    !inline && "flex-col",
+                )}
+            >
                 <span className="text-sm font-semibold leading-none tabular-nums text-theme-text-strong">
                     {value}
                 </span>

--- a/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
@@ -238,14 +238,12 @@ const MobileModelRow: FC<MobileModelRowProps> = ({ model }) => {
                                 alphaTooltip={false}
                                 perUserRpm={model.perUserRpm}
                             />
-                            <span className="inline-flex shrink-0 items-center gap-1">
-                                <BalanceAccessChip
-                                    access={balanceAccess}
-                                    className="whitespace-nowrap"
-                                />
-                                <PerPollenEstimate model={model} />
-                            </span>
+                            <BalanceAccessChip
+                                access={balanceAccess}
+                                className="whitespace-nowrap"
+                            />
                         </div>
+                        <PerPollenEstimate model={model} inline />
                     </div>
                     <ChevronIcon
                         expanded={expanded}

--- a/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
@@ -367,18 +367,6 @@ export const UnifiedModelTable: FC<UnifiedModelTableProps> = ({
 
     return (
         <div ref={containerRef}>
-            {activeTab === "agent" && (
-                <div className="mb-2 flex items-baseline gap-2 rounded-xl border border-divider bg-theme-bg-subtle px-3 py-2 text-xs leading-snug text-theme-text-muted">
-                    <span className="shrink-0 font-medium uppercase tracking-wide text-theme-text-soft">
-                        Agent pricing
-                    </span>
-                    <span>
-                        Rates apply to each base-model call. Agents can make
-                        multiple calls; Pollinations tool calls use the selected
-                        model&apos;s listed price.
-                    </span>
-                </div>
-            )}
             {/* Tab content — the selected modality */}
             {activeSection && isDesktop !== null && (
                 <TabContent

--- a/enter.pollinations.ai/frontend/src/components/models/models.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/models.tsx
@@ -1,5 +1,6 @@
 import {
     Alert,
+    BotIcon,
     Button,
     ChevronIcon,
     Chip,
@@ -218,6 +219,7 @@ export const Models: FC = () => {
         activeScope === "community"
             ? COMMUNITY_SECTION_ORDER
             : POLLINATIONS_SECTION_ORDER;
+    const hasAgents = scopedModels.some((model) => model.agent);
     const scopeLabel = SCOPE_LABELS[activeScope];
     const searchLabel = SEARCH_LABELS[activeTab];
     const searchTarget =
@@ -359,15 +361,31 @@ export const Models: FC = () => {
                             ))}
                         </div>
                         <div className="flex flex-wrap gap-1.5">
-                            {sectionOrder.map((section) => (
-                                <TabButton
-                                    key={section}
-                                    active={activeTab === section}
-                                    onClick={() => setActiveTab(section)}
-                                >
-                                    {sectionLabels[section]}
-                                </TabButton>
-                            ))}
+                            {sectionOrder.map((section) => {
+                                const showAgentsNew =
+                                    section === "agent" && hasAgents;
+                                return (
+                                    <TabButton
+                                        key={section}
+                                        active={activeTab === section}
+                                        onClick={() => setActiveTab(section)}
+                                        ariaLabel={
+                                            showAgentsNew
+                                                ? "Agents, new"
+                                                : undefined
+                                        }
+                                    >
+                                        <span className="inline-flex items-center gap-1.5">
+                                            {sectionLabels[section]}
+                                            {showAgentsNew && (
+                                                <Chip intent="news" size="sm">
+                                                    New
+                                                </Chip>
+                                            )}
+                                        </span>
+                                    </TabButton>
+                                );
+                            })}
                         </div>
                     </div>
                     <div className="flex w-full items-center justify-between gap-2">
@@ -467,17 +485,17 @@ export const Models: FC = () => {
                     </div>
                 )}
                 <div className="mt-4 space-y-2 border-t border-divider pt-4 text-[13px] leading-snug text-theme-text-muted">
-                    {activeTab === "agent" && (
-                        <p className="flex items-start gap-1.5">
-                            <TokensIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                            <span>
-                                <strong>Agent pricing</strong> — rates apply to
-                                each base-model call. Agents can make multiple
-                                calls; Pollinations tool calls use the selected
-                                model&apos;s listed price.
-                            </span>
-                        </p>
-                    )}
+                    <p className="flex items-start gap-1.5">
+                        <BotIcon className="mt-0.5 h-3.5 w-3.5 shrink-0 text-theme-text-soft" />
+                        <span>
+                            <strong className="text-theme-text-soft">
+                                agent pricing
+                            </strong>{" "}
+                            — rates apply to each base-model call; agents can
+                            make multiple calls, and tool calls use the selected
+                            model&apos;s listed price.
+                        </span>
+                    </p>
                     <p className="flex items-start gap-1.5">
                         <SparklesIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
                         <span>

--- a/enter.pollinations.ai/frontend/src/components/models/models.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/models.tsx
@@ -467,6 +467,17 @@ export const Models: FC = () => {
                     </div>
                 )}
                 <div className="mt-4 space-y-2 border-t border-divider pt-4 text-[13px] leading-snug text-theme-text-muted">
+                    {activeTab === "agent" && (
+                        <p className="flex items-start gap-1.5">
+                            <TokensIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                            <span>
+                                <strong>Agent pricing</strong> — rates apply to
+                                each base-model call. Agents can make multiple
+                                calls; Pollinations tool calls use the selected
+                                model&apos;s listed price.
+                            </span>
+                        </p>
+                    )}
                     <p className="flex items-start gap-1.5">
                         <SparklesIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
                         <span>

--- a/enter.pollinations.ai/src/services/prompt-agent-runtime.ts
+++ b/enter.pollinations.ai/src/services/prompt-agent-runtime.ts
@@ -124,20 +124,18 @@ async function loadMcpTools(
                     type: "http",
                     url: server.url,
                     headers: server.headers,
-                    fetch: async (input, init) => {
-                        const response = await globalThis.fetch.call(
-                            globalThis,
-                            input,
-                            { ...init, redirect: "manual" },
-                        );
-                        if (response.status >= 300 && response.status < 400) {
-                            await response.body?.cancel();
-                            throw new Error(
-                                "MCP server redirects are not allowed",
-                            );
-                        }
-                        return response;
-                    },
+                    // The redirect override is required, not optional: the MCP
+                    // client asks for redirect "error", which workerd rejects
+                    // outright ("must be one of follow or manual"). We follow
+                    // them — refusing bought little, since a hostile server can
+                    // proxy anywhere without a redirect and the config-time host
+                    // blocklist is the real SSRF control, while redirects are
+                    // ordinary (trailing slashes, http->https, moved paths).
+                    fetch: async (input, init) =>
+                        globalThis.fetch.call(globalThis, input, {
+                            ...init,
+                            redirect: "follow",
+                        }),
                 },
             });
             clients.push(client);

--- a/enter.pollinations.ai/test/prompt-agent-runtime.test.ts
+++ b/enter.pollinations.ai/test/prompt-agent-runtime.test.ts
@@ -295,7 +295,7 @@ describe("prompt-agent runtime", () => {
         });
     });
 
-    it("refuses MCP redirects without forwarding credentials, and keeps serving", async () => {
+    it("keeps serving when a redirect response cannot be used", async () => {
         const requests: { url: string; authorization: string | null }[] = [];
         vi.stubGlobal(
             "fetch",
@@ -344,9 +344,10 @@ describe("prompt-agent runtime", () => {
             },
         );
 
-        // The redirect is refused before it is followed, so the MCP credential
-        // never reaches the attacker host. That guarantee is independent of how
-        // the failure is handled.
+        // Redirects are followed in production (redirect: "follow"); this stub
+        // returns the 302 itself, so the transport simply cannot use it. The
+        // credential still goes only to the configured host, never to the
+        // redirect target, because nothing here follows the hop.
         // Compare the parsed hostname rather than a url prefix: a prefix match
         // also accepts attacker.example.evil.com, so it is not a sound host check.
         expect(requests.map((r) => new URL(r.url).hostname)).not.toContain(

--- a/operations/app-management/app.json
+++ b/operations/app-management/app.json
@@ -17,7 +17,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/13331",
     "approvedDate": "2026-08-15",
     "byop": false,
-    "requests24h": 0
+    "requests24h": 60
   },
   {
     "emoji": "💼",
@@ -37,7 +37,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/13390",
     "approvedDate": "2026-08-15",
     "byop": false,
-    "requests24h": 39
+    "requests24h": 24
   },
   {
     "emoji": "🛠️",
@@ -50,14 +50,14 @@
     "githubUsername": "fastnow",
     "githubUserId": "177708607",
     "repositoryUrl": "https://github.com/fastnow/fastnow.github.io/blob/main/fschart_pollinations.html",
-    "repositoryStars": 2,
+    "repositoryStars": 3,
     "discordUsername": null,
     "other": null,
     "submittedDate": "2026-08-13",
     "issueUrl": "https://github.com/pollinations/pollinations/issues/13311",
     "approvedDate": "2026-08-14",
     "byop": false,
-    "requests24h": 2
+    "requests24h": 3
   },
   {
     "emoji": "💼",
@@ -77,7 +77,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/11741",
     "approvedDate": "2026-08-14",
     "byop": false,
-    "requests24h": 27
+    "requests24h": 13
   },
   {
     "emoji": "🖼️",
@@ -117,7 +117,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/11729",
     "approvedDate": "2026-08-13",
     "byop": false,
-    "requests24h": 260
+    "requests24h": 282
   },
   {
     "emoji": "🖼️",
@@ -130,14 +130,14 @@
     "githubUsername": "fastnow",
     "githubUserId": "177708607",
     "repositoryUrl": "https://github.com/fastnow/fastnow.github.io",
-    "repositoryStars": 2,
+    "repositoryStars": 3,
     "discordUsername": null,
     "other": null,
     "submittedDate": "2026-05-30",
     "issueUrl": "https://github.com/pollinations/pollinations/issues/11403",
     "approvedDate": "2026-08-12",
     "byop": false,
-    "requests24h": 2
+    "requests24h": 3
   },
   {
     "emoji": "📚",
@@ -157,7 +157,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/13228",
     "approvedDate": "2026-08-10",
     "byop": false,
-    "requests24h": 3,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/5682c626-fcb3-47d6-af0f-793517f96d52"
   },
   {
@@ -178,7 +178,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/13239",
     "approvedDate": "2026-08-10",
     "byop": false,
-    "requests24h": 82,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/9e22683b-6c15-4e78-9130-bcb4d11bce13"
   },
   {
@@ -220,7 +220,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/13037",
     "approvedDate": "2026-08-09",
     "byop": false,
-    "requests24h": 217,
+    "requests24h": 52,
     "screenshotUrl": "https://media.pollinations.ai/2e3b778c-335d-433c-87cb-40d0ab82eb2f"
   },
   {
@@ -262,7 +262,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/10900",
     "approvedDate": "2026-08-08",
     "byop": false,
-    "requests24h": 0,
+    "requests24h": 3,
     "screenshotUrl": "https://media.pollinations.ai/318bfb77-244d-4ae2-a9f1-26486715cb82"
   },
   {
@@ -283,7 +283,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/11055",
     "approvedDate": "2026-08-08",
     "byop": true,
-    "requests24h": 3,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/9961f52d-ff10-408a-95e9-61f644c9f83b"
   },
   {
@@ -304,7 +304,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/11123",
     "approvedDate": "2026-08-08",
     "byop": false,
-    "requests24h": 7,
+    "requests24h": 8,
     "screenshotUrl": "https://media.pollinations.ai/959392eb-3147-4911-91dd-e3acbc380364"
   },
   {
@@ -325,7 +325,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/11153",
     "approvedDate": "2026-08-08",
     "byop": false,
-    "requests24h": 0,
+    "requests24h": 3,
     "screenshotUrl": "https://media.pollinations.ai/7c2533e0-8adf-46f4-8851-b4bf85c074b2"
   },
   {
@@ -346,7 +346,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/11155",
     "approvedDate": "2026-08-08",
     "byop": false,
-    "requests24h": 73,
+    "requests24h": 70,
     "screenshotUrl": "https://media.pollinations.ai/c9e1783d-d22a-4921-b655-0b1a24cf4633"
   },
   {
@@ -514,7 +514,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/11282",
     "approvedDate": "2026-08-08",
     "byop": false,
-    "requests24h": 1,
+    "requests24h": 8,
     "screenshotUrl": "https://media.pollinations.ai/ecc7b9fc-fa82-438b-b556-8a05e2006406"
   },
   {
@@ -577,7 +577,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/12445",
     "approvedDate": "2026-08-08",
     "byop": false,
-    "requests24h": 1,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/2818c565-7d57-4b9b-9e17-de56a4033e48"
   },
   {
@@ -640,7 +640,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/13116",
     "approvedDate": "2026-08-08",
     "byop": false,
-    "requests24h": 29,
+    "requests24h": 28,
     "screenshotUrl": "https://media.pollinations.ai/4bba7c83-4ad1-415e-9220-4e57b0b2f85f"
   },
   {
@@ -850,7 +850,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/12863",
     "approvedDate": "2026-08-05",
     "byop": true,
-    "requests24h": 0,
+    "requests24h": 3,
     "screenshotUrl": "https://media.pollinations.ai/32aad4c6-2969-4a14-94d1-763d19ab7862"
   },
   {
@@ -892,7 +892,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/12243",
     "approvedDate": "2026-08-05",
     "byop": false,
-    "requests24h": 3,
+    "requests24h": 13,
     "screenshotUrl": "https://media.pollinations.ai/e1e766bd-1283-428f-9eb1-43cd9a39cea5"
   },
   {
@@ -955,7 +955,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/12694",
     "approvedDate": "2026-07-28",
     "byop": false,
-    "requests24h": 3,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/43945ce5-fc63-4266-b0b6-c8c240a2b010"
   },
   {
@@ -1018,7 +1018,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/12742",
     "approvedDate": "2026-07-28",
     "byop": false,
-    "requests24h": 921,
+    "requests24h": 833,
     "screenshotUrl": "https://media.pollinations.ai/5b6cafa5-7461-40db-adc9-2072d16387ba"
   },
   {
@@ -1039,7 +1039,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/12765",
     "approvedDate": "2026-07-28",
     "byop": false,
-    "requests24h": 33,
+    "requests24h": 128,
     "screenshotUrl": "https://media.pollinations.ai/82614c3c-aef8-4784-97b4-3457aedd1a38"
   },
   {
@@ -1060,7 +1060,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/12754",
     "approvedDate": "2026-07-28",
     "byop": true,
-    "requests24h": 0,
+    "requests24h": 4,
     "screenshotUrl": "https://media.pollinations.ai/b7e4b219-6d14-46e5-b4a1-34bc265760b2"
   },
   {
@@ -1081,7 +1081,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/12773",
     "approvedDate": "2026-07-28",
     "byop": false,
-    "requests24h": 0,
+    "requests24h": 28,
     "screenshotUrl": "https://media.pollinations.ai/d4fbed8f-2495-489b-8ef1-f903ff6549a0"
   },
   {
@@ -1102,7 +1102,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/10161",
     "approvedDate": "2026-07-22",
     "byop": false,
-    "requests24h": 6,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/5c213cfa-c20e-48de-a8c1-1aa8c7e79a6c"
   },
   {
@@ -1123,7 +1123,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/10355",
     "approvedDate": "2026-07-22",
     "byop": false,
-    "requests24h": 8,
+    "requests24h": 12,
     "screenshotUrl": "https://media.pollinations.ai/ebe81dec-193a-4a04-8016-72a470871c68"
   },
   {
@@ -1144,7 +1144,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/12394",
     "approvedDate": "2026-07-13",
     "byop": false,
-    "requests24h": 1,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/8959502d-ef48-4198-9563-e8dca2220e4d"
   },
   {
@@ -1396,7 +1396,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/11771",
     "approvedDate": "2026-07-13",
     "byop": false,
-    "requests24h": 2,
+    "requests24h": 1,
     "screenshotUrl": "https://media.pollinations.ai/80b6ff7a-3451-4b03-a892-c12ff539ea67"
   },
   {
@@ -1438,7 +1438,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/11820",
     "approvedDate": "2026-07-13",
     "byop": false,
-    "requests24h": 164,
+    "requests24h": 104,
     "screenshotUrl": "https://media.pollinations.ai/0b3e46f4-2d1a-4eac-8d21-eebc49b2d321"
   },
   {
@@ -1542,7 +1542,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/12199",
     "approvedDate": "2026-07-13",
     "byop": false,
-    "requests24h": 71,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/bbd18580-7820-423e-b179-6225b1f05d1e"
   },
   {
@@ -1647,7 +1647,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/11799",
     "approvedDate": "2026-07-13",
     "byop": false,
-    "requests24h": 7,
+    "requests24h": 10,
     "screenshotUrl": "https://media.pollinations.ai/d7f2233d-9453-4c11-9055-af1b2a3df507"
   },
   {
@@ -1668,7 +1668,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/12152",
     "approvedDate": "2026-07-13",
     "byop": false,
-    "requests24h": 1,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/1936592d-d5a9-4087-848c-c579d1ae1b58"
   },
   {
@@ -1711,7 +1711,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/12240",
     "approvedDate": "2026-07-05",
     "byop": false,
-    "requests24h": 605440
+    "requests24h": 583336
   },
   {
     "emoji": "🖼️",
@@ -1731,7 +1731,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/12115",
     "approvedDate": "2026-07-05",
     "byop": false,
-    "requests24h": 0,
+    "requests24h": 43,
     "screenshotUrl": "https://media.pollinations.ai/2a5a86f9-b9a7-4258-912f-5746ce5aa237"
   },
   {
@@ -1752,7 +1752,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/12217",
     "approvedDate": "2026-07-05",
     "byop": false,
-    "requests24h": 0,
+    "requests24h": 43,
     "screenshotUrl": "https://media.pollinations.ai/d9935197-69f4-44b4-8c4a-b2d62dba6612"
   },
   {
@@ -1878,7 +1878,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/11911",
     "approvedDate": "2026-06-28",
     "byop": false,
-    "requests24h": 4,
+    "requests24h": 5,
     "screenshotUrl": "https://media.pollinations.ai/f987a9d0-c146-4f0f-9f3a-827743beb8d1"
   },
   {
@@ -1941,7 +1941,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/11962",
     "approvedDate": "2026-06-28",
     "byop": false,
-    "requests24h": 1,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/95d272f8-c9c2-43ca-93ec-dfba31b55ef0"
   },
   {
@@ -1983,7 +1983,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/12013",
     "approvedDate": "2026-06-28",
     "byop": false,
-    "requests24h": 44,
+    "requests24h": 99,
     "screenshotUrl": "https://media.pollinations.ai/afd75137-5765-44da-b71c-1e3e375e16e5"
   },
   {
@@ -2046,7 +2046,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/11987",
     "approvedDate": "2026-06-26",
     "byop": false,
-    "requests24h": 44,
+    "requests24h": 63,
     "screenshotUrl": "https://media.pollinations.ai/b5971d0f-5978-4780-8e02-50b877da891c"
   },
   {
@@ -2067,7 +2067,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/10492",
     "approvedDate": "2026-06-01",
     "byop": false,
-    "requests24h": 4,
+    "requests24h": 34,
     "screenshotUrl": "https://media.pollinations.ai/4286a626-555d-462a-866e-0992b3b7caf8"
   },
   {
@@ -2214,7 +2214,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/10234",
     "approvedDate": "2026-06-02",
     "byop": false,
-    "requests24h": 15,
+    "requests24h": 20,
     "screenshotUrl": "https://media.pollinations.ai/d1d4bce8-e6d0-4b38-bd0f-c6877b321b05"
   },
   {
@@ -2276,7 +2276,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/10380",
     "approvedDate": "2026-06-02",
     "byop": false,
-    "requests24h": 4,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/7229399e-ed74-4e98-8271-5d429c927c20"
   },
   {
@@ -2402,7 +2402,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/10487",
     "approvedDate": "2026-06-01",
     "byop": false,
-    "requests24h": 2,
+    "requests24h": 1,
     "screenshotUrl": "https://media.pollinations.ai/bcdf9453-1a26-43a9-a02a-200cff2b6096"
   },
   {
@@ -2423,7 +2423,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/10507",
     "approvedDate": "2026-06-01",
     "byop": false,
-    "requests24h": 2,
+    "requests24h": 3,
     "screenshotUrl": "https://media.pollinations.ai/4bc7a1b1-f075-4ae0-903a-e12527f1cbf9"
   },
   {
@@ -2444,7 +2444,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/10484",
     "approvedDate": "2026-06-01",
     "byop": false,
-    "requests24h": 245
+    "requests24h": 231
   },
   {
     "emoji": "🧩",
@@ -2547,7 +2547,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/10697",
     "approvedDate": "2026-06-01",
     "byop": false,
-    "requests24h": 0,
+    "requests24h": 142,
     "screenshotUrl": "https://media.pollinations.ai/6147ad0d-2388-4eda-b9cf-f040c39fb0dd"
   },
   {
@@ -2568,7 +2568,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/10699",
     "approvedDate": "2026-06-01",
     "byop": false,
-    "requests24h": 0,
+    "requests24h": 278,
     "screenshotUrl": "https://media.pollinations.ai/f47a6036-a284-48e6-8da9-7944d76b1975"
   },
   {
@@ -2589,7 +2589,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/10703",
     "approvedDate": "2026-06-01",
     "byop": false,
-    "requests24h": 2,
+    "requests24h": 1,
     "screenshotUrl": "https://media.pollinations.ai/bcdf9453-1a26-43a9-a02a-200cff2b6096"
   },
   {
@@ -2610,7 +2610,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/11421",
     "approvedDate": "2026-05-30",
     "byop": false,
-    "requests24h": 0,
+    "requests24h": 1,
     "screenshotUrl": "https://media.pollinations.ai/3c3d59f8-1465-4b24-bc78-11f6bd55960e"
   },
   {
@@ -2673,7 +2673,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/10101",
     "approvedDate": "2026-05-30",
     "byop": false,
-    "requests24h": 1,
+    "requests24h": 8,
     "screenshotUrl": "https://media.pollinations.ai/5faa4e70-a9f8-4208-b5e3-a2f6fd0fef5f"
   },
   {
@@ -2820,7 +2820,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/10085",
     "approvedDate": "2026-05-17",
     "byop": false,
-    "requests24h": 11,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/b56e29d6-9319-44e5-92fd-e789bd431741"
   },
   {
@@ -2946,7 +2946,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/10034",
     "approvedDate": "2026-05-17",
     "byop": false,
-    "requests24h": 1,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/f0e81945-113e-41ab-84e2-6d1ac44d588e"
   },
   {
@@ -2967,7 +2967,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/10015",
     "approvedDate": "2026-05-17",
     "byop": false,
-    "requests24h": 0,
+    "requests24h": 4,
     "screenshotUrl": "https://media.pollinations.ai/c60287d0-1547-4bf2-ba12-64d9c21629a4"
   },
   {
@@ -3009,7 +3009,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9995",
     "approvedDate": "2026-05-17",
     "byop": false,
-    "requests24h": 7,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/67adf1a9-fb34-4251-a209-42ee2b0ffc1f"
   },
   {
@@ -3114,7 +3114,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9987",
     "approvedDate": "2026-05-17",
     "byop": false,
-    "requests24h": 466,
+    "requests24h": 312,
     "screenshotUrl": "https://media.pollinations.ai/7f20cb3c-3c53-48d1-96c1-ef86908a77e1"
   },
   {
@@ -3217,7 +3217,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9949",
     "approvedDate": "2026-05-17",
     "byop": false,
-    "requests24h": 126,
+    "requests24h": 34,
     "screenshotUrl": "https://media.pollinations.ai/84af02b1-1819-4c4f-a5f5-be68ea07f9db"
   },
   {
@@ -3300,7 +3300,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9196",
     "approvedDate": "2026-05-17",
     "byop": false,
-    "requests24h": 107,
+    "requests24h": 157,
     "screenshotUrl": "https://media.pollinations.ai/d5475b43-a3b7-4fc8-b454-72908c4b02e8"
   },
   {
@@ -3509,7 +3509,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/10568",
     "approvedDate": "2026-05-17",
     "byop": false,
-    "requests24h": 46,
+    "requests24h": 40,
     "screenshotUrl": "https://media.pollinations.ai/08124785-7171-4564-a8f8-0eb76ab9ed0c"
   },
   {
@@ -3550,7 +3550,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/10958",
     "approvedDate": "2026-05-16",
     "byop": false,
-    "requests24h": 83,
+    "requests24h": 101,
     "screenshotUrl": "https://media.pollinations.ai/26f9d4b5-9a8a-45da-89a3-d6ea1e30e70b"
   },
   {
@@ -3571,7 +3571,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/10993",
     "approvedDate": "2026-05-16",
     "byop": false,
-    "requests24h": 2,
+    "requests24h": 1,
     "screenshotUrl": "https://media.pollinations.ai/e4f48491-bd63-4e45-8f3f-ddc94cecf09c"
   },
   {
@@ -3634,7 +3634,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/10563",
     "approvedDate": "2026-05-15",
     "byop": false,
-    "requests24h": 54,
+    "requests24h": 189,
     "screenshotUrl": "https://media.pollinations.ai/facd03b0-fc39-4eaa-9729-0dd78296286d"
   },
   {
@@ -3738,7 +3738,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/10016",
     "approvedDate": "2026-05-10",
     "byop": false,
-    "requests24h": 2,
+    "requests24h": 10,
     "screenshotUrl": "https://media.pollinations.ai/c810a54c-6af1-42cf-b586-6538c117e3bf"
   },
   {
@@ -3822,7 +3822,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/10349",
     "approvedDate": "2026-05-10",
     "byop": false,
-    "requests24h": 2,
+    "requests24h": 1,
     "screenshotUrl": "https://media.pollinations.ai/bcdf9453-1a26-43a9-a02a-200cff2b6096"
   },
   {
@@ -3947,7 +3947,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/10704",
     "approvedDate": "2026-05-10",
     "byop": false,
-    "requests24h": 7,
+    "requests24h": 59,
     "screenshotUrl": "https://media.pollinations.ai/36f320c1-749c-47d4-a618-271b55e32eed"
   },
   {
@@ -4003,14 +4003,14 @@
     "githubUsername": "ivLis-Studio",
     "githubUserId": "25863234",
     "repositoryUrl": "https://github.com/ivLis-Studio/ivLyrics",
-    "repositoryStars": 163,
+    "repositoryStars": 164,
     "discordUsername": "ivl.is",
     "other": null,
     "submittedDate": "2026-03-16",
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9169",
     "approvedDate": "2026-05-10",
     "byop": false,
-    "requests24h": 133,
+    "requests24h": 24,
     "screenshotUrl": "https://media.pollinations.ai/d0fa6dce-1a5e-4ae7-8fd3-3bc0af9ec46c"
   },
   {
@@ -4094,7 +4094,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/10755",
     "approvedDate": "2026-05-10",
     "byop": false,
-    "requests24h": 2,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/97ebfc70-165e-4bca-93a7-3deb22956c29"
   },
   {
@@ -4325,7 +4325,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/10670",
     "approvedDate": "2026-05-05",
     "byop": false,
-    "requests24h": 1,
+    "requests24h": 9,
     "screenshotUrl": "https://media.pollinations.ai/f66ce806-23df-4a1b-aa2b-1d0347820f8d"
   },
   {
@@ -4409,7 +4409,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/10390",
     "approvedDate": "2026-04-29",
     "byop": false,
-    "requests24h": 75,
+    "requests24h": 142,
     "screenshotUrl": "https://media.pollinations.ai/c0ebdadc-2f46-418f-8835-042fc8c60ef8"
   },
   {
@@ -4640,7 +4640,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9999",
     "approvedDate": "2026-04-20",
     "byop": false,
-    "requests24h": 7,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/b7f15460-d2a1-4089-8767-c0ae8de389ac"
   },
   {
@@ -4661,7 +4661,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/10340",
     "approvedDate": "2026-04-19",
     "byop": false,
-    "requests24h": 14,
+    "requests24h": 15,
     "screenshotUrl": "https://media.pollinations.ai/8a1ae5e5-2740-411c-9b12-55ec869e4f78"
   },
   {
@@ -4724,7 +4724,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/10332",
     "approvedDate": "2026-04-19",
     "byop": false,
-    "requests24h": 18,
+    "requests24h": 53,
     "screenshotUrl": "https://media.pollinations.ai/ae8c55a3-24f8-46bd-81ed-efe08e6098c7"
   },
   {
@@ -4787,7 +4787,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/4604",
     "approvedDate": "2026-04-18",
     "byop": false,
-    "requests24h": 63,
+    "requests24h": 50,
     "screenshotUrl": "https://media.pollinations.ai/ae17f81c-17b2-4676-a291-7baad08c56b4"
   },
   {
@@ -4829,7 +4829,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/10288",
     "approvedDate": "2026-04-17",
     "byop": false,
-    "requests24h": 40,
+    "requests24h": 26,
     "screenshotUrl": "https://media.pollinations.ai/8b770cfb-b4e9-4d43-a67d-69110e79d1db"
   },
   {
@@ -4850,7 +4850,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/10273",
     "approvedDate": "2026-04-17",
     "byop": false,
-    "requests24h": 342,
+    "requests24h": 300,
     "screenshotUrl": "https://media.pollinations.ai/37f4aa10-f7b6-47ea-8f4c-34f5a128921c"
   },
   {
@@ -4892,7 +4892,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/2186",
     "approvedDate": "2025-05-31",
     "byop": false,
-    "requests24h": 31,
+    "requests24h": 23,
     "screenshotUrl": "https://media.pollinations.ai/eca74344-6120-4e92-bc5d-aef087713f63"
   },
   {
@@ -4913,7 +4913,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/8490",
     "approvedDate": "2026-02-22",
     "byop": false,
-    "requests24h": 390,
+    "requests24h": 345,
     "screenshotUrl": "https://media.pollinations.ai/2816e11e-1142-4b77-8cf0-aba45562933f"
   },
   {
@@ -5102,7 +5102,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9146",
     "approvedDate": "2026-04-09",
     "byop": false,
-    "requests24h": 18,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/433f92ee-6e0e-474e-89fe-bce87bdcc1e1"
   },
   {
@@ -5228,7 +5228,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9209",
     "approvedDate": "2026-04-09",
     "byop": false,
-    "requests24h": 3,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/6958dbc0-e330-473b-ae0d-7adafffc785d"
   },
   {
@@ -5249,7 +5249,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9301",
     "approvedDate": "2026-04-09",
     "byop": false,
-    "requests24h": 2,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/e70acb92-1c62-4330-b832-0951c12c27d3"
   },
   {
@@ -5263,7 +5263,7 @@
     "githubUsername": "funniman23",
     "githubUserId": "128813894",
     "repositoryUrl": "https://github.com/funniman23/Dreamframe",
-    "repositoryStars": 5,
+    "repositoryStars": 6,
     "discordUsername": "funni_man24",
     "other": null,
     "submittedDate": "2026-03-15",
@@ -5353,7 +5353,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/7565",
     "approvedDate": "2026-04-09",
     "byop": false,
-    "requests24h": 12,
+    "requests24h": 4,
     "screenshotUrl": "https://media.pollinations.ai/730bb042-26a1-4084-bfcf-0e645cbffab8"
   },
   {
@@ -5479,7 +5479,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9972",
     "approvedDate": "2026-04-05",
     "byop": false,
-    "requests24h": 53,
+    "requests24h": 23,
     "screenshotUrl": "https://media.pollinations.ai/2caa7efb-bc90-4a57-85e8-b87fa67eecd1"
   },
   {
@@ -5500,7 +5500,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9917",
     "approvedDate": "2026-04-04",
     "byop": false,
-    "requests24h": 1,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/ed8a5f30-afb1-4a23-a876-a9ac325aa959"
   },
   {
@@ -5646,7 +5646,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9841",
     "approvedDate": "2026-04-02",
     "byop": false,
-    "requests24h": 1,
+    "requests24h": 12,
     "screenshotUrl": "https://media.pollinations.ai/c7ec7d9d-8722-4d31-80f0-54c2240eb57d"
   },
   {
@@ -5667,7 +5667,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9801",
     "approvedDate": "2026-04-02",
     "byop": false,
-    "requests24h": 0,
+    "requests24h": 5,
     "screenshotUrl": "https://media.pollinations.ai/c0f15332-24da-4686-9617-ca8941b025ac"
   },
   {
@@ -5688,7 +5688,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9791",
     "approvedDate": "2026-04-01",
     "byop": false,
-    "requests24h": 260,
+    "requests24h": 282,
     "screenshotUrl": "https://media.pollinations.ai/ca53c551-28ae-4a00-b6e1-18789286e582"
   },
   {
@@ -5709,7 +5709,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9778",
     "approvedDate": "2026-04-01",
     "byop": false,
-    "requests24h": 34,
+    "requests24h": 36,
     "screenshotUrl": "https://media.pollinations.ai/4cc09366-43cf-4c5c-affa-9aa3592cc7ec"
   },
   {
@@ -5731,7 +5731,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9782",
     "approvedDate": "2026-03-31",
     "byop": false,
-    "requests24h": 109
+    "requests24h": 13
   },
   {
     "emoji": "📝",
@@ -5793,7 +5793,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9778",
     "approvedDate": "2026-04-01",
     "byop": false,
-    "requests24h": 34,
+    "requests24h": 36,
     "screenshotUrl": "https://media.pollinations.ai/4cc09366-43cf-4c5c-affa-9aa3592cc7ec"
   },
   {
@@ -5815,7 +5815,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9782",
     "approvedDate": "2026-03-31",
     "byop": false,
-    "requests24h": 109
+    "requests24h": 13
   },
   {
     "emoji": "📚",
@@ -5877,7 +5877,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9761",
     "approvedDate": "2026-03-31",
     "byop": false,
-    "requests24h": 0,
+    "requests24h": 2,
     "screenshotUrl": "https://media.pollinations.ai/0b3a57e0-e701-4740-a1fd-68ede2967cca"
   },
   {
@@ -5919,7 +5919,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9758",
     "approvedDate": "2026-03-31",
     "byop": false,
-    "requests24h": 6,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/72f9b109-b0d8-4ecd-bd3b-42bab5707b61"
   },
   {
@@ -5982,7 +5982,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9305",
     "approvedDate": "2026-03-30",
     "byop": false,
-    "requests24h": 21,
+    "requests24h": 43,
     "screenshotUrl": "https://media.pollinations.ai/a93eee25-a5ab-483e-ba35-d391e4fc1326"
   },
   {
@@ -6003,7 +6003,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9299",
     "approvedDate": "2026-03-30",
     "byop": false,
-    "requests24h": 1,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/f16fd966-b3f2-43ed-abb4-21d718ce2cdd"
   },
   {
@@ -6024,7 +6024,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9297",
     "approvedDate": "2026-03-30",
     "byop": true,
-    "requests24h": 0,
+    "requests24h": 6,
     "screenshotUrl": "https://media.pollinations.ai/6a05e8c0-249e-465c-b512-1083904f36ea"
   },
   {
@@ -6045,7 +6045,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9472",
     "approvedDate": "2026-03-30",
     "byop": false,
-    "requests24h": 14,
+    "requests24h": 28,
     "screenshotUrl": "https://media.pollinations.ai/e21cde7c-2e0d-4bad-a04c-d661e23a597d"
   },
   {
@@ -6150,7 +6150,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9720",
     "approvedDate": "2026-03-29",
     "byop": false,
-    "requests24h": 3,
+    "requests24h": 2,
     "screenshotUrl": "https://media.pollinations.ai/be6b130e-9bcc-4664-a7b1-206f8c61d5c3"
   },
   {
@@ -6171,7 +6171,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9719",
     "approvedDate": "2026-03-29",
     "byop": false,
-    "requests24h": 21
+    "requests24h": 9
   },
   {
     "emoji": "🔀",
@@ -6253,7 +6253,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9265",
     "approvedDate": "2026-03-28",
     "byop": false,
-    "requests24h": 0,
+    "requests24h": 1,
     "screenshotUrl": "https://media.pollinations.ai/7aa17f22-f9f5-4b10-b131-c06dcf83a0ff"
   },
   {
@@ -6316,7 +6316,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9327",
     "approvedDate": "2026-03-28",
     "byop": false,
-    "requests24h": 249,
+    "requests24h": 20,
     "screenshotUrl": "https://media.pollinations.ai/21852067-eb4a-490b-987d-c611d6019d8f"
   },
   {
@@ -6358,7 +6358,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9335",
     "approvedDate": "2026-03-28",
     "byop": false,
-    "requests24h": 0,
+    "requests24h": 6,
     "screenshotUrl": "https://media.pollinations.ai/fb1956b6-becb-4e42-8e8c-effc83c86b7e"
   },
   {
@@ -6484,7 +6484,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9656",
     "approvedDate": "2026-03-28",
     "byop": false,
-    "requests24h": 41,
+    "requests24h": 16,
     "screenshotUrl": "https://media.pollinations.ai/30b85416-0921-4de1-bf3e-7479226af7ca"
   },
   {
@@ -6526,7 +6526,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9582",
     "approvedDate": "2026-03-28",
     "byop": false,
-    "requests24h": 0,
+    "requests24h": 3,
     "screenshotUrl": "https://media.pollinations.ai/87f98c77-9576-431a-ba90-12d178a22184"
   },
   {
@@ -6589,7 +6589,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9639",
     "approvedDate": "2026-03-28",
     "byop": false,
-    "requests24h": 24,
+    "requests24h": 19,
     "screenshotUrl": "https://media.pollinations.ai/a8d0bd73-3cd1-4b87-b0f5-1c488e93f8ac"
   },
   {
@@ -6610,7 +6610,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9631",
     "approvedDate": "2026-03-28",
     "byop": false,
-    "requests24h": 25,
+    "requests24h": 23,
     "screenshotUrl": "https://media.pollinations.ai/33fb0bf2-db5c-4643-82f2-f2eb1783a338"
   },
   {
@@ -6673,7 +6673,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9612",
     "approvedDate": "2026-03-26",
     "byop": false,
-    "requests24h": 0,
+    "requests24h": 26,
     "screenshotUrl": "https://media.pollinations.ai/63daf427-26b0-42a6-9f30-34a88047ca7e"
   },
   {
@@ -6694,7 +6694,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9592",
     "approvedDate": "2026-03-26",
     "byop": false,
-    "requests24h": 0,
+    "requests24h": 1,
     "screenshotUrl": "https://media.pollinations.ai/fb5ea938-5afa-4aa9-b87e-c65c5e3e1211"
   },
   {
@@ -6715,7 +6715,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9583",
     "approvedDate": "2026-03-26",
     "byop": false,
-    "requests24h": 5,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/6f87fe3a-fc23-486b-bf4b-65551bafdbdc"
   },
   {
@@ -6757,7 +6757,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9596",
     "approvedDate": "2026-03-26",
     "byop": false,
-    "requests24h": 0,
+    "requests24h": 230,
     "screenshotUrl": "https://media.pollinations.ai/e0afc3d3-5d81-44bb-b65f-7cb0e8456d56"
   },
   {
@@ -6779,7 +6779,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9451",
     "approvedDate": "2026-03-25",
     "byop": false,
-    "requests24h": 921
+    "requests24h": 833
   },
   {
     "emoji": "⚡",
@@ -6883,7 +6883,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9518",
     "approvedDate": "2026-03-25",
     "byop": false,
-    "requests24h": 74,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/56974ed5-4dd9-4e9b-995d-cd76a8fc619f"
   },
   {
@@ -6925,7 +6925,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9552",
     "approvedDate": "2026-03-25",
     "byop": false,
-    "requests24h": 0,
+    "requests24h": 2,
     "screenshotUrl": "https://media.pollinations.ai/00960940-3a32-4548-aa1f-98de44110d1e"
   },
   {
@@ -6988,7 +6988,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9511",
     "approvedDate": "2026-03-24",
     "byop": false,
-    "requests24h": 3,
+    "requests24h": 11,
     "screenshotUrl": "https://media.pollinations.ai/e71ef244-afee-41ad-b52f-171b7fd18b25"
   },
   {
@@ -7009,7 +7009,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9475",
     "approvedDate": "2026-03-23",
     "byop": false,
-    "requests24h": 4,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/bbec8cea-059c-41d7-a4b2-b4dd7c757df7"
   },
   {
@@ -7030,7 +7030,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9435",
     "approvedDate": "2026-03-23",
     "byop": false,
-    "requests24h": 7,
+    "requests24h": 5,
     "screenshotUrl": "https://media.pollinations.ai/8f8396f3-c3e0-4320-97fc-8404175e4df4"
   },
   {
@@ -7113,7 +7113,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9416",
     "approvedDate": "2026-03-22",
     "byop": false,
-    "requests24h": 107,
+    "requests24h": 157,
     "screenshotUrl": "https://media.pollinations.ai/d5475b43-a3b7-4fc8-b454-72908c4b02e8"
   },
   {
@@ -7197,7 +7197,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9387",
     "approvedDate": "2026-03-21",
     "byop": false,
-    "requests24h": 1
+    "requests24h": 0
   },
   {
     "emoji": "🧬",
@@ -7217,7 +7217,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9385",
     "approvedDate": "2026-03-21",
     "byop": false,
-    "requests24h": 34,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/2bc9e758-7acf-4b2c-9e37-52e8e5e9712e"
   },
   {
@@ -7322,7 +7322,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/8162",
     "approvedDate": "2026-03-20",
     "byop": false,
-    "requests24h": 17,
+    "requests24h": 10,
     "screenshotUrl": "https://media.pollinations.ai/9f94e86f-e63c-4c4a-b391-6728903b9ccb"
   },
   {
@@ -7427,7 +7427,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/8356",
     "approvedDate": "2026-03-18",
     "byop": false,
-    "requests24h": 1,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/23330836-abf6-415f-9c58-9b4065712065"
   },
   {
@@ -7448,7 +7448,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/8356",
     "approvedDate": "2026-03-18",
     "byop": false,
-    "requests24h": 1,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/1b85ff0e-3372-4e11-aed5-4216841fa57d"
   },
   {
@@ -7490,7 +7490,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/8707",
     "approvedDate": "2026-03-18",
     "byop": false,
-    "requests24h": 630,
+    "requests24h": 585,
     "screenshotUrl": "https://media.pollinations.ai/3929d329-3559-4f1a-a756-08a294ed1d15"
   },
   {
@@ -7511,7 +7511,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9059",
     "approvedDate": "2026-03-18",
     "byop": false,
-    "requests24h": 20,
+    "requests24h": 19,
     "screenshotUrl": "https://media.pollinations.ai/a2575060-1cc6-4046-8707-75a95905e79f"
   },
   {
@@ -7700,7 +7700,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9058",
     "approvedDate": "2026-03-15",
     "byop": false,
-    "requests24h": 20,
+    "requests24h": 19,
     "screenshotUrl": "https://media.pollinations.ai/4dbb7ac0-dbb7-48d0-b4a5-d1223c186b08"
   },
   {
@@ -7741,7 +7741,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/9085",
     "approvedDate": "2026-03-13",
     "byop": false,
-    "requests24h": 44,
+    "requests24h": 34,
     "screenshotUrl": "https://media.pollinations.ai/c9e70534-b01b-4182-b7b0-c28bbfe13310"
   },
   {
@@ -7804,7 +7804,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/pull/8921",
     "approvedDate": null,
     "byop": false,
-    "requests24h": 1,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/547a99b8-067b-462e-ac4c-89533b2f5147"
   },
   {
@@ -7825,7 +7825,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/8530",
     "approvedDate": "2026-02-24",
     "byop": false,
-    "requests24h": 1,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/72f52eb7-83e3-4c63-a59f-7fd9a5df84f6"
   },
   {
@@ -7972,7 +7972,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/8761",
     "approvedDate": "2026-03-02",
     "byop": false,
-    "requests24h": 46,
+    "requests24h": 36,
     "screenshotUrl": "https://media.pollinations.ai/cc5b7b86-bbaf-42a2-b8fa-06c54c649e37"
   },
   {
@@ -8014,7 +8014,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/8768",
     "approvedDate": "2026-03-02",
     "byop": false,
-    "requests24h": 0,
+    "requests24h": 2,
     "screenshotUrl": "https://media.pollinations.ai/31bdc1e1-12a6-470d-817f-375733043bb3"
   },
   {
@@ -8077,7 +8077,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/8801",
     "approvedDate": "2026-03-03",
     "byop": false,
-    "requests24h": 5,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/be9fadfe-ce68-4937-a4f6-d2fe04b05744"
   },
   {
@@ -8140,7 +8140,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/7576",
     "approvedDate": "2026-03-02",
     "byop": false,
-    "requests24h": 85,
+    "requests24h": 55,
     "screenshotUrl": "https://media.pollinations.ai/31cba991-8632-47b1-b6e3-8732771ca348"
   },
   {
@@ -8329,7 +8329,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/7744",
     "approvedDate": "2026-03-02",
     "byop": false,
-    "requests24h": 92,
+    "requests24h": 52,
     "screenshotUrl": "https://media.pollinations.ai/87884896-60a3-40bd-be88-398d9bafc162"
   },
   {
@@ -8392,7 +8392,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/8665",
     "approvedDate": "2026-03-01",
     "byop": false,
-    "requests24h": 349,
+    "requests24h": 121,
     "screenshotUrl": "https://media.pollinations.ai/8b5379bc-46cc-414d-9cbe-72a405e01c52"
   },
   {
@@ -8455,7 +8455,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/8318",
     "approvedDate": "2026-03-01",
     "byop": false,
-    "requests24h": 40,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/da615233-c6f1-46ed-ad66-7c7e77fec2df"
   },
   {
@@ -8560,7 +8560,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/8218",
     "approvedDate": "2026-03-01",
     "byop": false,
-    "requests24h": 0,
+    "requests24h": 2,
     "screenshotUrl": "https://media.pollinations.ai/985226be-46de-4b50-acc5-f10ff8e105c5"
   },
   {
@@ -8623,7 +8623,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/8557",
     "approvedDate": "2026-03-01",
     "byop": false,
-    "requests24h": 0,
+    "requests24h": 1,
     "screenshotUrl": "https://media.pollinations.ai/f11507eb-e6aa-4063-9f0f-190b05b68d7b"
   },
   {
@@ -8770,7 +8770,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/7241",
     "approvedDate": "2026-02-24",
     "byop": false,
-    "requests24h": 0,
+    "requests24h": 23,
     "screenshotUrl": "https://media.pollinations.ai/9afb6956-4582-441f-96b8-59ec63bfa48f"
   },
   {
@@ -8791,7 +8791,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/8475",
     "approvedDate": "2026-02-24",
     "byop": false,
-    "requests24h": 44,
+    "requests24h": 99,
     "screenshotUrl": "https://media.pollinations.ai/8ca9f837-5583-4e43-a989-79c318f48704"
   },
   {
@@ -8812,7 +8812,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/7531",
     "approvedDate": "2026-02-24",
     "byop": false,
-    "requests24h": 1,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/01c6da3d-6f33-4411-9cb8-020c2086e302"
   },
   {
@@ -9042,7 +9042,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/7273",
     "approvedDate": "2026-02-24",
     "byop": false,
-    "requests24h": 15,
+    "requests24h": 29,
     "screenshotUrl": "https://media.pollinations.ai/0542a7fa-ab81-4aff-82e6-4af16ebac205"
   },
   {
@@ -9126,7 +9126,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/8312",
     "approvedDate": "2026-02-23",
     "byop": false,
-    "requests24h": 95,
+    "requests24h": 16,
     "screenshotUrl": "https://media.pollinations.ai/fdf7b499-6e57-4223-be9e-0f8892356665"
   },
   {
@@ -9189,7 +9189,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/7911",
     "approvedDate": "2026-02-23",
     "byop": false,
-    "requests24h": 10,
+    "requests24h": 6,
     "screenshotUrl": "https://media.pollinations.ai/082ae314-d41c-477d-bf94-129c14bf9a4a"
   },
   {
@@ -9231,7 +9231,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/7247",
     "approvedDate": "2026-02-22",
     "byop": false,
-    "requests24h": 62,
+    "requests24h": 9,
     "screenshotUrl": "https://media.pollinations.ai/f98b87b0-cd34-4266-8fab-49bdc91e34b1"
   },
   {
@@ -9314,7 +9314,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/7626",
     "approvedDate": "2026-02-22",
     "byop": false,
-    "requests24h": 1,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/a16c2856-b0ef-4d54-9b35-80575f09dbed"
   },
   {
@@ -9335,7 +9335,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/7635",
     "approvedDate": "2026-02-22",
     "byop": false,
-    "requests24h": 0,
+    "requests24h": 2,
     "screenshotUrl": "https://media.pollinations.ai/8ce58884-618d-4b78-ba42-3d6dbf75f324"
   },
   {
@@ -9377,7 +9377,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/7663",
     "approvedDate": "2026-02-22",
     "byop": false,
-    "requests24h": 74,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/3b6386f9-2e65-4ace-b60b-3673da8a2279"
   },
   {
@@ -9398,7 +9398,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/7679",
     "approvedDate": "2026-02-22",
     "byop": false,
-    "requests24h": 3,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/40951f7b-1e8b-43d5-9815-53407184450f"
   },
   {
@@ -9440,7 +9440,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/7698",
     "approvedDate": "2026-02-22",
     "byop": false,
-    "requests24h": 240,
+    "requests24h": 176,
     "screenshotUrl": "https://media.pollinations.ai/ad09128d-d596-4d78-9c5d-25b90c1a0abe"
   },
   {
@@ -9482,7 +9482,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/7848",
     "approvedDate": "2026-02-22",
     "byop": false,
-    "requests24h": 11,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/e501c6d0-37c0-4595-95de-826ee99e2c50"
   },
   {
@@ -9524,7 +9524,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/7908",
     "approvedDate": "2026-02-22",
     "byop": false,
-    "requests24h": 38,
+    "requests24h": 37,
     "screenshotUrl": "https://media.pollinations.ai/e278cc23-9a7f-4c76-aff7-f7554f503f21"
   },
   {
@@ -9607,7 +9607,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/8049",
     "approvedDate": "2026-02-22",
     "byop": false,
-    "requests24h": 11,
+    "requests24h": 15,
     "screenshotUrl": "https://media.pollinations.ai/864714cf-3373-47e6-87e3-08fc324d0a9a"
   },
   {
@@ -9670,7 +9670,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/8470",
     "approvedDate": "2026-02-22",
     "byop": false,
-    "requests24h": 1,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/3be2b55e-4611-4c66-bd78-bb625448abf4"
   },
   {
@@ -9712,7 +9712,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/8373",
     "approvedDate": "2026-02-22",
     "byop": false,
-    "requests24h": 14
+    "requests24h": 5
   },
   {
     "emoji": "✍️",
@@ -9900,7 +9900,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/7327",
     "approvedDate": "2026-02-21",
     "byop": false,
-    "requests24h": 7,
+    "requests24h": 28,
     "screenshotUrl": "https://media.pollinations.ai/44232d04-d2e0-40bf-a457-7ee92b4e150c"
   },
   {
@@ -10004,7 +10004,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/7766",
     "approvedDate": "2026-02-16",
     "byop": false,
-    "requests24h": 0,
+    "requests24h": 60,
     "screenshotUrl": "https://media.pollinations.ai/650a1ca1-bcc0-4556-add2-77b8a6ef096d"
   },
   {
@@ -10067,7 +10067,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/8093",
     "approvedDate": "2026-02-16",
     "byop": false,
-    "requests24h": 11,
+    "requests24h": 23,
     "screenshotUrl": "https://media.pollinations.ai/6c5c5425-9ed1-4aca-b72c-70ca0f7caf5c"
   },
   {
@@ -10088,7 +10088,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/8191",
     "approvedDate": "2026-02-16",
     "byop": false,
-    "requests24h": 10,
+    "requests24h": 3,
     "screenshotUrl": "https://media.pollinations.ai/a0c89634-b454-4b9b-96bf-41f222f7bcce"
   },
   {
@@ -10151,7 +10151,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/7726",
     "approvedDate": "2026-02-16",
     "byop": false,
-    "requests24h": 28,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/49af64ca-fac1-4169-a2df-839d01883248"
   },
   {
@@ -10165,7 +10165,7 @@
     "githubUsername": "sligter",
     "githubUserId": "23713984",
     "repositoryUrl": "https://github.com/sligter/LandPPT",
-    "repositoryStars": 3548,
+    "repositoryStars": 3549,
     "discordUsername": null,
     "other": null,
     "submittedDate": "2026-01-17",
@@ -10193,7 +10193,7 @@
     "issueUrl": null,
     "approvedDate": "2026-02-16",
     "byop": false,
-    "requests24h": 1,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/dac7edd0-868e-43e5-a25f-a45bff1ce52a"
   },
   {
@@ -10403,7 +10403,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/7732",
     "approvedDate": "2026-02-16",
     "byop": true,
-    "requests24h": 129,
+    "requests24h": 59,
     "screenshotUrl": "https://media.pollinations.ai/5014f61d-958e-4687-b5ab-8a4e9ca5d5cb"
   },
   {
@@ -10446,7 +10446,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/8287",
     "approvedDate": "2026-02-15",
     "byop": false,
-    "requests24h": 93597
+    "requests24h": 106730
   },
   {
     "emoji": "🛡️",
@@ -10508,7 +10508,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/7932",
     "approvedDate": "2026-02-04",
     "byop": false,
-    "requests24h": 12,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/aa2e082c-aac9-4aa6-981c-c2bfe4c92c4e"
   },
   {
@@ -10529,7 +10529,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/7290",
     "approvedDate": null,
     "byop": false,
-    "requests24h": 2920,
+    "requests24h": 1239,
     "screenshotUrl": "https://media.pollinations.ai/17f87fdf-bbd9-4b07-85c9-eaabb212fcdc"
   },
   {
@@ -10591,7 +10591,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/7483",
     "approvedDate": "2026-01-20",
     "byop": false,
-    "requests24h": 0
+    "requests24h": 27
   },
   {
     "emoji": "🛠️",
@@ -10632,7 +10632,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6985",
     "approvedDate": "2026-01-12",
     "byop": false,
-    "requests24h": 49,
+    "requests24h": 313,
     "screenshotUrl": "https://media.pollinations.ai/f4e849d4-dc3d-4a8f-a13b-2e2a7b8cf49c"
   },
   {
@@ -10736,7 +10736,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/7058",
     "approvedDate": "2026-01-12",
     "byop": false,
-    "requests24h": 29,
+    "requests24h": 14,
     "screenshotUrl": "https://media.pollinations.ai/5b34bcef-ccb0-401c-8ce2-8b96e3f7750e"
   },
   {
@@ -10861,7 +10861,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6558",
     "approvedDate": "2026-01-12",
     "byop": false,
-    "requests24h": 1
+    "requests24h": 0
   },
   {
     "emoji": "🖼️",
@@ -11048,7 +11048,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/7060",
     "approvedDate": "2026-01-12",
     "byop": false,
-    "requests24h": 15,
+    "requests24h": 20,
     "screenshotUrl": "https://media.pollinations.ai/462cccdf-35a6-4f38-acd8-866a5ae6c3b6"
   },
   {
@@ -11090,7 +11090,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/7041",
     "approvedDate": "2026-01-12",
     "byop": false,
-    "requests24h": 573,
+    "requests24h": 730,
     "screenshotUrl": "https://media.pollinations.ai/808e0534-d4b7-48de-a1b0-2747fdad274c"
   },
   {
@@ -11173,7 +11173,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6932",
     "approvedDate": "2026-01-12",
     "byop": false,
-    "requests24h": 217,
+    "requests24h": 129,
     "screenshotUrl": "https://media.pollinations.ai/66fe8247-9d4a-4253-9689-a69a1aad8607"
   },
   {
@@ -11215,7 +11215,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6931",
     "approvedDate": "2026-01-12",
     "byop": false,
-    "requests24h": 9010
+    "requests24h": 269
   },
   {
     "emoji": "💬",
@@ -11277,7 +11277,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6920",
     "approvedDate": "2026-01-12",
     "byop": false,
-    "requests24h": 72,
+    "requests24h": 116,
     "screenshotUrl": "https://media.pollinations.ai/36a9e3b2-ba8f-409a-9770-0df7e20ebc70"
   },
   {
@@ -11298,7 +11298,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6912",
     "approvedDate": "2026-01-12",
     "byop": false,
-    "requests24h": 1,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/bae6eb8d-887d-41b7-b6b8-04a740d31c41"
   },
   {
@@ -11319,7 +11319,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6917",
     "approvedDate": "2026-01-12",
     "byop": false,
-    "requests24h": 36,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/1786d822-cb1a-425f-bba5-e3ec9e030dc1"
   },
   {
@@ -11340,7 +11340,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6910",
     "approvedDate": "2026-01-12",
     "byop": false,
-    "requests24h": 4,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/47b33191-4932-45d0-9331-8c9028866d63"
   },
   {
@@ -11382,7 +11382,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6882",
     "approvedDate": "2026-01-12",
     "byop": false,
-    "requests24h": 24,
+    "requests24h": 27,
     "screenshotUrl": "https://media.pollinations.ai/8fd0ca3d-3126-43f3-826f-a181e0f00d29"
   },
   {
@@ -11424,7 +11424,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6856",
     "approvedDate": "2026-01-12",
     "byop": false,
-    "requests24h": 332,
+    "requests24h": 240,
     "screenshotUrl": "https://media.pollinations.ai/93e68642-a5a7-41cd-a819-46ac941b09e2"
   },
   {
@@ -11465,7 +11465,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/7192",
     "approvedDate": "2026-01-13",
     "byop": false,
-    "requests24h": 432,
+    "requests24h": 171,
     "screenshotUrl": "https://media.pollinations.ai/207b2b12-aacc-430e-b96d-190b1c998aa1"
   },
   {
@@ -11527,7 +11527,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/7200",
     "approvedDate": "2026-01-13",
     "byop": false,
-    "requests24h": 2,
+    "requests24h": 3,
     "screenshotUrl": "https://media.pollinations.ai/32daf485-d49f-402f-816d-3a03bbc47684"
   },
   {
@@ -11569,7 +11569,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/7208",
     "approvedDate": "2026-01-13",
     "byop": false,
-    "requests24h": 6,
+    "requests24h": 2,
     "screenshotUrl": "https://media.pollinations.ai/9fbb9edc-a0a0-499b-8a62-c2f7d3d3855d"
   },
   {
@@ -11590,7 +11590,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/7088",
     "approvedDate": "2026-01-12",
     "byop": false,
-    "requests24h": 6,
+    "requests24h": 18,
     "screenshotUrl": "https://media.pollinations.ai/b739105f-598d-4f79-ba83-6d8c99f8d0b7"
   },
   {
@@ -11611,7 +11611,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/7076",
     "approvedDate": "2026-01-10",
     "byop": false,
-    "requests24h": 258,
+    "requests24h": 228,
     "screenshotUrl": "https://media.pollinations.ai/c57c9033-1183-4d49-b516-fb92a686ada2"
   },
   {
@@ -11632,7 +11632,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6991",
     "approvedDate": "2026-01-09",
     "byop": false,
-    "requests24h": 35
+    "requests24h": 19
   },
   {
     "emoji": "📚",
@@ -11652,7 +11652,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6980",
     "approvedDate": "2026-01-09",
     "byop": false,
-    "requests24h": 1,
+    "requests24h": 6,
     "screenshotUrl": "https://media.pollinations.ai/3eb10cc1-1020-4d80-adcc-815b5a3004a0"
   },
   {
@@ -11756,7 +11756,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/7014",
     "approvedDate": "2026-01-06",
     "byop": false,
-    "requests24h": 0
+    "requests24h": 1
   },
   {
     "emoji": "🎞️",
@@ -11776,7 +11776,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6547",
     "approvedDate": "2026-01-04",
     "byop": false,
-    "requests24h": 92
+    "requests24h": 53
   },
   {
     "emoji": "💬",
@@ -11796,7 +11796,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6505",
     "approvedDate": "2026-01-04",
     "byop": false,
-    "requests24h": 9010,
+    "requests24h": 269,
     "screenshotUrl": "https://media.pollinations.ai/d3957f87-67f0-4894-8dc0-17921cdf0428"
   },
   {
@@ -11859,7 +11859,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6805",
     "approvedDate": "2026-01-04",
     "byop": false,
-    "requests24h": 1,
+    "requests24h": 9,
     "screenshotUrl": "https://media.pollinations.ai/5bef8a36-715f-4093-bcba-dafb464721c1"
   },
   {
@@ -11900,7 +11900,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6762",
     "approvedDate": "2026-01-03",
     "byop": false,
-    "requests24h": 7,
+    "requests24h": 9,
     "screenshotUrl": "https://media.pollinations.ai/b830dd53-9dce-4300-a623-60cb334e22a7"
   },
   {
@@ -11921,7 +11921,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/7595",
     "approvedDate": "2026-01-03",
     "byop": true,
-    "requests24h": 14,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/073d4e53-a0d7-4b9f-bc9d-dcd86e11d293"
   },
   {
@@ -11942,7 +11942,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6756",
     "approvedDate": "2026-01-03",
     "byop": false,
-    "requests24h": 0,
+    "requests24h": 2,
     "screenshotUrl": "https://media.pollinations.ai/6ea6c9e7-fa79-4bfe-8329-c83a1c87728a"
   },
   {
@@ -11984,7 +11984,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6718",
     "approvedDate": "2025-12-20",
     "byop": false,
-    "requests24h": 2,
+    "requests24h": 3,
     "screenshotUrl": "https://media.pollinations.ai/48fd22a8-9ae3-471f-9b0f-6b3a3210afe2"
   },
   {
@@ -12047,7 +12047,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6714",
     "approvedDate": "2026-01-02",
     "byop": false,
-    "requests24h": 11,
+    "requests24h": 35,
     "screenshotUrl": "https://media.pollinations.ai/fc877222-edd8-48a7-a54d-9febd0dbea80"
   },
   {
@@ -12089,7 +12089,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6711",
     "approvedDate": "2026-01-02",
     "byop": false,
-    "requests24h": 1536,
+    "requests24h": 1545,
     "screenshotUrl": "https://media.pollinations.ai/4288fcde-57e7-4390-b28e-33ac78229d7b"
   },
   {
@@ -12110,7 +12110,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6703",
     "approvedDate": "2026-01-01",
     "byop": false,
-    "requests24h": 3,
+    "requests24h": 2,
     "screenshotUrl": "https://media.pollinations.ai/baf65ff2-e596-4236-8ac7-11b0d002732d"
   },
   {
@@ -12236,7 +12236,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6653",
     "approvedDate": "2025-12-31",
     "byop": false,
-    "requests24h": 209,
+    "requests24h": 54,
     "screenshotUrl": "https://media.pollinations.ai/cfe044f6-fb9d-4cff-b9fb-24572f9c57c0"
   },
   {
@@ -12278,7 +12278,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6647",
     "approvedDate": "2025-12-31",
     "byop": false,
-    "requests24h": 168,
+    "requests24h": 214,
     "screenshotUrl": "https://media.pollinations.ai/ac9c3202-6e30-4f63-b1dd-6960fa20cfb8"
   },
   {
@@ -12320,7 +12320,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6982",
     "approvedDate": "2025-12-30",
     "byop": false,
-    "requests24h": 0,
+    "requests24h": 40,
     "screenshotUrl": "https://media.pollinations.ai/f6b47451-e6cb-464e-84cc-3bc54250d981"
   },
   {
@@ -12425,7 +12425,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6724",
     "approvedDate": "2026-01-02",
     "byop": false,
-    "requests24h": 1,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/fd7aa8c7-2d11-4269-bc33-aabb3d9e81d7"
   },
   {
@@ -12446,7 +12446,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6630",
     "approvedDate": "2025-12-31",
     "byop": false,
-    "requests24h": 1,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/c30c5e88-107e-44e4-8861-23beaf8c214c"
   },
   {
@@ -12467,7 +12467,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6635",
     "approvedDate": "2025-12-30",
     "byop": false,
-    "requests24h": 165,
+    "requests24h": 84,
     "screenshotUrl": "https://media.pollinations.ai/48e5d4ab-1426-41e1-ab76-0acdae4821ce"
   },
   {
@@ -12488,7 +12488,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6551",
     "approvedDate": "2025-12-29",
     "byop": false,
-    "requests24h": 1,
+    "requests24h": 32,
     "screenshotUrl": "https://media.pollinations.ai/cb8dde72-a779-40a6-92d7-4a8afe35aa03"
   },
   {
@@ -12509,7 +12509,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6550",
     "approvedDate": "2025-12-29",
     "byop": false,
-    "requests24h": 1,
+    "requests24h": 9,
     "screenshotUrl": "https://media.pollinations.ai/75ff9e01-299a-4d22-8b65-5abece343fe2"
   },
   {
@@ -12572,7 +12572,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6482",
     "approvedDate": "2025-12-27",
     "byop": false,
-    "requests24h": 2,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/c68c2642-8086-4451-9f48-ebca5ded446d"
   },
   {
@@ -12593,7 +12593,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6504",
     "approvedDate": "2025-12-27",
     "byop": false,
-    "requests24h": 97,
+    "requests24h": 78,
     "screenshotUrl": "https://media.pollinations.ai/3713bbb7-2707-4ca5-8afb-fe12ac39470b"
   },
   {
@@ -12635,7 +12635,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6780",
     "approvedDate": "2025-12-27",
     "byop": false,
-    "requests24h": 62,
+    "requests24h": 82,
     "screenshotUrl": "https://media.pollinations.ai/e475f0d0-a562-45af-89ae-2b1b05c9a713"
   },
   {
@@ -12698,7 +12698,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6448",
     "approvedDate": "2025-12-25",
     "byop": false,
-    "requests24h": 30,
+    "requests24h": 32,
     "screenshotUrl": "https://media.pollinations.ai/1eea02d7-bb10-4d14-bf75-9d1b0d07069b"
   },
   {
@@ -12801,7 +12801,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6421",
     "approvedDate": "2025-12-24",
     "byop": false,
-    "requests24h": 14,
+    "requests24h": 1,
     "screenshotUrl": "https://media.pollinations.ai/4aa41441-fc7c-4974-a70b-5601da1208ef"
   },
   {
@@ -12822,7 +12822,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6438",
     "approvedDate": "2025-12-24",
     "byop": false,
-    "requests24h": 68,
+    "requests24h": 79,
     "screenshotUrl": "https://media.pollinations.ai/3bf2027a-7abe-4d1d-aacf-ce50f35a0dd6"
   },
   {
@@ -12843,7 +12843,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6424",
     "approvedDate": "2025-12-24",
     "byop": true,
-    "requests24h": 129,
+    "requests24h": 59,
     "screenshotUrl": "https://media.pollinations.ai/86198728-ff3c-4157-9acb-6074c2d86178"
   },
   {
@@ -12864,7 +12864,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6352",
     "approvedDate": "2025-12-22",
     "byop": false,
-    "requests24h": 56,
+    "requests24h": 24,
     "screenshotUrl": "https://media.pollinations.ai/fc30ed4b-dc15-4934-bf9b-e890eede8d8a"
   },
   {
@@ -12906,7 +12906,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6367",
     "approvedDate": "2025-12-22",
     "byop": false,
-    "requests24h": 4,
+    "requests24h": 1,
     "screenshotUrl": "https://media.pollinations.ai/16e477c7-3e23-4a2b-bd8f-fbdb12b033de"
   },
   {
@@ -12947,7 +12947,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6331",
     "approvedDate": "2025-12-22",
     "byop": true,
-    "requests24h": 129,
+    "requests24h": 59,
     "screenshotUrl": "https://media.pollinations.ai/f043f7fc-a465-473d-b106-5f250a1ec597"
   },
   {
@@ -13031,7 +13031,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/5660",
     "approvedDate": "2025-12-20",
     "byop": false,
-    "requests24h": 349,
+    "requests24h": 121,
     "screenshotUrl": "https://media.pollinations.ai/d1609b17-46f2-40d2-a22e-c4984f1db0cf"
   },
   {
@@ -13094,7 +13094,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6075",
     "approvedDate": "2025-12-16",
     "byop": false,
-    "requests24h": 43,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/0c499795-1467-44a2-8eb1-b439ba19efd9"
   },
   {
@@ -13115,7 +13115,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/6100",
     "approvedDate": "2025-12-16",
     "byop": false,
-    "requests24h": 154,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/6822822c-f92b-451f-a078-741391957aad"
   },
   {
@@ -13178,7 +13178,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/5737",
     "approvedDate": "2025-12-13",
     "byop": false,
-    "requests24h": 730,
+    "requests24h": 668,
     "screenshotUrl": "https://media.pollinations.ai/4b9305bd-1090-4261-92ec-60b42101427f"
   },
   {
@@ -13261,7 +13261,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/4914",
     "approvedDate": "2025-12-13",
     "byop": false,
-    "requests24h": 104,
+    "requests24h": 139,
     "screenshotUrl": "https://media.pollinations.ai/7f997220-5f6a-4eb2-96cf-c8c55bda287e"
   },
   {
@@ -13282,7 +13282,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/5373",
     "approvedDate": "2025-12-13",
     "byop": false,
-    "requests24h": 8,
+    "requests24h": 31,
     "screenshotUrl": "https://media.pollinations.ai/ea338ed0-0a86-4929-9008-989d9325a915"
   },
   {
@@ -13429,7 +13429,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/4930",
     "approvedDate": "2025-12-13",
     "byop": false,
-    "requests24h": 0,
+    "requests24h": 2,
     "screenshotUrl": "https://media.pollinations.ai/63cef618-5f05-410b-9a2a-4096aef295fd"
   },
   {
@@ -13492,7 +13492,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/5658",
     "approvedDate": "2025-12-04",
     "byop": false,
-    "requests24h": 58,
+    "requests24h": 59,
     "screenshotUrl": "https://media.pollinations.ai/5bd8d0be-e588-4ce6-8076-20e94a8a8408"
   },
   {
@@ -13513,7 +13513,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/5664",
     "approvedDate": "2025-12-04",
     "byop": false,
-    "requests24h": 144,
+    "requests24h": 76,
     "screenshotUrl": "https://media.pollinations.ai/c7d5a1a7-d86a-4918-8a2f-be9a263a2c4a"
   },
   {
@@ -13534,7 +13534,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/5662",
     "approvedDate": "2025-12-04",
     "byop": false,
-    "requests24h": 3,
+    "requests24h": 9,
     "screenshotUrl": "https://media.pollinations.ai/fa2f9a7d-c7cd-42bd-a81f-0cd349c11c1e"
   },
   {
@@ -13555,7 +13555,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/5640",
     "approvedDate": "2025-12-04",
     "byop": false,
-    "requests24h": 66,
+    "requests24h": 70,
     "screenshotUrl": "https://media.pollinations.ai/640310ef-1c69-4903-9f40-a6fbfbdaab47"
   },
   {
@@ -13597,7 +13597,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/5647",
     "approvedDate": "2025-12-04",
     "byop": false,
-    "requests24h": 53,
+    "requests24h": 55,
     "screenshotUrl": "https://media.pollinations.ai/4ec74410-fa2c-4eaa-9bc2-174a7a0f8708"
   },
   {
@@ -13618,7 +13618,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/5655",
     "approvedDate": "2025-12-04",
     "byop": false,
-    "requests24h": 53,
+    "requests24h": 52,
     "screenshotUrl": "https://media.pollinations.ai/76db77b9-3850-4e19-a588-9d8fa72a2a34"
   },
   {
@@ -13660,7 +13660,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/5588",
     "approvedDate": "2025-12-03",
     "byop": false,
-    "requests24h": 34,
+    "requests24h": 1,
     "screenshotUrl": "https://media.pollinations.ai/78a3fe4a-fa5c-45a3-91c3-56b8b04a01f1"
   },
   {
@@ -13723,7 +13723,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/5628",
     "approvedDate": "2025-12-03",
     "byop": false,
-    "requests24h": 41,
+    "requests24h": 203,
     "screenshotUrl": "https://media.pollinations.ai/5fefba7e-5c52-40a7-a805-7cd4470c7792"
   },
   {
@@ -13786,7 +13786,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/5490",
     "approvedDate": "2025-11-30",
     "byop": false,
-    "requests24h": 0,
+    "requests24h": 7,
     "screenshotUrl": "https://media.pollinations.ai/1056f386-9978-40d2-b914-52f0927fb2f3"
   },
   {
@@ -13932,7 +13932,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/4832",
     "approvedDate": "2025-10-28",
     "byop": false,
-    "requests24h": 6,
+    "requests24h": 1,
     "screenshotUrl": "https://media.pollinations.ai/7854897c-2446-48d6-b30d-3174fc296318"
   },
   {
@@ -13973,7 +13973,7 @@
     "issueUrl": null,
     "approvedDate": "2025-10-26",
     "byop": false,
-    "requests24h": 605440,
+    "requests24h": 583336,
     "screenshotUrl": "https://media.pollinations.ai/c0a95e1b-1525-4f34-9f16-24094c73b5d1"
   },
   {
@@ -14035,7 +14035,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/4776",
     "approvedDate": "2025-10-25",
     "byop": false,
-    "requests24h": 43,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/e3c864f5-7f20-4abf-a713-2c6113fcc393"
   },
   {
@@ -14119,7 +14119,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/4718",
     "approvedDate": "2025-10-22",
     "byop": false,
-    "requests24h": 154,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/6ca1c4ac-5623-4192-92ba-f6a3e7bb13d0"
   },
   {
@@ -14140,7 +14140,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/4678",
     "approvedDate": "2025-10-21",
     "byop": false,
-    "requests24h": 3,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/14577804-8826-4208-86f5-8c7cc05d0c0a"
   },
   {
@@ -14202,7 +14202,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/4613",
     "approvedDate": "2025-10-19",
     "byop": false,
-    "requests24h": 1877,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/3801554b-a512-4e4d-8f71-aed55ac7b3e2"
   },
   {
@@ -14223,7 +14223,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/4587",
     "approvedDate": "2025-10-16",
     "byop": false,
-    "requests24h": 62,
+    "requests24h": 9,
     "screenshotUrl": "https://media.pollinations.ai/420f5f87-2f9e-410e-b724-12a509ffebd3"
   },
   {
@@ -14244,7 +14244,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/4586",
     "approvedDate": "2025-10-16",
     "byop": false,
-    "requests24h": 196,
+    "requests24h": 147,
     "screenshotUrl": "https://media.pollinations.ai/e5ac195c-cdf1-44ab-81cf-4d74faca1ae5"
   },
   {
@@ -14517,7 +14517,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/4287",
     "approvedDate": "2025-10-02",
     "byop": false,
-    "requests24h": 41,
+    "requests24h": 203,
     "screenshotUrl": "https://media.pollinations.ai/b7b24296-6c2a-4a48-ba58-615c6a723c59"
   },
   {
@@ -14539,7 +14539,7 @@
     "issueUrl": null,
     "approvedDate": "2025-10-02",
     "byop": false,
-    "requests24h": 605440
+    "requests24h": 583336
   },
   {
     "emoji": "😼",
@@ -14894,7 +14894,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/3589",
     "approvedDate": "2025-08-11",
     "byop": false,
-    "requests24h": 1037,
+    "requests24h": 1092,
     "screenshotUrl": "https://media.pollinations.ai/ded5e7ff-fed4-47b6-b296-d0441f5b32bf"
   },
   {
@@ -14915,7 +14915,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/2041",
     "approvedDate": "2025-08-08",
     "byop": false,
-    "requests24h": 3,
+    "requests24h": 4,
     "screenshotUrl": "https://media.pollinations.ai/dc297e1f-2316-402f-a466-6dd8e4500692"
   },
   {
@@ -14978,7 +14978,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/3476",
     "approvedDate": "2025-08-05",
     "byop": false,
-    "requests24h": 9
+    "requests24h": 5
   },
   {
     "emoji": "🎨",
@@ -15353,7 +15353,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/2961",
     "approvedDate": "2025-07-12",
     "byop": false,
-    "requests24h": 44,
+    "requests24h": 99,
     "screenshotUrl": "https://media.pollinations.ai/eb0e7d0a-449c-4782-8166-c5d4b308ca14"
   },
   {
@@ -15437,7 +15437,7 @@
     "issueUrl": null,
     "approvedDate": "2025-07-05",
     "byop": false,
-    "requests24h": 4,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/ab42ed5e-562b-4f3b-9165-73940ce86589"
   },
   {
@@ -15520,7 +15520,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/2362",
     "approvedDate": "2025-06-13",
     "byop": false,
-    "requests24h": 4,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/c94aeea7-bb91-41f4-96c6-1042eb5292ab"
   },
   {
@@ -15688,7 +15688,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/2146",
     "approvedDate": "2025-05-30",
     "byop": false,
-    "requests24h": 240,
+    "requests24h": 176,
     "screenshotUrl": "https://media.pollinations.ai/d41c06e3-ee9b-4a72-ac24-48e60a227367"
   },
   {
@@ -15793,7 +15793,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/2020",
     "approvedDate": "2025-05-20",
     "byop": false,
-    "requests24h": 3,
+    "requests24h": 2,
     "screenshotUrl": "https://media.pollinations.ai/295df102-d06b-422c-bfdc-1f3350742184"
   },
   {
@@ -15835,7 +15835,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/1998",
     "approvedDate": "2025-05-19",
     "byop": false,
-    "requests24h": 66,
+    "requests24h": 40,
     "screenshotUrl": "https://media.pollinations.ai/804998cd-180a-46dc-a30c-516ba8118615"
   },
   {
@@ -15912,7 +15912,7 @@
     "githubUsername": "aandrew-me",
     "githubUserId": "66430340",
     "repositoryUrl": "https://github.com/aandrew-me/tgpt",
-    "repositoryStars": 3243,
+    "repositoryStars": 3245,
     "discordUsername": null,
     "other": null,
     "submittedDate": "2025-12-28",
@@ -15954,7 +15954,7 @@
     "githubUsername": "harry0703",
     "githubUserId": "4928832",
     "repositoryUrl": "https://github.com/harry0703/MoneyPrinterTurbo",
-    "repositoryStars": 103643,
+    "repositoryStars": 103989,
     "discordUsername": null,
     "other": null,
     "submittedDate": "2025-05-29",
@@ -15982,7 +15982,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/1887",
     "approvedDate": "2025-05-12",
     "byop": false,
-    "requests24h": 0,
+    "requests24h": 60,
     "screenshotUrl": "https://media.pollinations.ai/88ce24a2-82fd-4ab9-9305-d556ee0bbe7b"
   },
   {
@@ -16023,7 +16023,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/1887",
     "approvedDate": "2025-05-12",
     "byop": false,
-    "requests24h": 0,
+    "requests24h": 60,
     "screenshotUrl": "https://media.pollinations.ai/88ce24a2-82fd-4ab9-9305-d556ee0bbe7b"
   },
   {
@@ -16253,7 +16253,7 @@
     "issueUrl": null,
     "approvedDate": "2025-04-30",
     "byop": false,
-    "requests24h": 7,
+    "requests24h": 9,
     "screenshotUrl": "https://media.pollinations.ai/21242ef2-e36b-4f85-8ade-40f2c0c191a5"
   },
   {
@@ -16274,7 +16274,7 @@
     "issueUrl": null,
     "approvedDate": "2025-04-30",
     "byop": false,
-    "requests24h": 7,
+    "requests24h": 9,
     "screenshotUrl": "https://media.pollinations.ai/3892c9ac-7e2f-4f60-aed7-d26ec9de2365"
   },
   {
@@ -16330,7 +16330,7 @@
     "githubUsername": "aidevs",
     "githubUserId": "19439409",
     "repositoryUrl": "https://github.com/vercel/ai/tree/main/examples/ai-image-generator",
-    "repositoryStars": 26196,
+    "repositoryStars": 26212,
     "discordUsername": null,
     "other": null,
     "submittedDate": "2025-06-04",
@@ -16379,7 +16379,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/1730",
     "approvedDate": "2025-04-20",
     "byop": false,
-    "requests24h": 13,
+    "requests24h": 17,
     "screenshotUrl": "https://media.pollinations.ai/4108cef5-ec21-4c2f-a96e-d6b61142de44"
   },
   {
@@ -16463,7 +16463,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/1680",
     "approvedDate": "2025-04-15",
     "byop": false,
-    "requests24h": 605440,
+    "requests24h": 583336,
     "screenshotUrl": "https://media.pollinations.ai/cdf20f1c-84f7-432c-9499-44bde583dc9d"
   },
   {
@@ -16671,7 +16671,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/1445",
     "approvedDate": "2025-03-27",
     "byop": false,
-    "requests24h": 1,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/67fe10ee-c9de-426e-8fa6-7e32dd989fde"
   },
   {
@@ -16838,7 +16838,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/1349",
     "approvedDate": "2025-03-14",
     "byop": false,
-    "requests24h": 573,
+    "requests24h": 730,
     "screenshotUrl": "https://media.pollinations.ai/de0f6cf6-aaea-475b-944d-1a8149cf841d"
   },
   {
@@ -16963,7 +16963,7 @@
     "issueUrl": null,
     "approvedDate": "2025-03-01",
     "byop": true,
-    "requests24h": 129,
+    "requests24h": 59,
     "screenshotUrl": "https://media.pollinations.ai/fc0bf140-28ba-4d8d-901a-cbc9f50cb72f"
   },
   {
@@ -16977,7 +16977,7 @@
     "githubUsername": "lobehub",
     "githubUserId": "131470832",
     "repositoryUrl": "https://github.com/lobehub/lobehub",
-    "repositoryStars": 81699,
+    "repositoryStars": 81719,
     "discordUsername": null,
     "other": null,
     "submittedDate": "2025-06-04",
@@ -17172,7 +17172,7 @@
     "issueUrl": "https://github.com/pollinations/pollinations/issues/2268",
     "approvedDate": "2024-12-18",
     "byop": false,
-    "requests24h": 5,
+    "requests24h": 6,
     "screenshotUrl": "https://media.pollinations.ai/d4e0f497-3b41-4ea3-8f2d-2d95eef818a7"
   },
   {
@@ -17312,7 +17312,7 @@
     "githubUsername": "QwenLM",
     "githubUserId": "141221163",
     "repositoryUrl": "https://github.com/QwenLM/Qwen-Agent",
-    "repositoryStars": 16969,
+    "repositoryStars": 16970,
     "discordUsername": null,
     "other": null,
     "submittedDate": "2025-03-25",
@@ -17333,7 +17333,7 @@
     "githubUsername": "SillyTavern",
     "githubUserId": "134869877",
     "repositoryUrl": "https://github.com/SillyTavern/SillyTavern",
-    "repositoryStars": 32127,
+    "repositoryStars": 32165,
     "discordUsername": null,
     "other": null,
     "submittedDate": "2025-05-29",
@@ -17361,7 +17361,7 @@
     "issueUrl": null,
     "approvedDate": null,
     "byop": false,
-    "requests24h": 74,
+    "requests24h": 0,
     "screenshotUrl": "https://media.pollinations.ai/64d9e406-9802-4a8a-aba3-f6a3e9748c1b"
   },
   {
@@ -17382,7 +17382,7 @@
     "issueUrl": null,
     "approvedDate": null,
     "byop": false,
-    "requests24h": 15,
+    "requests24h": 20,
     "screenshotUrl": "https://media.pollinations.ai/0691f900-175a-4775-af42-ebe16822fe7b"
   },
   {

--- a/operations/app-management/app.json
+++ b/operations/app-management/app.json
@@ -1,5 +1,25 @@
 [
   {
+    "emoji": "🖼️",
+    "name": "NeuralCanvas",
+    "url": "https://play.google.com/store/apps/details?id=com.proApps.aiimagegenerator",
+    "description": "NeuralCanvas is a native Android app (Kotlin + Jetpack Compose) that turns a text prompt into an AI-generated image, built entirely on the Pollinations image API. How it uses Pollinations: every gener",
+    "language": "en",
+    "category": "image",
+    "platform": "android",
+    "githubUsername": "greysonmiller67-lang",
+    "githubUserId": "287692444",
+    "repositoryUrl": null,
+    "repositoryStars": null,
+    "discordUsername": null,
+    "other": null,
+    "submittedDate": "2026-08-16",
+    "issueUrl": "https://github.com/pollinations/pollinations/issues/13448",
+    "approvedDate": "2026-08-16",
+    "byop": false,
+    "requests24h": 0
+  },
+  {
     "emoji": "💼",
     "name": "Vyrsa Academy",
     "url": "https://vyrsa.xyz",

--- a/pollinations.ai/public/legal/PRIVACY_POLICY.md
+++ b/pollinations.ai/public/legal/PRIVACY_POLICY.md
@@ -1,6 +1,6 @@
 # Privacy Policy
 
-**Updated: 2026-06-24**
+**Updated: 2026-08-16**
 
 ## 1) Scope & Roles
 
@@ -78,7 +78,7 @@ Where data leaves the EEA, we use approved safeguards (e.g., EU Standard Contrac
 
 Access, correction, deletion, restriction, portability, objection to legitimate-interest processing, and withdrawal of consent where applicable.
 
-You can complain to your local authority or the Estonian Data Protection Inspectorate (AKI). **Contact:** hello@myceli.ai.
+You can complain to your local authority or the Estonian Data Protection Inspectorate (AKI). **Contact:** hello@pollinations.ai.
 
 ## 11) Security
 
@@ -103,4 +103,4 @@ Myceli.AI OÜ
 Registry code: 17186693  
 VAT number: EE102877908  
 Registered address: Harju maakond, Tallinn, Kesklinna linnaosa, Tornimäe tn 5, 10145, Estonia  
-Email: hello@myceli.ai
+Email: hello@pollinations.ai

--- a/pollinations.ai/public/legal/TERMS_OF_SERVICE.md
+++ b/pollinations.ai/public/legal/TERMS_OF_SERVICE.md
@@ -1,21 +1,24 @@
 # Terms of Service
 
-**Updated: 2026-07-02**
+**Updated: 2026-08-16**
 
 _2026-07-02 — Pollen purchases now include a service fee shown before payment, and prices are shown exclusive of tax; applicable VAT or similar taxes are added at checkout._
 
 _2026-05-11 — Wallet now expires after 12 months of account inactivity. Effective 2026-06-01; the inactivity clock starts on that date for all existing balances._
 
-## What Myceli.AI Is
+## About Pollinations
 
-We operate commercial, hosted services (dashboard & APIs) built on the open-source pollinations.ai codebase. We handle billing and support; the OSS remains under its repository licences.
+Pollinations.ai ("Pollinations", "we", "us") is a service operated by Myceli.AI OÜ, the legal service provider and contracting party. We operate commercial, hosted services (dashboard & APIs) built on the open-source Pollinations codebase. We handle billing and support; the open-source software remains under its repository licences.
 
-**Company identity:**  
-Myceli.AI OÜ  
-Registry code: 17186693  
-VAT number: EE102877908  
-Registered address: Harju maakond, Tallinn, Kesklinna linnaosa, Tornimäe tn 5, 10145, Estonia  
-Email: hello@myceli.ai
+**Legal operator:**
+
+- Myceli.AI OÜ
+- Registered in: Estonian Commercial Register
+- Registry code: 17186693
+- VAT number: EE102877908
+- Registered address: Harju maakond, Tallinn, Kesklinna linnaosa, Tornimäe tn 5, 10145, Estonia
+- General contact: hello@pollinations.ai
+- Billing contact: billing@pollinations.ai
 
 ---
 


### PR DESCRIPTION
Drops the redirect restriction on user-configured MCP servers; keeps the workerd redirect override, which is required because the MCP client asks for redirect "error".