### PR TITLE
fix: update Enter community links

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/layout/dashboard-shell.tsx
+++ b/enter.pollinations.ai/frontend/src/components/layout/dashboard-shell.tsx
@@ -1,5 +1,6 @@
 import {
     BookIcon,
+    BugIcon,
     CheckIcon,
     ChevronIcon,
     Chip,
@@ -104,14 +105,14 @@ const brandLinks: readonly BrandLink[] = [
         label: "Pollinations on GitHub",
         icon: <GitHubIcon className="h-full w-full" />,
         text: "github",
-        count: "4.4k",
+        count: "5k",
     },
     {
         href: "https://discord.gg/pollinations-ai-885844321461485618",
         label: "Discord community",
         icon: <DiscordIcon className="h-full w-full" />,
         text: "discord",
-        count: "18k",
+        count: "19k",
     },
 ];
 
@@ -123,16 +124,16 @@ const footerLinks: readonly FooterLink[] = [
 
 const accountMenuLinks: readonly AccountMenuLink[] = [
     {
-        href: "https://discord.com/channels/885844321461485618/1432378056126894343",
-        label: "#pollen-beta",
+        href: "https://discord.com/channels/885844321461485618/889573359111774329",
+        label: "Get Help",
         icon: <DiscordIcon className="h-full w-full" />,
-        ariaLabel: "#pollen-beta Discord channel",
+        ariaLabel: "Get help in the Discord community chat",
     },
     {
         href: "https://github.com/pollinations/pollinations/issues",
-        label: "Report an issue",
-        icon: <GitHubIcon className="h-full w-full" />,
-        ariaLabel: "Report an issue on GitHub",
+        label: "Report a Bug",
+        icon: <BugIcon className="h-full w-full" />,
+        ariaLabel: "Report a bug on GitHub",
     },
 ];
 

--- a/packages/ui/src/primitives/icons/index.tsx
+++ b/packages/ui/src/primitives/icons/index.tsx
@@ -47,6 +47,17 @@ export function BookIcon(props: IconProps) {
     );
 }
 
+export function BugIcon(props: IconProps) {
+    return (
+        <svg aria-hidden="true" viewBox="0 0 24 24" {...strokeProps} {...props}>
+            <path d="m8 2 1.9 1.9M14.1 3.9 16 2" />
+            <path d="M9 7V6a3 3 0 0 1 6 0v1" />
+            <path d="M12 20c-3.3 0-6-2.7-6-6v-3a6 6 0 0 1 12 0v3c0 3.3-2.7 6-6 6Z" />
+            <path d="M12 20v-9M6.5 9C4.6 8.8 3 7.1 3 5M6 13H2M3 21c0-2.1 1.7-3.9 3.8-4M17.5 9C19.4 8.8 21 7.1 21 5M18 13h4M21 21c0-2.1-1.7-3.9-3.8-4" />
+        </svg>
+    );
+}
+
 export function CheckIcon(props: IconProps) {
     return (
         <svg


### PR DESCRIPTION
- Refreshes the Enter drawer counts to 5k GitHub stars and 19k Discord members.
- Replaces the Pollen Beta shortcut with “Get Help” linking to the community chat.
- Renames “Report an issue” to “Report a Bug” and adds a shared UI bug icon.
- Verified with Biome, UI and Enter typechecks, and a local browser check including GitHub sign-in.