### PR TITLE
refactor: remove custom MCP servers from agents

### DIFF
--- a/enter.pollinations.ai/drizzle/0049_stormy_franklin_storm.sql
+++ b/enter.pollinations.ai/drizzle/0049_stormy_franklin_storm.sql
@@ -1,0 +1,12 @@
+UPDATE `agent`
+SET `config` = json_set(
+	json_remove(`config`, '$.pollinationsTools', '$.mcpServers'),
+	'$.mcpServers',
+	CASE
+		WHEN json_extract(`config`, '$.pollinationsTools') = 1
+			THEN json_array('pollinations')
+		ELSE json_array()
+	END
+);
+--> statement-breakpoint
+ALTER TABLE `agent` DROP COLUMN `mcp_headers_ciphertext`;

--- a/enter.pollinations.ai/drizzle/meta/0049_snapshot.json
+++ b/enter.pollinations.ai/drizzle/meta/0049_snapshot.json
@@ -1,0 +1,1821 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "ea149a3f-fe5c-496c-a615-45c2da883f7b",
+  "prevId": "dfd92e83-e77e-4e3e-a350-5810513c2a9e",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_account_user_id": {
+          "name": "idx_account_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent": {
+      "name": "agent",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_agent_owner_user_id": {
+          "name": "idx_agent_owner_user_id",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_owner_user_id_user_id_fk": {
+          "name": "agent_owner_user_id_user_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 5
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pollen_balance": {
+          "name": "pollen_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "byop_client_key_id": {
+          "name": "byop_client_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_apikey_key": {
+          "name": "idx_apikey_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_expires_at": {
+          "name": "idx_apikey_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_user_id": {
+          "name": "idx_apikey_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_byop_client_key_id": {
+          "name": "idx_apikey_byop_client_key_id",
+          "columns": [
+            "byop_client_key_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apikey_user_id_user_id_fk": {
+          "name": "apikey_user_id_user_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "community_endpoint": {
+      "name": "community_endpoint",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'text'"
+        },
+        "image_pricing": {
+          "name": "image_pricing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'request'"
+        },
+        "supports_image_edits": {
+          "name": "supports_image_edits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "input_modalities": {
+          "name": "input_modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_model": {
+          "name": "upstream_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bearer_token_ciphertext": {
+          "name": "bearer_token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'private'"
+        },
+        "per_user_rpm": {
+          "name": "per_user_rpm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_text_price": {
+          "name": "prompt_text_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_cached_price": {
+          "name": "prompt_cached_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "prompt_cache_write_price": {
+          "name": "prompt_cache_write_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "prompt_audio_price": {
+          "name": "prompt_audio_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "prompt_image_price": {
+          "name": "prompt_image_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "completion_text_price": {
+          "name": "completion_text_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completion_reasoning_price": {
+          "name": "completion_reasoning_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "completion_audio_price": {
+          "name": "completion_audio_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "completion_image_price": {
+          "name": "completion_image_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "delegates_generation": {
+          "name": "delegates_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "fallback_model_ids": {
+          "name": "fallback_model_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_reason": {
+          "name": "disabled_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_by": {
+          "name": "disabled_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_community_endpoint_owner_user_id": {
+          "name": "idx_community_endpoint_owner_user_id",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_community_endpoint_owner_name": {
+          "name": "idx_community_endpoint_owner_name",
+          "columns": [
+            "owner_user_id",
+            "name"
+          ],
+          "isUnique": true
+        },
+        "idx_community_endpoint_agent_id": {
+          "name": "idx_community_endpoint_agent_id",
+          "columns": [
+            "agent_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "community_endpoint_owner_user_id_user_id_fk": {
+          "name": "community_endpoint_owner_user_id_user_id_fk",
+          "tableFrom": "community_endpoint",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_endpoint_agent_id_agent_id_fk": {
+          "name": "community_endpoint_agent_id_agent_id_fk",
+          "tableFrom": "community_endpoint",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "device_code": {
+      "name": "device_code",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_device_code_device_code": {
+          "name": "idx_device_code_device_code",
+          "columns": [
+            "device_code"
+          ],
+          "isUnique": false
+        },
+        "idx_device_code_user_code": {
+          "name": "idx_device_code_user_code",
+          "columns": [
+            "user_code"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "device_code_user_id_user_id_fk": {
+          "name": "device_code_user_id_user_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "polar_checkout_credits": {
+      "name": "polar_checkout_credits",
+      "columns": {
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pollen_credited": {
+          "name": "pollen_credited",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "polar_created_at": {
+          "name": "polar_created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_slug": {
+          "name": "product_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_polar_checkout_credits_user_id": {
+          "name": "idx_polar_checkout_credits_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "polar_checkout_credits_user_id_user_id_fk": {
+          "name": "polar_checkout_credits_user_id_user_id_fk",
+          "tableFrom": "polar_checkout_credits",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rewards": {
+      "name": "rewards",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quest_id": {
+          "name": "quest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pollen_amount": {
+          "name": "pollen_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "balance_bucket": {
+          "name": "balance_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rewards_idempotency_key_unique": {
+          "name": "rewards_idempotency_key_unique",
+          "columns": [
+            "idempotency_key"
+          ],
+          "isUnique": true
+        },
+        "idx_rewards_user_id": {
+          "name": "idx_rewards_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "rewards_user_id_user_id_fk": {
+          "name": "rewards_user_id_user_id_fk",
+          "tableFrom": "rewards",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_session_user_id": {
+          "name": "idx_session_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_auto_top_up_attempt": {
+      "name": "stripe_auto_top_up_attempt",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount_usd": {
+          "name": "amount_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "stripe_auto_top_up_attempt_stripe_invoice_id_unique": {
+          "name": "stripe_auto_top_up_attempt_stripe_invoice_id_unique",
+          "columns": [
+            "stripe_invoice_id"
+          ],
+          "isUnique": true
+        },
+        "idx_stripe_auto_top_up_attempt_user_id": {
+          "name": "idx_stripe_auto_top_up_attempt_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_stripe_auto_top_up_attempt_status": {
+          "name": "idx_stripe_auto_top_up_attempt_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_auto_top_up_attempt_user_id_user_id_fk": {
+          "name": "stripe_auto_top_up_attempt_user_id_user_id_fk",
+          "tableFrom": "stripe_auto_top_up_attempt",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_card_fingerprint_attempt": {
+      "name": "stripe_card_fingerprint_attempt",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "card_fingerprint": {
+          "name": "card_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_stripe_card_fingerprint_attempt_user_created": {
+          "name": "idx_stripe_card_fingerprint_attempt_user_created",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_stripe_card_fingerprint_attempt_user_fingerprint": {
+          "name": "idx_stripe_card_fingerprint_attempt_user_fingerprint",
+          "columns": [
+            "user_id",
+            "card_fingerprint"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_card_fingerprint_attempt_user_id_user_id_fk": {
+          "name": "stripe_card_fingerprint_attempt_user_id_user_id_fk",
+          "tableFrom": "stripe_card_fingerprint_attempt",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_checkout_credits": {
+      "name": "stripe_checkout_credits",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pollen_credited": {
+          "name": "pollen_credited",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_stripe_checkout_credits_user_id": {
+          "name": "idx_stripe_checkout_credits_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_checkout_credits_user_id_user_id_fk": {
+          "name": "stripe_checkout_credits_user_id_user_id_fk",
+          "tableFrom": "stripe_checkout_credits",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "community_provider_name": {
+          "name": "community_provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "community_provider_url": {
+          "name": "community_provider_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'spore'"
+        },
+        "tier_balance": {
+          "name": "tier_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pack_balance": {
+          "name": "pack_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_tier_grant": {
+          "name": "last_tier_grant",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "auto_top_up_amount_usd": {
+          "name": "auto_top_up_amount_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_stripe_customer_id_unique": {
+          "name": "user_stripe_customer_id_unique",
+          "columns": [
+            "stripe_customer_id"
+          ],
+          "isUnique": true
+        },
+        "idx_user_email": {
+          "name": "idx_user_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "idx_user_auto_top_up_enabled": {
+          "name": "idx_user_auto_top_up_enabled",
+          "columns": [
+            "auto_top_up_enabled"
+          ],
+          "isUnique": false
+        },
+        "idx_user_github_id": {
+          "name": "idx_user_github_id",
+          "columns": [
+            "github_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_verification_identifier": {
+          "name": "idx_verification_identifier",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_item": {
+      "name": "media_item",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "app_key_id": {
+          "name": "app_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_media_item_owner_created": {
+          "name": "idx_media_item_owner_created",
+          "columns": [
+            "owner_user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "media_item_owner_user_id_user_id_fk": {
+          "name": "media_item_owner_user_id_user_id_fk",
+          "tableFrom": "media_item",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_tag": {
+      "name": "media_tag",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_media_tag_item_tag": {
+          "name": "idx_media_tag_item_tag",
+          "columns": [
+            "item_id",
+            "tag"
+          ],
+          "isUnique": true
+        },
+        "idx_media_tag_tag_item": {
+          "name": "idx_media_tag_tag_item",
+          "columns": [
+            "tag",
+            "item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "media_tag_item_id_media_item_id_fk": {
+          "name": "media_tag_item_id_media_item_id_fk",
+          "tableFrom": "media_tag",
+          "tableTo": "media_item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/enter.pollinations.ai/drizzle/meta/_journal.json
+++ b/enter.pollinations.ai/drizzle/meta/_journal.json
@@ -344,6 +344,13 @@
       "when": 1786716000000,
       "tag": "0048_heavy_jimmy_woo",
       "breakpoints": true
+    },
+    {
+      "idx": 49,
+      "version": "6",
+      "when": 1786889023916,
+      "tag": "0049_stormy_franklin_storm",
+      "breakpoints": true
     }
   ]
 }

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/agent-dialog.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/agent-dialog.tsx
@@ -22,7 +22,6 @@ import {
     agentListingToForm,
     type CommunityEndpoint,
     emptyAgentForm,
-    isValidMcpRow,
     type ManagedAgent,
     type ModelListingFormState,
     toAgentListingPayload,
@@ -67,18 +66,7 @@ export function AgentDialog({
                 ? {
                       systemPrompt: agent.systemPrompt,
                       baseModel: agent.baseModel,
-                      pollinationsTools: agent.pollinationsTools,
-                      mcpServers: agent.mcpServers.map((server) => ({
-                          id: crypto.randomUUID(),
-                          name: server.name,
-                          url: server.url,
-                          headers: Object.keys(server.headers).map((name) => ({
-                              id: crypto.randomUUID(),
-                              name,
-                              value: "",
-                              saved: true,
-                          })),
-                      })),
+                      mcpServers: agent.mcpServers,
                   }
                 : emptyAgentForm),
         });
@@ -87,119 +75,10 @@ export function AgentDialog({
     }, [open, agent, endpoint]);
 
     function updateAgentForm(
-        key: keyof Omit<AgentFormState, "mcpServers">,
-        value: string | boolean,
+        key: keyof AgentFormState,
+        value: string | AgentFormState["mcpServers"],
     ): void {
         setForm((current) => ({ ...current, [key]: value }));
-    }
-
-    function updateMcpServer(
-        index: number,
-        key: "name" | "url",
-        value: string,
-    ): void {
-        setForm((current) => ({
-            ...current,
-            mcpServers: current.mcpServers.map((row, rowIndex) =>
-                rowIndex === index
-                    ? {
-                          ...row,
-                          [key]: value,
-                      }
-                    : row,
-            ),
-        }));
-    }
-
-    function addMcpServer(): void {
-        setForm((current) => ({
-            ...current,
-            mcpServers: [
-                ...current.mcpServers,
-                {
-                    id: crypto.randomUUID(),
-                    name: "",
-                    url: "",
-                    headers: [],
-                },
-            ],
-        }));
-    }
-
-    function addMcpHeader(serverIndex: number, bearer = false): void {
-        setForm((current) => ({
-            ...current,
-            mcpServers: current.mcpServers.map((server, index) =>
-                index === serverIndex
-                    ? {
-                          ...server,
-                          headers: [
-                              ...server.headers,
-                              {
-                                  id: crypto.randomUUID(),
-                                  name: bearer ? "Authorization" : "",
-                                  value: bearer ? "Bearer " : "",
-                                  saved: false,
-                              },
-                          ],
-                      }
-                    : server,
-            ),
-        }));
-    }
-
-    function updateMcpHeader(
-        serverIndex: number,
-        headerIndex: number,
-        key: "name" | "value",
-        value: string,
-    ): void {
-        setForm((current) => ({
-            ...current,
-            mcpServers: current.mcpServers.map((server, index) =>
-                index === serverIndex
-                    ? {
-                          ...server,
-                          headers: server.headers.map((header, index) =>
-                              index === headerIndex
-                                  ? {
-                                        ...header,
-                                        [key]: value,
-                                        saved:
-                                            key === "name" &&
-                                            value !== header.name
-                                                ? false
-                                                : header.saved,
-                                    }
-                                  : header,
-                          ),
-                      }
-                    : server,
-            ),
-        }));
-    }
-
-    function removeMcpHeader(serverIndex: number, headerIndex: number): void {
-        setForm((current) => ({
-            ...current,
-            mcpServers: current.mcpServers.map((server, index) =>
-                index === serverIndex
-                    ? {
-                          ...server,
-                          headers: server.headers.filter(
-                              (_, index) => index !== headerIndex,
-                          ),
-                      }
-                    : server,
-            ),
-        }));
-    }
-
-    function removeMcpServer(index: number): void {
-        setForm((current) => ({
-            ...current,
-            mcpServers: current.mcpServers.filter((_, i) => i !== index),
-        }));
     }
 
     async function handleSubmit(event: FormEvent): Promise<void> {
@@ -229,8 +108,7 @@ export function AgentDialog({
         form.name.trim() !== "" &&
         form.title.trim() !== "" &&
         form.systemPrompt.trim() !== "" &&
-        form.baseModel.trim() !== "" &&
-        form.mcpServers.every(isValidMcpRow);
+        form.baseModel.trim() !== "";
     const submitLabel = endpoint
         ? "Save Agent"
         : form.visibility === "public"
@@ -294,12 +172,6 @@ export function AgentDialog({
                         form={form}
                         disabled={isSubmitting}
                         onChange={updateAgentForm}
-                        onAddMcp={addMcpServer}
-                        onUpdateMcp={updateMcpServer}
-                        onRemoveMcp={removeMcpServer}
-                        onAddMcpHeader={addMcpHeader}
-                        onUpdateMcpHeader={updateMcpHeader}
-                        onRemoveMcpHeader={removeMcpHeader}
                     />
                 </ScrollArea>
                 <div className="flex shrink-0 justify-end gap-2 border-t border-divider p-6 pt-4">

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/prompt-agent-fields.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/prompt-agent-fields.tsx
@@ -1,13 +1,4 @@
-import {
-    Button,
-    Chip,
-    FieldStack,
-    IconButton,
-    Input,
-    Switch,
-    Textarea,
-    XIcon,
-} from "@pollinations/ui";
+import { Chip, FieldStack, Switch, Textarea } from "@pollinations/ui";
 import { BaseModelInput } from "./base-model-input.tsx";
 import type { AgentFormState } from "./types.ts";
 
@@ -15,30 +6,13 @@ export function PromptAgentFields({
     form,
     disabled,
     onChange,
-    onAddMcp,
-    onUpdateMcp,
-    onRemoveMcp,
-    onAddMcpHeader,
-    onUpdateMcpHeader,
-    onRemoveMcpHeader,
 }: {
     form: AgentFormState;
     disabled: boolean;
     onChange: (
-        key: keyof Omit<AgentFormState, "mcpServers">,
-        value: string | boolean,
+        key: keyof AgentFormState,
+        value: string | AgentFormState["mcpServers"],
     ) => void;
-    onAddMcp: () => void;
-    onUpdateMcp: (index: number, key: "name" | "url", value: string) => void;
-    onRemoveMcp: (index: number) => void;
-    onAddMcpHeader: (serverIndex: number, bearer?: boolean) => void;
-    onUpdateMcpHeader: (
-        serverIndex: number,
-        headerIndex: number,
-        key: "name" | "value",
-        value: string,
-    ) => void;
-    onRemoveMcpHeader: (serverIndex: number, headerIndex: number) => void;
 }) {
     return (
         <div className="space-y-4">
@@ -71,241 +45,53 @@ export function PromptAgentFields({
             </FieldStack>
 
             <FieldStack
-                label="MCP servers"
-                helper="Streamable-HTTP MCP servers whose tools the agent can call. Optional request headers are stored encrypted."
+                label="Pollinations tools"
+                helper="Allow the agent to call Pollinations generation and model-discovery tools."
                 alignLabelRow
                 action={
-                    <Button
-                        type="button"
-                        size="sm"
-                        intent="info"
-                        className="shrink-0 text-sm"
+                    <Switch
+                        checked={form.mcpServers.includes("pollinations")}
                         disabled={disabled}
-                        onClick={onAddMcp}
-                    >
-                        Add MCP server
-                    </Button>
+                        ariaLabel="Allow Pollinations tools"
+                        onChange={(value) =>
+                            onChange(
+                                "mcpServers",
+                                value ? ["pollinations"] : [],
+                            )
+                        }
+                    />
                 }
             >
-                <div className="overflow-hidden rounded-md border border-divider">
-                    <div className="space-y-2 p-3">
-                        <div className="grid gap-2 sm:grid-cols-[10rem_minmax(0,1fr)] sm:items-center">
-                            <div className="flex flex-wrap items-center gap-2">
-                                <span className="font-medium">
-                                    Pollinations
-                                </span>
-                                <Chip size="sm" intent="neutral">
-                                    Built-in
-                                </Chip>
-                            </div>
-                            <div className="flex min-w-0 items-center gap-2">
-                                <span className="min-w-0 flex-1 break-all font-mono text-xs text-theme-text-muted">
-                                    https://mcp.pollinations.ai
-                                </span>
-                                <Switch
-                                    checked={form.pollinationsTools}
-                                    disabled={disabled}
-                                    ariaLabel="Allow Pollinations tools"
-                                    onChange={(value) =>
-                                        onChange("pollinationsTools", value)
-                                    }
-                                />
-                            </div>
-                        </div>
-                        <p className="text-xs text-theme-text-muted">
-                            Uses the caller's Pollinations API access.{" "}
-                            <a
-                                href="https://gen.pollinations.ai/docs#tag/mcp-server"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="underline decoration-current/40 underline-offset-2 hover:text-theme-text-soft"
-                            >
-                                API docs
-                            </a>
-                            {" · "}
-                            <a
-                                href="https://github.com/pollinations/pollinations/tree/main/packages/mcp"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="underline decoration-current/40 underline-offset-2 hover:text-theme-text-soft"
-                            >
-                                GitHub
-                            </a>
-                        </p>
+                <div className="space-y-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                        <span className="font-medium">Pollinations MCP</span>
+                        <Chip size="sm" intent="neutral">
+                            Built-in
+                        </Chip>
                     </div>
-                    {form.mcpServers.length > 0 &&
-                        form.mcpServers.map((row, index) => (
-                            <div
-                                key={row.id}
-                                className="space-y-3 border-t border-divider p-3"
-                            >
-                                <div className="grid gap-2 sm:grid-cols-[10rem_minmax(0,1fr)] sm:items-center">
-                                    <Input
-                                        name={`prompt-agent-mcp-name-${index}`}
-                                        aria-label={`MCP server ${index + 1} name`}
-                                        value={row.name}
-                                        placeholder="my-server"
-                                        autoComplete="off"
-                                        autoCapitalize="none"
-                                        spellCheck={false}
-                                        className="min-w-0"
-                                        disabled={disabled}
-                                        onChange={(e) =>
-                                            onUpdateMcp(
-                                                index,
-                                                "name",
-                                                e.target.value,
-                                            )
-                                        }
-                                    />
-                                    <div className="flex min-w-0 items-center gap-2">
-                                        <Input
-                                            name={`prompt-agent-mcp-url-${index}`}
-                                            aria-label={`MCP server ${index + 1} URL`}
-                                            type="url"
-                                            inputMode="url"
-                                            value={row.url}
-                                            placeholder="https://mcp.example.com"
-                                            autoComplete="off"
-                                            autoCapitalize="none"
-                                            spellCheck={false}
-                                            className="min-w-0 flex-1"
-                                            disabled={disabled}
-                                            onChange={(e) =>
-                                                onUpdateMcp(
-                                                    index,
-                                                    "url",
-                                                    e.target.value,
-                                                )
-                                            }
-                                        />
-                                        {!disabled && (
-                                            <IconButton
-                                                intent="danger"
-                                                title="Remove MCP server"
-                                                tooltip="Remove MCP server"
-                                                onClick={() =>
-                                                    onRemoveMcp(index)
-                                                }
-                                            >
-                                                <XIcon className="h-4 w-4" />
-                                            </IconButton>
-                                        )}
-                                    </div>
-                                </div>
-                                <div className="ml-4 space-y-2 rounded-md bg-theme-bg-subtle p-2">
-                                    <div className="flex flex-wrap items-center justify-between gap-2">
-                                        <span className="text-xs text-theme-text-muted">
-                                            Request headers
-                                        </span>
-                                        <div className="flex flex-wrap gap-2">
-                                            <Button
-                                                type="button"
-                                                size="sm"
-                                                disabled={
-                                                    disabled ||
-                                                    row.headers.length >= 16 ||
-                                                    row.headers.some(
-                                                        (header) =>
-                                                            header.name
-                                                                .trim()
-                                                                .toLowerCase() ===
-                                                            "authorization",
-                                                    )
-                                                }
-                                                onClick={() =>
-                                                    onAddMcpHeader(index, true)
-                                                }
-                                            >
-                                                Add bearer token
-                                            </Button>
-                                            <Button
-                                                type="button"
-                                                size="sm"
-                                                disabled={
-                                                    disabled ||
-                                                    row.headers.length >= 16
-                                                }
-                                                onClick={() =>
-                                                    onAddMcpHeader(index)
-                                                }
-                                            >
-                                                Add header
-                                            </Button>
-                                        </div>
-                                    </div>
-                                    {row.headers.map((header, headerIndex) => (
-                                        <div
-                                            key={header.id}
-                                            className="grid gap-2 sm:grid-cols-[12rem_minmax(0,1fr)] sm:items-center"
-                                        >
-                                            <Input
-                                                name={`prompt-agent-mcp-header-name-${index}-${headerIndex}`}
-                                                aria-label={`MCP server ${index + 1} header ${headerIndex + 1} name`}
-                                                value={header.name}
-                                                placeholder="Authorization"
-                                                autoComplete="off"
-                                                autoCapitalize="none"
-                                                spellCheck={false}
-                                                className="min-w-0"
-                                                disabled={disabled}
-                                                onChange={(event) =>
-                                                    onUpdateMcpHeader(
-                                                        index,
-                                                        headerIndex,
-                                                        "name",
-                                                        event.target.value,
-                                                    )
-                                                }
-                                            />
-                                            <div className="flex min-w-0 items-center gap-2">
-                                                <Input
-                                                    name={`prompt-agent-mcp-header-value-${index}-${headerIndex}`}
-                                                    aria-label={`MCP server ${index + 1} header ${headerIndex + 1} value`}
-                                                    type="password"
-                                                    value={header.value}
-                                                    placeholder={
-                                                        header.saved
-                                                            ? "Saved — leave blank to keep"
-                                                            : "Header value"
-                                                    }
-                                                    autoComplete="new-password"
-                                                    autoCapitalize="none"
-                                                    data-lpignore="true"
-                                                    data-1p-ignore="true"
-                                                    data-bwignore="true"
-                                                    className="min-w-0 flex-1"
-                                                    disabled={disabled}
-                                                    onChange={(event) =>
-                                                        onUpdateMcpHeader(
-                                                            index,
-                                                            headerIndex,
-                                                            "value",
-                                                            event.target.value,
-                                                        )
-                                                    }
-                                                />
-                                                {!disabled && (
-                                                    <IconButton
-                                                        intent="danger"
-                                                        title="Remove header"
-                                                        tooltip="Remove header"
-                                                        onClick={() =>
-                                                            onRemoveMcpHeader(
-                                                                index,
-                                                                headerIndex,
-                                                            )
-                                                        }
-                                                    >
-                                                        <XIcon className="h-4 w-4" />
-                                                    </IconButton>
-                                                )}
-                                            </div>
-                                        </div>
-                                    ))}
-                                </div>
-                            </div>
-                        ))}
+                    <p className="break-all font-mono text-xs text-theme-text-muted">
+                        https://mcp.pollinations.ai
+                    </p>
+                    <p className="text-xs text-theme-text-muted">
+                        Uses the caller's Pollinations API access.{" "}
+                        <a
+                            href="https://gen.pollinations.ai/docs#tag/mcp-server"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="underline decoration-current/40 underline-offset-2 hover:text-theme-text-soft"
+                        >
+                            API docs
+                        </a>
+                        {" · "}
+                        <a
+                            href="https://github.com/pollinations/pollinations/tree/main/packages/mcp"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="underline decoration-current/40 underline-offset-2 hover:text-theme-text-soft"
+                        >
+                            GitHub
+                        </a>
+                    </p>
                 </div>
             </FieldStack>
         </div>

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/types.ts
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/types.ts
@@ -10,55 +10,29 @@ import {
     MAX_COMMUNITY_PRICE_PER_IMAGE,
     MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS,
     MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS,
-    normalizeCommunityEndpointBaseUrl,
     normalizeCommunityEndpointInputModalities,
 } from "@shared/community-endpoints.ts";
 import type { ModelInputModality, Usage } from "@shared/registry/registry.ts";
 
 type EndpointFormPrices = Record<CommunityEndpointPriceKey, string>;
 
-export type McpHeaderRow = {
-    id: string;
-    name: string;
-    value: string;
-    saved: boolean;
-};
-
-export type McpServerRow = {
-    id: string;
-    name: string;
-    url: string;
-    headers: McpHeaderRow[];
-};
-
 export type ManagedAgent = {
     id: string;
     systemPrompt: string;
     baseModel: string;
-    pollinationsTools: boolean;
-    mcpServers: {
-        name: string;
-        url: string;
-        headers: Record<string, null>;
-    }[];
+    mcpServers: "pollinations"[];
     createdAt: string;
     updatedAt: string;
 };
 
 type AgentFields = Pick<
     ManagedAgent,
-    "systemPrompt" | "baseModel" | "pollinationsTools"
+    "systemPrompt" | "baseModel" | "mcpServers"
 >;
 
-export type AgentFormState = AgentFields & { mcpServers: McpServerRow[] };
+export type AgentFormState = AgentFields;
 
-export type AgentPayload = AgentFields & {
-    mcpServers: {
-        name: string;
-        url: string;
-        headers: Record<string, string | null>;
-    }[];
-};
+export type AgentPayload = AgentFields;
 
 export type CommunityProviderProfile = {
     name: string | null;
@@ -212,7 +186,6 @@ export const emptyForm: EndpointFormState = {
 export const emptyAgentForm: AgentFormState = {
     systemPrompt: "",
     baseModel: "",
-    pollinationsTools: false,
     mcpServers: [],
 };
 
@@ -399,90 +372,6 @@ export function observedUsageValue(
         : null;
 }
 
-// Mirrors the backend McpServerSchema name pattern (lowercase alphanumeric with
-// _ or -, max 40 chars) so client and server reject the same names.
-export const MCP_SERVER_NAME_PATTERN = /^[a-z0-9][a-z0-9_-]{0,39}$/;
-export const MCP_HEADER_NAME_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]{1,128}$/;
-
-export function isValidMcpRow(row: McpServerRow): boolean {
-    const name = row.name.trim();
-    const url = row.url.trim();
-    const nonEmptyHeaders = row.headers.filter(
-        (header) => header.name.trim() || header.value,
-    );
-    if (!name && !url && nonEmptyHeaders.length === 0) return true;
-    try {
-        normalizeCommunityEndpointBaseUrl(url);
-    } catch {
-        return false;
-    }
-    if (!MCP_SERVER_NAME_PATTERN.test(name)) return false;
-
-    const headerNames = new Set<string>();
-    for (const header of nonEmptyHeaders) {
-        const headerName = header.name.trim();
-        if (
-            !MCP_HEADER_NAME_PATTERN.test(headerName) ||
-            (!header.saved && !header.value) ||
-            header.value.includes("\r") ||
-            header.value.includes("\n")
-        ) {
-            return false;
-        }
-        const normalized = headerName.toLowerCase();
-        if (headerNames.has(normalized)) return false;
-        headerNames.add(normalized);
-    }
-    return nonEmptyHeaders.length <= 16;
-}
-
-// Validates and trims the MCP server rows, dropping fully-empty rows. Mirrors
-// the backend McpServerSchema so the API rejects the same inputs.
-function mcpServersToPayload(rows: McpServerRow[]): AgentPayload["mcpServers"] {
-    const servers: AgentPayload["mcpServers"] = [];
-    for (const row of rows) {
-        const name = row.name.trim();
-        const url = row.url.trim();
-        if (!name && !url) continue;
-        if (!MCP_SERVER_NAME_PATTERN.test(name)) {
-            throw new Error(
-                `MCP server name "${name}" must be lowercase alphanumeric with _ or - (max 40 chars)`,
-            );
-        }
-        if (!url) {
-            throw new Error(`MCP server "${name}" needs a URL`);
-        }
-        const headers: Record<string, string | null> = {};
-        for (const header of row.headers) {
-            const headerName = header.name.trim();
-            if (!headerName && !header.value) continue;
-            if (!MCP_HEADER_NAME_PATTERN.test(headerName)) {
-                throw new Error(
-                    `MCP server "${name}" has an invalid header name`,
-                );
-            }
-            if (!header.saved && !header.value) {
-                throw new Error(
-                    `MCP header "${headerName}" for server "${name}" needs a value`,
-                );
-            }
-            headers[headerName] = header.value || null;
-        }
-        try {
-            servers.push({
-                name,
-                url: normalizeCommunityEndpointBaseUrl(url),
-                headers,
-            });
-        } catch {
-            throw new Error(
-                `MCP server "${name}" must use HTTPS and target a public host`,
-            );
-        }
-    }
-    return servers;
-}
-
 export function toAgentPayload(form: AgentFormState): AgentPayload {
     const systemPrompt = form.systemPrompt.trim();
     if (!systemPrompt) {
@@ -492,21 +381,10 @@ export function toAgentPayload(form: AgentFormState): AgentPayload {
     if (!baseModel) {
         throw new Error("Base model is required for a prompt agent");
     }
-    const mcpServers = mcpServersToPayload(form.mcpServers);
-    const names = new Set(form.pollinationsTools ? ["pollinations"] : []);
-    for (const server of mcpServers) {
-        if (names.has(server.name)) {
-            throw new Error(
-                `MCP server name "${server.name}" is already in use`,
-            );
-        }
-        names.add(server.name);
-    }
     return {
         systemPrompt,
         baseModel,
-        pollinationsTools: form.pollinationsTools,
-        mcpServers,
+        mcpServers: form.mcpServers,
     };
 }
 

--- a/enter.pollinations.ai/frontend/src/components/news-faq/news-banner.tsx
+++ b/enter.pollinations.ai/frontend/src/components/news-faq/news-banner.tsx
@@ -45,7 +45,7 @@ const PINNED_NEWS: Highlight[] = [
         description:
             "Create managed prompt agents and call them through the Pollinations API like any other model.",
         details: [
-            "Choose a base model, add instructions, and optionally enable Pollinations tools or connect MCP servers.",
+            "Choose a base model, add instructions, and optionally enable Pollinations tools.",
             "Create an agent from [My Agents & Models](/my-models).",
         ],
     },

--- a/enter.pollinations.ai/src/routes/agent-runtime.ts
+++ b/enter.pollinations.ai/src/routes/agent-runtime.ts
@@ -1,5 +1,4 @@
 import * as schema from "@shared/db/better-auth.ts";
-import { decryptSecret } from "@shared/secret-encryption.ts";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { Hono } from "hono";
@@ -7,10 +6,7 @@ import { HTTPException } from "hono/http-exception";
 import { validator } from "hono-openapi";
 import type { Env } from "../env.ts";
 import { auth } from "../middleware/auth.ts";
-import {
-    parsePromptAgentConfig,
-    parsePromptAgentMcpHeaders,
-} from "../services/prompt-agent.ts";
+import { parsePromptAgentConfig } from "../services/prompt-agent.ts";
 import {
     handlePromptAgentRequest,
     PromptAgentRuntimeRequestSchema,
@@ -68,20 +64,8 @@ export const agentRuntimeRoutes = new Hono<Env>()
             if (!config) {
                 throw new Error(`Agent ${row.id} has invalid configuration`);
             }
-            const mcpHeaders = row.mcpHeadersCiphertext
-                ? parsePromptAgentMcpHeaders(
-                      await decryptSecret(
-                          row.mcpHeadersCiphertext,
-                          c.env.BETTER_AUTH_SECRET,
-                      ),
-                  )
-                : {};
-            if (!mcpHeaders) {
-                throw new Error(`Agent ${row.id} has invalid MCP credentials`);
-            }
             return await handlePromptAgentRequest(body, c.req.raw.signal, {
                 config,
-                mcpHeaders,
                 apiKey,
                 genBaseUrl: genBaseUrl(c.env),
                 pollinationsMcpUrl: pollinationsMcpUrl(c.env),

--- a/enter.pollinations.ai/src/routes/agents.ts
+++ b/enter.pollinations.ai/src/routes/agents.ts
@@ -1,6 +1,5 @@
 import * as schema from "@shared/db/better-auth.ts";
 import { validator } from "@shared/middleware/validator.ts";
-import { decryptSecret, encryptSecret } from "@shared/secret-encryption.ts";
 import { and, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { Hono } from "hono";
@@ -10,14 +9,9 @@ import { z } from "zod";
 import type { Env } from "../env.ts";
 import { auth } from "../middleware/auth.ts";
 import {
-    McpServerResponseSchema,
-    type PromptAgentConfig,
-    type PromptAgentInput,
+    BuiltinMcpServerIdSchema,
     PromptAgentInputSchema,
-    type PromptAgentMcpHeaders,
-    PromptAgentSchema,
     parsePromptAgentConfig,
-    parsePromptAgentMcpHeaders,
     serializePromptAgentConfig,
 } from "../services/prompt-agent.ts";
 import { requireAccountPermission } from "./account-permissions.ts";
@@ -28,8 +22,7 @@ const AgentResponseSchema = z.object({
     id: z.string(),
     systemPrompt: z.string(),
     baseModel: z.string(),
-    pollinationsTools: z.boolean(),
-    mcpServers: z.array(McpServerResponseSchema),
+    mcpServers: z.array(BuiltinMcpServerIdSchema),
     createdAt: z.string(),
     updatedAt: z.string(),
 });
@@ -47,93 +40,9 @@ function toResponse(row: AgentRow) {
     return {
         id: row.id,
         ...config,
-        mcpServers: config.mcpServers.map((server) => ({
-            name: server.name,
-            url: server.url,
-            headers: Object.fromEntries(
-                server.headers.map((name) => [name, null]),
-            ),
-        })),
         createdAt: row.createdAt,
         updatedAt: row.updatedAt,
     };
-}
-
-function savedHeaderValue(
-    headers: Record<string, string> | undefined,
-    name: string,
-): string | undefined {
-    const normalizedName = name.toLowerCase();
-    return Object.entries(headers ?? {}).find(
-        ([savedName]) => savedName.toLowerCase() === normalizedName,
-    )?.[1];
-}
-
-function resolveMcpServers(
-    servers: PromptAgentInput["mcpServers"],
-    currentServers: PromptAgentConfig["mcpServers"] = [],
-    currentHeaders: PromptAgentMcpHeaders = {},
-): {
-    mcpServers: PromptAgentConfig["mcpServers"];
-    mcpHeaders: PromptAgentMcpHeaders;
-} {
-    const mcpHeaders: PromptAgentMcpHeaders = {};
-    const mcpServers = servers.map((server, index) => {
-        const currentServer =
-            currentServers.find(
-                (candidate) => candidate.name === server.name,
-            ) ??
-            currentServers.find((candidate) => candidate.url === server.url) ??
-            currentServers[index];
-        const headers: Record<string, string> = {};
-        for (const [name, value] of Object.entries(server.headers)) {
-            const resolved =
-                value ??
-                savedHeaderValue(
-                    currentServer
-                        ? currentHeaders[currentServer.name]
-                        : undefined,
-                    name,
-                );
-            if (resolved === undefined) {
-                throw new HTTPException(400, {
-                    message: `MCP header "${name}" for server "${server.name}" needs a value`,
-                });
-            }
-            headers[name] = resolved;
-        }
-        if (Object.keys(headers).length > 0) {
-            mcpHeaders[server.name] = headers;
-        }
-        return {
-            name: server.name,
-            url: server.url,
-            headers: Object.keys(headers),
-        };
-    });
-    return { mcpServers, mcpHeaders };
-}
-
-async function encryptedMcpHeaders(
-    headers: PromptAgentMcpHeaders,
-    secret: string,
-): Promise<string | null> {
-    if (Object.keys(headers).length === 0) return null;
-    return encryptSecret(JSON.stringify(headers), secret);
-}
-
-async function storedMcpHeaders(
-    row: AgentRow,
-    secret: string,
-): Promise<PromptAgentMcpHeaders> {
-    if (!row.mcpHeadersCiphertext) return {};
-    const headers = parsePromptAgentMcpHeaders(
-        await decryptSecret(row.mcpHeadersCiphertext, secret),
-    );
-    if (!headers) {
-        throw new Error(`Agent ${row.id} has invalid MCP header credentials`);
-    }
-    return headers;
 }
 
 async function requireOwnedAgent(db: Db, id: string, ownerUserId: string) {
@@ -220,7 +129,7 @@ export const agentsRoutes = new Hono<Env>()
             tags: ["👤 Account"],
             summary: "Create Agent",
             description:
-                "Create an editable prompt agent. MCP header values are encrypted and never returned. The agent can later be registered separately as a community model. API keys require `account:keys`.",
+                "Create an editable prompt agent with optional access to Pollinations tools. The agent can later be registered separately as a community model. API keys require `account:keys`.",
             responses: {
                 200: {
                     description: "Created agent",
@@ -242,20 +151,12 @@ export const agentsRoutes = new Hono<Env>()
             requireAccountPermission(c.var.auth.apiKey, "keys");
             const db = drizzle(c.env.DB, { schema });
             const id = crypto.randomUUID();
-            const { mcpServers, mcpHeaders } = resolveMcpServers(
-                input.mcpServers,
-            );
-            const config = PromptAgentSchema.parse({ ...input, mcpServers });
             const [row] = await db
                 .insert(schema.agent)
                 .values({
                     id,
                     ownerUserId: user.id,
-                    config: serializePromptAgentConfig(config),
-                    mcpHeadersCiphertext: await encryptedMcpHeaders(
-                        mcpHeaders,
-                        c.env.BETTER_AUTH_SECRET,
-                    ),
+                    config: serializePromptAgentConfig(input),
                     createdAt: new Date(),
                     updatedAt: new Date(),
                 })
@@ -269,7 +170,7 @@ export const agentsRoutes = new Hono<Env>()
             tags: ["👤 Account"],
             summary: "Update Agent",
             description:
-                "Replace an agent configuration. Null MCP header values keep the saved value in the same server row. Omitted tools and servers are removed. Existing community model registration is unchanged. API keys require `account:keys`.",
+                "Replace an agent configuration. Existing community model registration is unchanged. API keys require `account:keys`.",
             responses: {
                 200: {
                     description: "Updated agent",
@@ -292,34 +193,13 @@ export const agentsRoutes = new Hono<Env>()
             requireAccountPermission(c.var.auth.apiKey, "keys");
             const db = drizzle(c.env.DB, { schema });
             const id = c.req.param("id");
-            const existing = await requireOwnedAgent(db, id, user.id);
-            const currentConfig = parsePromptAgentConfig(existing.config);
-            if (!currentConfig) {
-                throw new Error(
-                    `Agent ${existing.id} has invalid configuration`,
-                );
-            }
-            const resolvedMcp = resolveMcpServers(
-                input.mcpServers,
-                currentConfig.mcpServers,
-                await storedMcpHeaders(existing, c.env.BETTER_AUTH_SECRET),
-            );
-            const config = PromptAgentSchema.parse({
-                ...input,
-                mcpServers: resolvedMcp.mcpServers,
-            });
-            const serializedConfig = serializePromptAgentConfig(config);
-            const update: Partial<typeof schema.agent.$inferInsert> = {
-                config: serializedConfig,
-                mcpHeadersCiphertext: await encryptedMcpHeaders(
-                    resolvedMcp.mcpHeaders,
-                    c.env.BETTER_AUTH_SECRET,
-                ),
-                updatedAt: new Date(),
-            };
+            await requireOwnedAgent(db, id, user.id);
             const [row] = await db
                 .update(schema.agent)
-                .set(update)
+                .set({
+                    config: serializePromptAgentConfig(input),
+                    updatedAt: new Date(),
+                })
                 .where(
                     and(
                         eq(schema.agent.id, id),

--- a/enter.pollinations.ai/src/services/prompt-agent-runtime.ts
+++ b/enter.pollinations.ai/src/services/prompt-agent-runtime.ts
@@ -9,10 +9,7 @@ import {
     ToolLoopAgent,
 } from "ai";
 import { z } from "zod";
-import type {
-    PromptAgentConfig,
-    PromptAgentMcpHeaders,
-} from "./prompt-agent.ts";
+import type { PromptAgentConfig } from "./prompt-agent.ts";
 
 const log = getLogger(["enter", "prompt-agent-runtime"]);
 
@@ -31,18 +28,11 @@ export type PromptAgentRequest = z.output<typeof PromptAgentRequestSchema>;
 
 type PromptAgentRuntime = {
     config: PromptAgentConfig;
-    mcpHeaders: PromptAgentMcpHeaders;
     apiKey: string;
     genBaseUrl: string;
     pollinationsMcpUrl: string;
 };
 
-type McpServer = {
-    name: string;
-    url: string;
-    headers?: Record<string, string>;
-    includeTools?: string[];
-};
 type McpClient = Awaited<ReturnType<typeof createMCPClient>>;
 type McpTool = Awaited<ReturnType<McpClient["tools"]>>[string];
 type ToolCallCounts = Record<string, number>;
@@ -92,110 +82,76 @@ function agentErrorResponse(error: unknown): Response {
     );
 }
 
-async function loadMcpTools(
-    servers: McpServer[],
+async function loadPollinationsTools(
+    url: string,
+    apiKey: string,
     signal: AbortSignal,
 ): Promise<{
     tools: Record<string, McpTool>;
     close: () => Promise<void>;
 }> {
-    const clients: McpClient[] = [];
+    let client: McpClient | undefined;
     const tools: Record<string, McpTool> = {};
     let closed = false;
 
     const close = async () => {
         if (closed) return;
         closed = true;
-        await Promise.all(clients.map((client) => client.close()));
+        await client?.close();
     };
 
-    for (const server of servers) {
-        // Isolated per server: a broken MCP endpoint must not take down the whole
-        // agent. A user can save any url, and third-party servers go down; losing
-        // one server's tools is recoverable, losing the request is not.
-        try {
-            const client = await createMCPClient({
-                clientName: "pollinations-prompt-agent",
-                initializationOptions: {
-                    signal,
-                    timeout: MCP_INITIALIZATION_TIMEOUT_MS,
-                },
-                transport: {
-                    type: "http",
-                    url: server.url,
-                    headers: server.headers,
-                    // The redirect override is required, not optional: the MCP
-                    // client asks for redirect "error", which workerd rejects
-                    // outright ("must be one of follow or manual"). We follow
-                    // them — refusing bought little, since a hostile server can
-                    // proxy anywhere without a redirect and the config-time host
-                    // blocklist is the real SSRF control, while redirects are
-                    // ordinary (trailing slashes, http->https, moved paths).
-                    fetch: async (input, init) =>
-                        globalThis.fetch.call(globalThis, input, {
-                            ...init,
-                            redirect: "follow",
-                        }),
-                },
-            });
-            clients.push(client);
-            let loaded = 0;
-            for (const [name, definition] of Object.entries(
-                await client.tools(),
-            )) {
-                if (server.includeTools && !server.includeTools.includes(name))
-                    continue;
-                tools[`mcp__${server.name}__${name}`] = definition;
-                loaded++;
-            }
-            log.info("MCP_SERVER_LOADED: name={name} url={url} tools={tools}", {
-                name: server.name,
-                url: server.url,
-                tools: loaded,
-            });
-        } catch (error) {
-            // The agent route returns a Response rather than throwing, so Hono's
-            // onError never fires and nothing reaches error_event: this log is the
-            // only signal that a server dropped out.
-            log.error(
-                "MCP_SERVER_FAILED: name={name} url={url} error={error}",
-                {
-                    name: server.name,
-                    url: server.url,
-                    error:
-                        error instanceof Error ? error.message : String(error),
-                },
-            );
+    try {
+        client = await createMCPClient({
+            clientName: "pollinations-prompt-agent",
+            initializationOptions: {
+                signal,
+                timeout: MCP_INITIALIZATION_TIMEOUT_MS,
+            },
+            transport: {
+                type: "http",
+                url,
+                headers: { Authorization: `Bearer ${apiKey}` },
+                // The MCP client asks for redirect "error", which workerd does
+                // not support. Use a valid fetch mode for the hosted endpoint.
+                fetch: async (input, init) =>
+                    globalThis.fetch.call(globalThis, input, {
+                        ...init,
+                        redirect: "follow",
+                    }),
+            },
+        });
+        for (const [name, definition] of Object.entries(await client.tools())) {
+            if (!POLLINATIONS_AGENT_TOOLS.includes(name)) continue;
+            tools[`mcp__pollinations__${name}`] = definition;
         }
+        log.info("MCP_SERVER_LOADED: name={name} url={url} tools={tools}", {
+            name: "pollinations",
+            url,
+            tools: Object.keys(tools).length,
+        });
+    } catch (error) {
+        // Tool availability is recoverable; the base model can still answer.
+        log.error("MCP_SERVER_FAILED: name={name} url={url} error={error}", {
+            name: "pollinations",
+            url,
+            error: error instanceof Error ? error.message : String(error),
+        });
     }
 
     return { tools, close };
 }
 
 async function createAgent(runtime: PromptAgentRuntime, signal: AbortSignal) {
-    const servers: McpServer[] = runtime.config.mcpServers.map((server) => {
-        const storedHeaders = runtime.mcpHeaders[server.name] ?? {};
-        return {
-            name: server.name,
-            url: server.url,
-            headers: Object.fromEntries(
-                server.headers.flatMap((name) =>
-                    storedHeaders[name] === undefined
-                        ? []
-                        : [[name, storedHeaders[name]]],
-                ),
-            ),
-        };
-    });
-    if (runtime.config.pollinationsTools) {
-        servers.push({
-            name: "pollinations",
-            url: runtime.pollinationsMcpUrl,
-            headers: { Authorization: `Bearer ${runtime.apiKey}` },
-            includeTools: POLLINATIONS_AGENT_TOOLS,
-        });
-    }
-    const { tools, close } = await loadMcpTools(servers, signal);
+    const { tools, close } = runtime.config.mcpServers.includes("pollinations")
+        ? await loadPollinationsTools(
+              runtime.pollinationsMcpUrl,
+              runtime.apiKey,
+              signal,
+          )
+        : {
+              tools: {} as Record<string, McpTool>,
+              close: async () => {},
+          };
     const toolCallCounts: ToolCallCounts = {};
     let toolCalls = 0;
     for (const [name, tool] of Object.entries(tools)) {

--- a/enter.pollinations.ai/src/services/prompt-agent.ts
+++ b/enter.pollinations.ai/src/services/prompt-agent.ts
@@ -1,123 +1,29 @@
 // Configuration for no-code prompt agents. All agents run in the shared Enter
-// Worker; the agent row selects the prompt, model, and available MCP tools.
-import { normalizeCommunityEndpointBaseUrl } from "@shared/community-endpoints.ts";
+// Worker; the agent row selects the prompt, model, and attached MCP servers.
 import { z } from "zod";
 
-const McpServerUrlSchema = z
-    .string()
-    .url()
-    .refine((value) => {
-        try {
-            normalizeCommunityEndpointBaseUrl(value);
-            return true;
-        } catch {
-            return false;
-        }
-    }, "MCP server URL must use https and target a public host")
-    .transform(normalizeCommunityEndpointBaseUrl);
-
-const McpHeaderNameSchema = z
-    .string()
-    .min(1)
-    .max(128)
-    .regex(/^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/, "MCP header name is invalid");
-const McpHeaderValueSchema = z
-    .string()
-    .min(1)
-    .max(8192)
-    .refine((value) => !value.includes("\r") && !value.includes("\n"), {
-        message: "MCP header value cannot contain line breaks",
-    });
-const McpHeadersInputSchema = z
-    .record(McpHeaderNameSchema, McpHeaderValueSchema.nullable())
-    .refine((headers) => Object.keys(headers).length <= 16, {
-        message: "An MCP server can have at most 16 headers",
-    })
-    .superRefine((headers, context) => {
-        const names = new Set<string>();
-        for (const name of Object.keys(headers)) {
-            const normalized = name.toLowerCase();
-            if (!names.has(normalized)) {
-                names.add(normalized);
-                continue;
-            }
-            context.addIssue({
-                code: "custom",
-                path: [name],
-                message: `MCP header name "${name}" is already in use`,
-            });
-        }
-    });
-
-const McpServerBaseSchema = z.object({
-    // Namespaces the server's tools (mcp__<name>__<tool>); lowercase to match
-    // the community tool-name pattern so its fees can be declared.
-    name: z
-        .string()
-        .trim()
-        .regex(
-            /^[a-z0-9][a-z0-9_-]{0,39}$/,
-            "MCP server name must be lowercase alphanumeric with _ or - (max 40 chars)",
-        ),
-    url: McpServerUrlSchema,
-});
-
-const McpServerSchema = McpServerBaseSchema.extend({
-    // Header names are safe to return; their encrypted values live separately.
-    headers: z.array(McpHeaderNameSchema).max(16).optional().default([]),
-});
-
-export const McpServerInputSchema = McpServerBaseSchema.extend({
-    // Null means "keep the saved value" on update. Values are never returned.
-    headers: McpHeadersInputSchema.optional().default({}),
-});
-
-function addUniqueMcpServerNameIssues(
-    config: { pollinationsTools?: boolean; mcpServers: { name: string }[] },
-    context: z.RefinementCtx,
-) {
-    const names = new Set(config.pollinationsTools ? ["pollinations"] : []);
-    for (const [index, server] of config.mcpServers.entries()) {
-        if (!names.has(server.name)) {
-            names.add(server.name);
-            continue;
-        }
-        context.addIssue({
-            code: "custom",
-            path: ["mcpServers", index, "name"],
-            message: `MCP server name "${server.name}" is already in use`,
-        });
-    }
-}
+export const BuiltinMcpServerIdSchema = z.literal("pollinations");
 
 export const PromptAgentSchema = z
     .object({
         systemPrompt: z.string().trim().min(1).max(8000),
         baseModel: z.string().trim().min(1).max(253),
-        pollinationsTools: z.boolean().optional().default(false),
-        mcpServers: z.array(McpServerSchema).max(8).optional().default([]),
+        mcpServers: z
+            .array(BuiltinMcpServerIdSchema)
+            .max(1)
+            .optional()
+            .default([]),
     })
-    .superRefine(addUniqueMcpServerNameIssues)
     .describe(
-        "No-code agent config: a system prompt over a base model, with optional MCP servers. The platform runs it; no worker source or bearerToken is needed.",
+        "No-code agent config: a system prompt over a base model, with optional access to the built-in Pollinations MCP server.",
     );
 
-export const PromptAgentInputSchema = z
-    .object({
-        systemPrompt: PromptAgentSchema.shape.systemPrompt,
-        baseModel: PromptAgentSchema.shape.baseModel,
-        pollinationsTools: PromptAgentSchema.shape.pollinationsTools,
-        mcpServers: z.array(McpServerInputSchema).max(8).optional().default([]),
-    })
-    .superRefine(addUniqueMcpServerNameIssues);
-
-export const McpServerResponseSchema = McpServerBaseSchema.extend({
-    headers: z.record(McpHeaderNameSchema, z.null()),
-});
+// Stored configs may still contain unrelated historical fields, which Zod
+// strips. New writes are strict so removed fields fail visibly.
+export const PromptAgentInputSchema = PromptAgentSchema.strict();
 
 export type PromptAgentConfig = z.infer<typeof PromptAgentSchema>;
 export type PromptAgentInput = z.infer<typeof PromptAgentInputSchema>;
-export type PromptAgentMcpHeaders = Record<string, Record<string, string>>;
 
 export function agentRuntimeBaseUrl(env: {
     AGENT_RUNTIME_BASE_URL: string;
@@ -136,20 +42,4 @@ export function parsePromptAgentConfig(raw: string): PromptAgentConfig | null {
 
 export function serializePromptAgentConfig(config: PromptAgentConfig): string {
     return JSON.stringify(config);
-}
-
-export function parsePromptAgentMcpHeaders(
-    raw: string,
-): PromptAgentMcpHeaders | null {
-    try {
-        const parsed = z
-            .record(
-                z.string(),
-                z.record(McpHeaderNameSchema, McpHeaderValueSchema),
-            )
-            .safeParse(JSON.parse(raw));
-        return parsed.success ? parsed.data : null;
-    } catch {
-        return null;
-    }
 }

--- a/enter.pollinations.ai/test/community-endpoint-rpm-input.test.ts
+++ b/enter.pollinations.ai/test/community-endpoint-rpm-input.test.ts
@@ -3,7 +3,6 @@ import {
     agentListingToForm,
     emptyAgentForm,
     emptyForm,
-    isValidMcpRow,
     isValidPerUserRpm,
     publicCommunityFallbackOptions,
     toAgentListingPayload,
@@ -25,84 +24,19 @@ describe("community endpoint per-user RPM input", () => {
         expect(isValidPerUserRpm("0")).toBe(false);
     });
 
-    it("validates and normalizes agent MCP servers", () => {
-        expect(
-            isValidMcpRow({
-                id: "1",
-                name: "docs",
-                url: "https://mcp.example.com/rpc/",
-                headers: [],
-            }),
-        ).toBe(true);
-        expect(
-            isValidMcpRow({
-                id: "2",
-                name: "docs",
-                url: "ftp://mcp.example.com/rpc",
-                headers: [],
-            }),
-        ).toBe(false);
+    it("serializes the prompt-agent fields", () => {
         expect(
             toAgentPayload({
                 ...emptyAgentForm,
-                systemPrompt: "Help",
-                baseModel: "openai",
-                mcpServers: [
-                    {
-                        id: "3",
-                        name: "docs",
-                        url: "https://mcp.example.com/rpc/",
-                        headers: [
-                            {
-                                id: "header-1",
-                                name: "Authorization",
-                                value: "Bearer secret",
-                                saved: false,
-                            },
-                            {
-                                id: "header-2",
-                                name: "X-Saved",
-                                value: "",
-                                saved: true,
-                            },
-                        ],
-                    },
-                ],
-            }).mcpServers,
-        ).toEqual([
-            {
-                name: "docs",
-                url: "https://mcp.example.com/rpc",
-                headers: {
-                    Authorization: "Bearer secret",
-                    "X-Saved": null,
-                },
-            },
-        ]);
-    });
-
-    it("rejects duplicate agent MCP names", () => {
-        expect(() =>
-            toAgentPayload({
-                ...emptyAgentForm,
-                systemPrompt: "Help",
-                baseModel: "openai",
-                mcpServers: [
-                    {
-                        id: "1",
-                        name: "docs",
-                        url: "https://one.example.com/mcp",
-                        headers: [],
-                    },
-                    {
-                        id: "2",
-                        name: "docs",
-                        url: "https://two.example.com/mcp",
-                        headers: [],
-                    },
-                ],
+                systemPrompt: " Help ",
+                baseModel: " openai ",
+                mcpServers: ["pollinations"],
             }),
-        ).toThrow('MCP server name "docs" is already in use');
+        ).toEqual({
+            systemPrompt: "Help",
+            baseModel: "openai",
+            mcpServers: ["pollinations"],
+        });
     });
 
     it("does not offer agent listings as fallback models", () => {

--- a/enter.pollinations.ai/test/prompt-agent-runtime.test.ts
+++ b/enter.pollinations.ai/test/prompt-agent-runtime.test.ts
@@ -11,7 +11,10 @@ import {
     agentRuntimeRoutes,
     POLLINATIONS_MCP_URL,
 } from "../src/routes/agent-runtime.ts";
-import { PromptAgentSchema } from "../src/services/prompt-agent.ts";
+import {
+    PromptAgentInputSchema,
+    PromptAgentSchema,
+} from "../src/services/prompt-agent.ts";
 import {
     handlePromptAgentRequest,
     type PromptAgentRequest,
@@ -24,10 +27,8 @@ const BASE_RUNTIME: PromptAgentRuntime = {
     config: {
         systemPrompt: "You are a test agent.",
         baseModel: "openai",
-        pollinationsTools: false,
         mcpServers: [],
     },
-    mcpHeaders: {},
     apiKey: "sk_test",
     genBaseUrl: "https://gen.test.example",
     pollinationsMcpUrl: "https://mcp.pollinations.test/",
@@ -66,63 +67,25 @@ describe("prompt-agent config", () => {
     const config = {
         systemPrompt: "You are a test agent.",
         baseModel: "openai",
-        pollinationsTools: false,
+        mcpServers: [],
     };
 
-    it("accepts public HTTPS MCP servers", () => {
+    it("rejects custom MCP configuration on write", () => {
+        expect(
+            PromptAgentInputSchema.safeParse({
+                ...config,
+                mcpServers: [{ name: "docs", url: "https://mcp.example.com" }],
+            }).success,
+        ).toBe(false);
+    });
+
+    it("accepts the built-in Pollinations MCP server", () => {
         expect(
             PromptAgentSchema.parse({
                 ...config,
-                mcpServers: [
-                    { name: "docs", url: "https://mcp.example.com/rpc/" },
-                ],
-            }).mcpServers,
-        ).toEqual([
-            {
-                name: "docs",
-                url: "https://mcp.example.com/rpc",
-                headers: [],
-            },
-        ]);
-    });
-
-    it("rejects plaintext and private-host MCP servers", () => {
-        for (const url of [
-            "http://mcp.example.com/rpc",
-            "https://localhost/rpc",
-            "https://127.0.0.1/rpc",
-        ]) {
-            expect(
-                PromptAgentSchema.safeParse({
-                    ...config,
-                    mcpServers: [{ name: "docs", url }],
-                }).success,
-            ).toBe(false);
-        }
-    });
-
-    it("rejects duplicate MCP server names", () => {
-        expect(
-            PromptAgentSchema.safeParse({
-                ...config,
-                mcpServers: [
-                    { name: "docs", url: "https://one.example.com/mcp" },
-                    { name: "docs", url: "https://two.example.com/mcp" },
-                ],
-            }).success,
-        ).toBe(false);
-        expect(
-            PromptAgentSchema.safeParse({
-                ...config,
-                pollinationsTools: true,
-                mcpServers: [
-                    {
-                        name: "pollinations",
-                        url: "https://example.com/mcp",
-                    },
-                ],
-            }).success,
-        ).toBe(false);
+                mcpServers: ["pollinations"],
+            }),
+        ).toEqual({ ...config, mcpServers: ["pollinations"] });
     });
 });
 
@@ -174,7 +137,6 @@ describe("prompt-agent runtime", () => {
             config: JSON.stringify({
                 systemPrompt: "Answer briefly.",
                 baseModel: "openai-fast",
-                pollinationsTools: false,
                 mcpServers: [],
             }),
             createdAt: new Date(),
@@ -295,75 +257,6 @@ describe("prompt-agent runtime", () => {
         });
     });
 
-    it("keeps serving when a redirect response cannot be used", async () => {
-        const requests: { url: string; authorization: string | null }[] = [];
-        vi.stubGlobal(
-            "fetch",
-            vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-                const request = new Request(input, init);
-                if (request.url.startsWith("https://mcp.example.com/")) {
-                    requests.push({
-                        url: request.url,
-                        authorization: request.headers.get("Authorization"),
-                    });
-                    return new Response(null, {
-                        status: 302,
-                        headers: { Location: "https://attacker.example/mcp" },
-                    });
-                }
-                requests.push({
-                    url: request.url,
-                    authorization: request.headers.get("Authorization"),
-                });
-                return Response.json({
-                    choices: [
-                        { message: { role: "assistant", content: "no tools" } },
-                    ],
-                    usage: { prompt_tokens: 2, completion_tokens: 2 },
-                });
-            }),
-        );
-
-        const response = await runAgent(
-            { messages: [{ role: "user", content: "hello" }] },
-            {
-                ...BASE_RUNTIME,
-                config: {
-                    ...BASE_RUNTIME.config,
-                    mcpServers: [
-                        {
-                            name: "docs",
-                            url: "https://mcp.example.com/rpc",
-                            headers: ["Authorization"],
-                        },
-                    ],
-                },
-                mcpHeaders: {
-                    docs: { Authorization: "Bearer mcp-secret" },
-                },
-            },
-        );
-
-        // Redirects are followed in production (redirect: "follow"); this stub
-        // returns the 302 itself, so the transport simply cannot use it. The
-        // credential still goes only to the configured host, never to the
-        // redirect target, because nothing here follows the hop.
-        // Compare the parsed hostname rather than a url prefix: a prefix match
-        // also accepts attacker.example.evil.com, so it is not a sound host check.
-        expect(requests.map((r) => new URL(r.url).hostname)).not.toContain(
-            "attacker.example",
-        );
-        expect(
-            requests.filter((r) => r.url === "https://mcp.example.com/rpc")
-                .length,
-        ).toBeGreaterThan(0);
-        // The server drops out rather than failing the request: the agent answers
-        // without its tools.
-        const body = await response.text();
-        expect(response.status, body).toBe(200);
-        expect(JSON.parse(body).choices[0].message.content).toBe("no tools");
-    });
-
     it("runs the MCP tool loop and reuses the negotiated session", async () => {
         const mcpRequests: Request[] = [];
         let modelCalls = 0;
@@ -371,7 +264,7 @@ describe("prompt-agent runtime", () => {
             async (input: RequestInfo | URL, init?: RequestInit) => {
                 const request = new Request(input, init);
                 const url = new URL(request.url);
-                if (url.hostname === "mcp.example.com") {
+                if (request.url === BASE_RUNTIME.pollinationsMcpUrl) {
                     mcpRequests.push(request.clone());
                     if (request.method === "GET") {
                         return new Response(null, { status: 405 });
@@ -410,7 +303,7 @@ describe("prompt-agent runtime", () => {
                             result: {
                                 tools: [
                                     {
-                                        name: "lookup",
+                                        name: "listModels",
                                         inputSchema: { type: "object" },
                                     },
                                 ],
@@ -439,7 +332,7 @@ describe("prompt-agent runtime", () => {
                                         {
                                             id: "c1",
                                             function: {
-                                                name: "mcp__docs__lookup",
+                                                name: "mcp__pollinations__listModels",
                                                 arguments: "{}",
                                             },
                                         },
@@ -466,19 +359,7 @@ describe("prompt-agent runtime", () => {
                 ...BASE_RUNTIME,
                 config: {
                     ...BASE_RUNTIME.config,
-                    mcpServers: [
-                        {
-                            name: "docs",
-                            url: "https://mcp.example.com/rpc",
-                            headers: ["Authorization", "X-Tenant"],
-                        },
-                    ],
-                },
-                mcpHeaders: {
-                    docs: {
-                        Authorization: "Bearer mcp-secret",
-                        "X-Tenant": "pollinations",
-                    },
+                    mcpServers: ["pollinations"],
                 },
             },
         );
@@ -526,9 +407,8 @@ describe("prompt-agent runtime", () => {
         }
         for (const request of mcpRequests) {
             expect(request.headers.get("Authorization")).toBe(
-                "Bearer mcp-secret",
+                `Bearer ${BASE_RUNTIME.apiKey}`,
             );
-            expect(request.headers.get("X-Tenant")).toBe("pollinations");
         }
     });
 
@@ -539,7 +419,7 @@ describe("prompt-agent runtime", () => {
             "fetch",
             vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
                 const request = new Request(input, init);
-                if (new URL(request.url).hostname === "mcp.example.com") {
+                if (request.url === BASE_RUNTIME.pollinationsMcpUrl) {
                     if (request.method === "DELETE") {
                         return new Response(null, { status: 200 });
                     }
@@ -568,7 +448,7 @@ describe("prompt-agent runtime", () => {
                             result: {
                                 tools: [
                                     {
-                                        name: "lookup",
+                                        name: "listModels",
                                         inputSchema: { type: "object" },
                                     },
                                 ],
@@ -599,7 +479,7 @@ describe("prompt-agent runtime", () => {
                                             id: `call-${index}`,
                                             type: "function",
                                             function: {
-                                                name: "mcp__docs__lookup",
+                                                name: "mcp__pollinations__listModels",
                                                 arguments: "{}",
                                             },
                                         }),
@@ -626,13 +506,7 @@ describe("prompt-agent runtime", () => {
                 ...BASE_RUNTIME,
                 config: {
                     ...BASE_RUNTIME.config,
-                    mcpServers: [
-                        {
-                            name: "docs",
-                            url: "https://mcp.example.com/rpc",
-                            headers: [],
-                        },
-                    ],
+                    mcpServers: ["pollinations"],
                 },
             },
         );
@@ -644,15 +518,13 @@ describe("prompt-agent runtime", () => {
         expect(body.usage.tool_call_counts.mcp_call).toBe(17);
     });
 
-    it("keeps running when an MCP server fails to load", async () => {
-        // A user can save any MCP url and third-party servers go down; losing one
-        // server's tools must not take down the whole agent request.
+    it("keeps running when the Pollinations MCP fails to load", async () => {
         let modelCalls = 0;
         vi.stubGlobal(
             "fetch",
             vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
                 const request = new Request(input, init);
-                if (request.url === "https://mcp.broken.example/sse") {
+                if (request.url === BASE_RUNTIME.pollinationsMcpUrl) {
                     return new Response("Method Not Allowed", { status: 405 });
                 }
                 modelCalls++;
@@ -676,13 +548,7 @@ describe("prompt-agent runtime", () => {
                 ...BASE_RUNTIME,
                 config: {
                     ...BASE_RUNTIME.config,
-                    mcpServers: [
-                        {
-                            name: "websearch",
-                            url: "https://mcp.broken.example/sse",
-                            headers: [],
-                        },
-                    ],
+                    mcpServers: ["pollinations"],
                 },
             },
         );
@@ -770,7 +636,7 @@ describe("prompt-agent runtime", () => {
                 ...BASE_RUNTIME,
                 config: {
                     ...BASE_RUNTIME.config,
-                    pollinationsTools: true,
+                    mcpServers: ["pollinations"],
                 },
             },
         );
@@ -962,7 +828,7 @@ describe("prompt-agent runtime", () => {
                 ...BASE_RUNTIME,
                 config: {
                     ...BASE_RUNTIME.config,
-                    pollinationsTools: true,
+                    mcpServers: ["pollinations"],
                 },
             },
         );
@@ -1100,8 +966,7 @@ describe("prompt-agent runtime", () => {
         const fetchMock = vi.fn(
             async (input: RequestInfo | URL, init?: RequestInit) => {
                 const request = new Request(input, init);
-                const url = new URL(request.url);
-                if (url.hostname === "mcp.example.com") {
+                if (request.url === BASE_RUNTIME.pollinationsMcpUrl) {
                     if (request.method === "GET") {
                         return new Response(null, { status: 405 });
                     }
@@ -1136,7 +1001,7 @@ describe("prompt-agent runtime", () => {
                             result: {
                                 tools: [
                                     {
-                                        name: "lookup",
+                                        name: "listModels",
                                         inputSchema: { type: "object" },
                                     },
                                 ],
@@ -1160,7 +1025,7 @@ describe("prompt-agent runtime", () => {
                                         {
                                             id: "c1",
                                             function: {
-                                                name: "mcp__docs__lookup",
+                                                name: "mcp__pollinations__listModels",
                                                 arguments: "{}",
                                             },
                                         },
@@ -1195,13 +1060,7 @@ describe("prompt-agent runtime", () => {
                 ...BASE_RUNTIME,
                 config: {
                     ...BASE_RUNTIME.config,
-                    mcpServers: [
-                        {
-                            name: "docs",
-                            url: "https://mcp.example.com/rpc",
-                            headers: [],
-                        },
-                    ],
+                    mcpServers: ["pollinations"],
                 },
             },
         );

--- a/enter.pollinations.ai/test/request-inputs.test.ts
+++ b/enter.pollinations.ai/test/request-inputs.test.ts
@@ -3,7 +3,7 @@ import { Hono } from "hono";
 import { describe, expect, it } from "vitest";
 
 describe("request input redaction", () => {
-    it("redacts custom header objects from error inputs", async () => {
+    it("redacts nested header objects from error inputs", async () => {
         const app = new Hono().post("/", async (c) =>
             c.json(await collectRequestInputs(c)),
         );
@@ -11,7 +11,7 @@ describe("request input redaction", () => {
             method: "POST",
             headers: { "content-type": "application/json" },
             body: JSON.stringify({
-                mcpServers: [
+                connectors: [
                     {
                         name: "docs",
                         headers: {
@@ -24,7 +24,7 @@ describe("request input redaction", () => {
 
         await expect(response.json()).resolves.toMatchObject({
             body: {
-                mcpServers: [{ name: "docs", headers: "[redacted]" }],
+                connectors: [{ name: "docs", headers: "[redacted]" }],
             },
         });
     });

--- a/gen.pollinations.ai/src/agent-catalog.ts
+++ b/gen.pollinations.ai/src/agent-catalog.ts
@@ -12,7 +12,7 @@ import type { GenerationModelEntry } from "./model-registry.ts";
 /** The agent fields the catalog reads out of the stored agent config. */
 export type AgentCatalogConfig = {
     baseModel: string;
-    pollinationsTools: boolean;
+    mcpServers: "pollinations"[];
 };
 
 /** Every environment binding the agent catalog needs. */
@@ -43,7 +43,12 @@ export function parseAgentCatalogConfig(
         }
         return {
             baseModel: parsed.baseModel,
-            pollinationsTools: parsed.pollinationsTools === true,
+            mcpServers: Array.isArray(parsed.mcpServers)
+                ? parsed.mcpServers.filter(
+                      (server): server is "pollinations" =>
+                          server === "pollinations",
+                  )
+                : [],
         };
     } catch {
         return null;
@@ -56,7 +61,9 @@ function applyBaseModelMetadata(
 ): void {
     const config = entry.agentConfig;
     if (!config) return;
-    const agentCapabilities: ModelCapability[] = config.pollinationsTools
+    const agentCapabilities: ModelCapability[] = config.mcpServers.includes(
+        "pollinations",
+    )
         ? ["pollinations_models"]
         : [];
 

--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -53,7 +53,7 @@ import {
 } from "@shared/registry/registry.ts";
 import { DEFAULT_TEXT_MODEL } from "@shared/registry/text.ts";
 import { FALLBACK_TARGET_HEADER } from "@shared/registry/usage-headers.ts";
-import { decryptSecret, encryptSecret } from "@shared/secret-encryption.ts";
+import { encryptSecret } from "@shared/secret-encryption.ts";
 import {
     createTestApiKey,
     createTestUser,
@@ -3739,17 +3739,7 @@ fixtureTest(
         const promptAgent = {
             systemPrompt: "You are a terse SQL tutor.",
             baseModel: "openai-fast",
-            pollinationsTools: true,
-            mcpServers: [
-                {
-                    name: "docs",
-                    url: "https://mcp.example.com/rpc",
-                    headers: {
-                        Authorization: "Bearer mcp-secret",
-                        "X-Team": "pollinations",
-                    },
-                },
-            ],
+            mcpServers: ["pollinations"],
         };
         const createAgentResponse = await fetchEnterApi(
             enterApi,
@@ -3768,45 +3758,23 @@ fixtureTest(
             id: string;
             systemPrompt: string;
             baseModel: string;
-            mcpServers: typeof promptAgent.mcpServers;
+            mcpServers: string[];
         };
         expect(agent).toMatchObject({
             systemPrompt: "You are a terse SQL tutor.",
             baseModel: "openai-fast",
-            pollinationsTools: true,
-            mcpServers: [
-                {
-                    name: "docs",
-                    headers: {
-                        Authorization: null,
-                        "X-Team": null,
-                    },
-                },
-            ],
+            mcpServers: ["pollinations"],
         });
         expect(agent).not.toHaveProperty("apiKeyId");
         expect(agent).not.toHaveProperty("apiKeyCiphertext");
         expect(agent).not.toHaveProperty("bearerTokenCiphertext");
-        expect(agent).not.toHaveProperty("mcpHeadersCiphertext");
         expect(agent).not.toHaveProperty("baseUrl");
         const [storedAgent] = await db
             .select()
             .from(agentTable)
             .where(eq(agentTable.id, agent.id));
         expect(storedAgent.id).toBe(agent.id);
-        expect(storedAgent.config).not.toContain("mcp-secret");
-        expect(storedAgent.mcpHeadersCiphertext).not.toContain("mcp-secret");
-        await expect(
-            decryptSecret(
-                storedAgent.mcpHeadersCiphertext ?? "",
-                env.BETTER_AUTH_SECRET,
-            ).then(JSON.parse),
-        ).resolves.toEqual({
-            docs: {
-                Authorization: "Bearer mcp-secret",
-                "X-Team": "pollinations",
-            },
-        });
+        expect(JSON.parse(storedAgent.config)).toEqual(promptAgent);
         const partialUpdateResponse = await fetchEnterApi(
             enterApi,
             new Request(`https://enter.test/api/account/agents/${agent.id}`, {
@@ -3833,15 +3801,6 @@ fixtureTest(
                 body: JSON.stringify({
                     ...promptAgent,
                     systemPrompt: "You are an editable SQL tutor.",
-                    mcpServers: [
-                        {
-                            ...promptAgent.mcpServers[0],
-                            headers: {
-                                Authorization: null,
-                                "X-Team": null,
-                            },
-                        },
-                    ],
                 }),
             }),
             enterEnv,
@@ -3850,119 +3809,15 @@ fixtureTest(
         await expect(updateAgentResponse.json()).resolves.toMatchObject({
             id: agent.id,
             systemPrompt: "You are an editable SQL tutor.",
-            pollinationsTools: true,
-            mcpServers: [
-                {
-                    name: "docs",
-                    url: "https://mcp.example.com/rpc",
-                    headers: {
-                        Authorization: null,
-                        "X-Team": null,
-                    },
-                },
-            ],
+            mcpServers: ["pollinations"],
         });
         const [agentAfterPromptUpdate] = await db
             .select()
             .from(agentTable)
             .where(eq(agentTable.id, agent.id));
-        await expect(
-            decryptSecret(
-                agentAfterPromptUpdate.mcpHeadersCiphertext ?? "",
-                env.BETTER_AUTH_SECRET,
-            ).then(JSON.parse),
-        ).resolves.toEqual({
-            docs: {
-                Authorization: "Bearer mcp-secret",
-                "X-Team": "pollinations",
-            },
-        });
-
-        const reuseHeadersAtNewUrlResponse = await fetchEnterApi(
-            enterApi,
-            new Request(`https://enter.test/api/account/agents/${agent.id}`, {
-                method: "PATCH",
-                headers: {
-                    "Content-Type": "application/json",
-                    Cookie: cookie,
-                },
-                body: JSON.stringify({
-                    systemPrompt: "You are an editable SQL tutor.",
-                    baseModel: promptAgent.baseModel,
-                    pollinationsTools: true,
-                    mcpServers: [
-                        {
-                            name: "docs",
-                            url: "https://other.example.com/rpc",
-                            headers: { Authorization: null },
-                        },
-                    ],
-                }),
-            }),
-            enterEnv,
-        );
-        expect(reuseHeadersAtNewUrlResponse.status).toBe(200);
-        const [agentAfterUrlUpdate] = await db
-            .select()
-            .from(agentTable)
-            .where(eq(agentTable.id, agent.id));
-        await expect(
-            decryptSecret(
-                agentAfterUrlUpdate.mcpHeadersCiphertext ?? "",
-                env.BETTER_AUTH_SECRET,
-            ).then(JSON.parse),
-        ).resolves.toEqual({
-            docs: { Authorization: "Bearer mcp-secret" },
-        });
-
-        const updateHeadersResponse = await fetchEnterApi(
-            enterApi,
-            new Request(`https://enter.test/api/account/agents/${agent.id}`, {
-                method: "PATCH",
-                headers: {
-                    "Content-Type": "application/json",
-                    Cookie: cookie,
-                },
-                body: JSON.stringify({
-                    systemPrompt: "You are an editable SQL tutor.",
-                    baseModel: promptAgent.baseModel,
-                    pollinationsTools: true,
-                    mcpServers: [
-                        {
-                            name: "docs",
-                            url: "https://mcp.example.com/rpc",
-                            headers: {
-                                Authorization: null,
-                                "X-New": "new-secret",
-                            },
-                        },
-                    ],
-                }),
-            }),
-            enterEnv,
-        );
-        expect(updateHeadersResponse.status).toBe(200);
-        await expect(updateHeadersResponse.json()).resolves.toMatchObject({
-            mcpServers: [
-                {
-                    headers: { Authorization: null, "X-New": null },
-                },
-            ],
-        });
-        const [agentAfterHeaderUpdate] = await db
-            .select()
-            .from(agentTable)
-            .where(eq(agentTable.id, agent.id));
-        await expect(
-            decryptSecret(
-                agentAfterHeaderUpdate.mcpHeadersCiphertext ?? "",
-                env.BETTER_AUTH_SECRET,
-            ).then(JSON.parse),
-        ).resolves.toEqual({
-            docs: {
-                Authorization: "Bearer mcp-secret",
-                "X-New": "new-secret",
-            },
+        expect(JSON.parse(agentAfterPromptUpdate.config)).toEqual({
+            ...promptAgent,
+            systemPrompt: "You are an editable SQL tutor.",
         });
         const registerResponse = await fetchEnterApi(
             enterApi,
@@ -4097,7 +3952,7 @@ fixtureTest(
         if (!registryEntry) throw new Error("Agent listing was not registered");
         expect(registryEntry.agentConfig).toEqual({
             baseModel: promptAgent.baseModel,
-            pollinationsTools: true,
+            mcpServers: ["pollinations"],
         });
         expect(registryEntry.definition.cost).toMatchObject({
             promptTextTokens: 0,
@@ -4562,7 +4417,6 @@ fixtureTest(
                 kind: "prompt",
                 systemPrompt: "Use the available tools.",
                 baseModel: "openai",
-                pollinationsTools: false,
                 mcpServers: [],
             }),
             createdAt: new Date(),

--- a/packages/polli-cli/SKILL.md
+++ b/packages/polli-cli/SKILL.md
@@ -171,7 +171,7 @@ polli agents create --config agent.json
 polli agents update <id> --config agent.json
 polli agents delete <id>
 ```
-The config file is sent directly to the agent API. A create config contains `systemPrompt`, `baseModel`, and optional `pollinationsTools` and `mcpServers`. Each MCP server accepts `name`, `url`, and optional `headers`, for example `{"Authorization":"Bearer ..."}`. Header values are encrypted by the API and returned as `null`; passing those `null` values back on update keeps the saved credentials. Omitted update fields remain unchanged; use `false` or `[]` to clear optional settings.
+The config file is sent directly to the agent API. It contains `systemPrompt`, `baseModel`, and optional `mcpServers`. The only supported server ID is currently `"pollinations"`. Updates replace the complete agent configuration.
 
 ### Manage API keys
 ```bash

--- a/packages/polli-cli/src/commands/agents.ts
+++ b/packages/polli-cli/src/commands/agents.ts
@@ -14,12 +14,7 @@ type Agent = {
     id: string;
     systemPrompt: string;
     baseModel: string;
-    pollinationsTools: boolean;
-    mcpServers: {
-        name: string;
-        url: string;
-        headers: Record<string, null>;
-    }[];
+    mcpServers: string[];
     createdAt: string;
     updatedAt: string;
 };
@@ -44,9 +39,11 @@ function printAgents(agents: Agent[]): void {
         agents.map((agent) => ({
             id: chalk.dim(agent.id),
             model: agent.baseModel,
-            mcp_servers: agent.mcpServers?.length ?? 0,
+            pollinations_tools: agent.mcpServers.includes("pollinations")
+                ? "yes"
+                : "no",
         })),
-        ["id", "model", "mcp_servers"],
+        ["id", "model", "pollinations_tools"],
     );
 }
 

--- a/shared/db/better-auth.ts
+++ b/shared/db/better-auth.ts
@@ -203,7 +203,6 @@ export const agent = sqliteTable("agent", {
     .notNull()
     .references(() => user.id, { onDelete: "cascade" }),
   config: text("config").notNull(),
-  mcpHeadersCiphertext: text("mcp_headers_ciphertext"),
   createdAt: integer("created_at", { mode: "timestamp" })
     .defaultNow()
     .notNull(),


### PR DESCRIPTION
- Removes per-agent custom MCP URLs, headers, credential encryption, and third-party runtime loading until reusable account-level MCPs are designed.
- Stores enabled MCP server IDs in `mcpServers`; `pollinations` is the only supported ID and keeps caller-token forwarding plus the generation/discovery tool allowlist.
- Simplifies the agent dashboard, API, catalog integration, CLI output, and tests around the built-in server.
- Migrates legacy `pollinationsTools` configs to the ID array, removes embedded custom definitions, and drops `agent.mcp_headers_ciphertext`.

Deployment note: the D1 migration and new Enter Worker must remain paired; the existing production workflow applies migrations immediately before deployment.

Checks: Enter 25/25 focused tests, Gen managed-agent integration, Enter/Gen typechecks, Biome, Drizzle check, seeded legacy migration test, and all 51 migrations on fresh local D1.