### PR TITLE
chore: promote main to production

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/agent-dialog.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/agent-dialog.tsx
@@ -159,20 +159,12 @@ export function AgentDialog({
                     />
 
                     <div className="border-t border-divider pt-4">
-                        <p className="text-sm font-semibold text-theme-text-strong">
-                            Agent details
-                        </p>
-                        <p className="mt-0.5 text-xs text-theme-text-muted">
-                            Choose the model, instructions, and tools used on
-                            every request.
-                        </p>
+                        <PromptAgentFields
+                            form={form}
+                            disabled={isSubmitting}
+                            onChange={updateAgentForm}
+                        />
                     </div>
-
-                    <PromptAgentFields
-                        form={form}
-                        disabled={isSubmitting}
-                        onChange={updateAgentForm}
-                    />
                 </ScrollArea>
                 <div className="flex shrink-0 justify-end gap-2 border-t border-divider p-6 pt-4">
                     <Button

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/prompt-agent-fields.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/prompt-agent-fields.tsx
@@ -44,11 +44,22 @@ export function PromptAgentFields({
                 />
             </FieldStack>
 
-            <FieldStack
-                label="Pollinations tools"
-                helper="Allow the agent to call Pollinations generation and model-discovery tools."
-                alignLabelRow
-                action={
+            <div className="space-y-2">
+                <div className="flex items-start justify-between gap-3">
+                    <div className="space-y-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                            <span className="font-medium">
+                                Pollinations MCP
+                            </span>
+                            <Chip size="sm" intent="neutral">
+                                Built-in
+                            </Chip>
+                        </div>
+                        <p className="text-xs text-theme-text-muted">
+                            Allow the agent to call Pollinations generation and
+                            model-discovery tools.
+                        </p>
+                    </div>
                     <Switch
                         checked={form.mcpServers.includes("pollinations")}
                         disabled={disabled}
@@ -60,40 +71,31 @@ export function PromptAgentFields({
                             )
                         }
                     />
-                }
-            >
-                <div className="space-y-1">
-                    <div className="flex flex-wrap items-center gap-2">
-                        <span className="font-medium">Pollinations MCP</span>
-                        <Chip size="sm" intent="neutral">
-                            Built-in
-                        </Chip>
-                    </div>
-                    <p className="break-all font-mono text-xs text-theme-text-muted">
-                        https://mcp.pollinations.ai
-                    </p>
-                    <p className="text-xs text-theme-text-muted">
-                        Uses the caller's Pollinations API access.{" "}
-                        <a
-                            href="https://gen.pollinations.ai/docs#tag/mcp-server"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="underline decoration-current/40 underline-offset-2 hover:text-theme-text-soft"
-                        >
-                            API docs
-                        </a>
-                        {" · "}
-                        <a
-                            href="https://github.com/pollinations/pollinations/tree/main/packages/mcp"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="underline decoration-current/40 underline-offset-2 hover:text-theme-text-soft"
-                        >
-                            GitHub
-                        </a>
-                    </p>
                 </div>
-            </FieldStack>
+                <p className="break-all font-mono text-xs text-theme-text-muted">
+                    https://mcp.pollinations.ai
+                </p>
+                <p className="text-xs text-theme-text-muted">
+                    Uses the caller's Pollinations API access.{" "}
+                    <a
+                        href="https://gen.pollinations.ai/docs#tag/mcp-server"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="underline decoration-current/40 underline-offset-2 hover:text-theme-text-soft"
+                    >
+                        API docs
+                    </a>
+                    {" · "}
+                    <a
+                        href="https://github.com/pollinations/pollinations/tree/main/packages/mcp"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="underline decoration-current/40 underline-offset-2 hover:text-theme-text-soft"
+                    >
+                        GitHub
+                    </a>
+                </p>
+            </div>
         </div>
     );
 }

--- a/enter.pollinations.ai/src/services/prompt-agent-runtime.ts
+++ b/enter.pollinations.ai/src/services/prompt-agent-runtime.ts
@@ -278,6 +278,27 @@ function safeMcpModelOutput({ output }: { output: unknown }) {
           };
 }
 
+function escapeHtml(value: string): string {
+    return value.replace(
+        /[&<>"']/g,
+        (character) =>
+            ({
+                "&": "&amp;",
+                "<": "&lt;",
+                ">": "&gt;",
+                '"': "&quot;",
+                "'": "&#39;",
+            })[character] ?? character,
+    );
+}
+
+function toolOutputText(output: unknown): string {
+    const modelOutput = safeMcpModelOutput({ output });
+    return modelOutput.type === "text"
+        ? modelOutput.value
+        : modelOutput.value.map((part) => part.text).join("\n");
+}
+
 function mediaResultContent(
     toolName: string,
     output: unknown,
@@ -338,6 +359,51 @@ function mediaResultContent(
     return `${hasContent ? "\n\n" : ""}${links.join("\n\n")}\n\n`;
 }
 
+function toolResultContent(
+    part: {
+        toolCallId: string;
+        toolName: string;
+        input: unknown;
+        output: unknown;
+    },
+    seenUrls: Set<string>,
+    hasContent: boolean,
+): string {
+    const details = toolDetailsContent(
+        part,
+        "Tool Executed",
+        toolOutputText(part.output),
+        hasContent,
+    );
+    const media = mediaResultContent(
+        part.toolName,
+        part.output,
+        seenUrls,
+        true,
+    );
+    return `${details}${media || "\n\n"}`;
+}
+
+function toolDetailsContent(
+    part: { toolCallId: string; toolName: string; input: unknown },
+    summary: string,
+    output: string,
+    hasContent: boolean,
+): string {
+    const name = part.toolName.replace(/^mcp__pollinations__/, "");
+    const argumentsJson = JSON.stringify(part.input ?? {});
+    return (
+        (hasContent ? "\n\n" : "") +
+        `<details type="tool_calls" done="true" ` +
+        `id="${escapeHtml(part.toolCallId)}" ` +
+        `name="${escapeHtml(name)}" ` +
+        `arguments="${escapeHtml(argumentsJson)}">\n` +
+        `<summary>${summary}</summary>\n` +
+        `${escapeHtml(output)}\n` +
+        "</details>"
+    );
+}
+
 async function runAgent(
     runtime: PromptAgentRuntime,
     messages: ModelMessage[],
@@ -356,12 +422,19 @@ async function runAgent(
             for (const part of step.content) {
                 if (part.type === "text") content += part.text;
                 if (part.type === "tool-result") {
-                    content += mediaResultContent(
-                        part.toolName,
-                        part.output,
+                    content += toolResultContent(
+                        part,
                         seenUrls,
                         content.length > 0,
                     );
+                }
+                if (part.type === "tool-error") {
+                    content += `${toolDetailsContent(
+                        part,
+                        "Tool Failed",
+                        agentErrorMessage(part.error),
+                        content.length > 0,
+                    )}\n\n`;
                 }
             }
         }
@@ -418,9 +491,8 @@ async function streamAgent(
                         );
                     }
                     if (part.type === "tool-result") {
-                        const content = mediaResultContent(
-                            part.toolName,
-                            part.output,
+                        const content = toolResultContent(
+                            part,
                             seenUrls,
                             hasContent,
                         );
@@ -435,6 +507,23 @@ async function streamAgent(
                                 ),
                             );
                         }
+                    }
+                    if (part.type === "tool-error") {
+                        const content = toolDetailsContent(
+                            part,
+                            "Tool Failed",
+                            agentErrorMessage(part.error),
+                            hasContent,
+                        );
+                        hasContent = true;
+                        send(
+                            contentChunk(
+                                id,
+                                created,
+                                runtime.config.baseModel,
+                                `${content}\n\n`,
+                            ),
+                        );
                     }
                 }
                 const [reason, usage, steps] = await Promise.all([

--- a/enter.pollinations.ai/test/prompt-agent-runtime.test.ts
+++ b/enter.pollinations.ai/test/prompt-agent-runtime.test.ts
@@ -373,7 +373,14 @@ describe("prompt-agent runtime", () => {
                 tool_call_counts: Record<string, number>;
             };
         };
-        expect(json.choices[0].message.content).toBe("checking done");
+        expect(json.choices[0].message.content).toBe(
+            "checking \n\n" +
+                '<details type="tool_calls" done="true" id="c1" name="listModels" arguments="{}">\n' +
+                "<summary>Tool Executed</summary>\n" +
+                "found\n" +
+                "</details>\n\n" +
+                "done",
+        );
         expect(json.choices[0].finish_reason).toBe("stop");
         expect(json.usage.tool_call_counts).toEqual({ mcp_call: 1 });
         // Usage from both model rounds is summed into the total.
@@ -848,11 +855,16 @@ describe("prompt-agent runtime", () => {
             };
             content = json.choices[0].message.content;
         }
-        expect(content).toBe(
-            "Drawing\n\n" +
-                "![Generated image](<https://images.example/pirate.png>)\n\n" +
-                "Finished",
+        expect(content).toContain(
+            '<details type="tool_calls" done="true" id="c1" name="generateImage" arguments="{&quot;prompt&quot;:&quot;a pirate&quot;}">',
         );
+        expect(content).toContain("[image output omitted");
+        expect(content).not.toContain("U0hPVUxEX05PVF9SRUFDSF9NT0RFTA==");
+        expect(content).toContain(
+            "![Generated image](<https://images.example/pirate.png>)",
+        );
+        expect(content.startsWith("Drawing\n\n")).toBe(true);
+        expect(content.endsWith("Finished")).toBe(true);
     });
 
     it("streams SSE with usage on the final chunk when stream:true", async () => {
@@ -1071,7 +1083,18 @@ describe("prompt-agent runtime", () => {
             choices: { message: { content: string } }[];
             usage: { tool_call_counts: Record<string, number> };
         };
-        expect(json.choices[0].message.content).toBe("sorry, lookup failed");
+        expect(json.choices[0].message.content).toContain(
+            '<details type="tool_calls" done="true" id="c1" name="listModels" arguments="{}">',
+        );
+        expect(json.choices[0].message.content).toContain(
+            "<summary>Tool Failed</summary>",
+        );
+        expect(json.choices[0].message.content).toContain(
+            "MCP HTTP Transport Error",
+        );
+        expect(
+            json.choices[0].message.content.endsWith("sorry, lookup failed"),
+        ).toBe(true);
         // The (failed) tool call is still counted — the owner's tool ran.
         expect(json.usage.tool_call_counts).toEqual({ mcp_call: 1 });
     });


### PR DESCRIPTION
- Promotes the latest `main` changes to production.
- Includes managed-agent tool-call output from #13465.