### PR TITLE
fix: scope delegating endpoint cache

### DIFF
--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -75,6 +75,7 @@ import {
     getGenerationModelRegistry,
     resetGenerationModelRegistryCache,
 } from "./model-registry.ts";
+import { resolveModelDefinition } from "./middleware/model.ts";
 import { communityEndpointGatewayContext } from "./text/communityEndpoint.ts";
 
 const db = drizzle(env.DB);
@@ -4571,6 +4572,25 @@ fixtureTest(
         expect(fallbackIds(id("repriced-primary"))).toBeUndefined();
         expect(fallbackIds(id("delegating-primary"))).toBeUndefined();
         expect(fallbackIds(id("managed-primary"))).toBeUndefined();
+
+        expect(
+            (
+                await resolveModelDefinition(
+                    id("delegating-target"),
+                    "generate.text",
+                    env,
+                )
+            ).cacheScope,
+        ).toMatch(/^agent:/);
+        expect(
+            (
+                await resolveModelDefinition(
+                    id("valid-target"),
+                    "generate.text",
+                    env,
+                )
+            ).cacheScope,
+        ).toBeUndefined();
 
         // Same image pricing mode on both sides: the price columns mean the
         // same thing, so the link stands.

--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -71,11 +71,11 @@ import {
 } from "./community-models.ts";
 import { callCommunityImageEndpoint } from "./image/communityEndpoint.ts";
 import worker from "./index.ts";
+import { resolveModelDefinition } from "./middleware/model.ts";
 import {
     getGenerationModelRegistry,
     resetGenerationModelRegistryCache,
 } from "./model-registry.ts";
-import { resolveModelDefinition } from "./middleware/model.ts";
 import { communityEndpointGatewayContext } from "./text/communityEndpoint.ts";
 
 const db = drizzle(env.DB);

--- a/gen.pollinations.ai/src/middleware/model.ts
+++ b/gen.pollinations.ai/src/middleware/model.ts
@@ -1,4 +1,7 @@
-import type { CommunityEndpointRuntime } from "@shared/community-endpoints.ts";
+import {
+    type CommunityEndpointRuntime,
+    isDelegatingEndpoint,
+} from "@shared/community-endpoints.ts";
 import { DEFAULT_AUDIO_MODEL } from "@shared/registry/audio.ts";
 import { DEFAULT_EMBEDDING_MODEL } from "@shared/registry/embeddings.ts";
 import { DEFAULT_IMAGE_MODEL } from "@shared/registry/image.ts";
@@ -126,9 +129,14 @@ export async function resolveModelDefinition(
         }),
         // An agent run executes tools and spends the caller's balance, so its
         // answer belongs to that caller and must never be replayed to another.
-        ...(entry.communityEndpoint?.kind === "agent" && {
-            cacheScope: `agent:${entry.communityEndpoint.agentId}`,
-        }),
+        ...(entry.communityEndpoint &&
+            isDelegatingEndpoint(entry.communityEndpoint) && {
+                cacheScope: `agent:${
+                    entry.communityEndpoint.kind === "agent"
+                        ? entry.communityEndpoint.agentId
+                        : entry.communityEndpoint.id
+                }`,
+            }),
         ...(entry.fallbackEntries && {
             fallbackEntries: entry.fallbackEntries,
         }),


### PR DESCRIPTION
- Scopes every delegating endpoint cache entry to the calling API key.
- Uses the managed agent ID or external endpoint ID as the stable cache namespace.
- Adds coverage for delegating and ordinary external community endpoints.

Checks:
- `npm run typecheck` in `gen.pollinations.ai`
- Targeted Vitest could not start in the current workspace: the Cloudflare worker pool exited before test discovery (0 tests); the added test is included for CI.
