### PR TITLE
fix: preserve aspect ratio for image edits when size is omitted

### DIFF
--- a/gen.pollinations.ai/src/image/handler.ts
+++ b/gen.pollinations.ai/src/image/handler.ts
@@ -38,7 +38,12 @@ import {
     contentPolicyMessage,
     firstContentPolicyMessage,
 } from "./utils/contentModeration.ts";
-import { bufferToUint8Array, detectMimeType } from "./utils/imageDownload.ts";
+import {
+    bufferToUint8Array,
+    detectMimeType,
+    downloadUserImage,
+    readImageDimensions,
+} from "./utils/imageDownload.ts";
 import { setImagesBinding } from "./utils/imageTransform.ts";
 import { buildTrackingHeaders } from "./utils/trackingHeaders.ts";
 
@@ -474,6 +479,29 @@ async function generateVideoResult(
     );
 }
 
+/**
+ * Edit requests that omit `size` should preserve the source image's aspect
+ * ratio instead of silently defaulting to the model's square default (e.g.
+ * 1024x1024). Downloads the first reference image, reads its actual
+ * dimensions, and overrides the params. Explicit size requests and video
+ * models are untouched; any failure falls back to the model default.
+ */
+export async function resolveEditDimensionsForImage(
+    safeParams: RuntimeImageParams,
+): Promise<RuntimeImageParams> {
+    if (safeParams.dimensionsExplicit) return safeParams;
+    const imageUrls = safeParams.image;
+    if (!imageUrls?.length || isVideoModel(safeParams.model)) return safeParams;
+    try {
+        const { buffer, mimeType } = await downloadUserImage(imageUrls[0]);
+        const dimensions = readImageDimensions(buffer, mimeType);
+        if (!dimensions) return safeParams;
+        return { ...safeParams, ...dimensions };
+    } catch {
+        // Keep the model default if the source image cannot be read.
+        return safeParams;
+    }
+}
 export async function generateImageOrVideoResponse(
     c: ImageContext,
     prompt: string,
@@ -481,7 +509,9 @@ export async function generateImageOrVideoResponse(
 ): Promise<Response> {
     syncImageEnvironment(c.env);
     const originalPrompt = decodePrompt(prompt || "random_prompt");
-    const safeParams = parseImageParams(c, body);
+    const safeParams = await resolveEditDimensionsForImage(
+        parseImageParams(c, body),
+    );
     c.var.track.setPricingInput({
         resolution: safeParams.resolution,
         quality: safeParams.quality,

--- a/gen.pollinations.ai/src/image/handler.ts
+++ b/gen.pollinations.ai/src/image/handler.ts
@@ -50,6 +50,10 @@ import { buildTrackingHeaders } from "./utils/trackingHeaders.ts";
 type ImageContext = Context<Env>;
 type RuntimeImageParams = Omit<ImageParams, "model"> & { model: string };
 
+const EDIT_IMAGE_PROBE_TIMEOUT_MS = 10_000;
+const EDIT_DIMENSION_STEP = 16;
+const MIN_EDIT_DIMENSION = 256;
+
 const IMAGE_ENV_KEYS = [
     "AWS_ACCESS_KEY_ID",
     "AWS_REGION",
@@ -491,12 +495,28 @@ export async function resolveEditDimensionsForImage(
 ): Promise<RuntimeImageParams> {
     if (safeParams.dimensionsExplicit) return safeParams;
     const imageUrls = safeParams.image;
-    if (!imageUrls?.length || isVideoModel(safeParams.model)) return safeParams;
+    if (!imageUrls?.length) return safeParams;
     try {
-        const { buffer, mimeType } = await downloadUserImage(imageUrls[0]);
-        const dimensions = readImageDimensions(buffer, mimeType);
-        if (!dimensions) return safeParams;
-        return { ...safeParams, ...dimensions };
+        const { buffer, mimeType } = await downloadUserImage(
+            imageUrls[0],
+            AbortSignal.timeout(EDIT_IMAGE_PROBE_TIMEOUT_MS),
+        );
+        const source = readImageDimensions(buffer, mimeType);
+        if (!source) return safeParams;
+
+        const targetLongEdge = Math.max(safeParams.width, safeParams.height);
+        const scale = targetLongEdge / Math.max(source.width, source.height);
+        const normalizeSide = (side: number) =>
+            Math.max(
+                MIN_EDIT_DIMENSION,
+                Math.round((side * scale) / EDIT_DIMENSION_STEP) *
+                    EDIT_DIMENSION_STEP,
+            );
+        return {
+            ...safeParams,
+            width: normalizeSide(source.width),
+            height: normalizeSide(source.height),
+        };
     } catch {
         // Keep the model default if the source image cannot be read.
         return safeParams;
@@ -509,9 +529,13 @@ export async function generateImageOrVideoResponse(
 ): Promise<Response> {
     syncImageEnvironment(c.env);
     const originalPrompt = decodePrompt(prompt || "random_prompt");
-    const safeParams = await resolveEditDimensionsForImage(
-        parseImageParams(c, body),
-    );
+    const parsedParams = parseImageParams(c, body);
+    const definition = c.var.model.definition;
+    const safeParams =
+        definition.category === "image" &&
+        definition.inputModalities?.includes("image")
+            ? await resolveEditDimensionsForImage(parsedParams)
+            : parsedParams;
     c.var.track.setPricingInput({
         resolution: safeParams.resolution,
         quality: safeParams.quality,

--- a/gen.pollinations.ai/test/image/editSizeAspectRatio.test.ts
+++ b/gen.pollinations.ai/test/image/editSizeAspectRatio.test.ts
@@ -1,82 +1,19 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+    CreateImageEditRequestSchema,
+    CreateImageRequestSchema,
+} from "@shared/schemas/openai.ts";
+import { describe, expect, it } from "vitest";
 import { resolveEditDimensionsForImage } from "../../src/image/handler.ts";
 import type { ImageParams } from "../../src/image/params.ts";
 
-/** Minimal valid PNG header (8-byte signature + IHDR with width/height). */
-function makePng(width: number, height: number): Buffer {
+function pngDataUri(width: number, height: number): string {
     const bytes = new Uint8Array(33);
     bytes.set([137, 80, 78, 71, 13, 10, 26, 10], 0);
-    bytes.set([0, 0, 0, 13], 8); // IHDR chunk length
-    bytes.set([73, 72, 68, 82], 12); // "IHDR"
-    bytes.set(
-        [
-            (width >> 24) & 0xff,
-            (width >> 16) & 0xff,
-            (width >> 8) & 0xff,
-            width & 0xff,
-        ],
-        16,
-    );
-    bytes.set(
-        [
-            (height >> 24) & 0xff,
-            (height >> 16) & 0xff,
-            (height >> 8) & 0xff,
-            height & 0xff,
-        ],
-        20,
-    );
-    return Buffer.from(bytes);
-}
-
-/**
- * Minimal valid JPEG header (SOI + APP0 + SOF0). SOF0 declares its full
- * segment length (17 = 8 + 3 components + length field) so the parser can
- * walk past it.
- */
-function makeJpeg(width: number, height: number): Buffer {
-    const bytes = new Uint8Array([
-        0xff,
-        0xd8, // SOI
-        0xff,
-        0xe0,
-        0x00,
-        0x10,
-        0x4a,
-        0x46,
-        0x49,
-        0x46,
-        0x00,
-        0x01,
-        0x01,
-        0x00,
-        0x00,
-        0x01,
-        0x00,
-        0x01,
-        0x00,
-        0x00, // APP0 (len 16)
-        0xff,
-        0xc0,
-        0x00,
-        0x11,
-        0x08, // SOF0 (len 17), precision 8
-        (height >> 8) & 0xff,
-        height & 0xff, // height
-        (width >> 8) & 0xff,
-        width & 0xff, // width
-        0x03, // 3 components
-        0x01,
-        0x11,
-        0x00, // component 1: id/sampling/qt
-        0x02,
-        0x11,
-        0x00, // component 2
-        0x03,
-        0x11,
-        0x00, // component 3
-    ]);
-    return Buffer.from(bytes);
+    bytes.set([0, 0, 0, 13, 73, 72, 68, 82], 8);
+    const view = new DataView(bytes.buffer);
+    view.setUint32(16, width);
+    view.setUint32(20, height);
+    return `data:image/png;base64,${Buffer.from(bytes).toString("base64")}`;
 }
 
 function makeParams(overrides: Partial<ImageParams> = {}): ImageParams {
@@ -96,100 +33,58 @@ function makeParams(overrides: Partial<ImageParams> = {}): ImageParams {
     };
 }
 
-function mockImageFetch(buffer: Buffer, contentType: string): void {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(new Uint8Array(buffer), {
-            status: 200,
-            headers: { "content-type": contentType },
-        }),
-    );
-}
+describe("image edit dimensions", () => {
+    it("does not default an omitted JSON edit size to square", () => {
+        const edit = CreateImageEditRequestSchema.parse({
+            prompt: "add flowers",
+            image: "https://example.com/source.png",
+        });
+        const generation = CreateImageRequestSchema.parse({
+            prompt: "flowers",
+        });
+        const explicit = CreateImageEditRequestSchema.parse({
+            prompt: "add flowers",
+            image: "https://example.com/source.png",
+            size: "512x1024",
+        });
 
-function spyOnFetch(): void {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(null, { status: 404 }),
-    );
-}
-
-afterEach(() => {
-    vi.restoreAllMocks();
-});
-
-describe("resolveEditDimensionsForImage", () => {
-    it("preserves a portrait source aspect ratio when size is omitted", async () => {
-        mockImageFetch(makePng(800, 1200), "image/png");
-
-        const resolved = await resolveEditDimensionsForImage(
-            makeParams({ image: ["https://example.com/portrait.png"] }),
-        );
-
-        expect(resolved.width).toBe(800);
-        expect(resolved.height).toBe(1200);
+        expect(edit.size).toBeUndefined();
+        expect(generation.size).toBe("1024x1024");
+        expect(explicit.size).toBe("512x1024");
     });
 
-    it("preserves a landscape source aspect ratio when size is omitted", async () => {
-        mockImageFetch(makeJpeg(1536, 1024), "image/jpeg");
-
+    it.each([
+        [800, 1200, 688, 1024],
+        [1536, 1024, 1024, 688],
+        [4032, 3024, 1024, 768],
+        [100, 10_000, 256, 1024],
+    ])("fits a %ix%i source into safe defaults as %ix%i", async (sourceWidth, sourceHeight, width, height) => {
         const resolved = await resolveEditDimensionsForImage(
-            makeParams({ image: ["https://example.com/landscape.jpg"] }),
+            makeParams({
+                image: [pngDataUri(sourceWidth, sourceHeight)],
+            }),
         );
 
-        expect(resolved.width).toBe(1536);
-        expect(resolved.height).toBe(1024);
+        expect(resolved).toMatchObject({ width, height });
+        expect(resolved.dimensionsExplicit).toBe(false);
     });
 
-    it("does not download or override when the caller explicitly passed size", async () => {
-        spyOnFetch();
+    it("leaves an explicit size unchanged", async () => {
         const params = makeParams({
-            image: ["https://example.com/portrait.png"],
+            image: [pngDataUri(800, 1200)],
             width: 512,
             height: 1024,
             dimensionsExplicit: true,
         });
 
-        const resolved = await resolveEditDimensionsForImage(params);
-
-        expect(resolved).toBe(params);
-        expect(globalThis.fetch).not.toHaveBeenCalled();
+        expect(await resolveEditDimensionsForImage(params)).toBe(params);
     });
 
-    it("falls back to the model default when the source image cannot be read", async () => {
-        vi.spyOn(globalThis, "fetch").mockRejectedValue(
-            new TypeError("Network connection lost"),
-        );
+    it("keeps model defaults when source dimensions are unreadable", async () => {
         const params = makeParams({
-            image: ["https://example.com/broken.png"],
+            image: ["data:image/png;base64,AQID"],
         });
 
-        const resolved = await resolveEditDimensionsForImage(params);
-
-        expect(resolved).toBe(params);
-        expect(resolved.width).toBe(1024);
-        expect(resolved.height).toBe(1024);
-    });
-
-    it("keeps model defaults when dimensions cannot be parsed", async () => {
-        mockImageFetch(Buffer.from([1, 2, 3, 4]), "application/octet-stream");
-        const params = makeParams({
-            image: ["https://example.com/mystery.bin"],
-        });
-
-        const resolved = await resolveEditDimensionsForImage(params);
-
-        expect(resolved).toBe(params);
-        expect(globalThis.fetch).toHaveBeenCalledTimes(1);
-    });
-
-    it("leaves video models untouched", async () => {
-        spyOnFetch();
-        const params = makeParams({
-            model: "veo",
-            image: ["https://example.com/first-frame.png"],
-        });
-
-        const resolved = await resolveEditDimensionsForImage(params);
-
-        expect(resolved).toBe(params);
-        expect(globalThis.fetch).not.toHaveBeenCalled();
+        expect(await resolveEditDimensionsForImage(params)).toBe(params);
     });
 });

--- a/gen.pollinations.ai/test/image/editSizeAspectRatio.test.ts
+++ b/gen.pollinations.ai/test/image/editSizeAspectRatio.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveEditDimensionsForImage } from "../../src/image/handler.ts";
+import type { ImageParams } from "../../src/image/params.ts";
+
+/** Minimal valid PNG header (8-byte signature + IHDR with width/height). */
+function makePng(width: number, height: number): Buffer {
+    const bytes = new Uint8Array(33);
+    bytes.set([137, 80, 78, 71, 13, 10, 26, 10], 0);
+    bytes.set([0, 0, 0, 13], 8); // IHDR chunk length
+    bytes.set([73, 72, 68, 82], 12); // "IHDR"
+    bytes.set(
+        [
+            (width >> 24) & 0xff,
+            (width >> 16) & 0xff,
+            (width >> 8) & 0xff,
+            width & 0xff,
+        ],
+        16,
+    );
+    bytes.set(
+        [
+            (height >> 24) & 0xff,
+            (height >> 16) & 0xff,
+            (height >> 8) & 0xff,
+            height & 0xff,
+        ],
+        20,
+    );
+    return Buffer.from(bytes);
+}
+
+/**
+ * Minimal valid JPEG header (SOI + APP0 + SOF0). SOF0 declares its full
+ * segment length (17 = 8 + 3 components + length field) so the parser can
+ * walk past it.
+ */
+function makeJpeg(width: number, height: number): Buffer {
+    const bytes = new Uint8Array([
+        0xff,
+        0xd8, // SOI
+        0xff,
+        0xe0,
+        0x00,
+        0x10,
+        0x4a,
+        0x46,
+        0x49,
+        0x46,
+        0x00,
+        0x01,
+        0x01,
+        0x00,
+        0x00,
+        0x01,
+        0x00,
+        0x01,
+        0x00,
+        0x00, // APP0 (len 16)
+        0xff,
+        0xc0,
+        0x00,
+        0x11,
+        0x08, // SOF0 (len 17), precision 8
+        (height >> 8) & 0xff,
+        height & 0xff, // height
+        (width >> 8) & 0xff,
+        width & 0xff, // width
+        0x03, // 3 components
+        0x01,
+        0x11,
+        0x00, // component 1: id/sampling/qt
+        0x02,
+        0x11,
+        0x00, // component 2
+        0x03,
+        0x11,
+        0x00, // component 3
+    ]);
+    return Buffer.from(bytes);
+}
+
+function makeParams(overrides: Partial<ImageParams> = {}): ImageParams {
+    return {
+        model: "gpt-image-2",
+        width: 1024,
+        height: 1024,
+        dimensionsExplicit: false,
+        seed: 42,
+        safe: false,
+        quality: "medium",
+        image: [],
+        transparent: false,
+        reasoning: "balanced",
+        audio: false,
+        ...overrides,
+    };
+}
+
+function mockImageFetch(buffer: Buffer, contentType: string): void {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(new Uint8Array(buffer), {
+            status: 200,
+            headers: { "content-type": contentType },
+        }),
+    );
+}
+
+function spyOnFetch(): void {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(null, { status: 404 }),
+    );
+}
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe("resolveEditDimensionsForImage", () => {
+    it("preserves a portrait source aspect ratio when size is omitted", async () => {
+        mockImageFetch(makePng(800, 1200), "image/png");
+
+        const resolved = await resolveEditDimensionsForImage(
+            makeParams({ image: ["https://example.com/portrait.png"] }),
+        );
+
+        expect(resolved.width).toBe(800);
+        expect(resolved.height).toBe(1200);
+    });
+
+    it("preserves a landscape source aspect ratio when size is omitted", async () => {
+        mockImageFetch(makeJpeg(1536, 1024), "image/jpeg");
+
+        const resolved = await resolveEditDimensionsForImage(
+            makeParams({ image: ["https://example.com/landscape.jpg"] }),
+        );
+
+        expect(resolved.width).toBe(1536);
+        expect(resolved.height).toBe(1024);
+    });
+
+    it("does not download or override when the caller explicitly passed size", async () => {
+        spyOnFetch();
+        const params = makeParams({
+            image: ["https://example.com/portrait.png"],
+            width: 512,
+            height: 1024,
+            dimensionsExplicit: true,
+        });
+
+        const resolved = await resolveEditDimensionsForImage(params);
+
+        expect(resolved).toBe(params);
+        expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the model default when the source image cannot be read", async () => {
+        vi.spyOn(globalThis, "fetch").mockRejectedValue(
+            new TypeError("Network connection lost"),
+        );
+        const params = makeParams({
+            image: ["https://example.com/broken.png"],
+        });
+
+        const resolved = await resolveEditDimensionsForImage(params);
+
+        expect(resolved).toBe(params);
+        expect(resolved.width).toBe(1024);
+        expect(resolved.height).toBe(1024);
+    });
+
+    it("keeps model defaults when dimensions cannot be parsed", async () => {
+        mockImageFetch(Buffer.from([1, 2, 3, 4]), "application/octet-stream");
+        const params = makeParams({
+            image: ["https://example.com/mystery.bin"],
+        });
+
+        const resolved = await resolveEditDimensionsForImage(params);
+
+        expect(resolved).toBe(params);
+        expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("leaves video models untouched", async () => {
+        spyOnFetch();
+        const params = makeParams({
+            model: "veo",
+            image: ["https://example.com/first-frame.png"],
+        });
+
+        const resolved = await resolveEditDimensionsForImage(params);
+
+        expect(resolved).toBe(params);
+        expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+});

--- a/shared/schemas/openai.ts
+++ b/shared/schemas/openai.ts
@@ -558,9 +558,15 @@ const imageNField = z
     .optional()
     .default(1)
     .meta({ description: "Number of images to generate (currently max 1)" });
-const imageSizeField = z.string().optional().default("1024x1024").meta({
+const imageSizeMeta = {
     description: "Image size as WIDTHxHEIGHT (e.g., 1024x1024, 512x512)",
-});
+};
+const imageSizeField = z
+    .string()
+    .optional()
+    .default("1024x1024")
+    .meta(imageSizeMeta);
+const imageEditSizeField = z.string().optional().meta(imageSizeMeta);
 const imageQualityField = z
     .enum(["standard", "hd", "low", "medium", "high"])
     .optional()
@@ -664,7 +670,7 @@ export const CreateImageEditRequestSchema = z
             }),
         model: imageModelField,
         n: imageNField,
-        size: imageSizeField,
+        size: imageEditSizeField,
         quality: imageQualityField,
         resolution: imageResolutionField,
         safe: SafeSchema,


### PR DESCRIPTION
Fixes #12583
References #10944

- Preserves the source image's aspect ratio when an image edit omits `size`.
- Leaves caller-provided dimensions unchanged.
- Removes the square default only from JSON edit requests; image generation still defaults to `1024x1024`.
- Runs inference only for image models that accept image input.
- Fits derived dimensions into the model's existing size budget, aligned to 16px with a 256px minimum, so large or extreme inputs are not forwarded raw.
- Reuses the existing guarded image downloader and dimension reader; no cache, provider table, or new public parameter.

Validation:

- 7 focused aspect-ratio and schema tests
- 31 related parameter, routing, and image-decoder tests
- Gen TypeScript check
- Biome on all modified files
