### PR TITLE
feat: expand publisher access request

### DIFF
--- a/.github/ISSUE_TEMPLATE/community-model-allowlist.yml
+++ b/.github/ISSUE_TEMPLATE/community-model-allowlist.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Use this form to request account-level access to publish community models, managed agents, or both in the Pollinations model catalog. It does **not** register or submit a specific model or agent. Private and app-scoped deployments can be registered without approval.
+        Use this form to request account-level access to publish community models, managed agents, or both in the Pollinations model catalog. It does **not** register or submit a specific model or agent. Private deployments can be registered without approval.
 
         Submit this form from the same GitHub account you use to sign in at [enter.pollinations.ai](https://enter.pollinations.ai).
 

--- a/.github/ISSUE_TEMPLATE/community-model-allowlist.yml
+++ b/.github/ISSUE_TEMPLATE/community-model-allowlist.yml
@@ -1,21 +1,33 @@
-name: Community Model Publisher Allowlist
-description: Request account access to publish community models
-title: "[Community Model Publisher Access]: "
+name: Community Publisher Access
+description: Request access to publish public community models, managed agents, or both
+title: "[Community Publisher Access]: "
 body:
   - type: markdown
     attributes:
       value: |
-        Use this form to request account-level access to publish community models in the Pollinations model catalog. It does **not** register or submit a specific model. Private models can be registered without approval.
+        Use this form to request account-level access to publish community models, managed agents, or both in the Pollinations model catalog. It does **not** register or submit a specific model or agent. Private and app-scoped deployments can be registered without approval.
 
         Submit this form from the same GitHub account you use to sign in at [enter.pollinations.ai](https://enter.pollinations.ai).
 
         This issue is public. **Never include API keys, bearer tokens, or other credentials.**
 
   - type: dropdown
+    id: publishing-access
+    attributes:
+      label: What do you want to publish?
+      description: Select one or both.
+      multiple: true
+      options:
+        - Public community models
+        - Public managed agents
+    validations:
+      required: true
+
+  - type: dropdown
     id: model-types
     attributes:
-      label: What kinds of models do you want to publish?
-      description: Select every model type you plan to add.
+      label: Community model types (if applicable)
+      description: If you are requesting model publishing access, select every model type you plan to add.
       multiple: true
       options:
         - Text or chat
@@ -23,16 +35,14 @@ body:
         - Embeddings
         - Speech or text-to-speech
         - Transcription or speech-to-text
-    validations:
-      required: true
 
   - type: textarea
     id: publishing-plans
     attributes:
       label: Publishing plans
-      description: Describe the models, providers, or endpoints you plan to publish and why they would be useful in the public catalog.
+      description: Describe the models and/or managed agents you plan to publish and why they would be useful in the public catalog.
       placeholder: |
-        Models/providers:
+        Models, agents, or providers:
         Main capabilities and intended use:
         Why they are a good fit for the public catalog:
     validations:
@@ -42,22 +52,22 @@ body:
     id: relevant-links
     attributes:
       label: Relevant links
-      description: Optional links to model cards, provider documentation, repositories, demos, or prior work. Do not include credentials.
+      description: Optional links to model cards, provider or tool documentation, repositories, demos, or prior work. Do not include credentials.
       placeholder: "https://..."
 
   - type: input
     id: discord-username
     attributes:
       label: Discord username
-      description: Optional. If you're in the Pollinations Discord server, share your username so we can assign you the Community Provider role and tag you about your models.
+      description: Optional. If you're in the Pollinations Discord server, share your username so we can assign you the Community Provider role and tag you about your deployments.
       placeholder: "your-discord-username"
 
   - type: textarea
     id: availability
     attributes:
-      label: Availability and limits
-      description: Tell us where the endpoint is hosted and any capacity, rate-limit, or uptime constraints reviewers should know.
-      placeholder: "Hosted on ..., approximately ... concurrent requests, ... rate limit"
+      label: Technical setup and limits
+      description: For models, include endpoint hosting, capacity, rate limits, and uptime constraints. For agents, include the base model, tools, and expected request patterns or limits.
+      placeholder: "Hosted on ..., uses ..., approximately ... concurrent requests, ... rate limit"
     validations:
       required: true
 
@@ -68,9 +78,11 @@ body:
       options:
         - label: I am submitting from the same GitHub account I use to sign in to Pollinations.
           required: true
-        - label: I understand that published community models must use OpenAI-compatible upstream endpoints.
+        - label: If I publish community models, their upstream endpoints will be OpenAI compatible.
+          required: true
+        - label: If I publish managed agents, callers will use their own Pollinations balance and API-key permissions.
           required: true
         - label: I have not included API keys, bearer tokens, or other credentials in this issue.
           required: true
-        - label: I understand that public community models are monitored and may be deactivated for sustained failures or abuse.
+        - label: I understand that public deployments are monitored and may be deactivated for sustained failures or abuse.
           required: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,3 +249,4 @@ Fixes #issue
 
 - Use "Fixes #issue" or "Addresses #issue" in PRs.
 - Email: `{username} <{user_id}+{username}@users.noreply.github.com>` (user_id from issue API).
+- For publisher-allowlist PRs prompted by an access-request issue, add the requester as a `Co-authored-by` contributor using their numeric GitHub ID.

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoints.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoints.tsx
@@ -44,6 +44,9 @@ type CommunityEndpointsProps = {
     fallbackOptions: FallbackModelOption[];
 };
 
+const PUBLISHER_ACCESS_REQUEST_URL =
+    "https://github.com/pollinations/pollinations/issues/new?template=community-model-allowlist.yml";
+
 export function CommunityEndpoints({
     onChange,
     canPublish,
@@ -288,21 +291,21 @@ export function CommunityEndpoints({
         }
     }
 
+    const publisherAccessRequestLink = (
+        <InlineLink href={PUBLISHER_ACCESS_REQUEST_URL} showIcon={false}>
+            publisher access request
+        </InlineLink>
+    );
+
     const privateModelGuidance = (
         <>
             Your models are private — callable only by you and shown only when{" "}
             <strong>/models</strong> is authenticated with your API key. Enter
             the upstream model ID manually, then test the saved model by calling
             its model ID. Public publishing is allowlist-only. To request
-            publishing access for your account, submit a{" "}
-            <InlineLink
-                href="https://github.com/pollinations/pollinations/issues/new?template=community-model-allowlist.yml"
-                showIcon={false}
-            >
-                community model publisher allowlist request
-            </InlineLink>{" "}
-            form. You can register and test private models without approval. For
-            questions, ask in{" "}
+            publishing access for models, agents, or both, submit a{" "}
+            {publisherAccessRequestLink}. You can register and test private or
+            app-scoped models without approval. For questions, ask in{" "}
             <InlineLink
                 href="https://discord.gg/pollinations-ai-885844321461485618"
                 showIcon={false}
@@ -447,6 +450,17 @@ export function CommunityEndpoints({
                             agentEndpoints.map(renderEndpointCard)
                         )}
                     </div>
+                    {!isLoading && !canPublish && (
+                        <p className="mt-4 flex items-start gap-1.5 border-t border-divider pt-4 text-[13px] leading-snug text-theme-text-muted">
+                            <GlobeIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                            <span>
+                                Private and app-scoped agents do not need
+                                approval. To publish agents for everyone in{" "}
+                                <strong>/models</strong>, submit a{" "}
+                                {publisherAccessRequestLink} for agents or both.
+                            </span>
+                        </p>
+                    )}
                 </Section>
 
                 <Section

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoints.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoints.tsx
@@ -304,8 +304,8 @@ export function CommunityEndpoints({
             the upstream model ID manually, then test the saved model by calling
             its model ID. Public publishing is allowlist-only. To request
             publishing access for models, agents, or both, submit a{" "}
-            {publisherAccessRequestLink}. You can register and test private or
-            app-scoped models without approval. For questions, ask in{" "}
+            {publisherAccessRequestLink}. You can register and test private
+            models without approval. For questions, ask in{" "}
             <InlineLink
                 href="https://discord.gg/pollinations-ai-885844321461485618"
                 showIcon={false}
@@ -454,10 +454,10 @@ export function CommunityEndpoints({
                         <p className="mt-4 flex items-start gap-1.5 border-t border-divider pt-4 text-[13px] leading-snug text-theme-text-muted">
                             <GlobeIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
                             <span>
-                                Private and app-scoped agents do not need
-                                approval. To publish agents for everyone in{" "}
-                                <strong>/models</strong>, submit a{" "}
-                                {publisherAccessRequestLink} for agents or both.
+                                Private agents do not need approval. To publish
+                                agents for everyone in <strong>/models</strong>,
+                                submit a {publisherAccessRequestLink} for agents
+                                or both.
                             </span>
                         </p>
                     )}


### PR DESCRIPTION
- Adds a required one-or-both selector for public community models and managed agents.
- Generalizes the existing access form while keeping its stable issue-template URL.
- Links the Agents section to the same publisher-access request flow.
- Documents co-author attribution for applicants in future allowlist PRs.

Checks:
- `biome check --write enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoints.tsx`
- Parsed the issue-form YAML with Ruby
- `git diff --check`