### PR TITLE
feat: show managed agent tool calls

### DIFF
--- a/enter.pollinations.ai/src/services/prompt-agent-runtime.ts
+++ b/enter.pollinations.ai/src/services/prompt-agent-runtime.ts
@@ -278,6 +278,27 @@ function safeMcpModelOutput({ output }: { output: unknown }) {
           };
 }
 
+function escapeHtml(value: string): string {
+    return value.replace(
+        /[&<>"']/g,
+        (character) =>
+            ({
+                "&": "&amp;",
+                "<": "&lt;",
+                ">": "&gt;",
+                '"': "&quot;",
+                "'": "&#39;",
+            })[character] ?? character,
+    );
+}
+
+function toolOutputText(output: unknown): string {
+    const modelOutput = safeMcpModelOutput({ output });
+    return modelOutput.type === "text"
+        ? modelOutput.value
+        : modelOutput.value.map((part) => part.text).join("\n");
+}
+
 function mediaResultContent(
     toolName: string,
     output: unknown,
@@ -338,6 +359,51 @@ function mediaResultContent(
     return `${hasContent ? "\n\n" : ""}${links.join("\n\n")}\n\n`;
 }
 
+function toolResultContent(
+    part: {
+        toolCallId: string;
+        toolName: string;
+        input: unknown;
+        output: unknown;
+    },
+    seenUrls: Set<string>,
+    hasContent: boolean,
+): string {
+    const details = toolDetailsContent(
+        part,
+        "Tool Executed",
+        toolOutputText(part.output),
+        hasContent,
+    );
+    const media = mediaResultContent(
+        part.toolName,
+        part.output,
+        seenUrls,
+        true,
+    );
+    return `${details}${media || "\n\n"}`;
+}
+
+function toolDetailsContent(
+    part: { toolCallId: string; toolName: string; input: unknown },
+    summary: string,
+    output: string,
+    hasContent: boolean,
+): string {
+    const name = part.toolName.replace(/^mcp__pollinations__/, "");
+    const argumentsJson = JSON.stringify(part.input ?? {});
+    return (
+        (hasContent ? "\n\n" : "") +
+        `<details type="tool_calls" done="true" ` +
+        `id="${escapeHtml(part.toolCallId)}" ` +
+        `name="${escapeHtml(name)}" ` +
+        `arguments="${escapeHtml(argumentsJson)}">\n` +
+        `<summary>${summary}</summary>\n` +
+        `${escapeHtml(output)}\n` +
+        "</details>"
+    );
+}
+
 async function runAgent(
     runtime: PromptAgentRuntime,
     messages: ModelMessage[],
@@ -356,12 +422,19 @@ async function runAgent(
             for (const part of step.content) {
                 if (part.type === "text") content += part.text;
                 if (part.type === "tool-result") {
-                    content += mediaResultContent(
-                        part.toolName,
-                        part.output,
+                    content += toolResultContent(
+                        part,
                         seenUrls,
                         content.length > 0,
                     );
+                }
+                if (part.type === "tool-error") {
+                    content += `${toolDetailsContent(
+                        part,
+                        "Tool Failed",
+                        agentErrorMessage(part.error),
+                        content.length > 0,
+                    )}\n\n`;
                 }
             }
         }
@@ -418,9 +491,8 @@ async function streamAgent(
                         );
                     }
                     if (part.type === "tool-result") {
-                        const content = mediaResultContent(
-                            part.toolName,
-                            part.output,
+                        const content = toolResultContent(
+                            part,
                             seenUrls,
                             hasContent,
                         );
@@ -435,6 +507,23 @@ async function streamAgent(
                                 ),
                             );
                         }
+                    }
+                    if (part.type === "tool-error") {
+                        const content = toolDetailsContent(
+                            part,
+                            "Tool Failed",
+                            agentErrorMessage(part.error),
+                            hasContent,
+                        );
+                        hasContent = true;
+                        send(
+                            contentChunk(
+                                id,
+                                created,
+                                runtime.config.baseModel,
+                                `${content}\n\n`,
+                            ),
+                        );
                     }
                 }
                 const [reason, usage, steps] = await Promise.all([

--- a/enter.pollinations.ai/test/prompt-agent-runtime.test.ts
+++ b/enter.pollinations.ai/test/prompt-agent-runtime.test.ts
@@ -373,7 +373,14 @@ describe("prompt-agent runtime", () => {
                 tool_call_counts: Record<string, number>;
             };
         };
-        expect(json.choices[0].message.content).toBe("checking done");
+        expect(json.choices[0].message.content).toBe(
+            "checking \n\n" +
+                '<details type="tool_calls" done="true" id="c1" name="listModels" arguments="{}">\n' +
+                "<summary>Tool Executed</summary>\n" +
+                "found\n" +
+                "</details>\n\n" +
+                "done",
+        );
         expect(json.choices[0].finish_reason).toBe("stop");
         expect(json.usage.tool_call_counts).toEqual({ mcp_call: 1 });
         // Usage from both model rounds is summed into the total.
@@ -848,11 +855,16 @@ describe("prompt-agent runtime", () => {
             };
             content = json.choices[0].message.content;
         }
-        expect(content).toBe(
-            "Drawing\n\n" +
-                "![Generated image](<https://images.example/pirate.png>)\n\n" +
-                "Finished",
+        expect(content).toContain(
+            '<details type="tool_calls" done="true" id="c1" name="generateImage" arguments="{&quot;prompt&quot;:&quot;a pirate&quot;}">',
         );
+        expect(content).toContain("[image output omitted");
+        expect(content).not.toContain("U0hPVUxEX05PVF9SRUFDSF9NT0RFTA==");
+        expect(content).toContain(
+            "![Generated image](<https://images.example/pirate.png>)",
+        );
+        expect(content.startsWith("Drawing\n\n")).toBe(true);
+        expect(content.endsWith("Finished")).toBe(true);
     });
 
     it("streams SSE with usage on the final chunk when stream:true", async () => {
@@ -1071,7 +1083,18 @@ describe("prompt-agent runtime", () => {
             choices: { message: { content: string } }[];
             usage: { tool_call_counts: Record<string, number> };
         };
-        expect(json.choices[0].message.content).toBe("sorry, lookup failed");
+        expect(json.choices[0].message.content).toContain(
+            '<details type="tool_calls" done="true" id="c1" name="listModels" arguments="{}">',
+        );
+        expect(json.choices[0].message.content).toContain(
+            "<summary>Tool Failed</summary>",
+        );
+        expect(json.choices[0].message.content).toContain(
+            "MCP HTTP Transport Error",
+        );
+        expect(
+            json.choices[0].message.content.endsWith("sorry, lookup failed"),
+        ).toBe(true);
         // The (failed) tool call is still counted — the owner's tool ran.
         expect(json.usage.tool_call_counts).toEqual({ mcp_call: 1 });
     });


### PR DESCRIPTION
- Adds Open WebUI-compatible tool execution blocks to managed-agent responses.
- Includes tool IDs, names, parameters, outputs, and failures without exposing inline binary media.
- Uses the same renderer for streaming and non-streaming responses while preserving generated media links.
- Covers both response modes and the tool-error path.

Checks:
- `npx tsc --noEmit`
- `npx vitest run test/prompt-agent-runtime.test.ts` (19 passed)
- `npx biome check --write src/services/prompt-agent-runtime.ts test/prompt-agent-runtime.test.ts`
- `npm run build:frontend`