### PR TITLE
feat: add quest reward campaigns

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/quests/quest-overview.tsx
+++ b/enter.pollinations.ai/frontend/src/components/quests/quest-overview.tsx
@@ -8,6 +8,7 @@ import {
     DiscordIcon,
     GitHubIcon,
     InlineLink,
+    Input,
     Markdown,
     RocketIcon,
     SearchIcon,
@@ -42,6 +43,7 @@ type QuestReward = {
     balanceBucket: string;
     earnedAt: string;
     claimedAt: string | null;
+    url?: string | null;
 };
 
 type QuestOverviewProps = Record<string, never>;
@@ -118,6 +120,13 @@ const CATEGORIES: CategoryMeta[] = [
 
 function issueNumberFromId(id: string): number | null {
     const match = /^github:issue:(\d+)$/.exec(id);
+    return match ? Number(match[1]) : null;
+}
+
+function githubNumberFromUrl(url: string | null | undefined): number | null {
+    const match = url?.match(
+        /github\.com\/[^/]+\/[^/]+\/(?:issues|pull)\/(\d+)/,
+    );
     return match ? Number(match[1]) : null;
 }
 
@@ -589,6 +598,9 @@ export function QuestRow({
 
 export const QuestOverview: FC<QuestOverviewProps> = () => {
     const [state, setState] = useState<FetchState>(INITIAL_STATE);
+    const [couponCode, setCouponCode] = useState("");
+    const [couponMessage, setCouponMessage] = useState<string | null>(null);
+    const [redeemingCoupon, setRedeemingCoupon] = useState(false);
     // Guards the auto-check so React 18 StrictMode's double-mount fires it once.
     const autoCheckedRef = useRef(false);
     // Logged-out visitors see a preview: every quest shown open (so all
@@ -705,6 +717,51 @@ export const QuestOverview: FC<QuestOverviewProps> = () => {
         }
     }
 
+    async function handleRedeemCoupon(): Promise<void> {
+        const code = couponCode.trim();
+        if (!code || redeemingCoupon) return;
+
+        setRedeemingCoupon(true);
+        setCouponMessage(null);
+        try {
+            const response = await apiClient.quests.coupons.redeem.$post({
+                json: { code },
+            });
+            if (!response.ok) {
+                const message =
+                    response.status === 404
+                        ? "Quest code not found."
+                        : response.status === 409
+                          ? "You already redeemed this quest code."
+                          : "Could not redeem this quest code.";
+                throw new Error(message);
+            }
+
+            const result = (await response.json()) as {
+                pollenAmount: number;
+            };
+            const questData = await loadQuestData();
+            setState((current) => ({
+                ...current,
+                ...questData,
+                checking: false,
+                loading: false,
+            }));
+            setCouponCode("");
+            setCouponMessage(
+                `${formatRewardAmount(result.pollenAmount)} Quest Pollen added to your wallet.`,
+            );
+        } catch (error) {
+            setCouponMessage(
+                error instanceof Error
+                    ? error.message
+                    : "Could not redeem this quest code.",
+            );
+        } finally {
+            setRedeemingCoupon(false);
+        }
+    }
+
     // A reward's questId IS the catalog id it earned (one reward == one quest),
     // so the earned-set / reward lookup key directly off questId.
     const rewardedCatalogIds = useMemo(
@@ -783,6 +840,29 @@ export const QuestOverview: FC<QuestOverviewProps> = () => {
         }
         return byCat;
     }, [state.catalog, rewardedCatalogIds, rewardByKey, previewAll]);
+
+    // Rewards created by a maintainer or another non-catalog source still need
+    // their own claim control. This is deliberately derived from the ledger —
+    // no synthetic catalog entry or special balance path.
+    const bonusRewardCards = useMemo(() => {
+        const catalogIds = new Set(state.catalog.map((quest) => quest.id));
+        return state.rewards
+            .filter(
+                (reward) =>
+                    reward.questId == null || !catalogIds.has(reward.questId),
+            )
+            .map<QuestCard>((reward) => ({
+                key: reward.id,
+                rewardId: reward.id,
+                title: reward.title,
+                url: reward.url ?? undefined,
+                issueNumber: githubNumberFromUrl(reward.url) ?? undefined,
+                reward: reward.pollenAmount,
+                balanceBucket: reward.balanceBucket,
+                status: reward.claimedAt ? "claimed" : "claimable",
+                earnedAmount: reward.pollenAmount,
+            }));
+    }, [state.catalog, state.rewards]);
 
     // Logged-out totals for the summary cards: across every available quest
     // shown (coming_soon excluded), how many there are and the pollen on offer,
@@ -966,6 +1046,45 @@ export const QuestOverview: FC<QuestOverviewProps> = () => {
                                 </span>
                             </div>
                         )}
+                        <div className="mt-4 border-t border-divider pt-4">
+                            <p className="mb-2 text-sm font-semibold text-theme-text-soft">
+                                Have a quest code?
+                            </p>
+                            <form
+                                className="flex max-w-md gap-2"
+                                onSubmit={(event) => {
+                                    event.preventDefault();
+                                    void handleRedeemCoupon();
+                                }}
+                            >
+                                <Input
+                                    aria-label="Quest code"
+                                    value={couponCode}
+                                    onChange={(event) => {
+                                        setCouponCode(event.target.value);
+                                        setCouponMessage(null);
+                                    }}
+                                    placeholder="Enter code"
+                                    autoCapitalize="characters"
+                                    className="flex-1"
+                                    disabled={redeemingCoupon}
+                                />
+                                <Button
+                                    type="submit"
+                                    disabled={
+                                        redeemingCoupon ||
+                                        couponCode.trim().length === 0
+                                    }
+                                >
+                                    {redeemingCoupon ? "Redeeming…" : "Redeem"}
+                                </Button>
+                            </form>
+                            {couponMessage && (
+                                <p className="mt-2 text-[13px] text-theme-text-muted">
+                                    {couponMessage}
+                                </p>
+                            )}
+                        </div>
                     </>
                 )}
                 {/* Logged-out summary: the same two-card pair, but the numbers are
@@ -1063,6 +1182,39 @@ export const QuestOverview: FC<QuestOverviewProps> = () => {
             )}
 
             <div className={`flex flex-col gap-6 ${dimWhileChecking}`}>
+                {bonusRewardCards.length > 0 && (
+                    <Section
+                        title="Bonus rewards"
+                        framed
+                        panelClassName="flex flex-col gap-2"
+                        action={
+                            <Chip
+                                intent="neutral"
+                                size="sm"
+                                className="tabular-nums"
+                            >
+                                {
+                                    bonusRewardCards.filter(
+                                        (card) => card.status === "claimed",
+                                    ).length
+                                }{" "}
+                                / {bonusRewardCards.length}
+                            </Chip>
+                        }
+                    >
+                        {bonusRewardCards.map((card) => (
+                            <QuestRow
+                                key={card.key}
+                                card={card}
+                                icon={SparkleIcon}
+                                claiming={
+                                    state.claimingRewardId === card.rewardId
+                                }
+                                onClaim={handleClaimReward}
+                            />
+                        ))}
+                    </Section>
+                )}
                 {CATEGORIES.map((category) => {
                     const cards = sections[category.key];
                     if (cards.length === 0) return null;

--- a/enter.pollinations.ai/src/routes/admin.ts
+++ b/enter.pollinations.ai/src/routes/admin.ts
@@ -6,6 +6,8 @@ import {
     exportD1TinybirdPage,
     isD1TinybirdDatasource,
 } from "../services/d1-tinybird-sync.ts";
+import { questCouponAdminRoutes } from "./quest-coupons.ts";
+import { questGrantAdminRoutes } from "./quest-grants.ts";
 import { statusNoticeAdminRoutes } from "./status-notice.ts";
 
 export const adminRoutes = new Hono<Env>()
@@ -82,7 +84,9 @@ export const adminRoutes = new Hono<Env>()
             done: result.done,
         });
     })
-    .route("/status-notice", statusNoticeAdminRoutes);
+    .route("/status-notice", statusNoticeAdminRoutes)
+    .route("/quest-coupons", questCouponAdminRoutes)
+    .route("/quest-grants", questGrantAdminRoutes);
 
 async function sha256(value: string): Promise<string> {
     const bytes = new TextEncoder().encode(value);

--- a/enter.pollinations.ai/src/routes/quest-coupons.ts
+++ b/enter.pollinations.ai/src/routes/quest-coupons.ts
@@ -1,0 +1,135 @@
+import {
+    claimReward,
+    MAX_REWARD_AMOUNT,
+    recordRewards,
+} from "@shared/billing/rewards.ts";
+import * as schema from "@shared/db/better-auth.ts";
+import { rewards } from "@shared/db/better-auth.ts";
+import { validator } from "@shared/middleware/validator.ts";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
+import { z } from "zod";
+import type { Env } from "../env.ts";
+import { auth } from "../middleware/auth.ts";
+
+const COUPON_KEY_PREFIX = "quest-coupon:";
+const couponCodePattern = /^[A-Z0-9][A-Z0-9_-]{0,63}$/;
+
+const couponDefinitionSchema = z.object({
+    questId: z
+        .string()
+        .trim()
+        .regex(/^[a-z0-9][a-z0-9:_-]{0,99}$/),
+    title: z.string().trim().min(1).max(200),
+    rewardAmount: z.number().positive().max(MAX_REWARD_AMOUNT),
+});
+
+const couponCodeSchema = z.object({ code: z.string().trim().min(1).max(64) });
+const couponInputSchema = couponDefinitionSchema.extend({
+    code: z.string().trim().min(1).max(64),
+});
+
+type CouponDefinition = z.infer<typeof couponDefinitionSchema>;
+
+function normalizeCode(code: string): string {
+    const normalized = code.trim().toUpperCase();
+    if (!couponCodePattern.test(normalized)) {
+        throw new HTTPException(400, { message: "Invalid quest code" });
+    }
+    return normalized;
+}
+
+function couponKey(code: string): string {
+    return `${COUPON_KEY_PREFIX}${normalizeCode(code)}`;
+}
+
+async function loadCoupon(
+    kv: KVNamespace,
+    code: string,
+): Promise<CouponDefinition | null> {
+    const stored = await kv.get<unknown>(couponKey(code), "json");
+    const parsed = couponDefinitionSchema.safeParse(stored);
+    return parsed.success ? parsed.data : null;
+}
+
+/** Hidden quest rewards redeemed by a dashboard user. */
+export const questCouponRoutes = new Hono<Env>().post(
+    "/redeem",
+    auth({ allowApiKey: true, allowSessionCookie: true }),
+    validator("json", couponCodeSchema),
+    async (c) => {
+        await c.var.auth.requireAuthorization({
+            message: "Authentication required to redeem a quest code",
+        });
+        if (c.var.auth.apiKey) {
+            throw new HTTPException(403, {
+                message: "Quest codes require a dashboard session",
+            });
+        }
+
+        const user = c.var.auth.requireUser();
+        const { code } = c.req.valid("json");
+        const coupon = await loadCoupon(c.env.KV, code);
+        if (!coupon) {
+            throw new HTTPException(404, { message: "Quest code not found" });
+        }
+
+        const db = drizzle(c.env.DB, { schema });
+        const idempotencyKey = `quest:${coupon.questId}:user:${user.id}`;
+        const recorded = await recordRewards(db, [
+            {
+                idempotencyKey,
+                userId: user.id,
+                amount: coupon.rewardAmount,
+                bucket: "tier",
+                questId: coupon.questId,
+                title: coupon.title,
+            },
+        ]);
+
+        const rewardId =
+            recorded.rewardIds[0] ??
+            (
+                await db
+                    .select({ id: rewards.id })
+                    .from(rewards)
+                    .where(eq(rewards.idempotencyKey, idempotencyKey))
+                    .limit(1)
+            )[0]?.id;
+        if (!rewardId) {
+            throw new HTTPException(500, {
+                message: "Could not record quest reward",
+            });
+        }
+
+        const result = await claimReward(db, { rewardId, userId: user.id });
+        if (!result.claimed) {
+            throw new HTTPException(409, {
+                message: "Quest code already redeemed",
+            });
+        }
+
+        return c.json({
+            redeemed: true,
+            questId: coupon.questId,
+            pollenAmount: coupon.rewardAmount,
+            newBalance: result.newBalance,
+        });
+    },
+);
+
+/** Minimal operator API: PUT creates/updates a campaign; DELETE disables it. */
+export const questCouponAdminRoutes = new Hono<Env>()
+    .put("/", validator("json", couponInputSchema), async (c) => {
+        const { code: rawCode, ...coupon } = c.req.valid("json");
+        const code = normalizeCode(rawCode);
+        await c.env.KV.put(couponKey(code), JSON.stringify(coupon));
+        return c.json({ code, coupon });
+    })
+    .delete("/", validator("json", couponCodeSchema), async (c) => {
+        const code = normalizeCode(c.req.valid("json").code);
+        await c.env.KV.delete(couponKey(code));
+        return c.json({ code, coupon: null });
+    });

--- a/enter.pollinations.ai/src/routes/quest-grants.ts
+++ b/enter.pollinations.ai/src/routes/quest-grants.ts
@@ -1,0 +1,85 @@
+import { MAX_REWARD_AMOUNT, recordRewards } from "@shared/billing/rewards.ts";
+import * as schema from "@shared/db/better-auth.ts";
+import { validator } from "@shared/middleware/validator.ts";
+import { inArray, sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import { Hono } from "hono";
+import { z } from "zod";
+import type { Env } from "../env.ts";
+
+const githubUsernameSchema = z
+    .string()
+    .trim()
+    .regex(/^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$/);
+
+const grantRewardsSchema = z.object({
+    campaignId: z
+        .string()
+        .trim()
+        .regex(/^[a-z0-9][a-z0-9_-]{0,99}$/),
+    title: z.string().trim().min(1).max(200),
+    pollenAmount: z.number().positive().max(MAX_REWARD_AMOUNT),
+    sourceUrl: z
+        .url()
+        .refine((value) =>
+            ["http:", "https:"].includes(new URL(value).protocol),
+        )
+        .optional(),
+    githubUsernames: z.array(githubUsernameSchema).min(1).max(100),
+});
+
+/** Bulk contributor grants. Authentication is enforced by the parent admin route. */
+export const questGrantAdminRoutes = new Hono<Env>().post(
+    "/",
+    validator("json", grantRewardsSchema),
+    async (c) => {
+        const input = c.req.valid("json");
+        const requested = [
+            ...new Set(input.githubUsernames.map((name) => name.toLowerCase())),
+        ];
+        const db = drizzle(c.env.DB, { schema });
+        const users = await db
+            .select({
+                id: schema.user.id,
+                githubUsername: schema.user.githubUsername,
+            })
+            .from(schema.user)
+            .where(
+                inArray(
+                    sql<string>`lower(${schema.user.githubUsername})`,
+                    requested,
+                ),
+            );
+        const usersByLogin = new Map(
+            users.flatMap((user) =>
+                user.githubUsername
+                    ? [[user.githubUsername.toLowerCase(), user] as const]
+                    : [],
+            ),
+        );
+        const matched = requested.flatMap((login) => {
+            const user = usersByLogin.get(login);
+            return user ? [user] : [];
+        });
+        const questId = `grant:${input.campaignId}`;
+        const result = await recordRewards(
+            db,
+            matched.map((user) => ({
+                idempotencyKey: `quest:${questId}:user:${user.id}`,
+                userId: user.id,
+                amount: input.pollenAmount,
+                bucket: "tier",
+                questId,
+                title: input.title,
+                url: input.sourceUrl,
+            })),
+        );
+
+        return c.json({
+            campaignId: input.campaignId,
+            matched: matched.length,
+            recorded: result.recorded,
+            missing: requested.filter((login) => !usersByLogin.has(login)),
+        });
+    },
+);

--- a/enter.pollinations.ai/src/routes/quests.ts
+++ b/enter.pollinations.ai/src/routes/quests.ts
@@ -17,6 +17,7 @@ import type {
     QuestEvaluationContext,
 } from "../services/quests/types.ts";
 import { requireAccountPermission } from "./account-permissions.ts";
+import { questCouponRoutes } from "./quest-coupons.ts";
 
 // Bumped to v26: established GitHub, app_paid_request, and app_users_10 are
 // available; Early Adopter and app_pollen_10 are visible as coming soon.
@@ -51,6 +52,7 @@ const rewardSchema = z.object({
     balanceBucket: z.string(),
     earnedAt: z.string(),
     claimedAt: z.string().nullable(),
+    url: z.string().nullable().optional(),
 });
 
 const questRewardsResponseSchema = z.object({
@@ -202,6 +204,7 @@ export const questsRoutes = new Hono<Env>()
                     balanceBucket: rewardsTable.balanceBucket,
                     earnedAt: rewardsTable.earnedAt,
                     claimedAt: rewardsTable.claimedAt,
+                    url: rewardsTable.url,
                 })
                 .from(rewardsTable)
                 .where(eq(rewardsTable.userId, user.id))
@@ -217,6 +220,7 @@ export const questsRoutes = new Hono<Env>()
                 claimedAt: row.claimedAt
                     ? formatRewardTimestamp(row.claimedAt)
                     : null,
+                url: row.url,
             }));
 
             return c.json({ rewards });
@@ -281,7 +285,8 @@ export const questsRoutes = new Hono<Env>()
                 },
             });
         },
-    );
+    )
+    .route("/coupons", questCouponRoutes);
 
 async function readCached(
     kv: KVNamespace,

--- a/enter.pollinations.ai/test/quest-coupons.test.ts
+++ b/enter.pollinations.ai/test/quest-coupons.test.ts
@@ -1,0 +1,102 @@
+import { env, SELF } from "cloudflare:test";
+import * as schema from "@shared/db/better-auth.ts";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import { expect } from "vitest";
+import { test } from "./fixtures.ts";
+
+const baseUrl = "http://localhost:3000/api";
+
+async function seedCoupon(code: string, questId = "coupon:launch") {
+    const response = await SELF.fetch(`${baseUrl}/admin/quest-coupons`, {
+        method: "PUT",
+        headers: {
+            Authorization: `Bearer ${env.PLN_ENTER_TOKEN}`,
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+            code,
+            questId,
+            title: "Launch thank-you",
+            rewardAmount: 2.5,
+        }),
+    });
+    expect(response.status).toBe(200);
+}
+
+async function redeemCoupon(code: string, sessionToken?: string) {
+    return await SELF.fetch(`${baseUrl}/quests/coupons/redeem`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            ...(sessionToken && {
+                Cookie: `better-auth.session_token=${sessionToken}`,
+            }),
+        },
+        body: JSON.stringify({ code }),
+    });
+}
+
+test("quest coupon records and immediately claims one reward per campaign", async ({
+    sessionToken,
+}) => {
+    const db = drizzle(env.DB, { schema });
+    const [userBefore] = await db
+        .select({ id: schema.user.id, tierBalance: schema.user.tierBalance })
+        .from(schema.user)
+        .limit(1);
+    expect(userBefore).toBeDefined();
+
+    await seedCoupon("launch-2026");
+
+    const redeemed = await redeemCoupon(" launch-2026 ", sessionToken);
+    expect(redeemed.status).toBe(200);
+    expect(await redeemed.json()).toMatchObject({
+        redeemed: true,
+        questId: "coupon:launch",
+        pollenAmount: 2.5,
+        newBalance: (userBefore?.tierBalance ?? 0) + 2.5,
+    });
+
+    const duplicate = await redeemCoupon("LAUNCH-2026", sessionToken);
+    expect(duplicate.status).toBe(409);
+
+    const rewardRows = await db
+        .select()
+        .from(schema.rewards)
+        .where(eq(schema.rewards.questId, "coupon:launch"));
+    expect(rewardRows).toHaveLength(1);
+    expect(rewardRows[0]).toMatchObject({
+        userId: userBefore?.id,
+        title: "Launch thank-you",
+        pollenAmount: 2.5,
+        balanceBucket: "tier",
+    });
+    expect(rewardRows[0]?.claimedAt).not.toBeNull();
+
+    const [userAfter] = await db
+        .select({ tierBalance: schema.user.tierBalance })
+        .from(schema.user)
+        .where(eq(schema.user.id, userBefore?.id ?? ""));
+    expect(userAfter?.tierBalance).toBe((userBefore?.tierBalance ?? 0) + 2.5);
+});
+
+test("quest coupon requires a session and can be disabled", async ({
+    sessionToken,
+}) => {
+    await seedCoupon("community-gift");
+    expect((await redeemCoupon("community-gift")).status).toBe(401);
+
+    const disabled = await SELF.fetch(`${baseUrl}/admin/quest-coupons`, {
+        method: "DELETE",
+        headers: {
+            Authorization: `Bearer ${env.PLN_ENTER_TOKEN}`,
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ code: "community-gift" }),
+    });
+    expect(disabled.status).toBe(200);
+    expect((await redeemCoupon("community-gift", sessionToken)).status).toBe(
+        404,
+    );
+});

--- a/enter.pollinations.ai/test/quest-grants.test.ts
+++ b/enter.pollinations.ai/test/quest-grants.test.ts
@@ -1,0 +1,99 @@
+import { env, SELF } from "cloudflare:test";
+import * as schema from "@shared/db/better-auth.ts";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import { expect } from "vitest";
+import { test } from "./fixtures.ts";
+
+const baseUrl = "http://localhost:3000/api";
+
+test("admin grant records one claimable reward per user and campaign", async ({
+    sessionToken,
+}) => {
+    const db = drizzle(env.DB, { schema });
+    const [user] = await db
+        .select({
+            id: schema.user.id,
+            githubUsername: schema.user.githubUsername,
+        })
+        .from(schema.user)
+        .limit(1);
+    expect(user?.githubUsername).toBeTruthy();
+
+    const request = {
+        campaignId: "unmerged-pr-thanks-2026-08",
+        title: "Thanks for contributing",
+        pollenAmount: 3,
+        sourceUrl: "https://github.com/pollinations/pollinations/issues/12583",
+        githubUsernames: [
+            user?.githubUsername?.toUpperCase() ?? "",
+            user?.githubUsername ?? "",
+            "missing-user",
+        ],
+    };
+    const grant = await SELF.fetch(`${baseUrl}/admin/quest-grants`, {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${env.PLN_ENTER_TOKEN}`,
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify(request),
+    });
+    expect(grant.status).toBe(200);
+    expect(await grant.json()).toEqual({
+        campaignId: request.campaignId,
+        matched: 1,
+        recorded: 1,
+        missing: ["missing-user"],
+    });
+
+    const retry = await SELF.fetch(`${baseUrl}/admin/quest-grants`, {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${env.PLN_ENTER_TOKEN}`,
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify(request),
+    });
+    expect(retry.status).toBe(200);
+    expect(await retry.json()).toMatchObject({ recorded: 0 });
+
+    const [reward] = await db
+        .select()
+        .from(schema.rewards)
+        .where(eq(schema.rewards.questId, "grant:unmerged-pr-thanks-2026-08"));
+    expect(reward).toMatchObject({
+        userId: user?.id,
+        title: request.title,
+        pollenAmount: 3,
+        balanceBucket: "tier",
+        url: request.sourceUrl,
+        claimedAt: null,
+    });
+
+    const listed = await SELF.fetch(`${baseUrl}/quests/rewards`, {
+        headers: {
+            Cookie: `better-auth.session_token=${sessionToken}`,
+        },
+    });
+    expect(listed.status).toBe(200);
+    expect(await listed.json()).toMatchObject({
+        rewards: [
+            {
+                id: reward?.id,
+                questId: "grant:unmerged-pr-thanks-2026-08",
+                url: request.sourceUrl,
+                claimedAt: null,
+            },
+        ],
+    });
+});
+
+test("admin grant rejects requests without the admin token", async () => {
+    const response = await SELF.fetch(`${baseUrl}/admin/quest-grants`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+    });
+    expect(response.status).toBe(401);
+});

--- a/enter.pollinations.ai/wrangler.toml
+++ b/enter.pollinations.ai/wrangler.toml
@@ -235,6 +235,7 @@ D1_EXPORT_TOKEN_SHA256 = "93b05a64761af544d325ac158513bef41959e8777a7375981ec7ae
 GITHUB_CLIENT_ID = "test_github_client_id"
 GITHUB_CLIENT_SECRET = "test_github_client_secret"
 BETTER_AUTH_SECRET = "not-a-secret-workers-test-only"
+PLN_ENTER_TOKEN = "test-admin-token"
 TINYBIRD_INGEST_URL = "http://localhost:7181/v0/events?name=generation_event_v2"
 TINYBIRD_STRIPE_INGEST_URL = "http://localhost:7181/v0/events?name=stripe_event"
 TINYBIRD_INGEST_TOKEN = "test_tinybird_ingest_token"


### PR DESCRIPTION
Fixes #13000

- Adds admin-managed coupon campaigns that redeem as hidden quests and immediately credit Quest Pollen.
- Adds an idempotent bulk grant endpoint for rewarding GitHub contributors by campaign, amount, reason, and source URL.
- Shows rewards without catalog entries in a dedicated Bonus rewards section with the normal claim flow.
- Reuses the existing reward ledger and balance claim transaction; no migration or direct balance adjustment.

Checks: 34 coupon, grant, and quest tests; Enter TypeScript; Biome; production frontend build.