### PR TITLE
fix: show agent pricing only in agent category

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/models.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/models.tsx
@@ -492,9 +492,8 @@ export const Models: FC = () => {
                                 <strong className="text-theme-text-soft">
                                     agent pricing
                                 </strong>{" "}
-                                — rates apply to each base-model call; agents
-                                can make multiple calls, and tool calls use the
-                                selected model&apos;s listed price.
+                                — agents may make multiple model calls. Each is
+                                billed at that model&apos;s listed price.
                             </span>
                         </p>
                     )}

--- a/enter.pollinations.ai/frontend/src/components/models/models.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/models.tsx
@@ -485,17 +485,19 @@ export const Models: FC = () => {
                     </div>
                 )}
                 <div className="mt-4 space-y-2 border-t border-divider pt-4 text-[13px] leading-snug text-theme-text-muted">
-                    <p className="flex items-start gap-1.5">
-                        <BotIcon className="mt-0.5 h-3.5 w-3.5 shrink-0 text-theme-text-soft" />
-                        <span>
-                            <strong className="text-theme-text-soft">
-                                agent pricing
-                            </strong>{" "}
-                            — rates apply to each base-model call; agents can
-                            make multiple calls, and tool calls use the selected
-                            model&apos;s listed price.
-                        </span>
-                    </p>
+                    {activeTab === "agent" && (
+                        <p className="flex items-start gap-1.5">
+                            <BotIcon className="mt-0.5 h-3.5 w-3.5 shrink-0 text-theme-text-soft" />
+                            <span>
+                                <strong className="text-theme-text-soft">
+                                    agent pricing
+                                </strong>{" "}
+                                — rates apply to each base-model call; agents
+                                can make multiple calls, and tool calls use the
+                                selected model&apos;s listed price.
+                            </span>
+                        </p>
+                    )}
                     <p className="flex items-start gap-1.5">
                         <SparklesIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
                         <span>


### PR DESCRIPTION
- Shows the agent-specific pricing note only when the Agent category is selected.
- Keeps the shared `/gen`, token, duration, and usage legends visible across model categories.
- Fixes the unconditional footer rendering without adding state or new components.

Checks:
- `npx biome check --write enter.pollinations.ai/frontend/src/components/models/models.tsx`
- `npm run typecheck` in `enter.pollinations.ai`