### PR TITLE
feat: add Nemotron 3.5 Lightning on RunInfra

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -1157,6 +1157,16 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.0000005,
     },
   },
+  "nemotron-3.5-lightning": {
+    "cost": {
+      "completionTextTokens": 0.00000015,
+      "promptTextTokens": 0.00000005,
+    },
+    "price": {
+      "completionTextTokens": 0.00000015,
+      "promptTextTokens": 0.00000005,
+    },
+  },
   "nova": {
     "cost": {
       "completionTextTokens": 0.00000275,

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -391,6 +391,10 @@ const models: ModelDefinition[] = [
         transform: createReasoningEffortTransform("toggle"),
     },
     {
+        name: "nemotron-3.5-lightning",
+        config: portkeyConfig["nemotron-3-5-lightning-30b"],
+    },
+    {
         name: "mimo-v2.5",
         config: portkeyConfig["xiaomi/mimo-v2.5"],
         transform: stripCacheControl,

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -283,7 +283,11 @@ export const portkeyConfig: PortkeyConfigMap = {
             model: "accounts/fireworks/models/qwen3p8-2p4t-a95b",
         }),
 
-    // -- RunInfra (Qwen) ------------------------------------------------------
+    // -- RunInfra -------------------------------------------------------------
+    "nemotron-3-5-lightning-30b": () =>
+        createRunInfraModelConfig({
+            model: "nemotron-3-5-lightning-30b",
+        }),
     "qwen3-8-27b": () =>
         createRunInfraModelConfig({
             model: "qwen3-8-27b",

--- a/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
+++ b/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
@@ -96,6 +96,19 @@ describe("resolveModelConfig", () => {
         expect(result.options.provider).toBeUndefined();
     });
 
+    it("routes Nemotron 3.5 Lightning directly to RunInfra without fallback", () => {
+        const result = resolveModelConfig(messages, {
+            model: "nemotron-3.5-lightning",
+        });
+
+        expect(result.options.model).toBe("nemotron-3-5-lightning-30b");
+        expect(result.options.modelConfig).toMatchObject({
+            provider: "openai",
+            "custom-host": "https://api.runinfra.ai/v1",
+        });
+        expect(result.options.provider).toBeUndefined();
+    });
+
     it("routes Step Flash directly to DeepInfra without fallback", () => {
         const result = resolveModelConfig(messages, { model: "step-flash" });
 

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -1381,6 +1381,29 @@ export const TEXT_SERVICES = {
         contextLength: 262144,
         isSpecialized: false,
     },
+    "nemotron-3.5-lightning": {
+        aliases: [],
+        provider: "runinfra",
+        brand: "NVIDIA",
+        category: "text",
+        addedDate: new Date("2026-08-17").getTime(),
+        paidOnly: true,
+        priceMultiplier: 1,
+        cost: {
+            // RunInfra nemotron-3-5-lightning-30b rates after 2026-08-18 promotion.
+            promptTextTokens: perMillion(0.05),
+            completionTextTokens: perMillion(0.15),
+        },
+        title: "NVIDIA Nemotron 3.5 Lightning",
+        description:
+            "Fast open-weight reasoning for high-volume tasks and structured generation",
+        inputModalities: ["text"],
+        outputModalities: ["text"],
+        tools: false,
+        reasoning: true,
+        contextLength: 262144,
+        isSpecialized: false,
+    },
     "mimo-v2.5": {
         aliases: ["mimo", "mimo-2.5"],
         provider: "openrouter",


### PR DESCRIPTION
- Adds paid-only `nemotron-3.5-lightning` through RunInfra model `nemotron-3-5-lightning-30b`.
- Bills the permanent post-promotion rates: $0.05/M input and $0.15/M output, multiplier 1, with no cached-input discount.
- Exposes text reasoning without aliases, tools, Pollinations GPUs, or fallback.
- Adds resolver coverage and the effective-price snapshot.

Validation:
- Direct provider: basic/JSON/streaming, every reasoning level, standard parameters, useful unsupported-tool/image errors, context error, prefix-cache accounting, and 16/16 burst.
- Full local E2E: both API surfaces, catalogs, permissions, output cache, exact billing reconciliation, paid-only rejection, errors, and 16/16 burst.
- Focused gen/enter tests, typecheck, Biome, and diff checks pass.

Stacked on #13486 for the shared RunInfra provider integration. Also requires dedicated encrypted-secret PR #13485. Keep draft until both dependencies deploy and staging verification passes.