### PR TITLE
feat: show quest progress

### DIFF
--- a/enter.pollinations.ai/frontend/src/backend-types.ts
+++ b/enter.pollinations.ai/frontend/src/backend-types.ts
@@ -4,3 +4,4 @@
 // because route types include hono-openapi declarations.
 export type { FrontendApiRoutes as ApiRoutes } from "../../src/frontend-api.ts";
 export type { QuestCatalogResponse } from "../../src/routes/quests.ts";
+export type { QuestCheckResult } from "../../src/services/quest-checker.ts";

--- a/enter.pollinations.ai/frontend/src/components/quests/quest-overview.tsx
+++ b/enter.pollinations.ai/frontend/src/components/quests/quest-overview.tsx
@@ -30,9 +30,13 @@ import {
     useState,
 } from "react";
 import { apiClient } from "../../api.ts";
-import type { QuestCatalogResponse } from "../../backend-types.ts";
+import type {
+    QuestCatalogResponse,
+    QuestCheckResult,
+} from "../../backend-types.ts";
 
 type QuestCatalogItem = QuestCatalogResponse["quests"][number];
+type QuestProgress = QuestCheckResult["progress"][number];
 
 type QuestReward = {
     id: string;
@@ -50,6 +54,7 @@ type QuestOverviewProps = Record<string, never>;
 type FetchState = {
     catalog: QuestCatalogItem[];
     rewards: QuestReward[];
+    progress: QuestProgress[];
     loading: boolean;
     checking: boolean;
     error: string | null;
@@ -63,6 +68,7 @@ type FetchState = {
 const INITIAL_STATE: FetchState = {
     catalog: [],
     rewards: [],
+    progress: [],
     loading: true,
     checking: false,
     error: null,
@@ -222,6 +228,7 @@ export type QuestCard = {
     balanceBucket?: string | null;
     status: QuestCardStatus;
     earnedAmount?: number | null;
+    progress?: QuestProgress;
     // coming_soon quests render at the bottom of their lane in the receded
     // (claimed) style, with a clock + "Coming soon" in place of the reward.
     comingSoon?: boolean;
@@ -392,6 +399,39 @@ function QuestDescription({ children }: { children: string }) {
     );
 }
 
+function QuestProgressBar({ progress }: { progress: QuestProgress }) {
+    const percentage = Math.min(
+        100,
+        Math.max(0, (progress.current / progress.target) * 100),
+    );
+    const formatValue = (value: number) =>
+        progress.unit === "pollen"
+            ? formatPollen(value)
+            : value.toLocaleString();
+
+    return (
+        <div className="mt-1 flex max-w-sm items-center gap-2">
+            <div
+                role="progressbar"
+                aria-label={`${progress.questId} progress`}
+                aria-valuemin={0}
+                aria-valuemax={progress.target}
+                aria-valuenow={Math.min(progress.current, progress.target)}
+                className="h-1.5 min-w-24 flex-1 overflow-hidden rounded-full bg-theme-bg-active"
+            >
+                <div
+                    className="h-full rounded-full bg-theme-text-soft"
+                    style={{ width: `${percentage}%` }}
+                />
+            </div>
+            <span className="shrink-0 text-xs tabular-nums text-theme-text-muted">
+                {formatValue(progress.current)} / {formatValue(progress.target)}{" "}
+                {progress.unit}
+            </span>
+        </div>
+    );
+}
+
 // Leading marker for a quest row, by lifecycle stage:
 //   open      → ambient theme tile + section icon (vanilla amber — the row's
 //                bucket lives on the reward chip; the marker is just "do this")
@@ -450,6 +490,10 @@ export function QuestRow({
     const claimed = card.status === "claimed";
     const claimableRewardId =
         card.status === "claimable" ? card.rewardId : undefined;
+    const progress =
+        !card.comingSoon && card.progress ? (
+            <QuestProgressBar progress={card.progress} />
+        ) : null;
     const rewardAmount = earned
         ? (card.earnedAmount ?? card.reward)
         : card.reward;
@@ -551,6 +595,7 @@ export function QuestRow({
                             {issueLink}
                         </div>
                     )}
+                    {progress}
                 </div>
                 <div className="flex items-center gap-2.5">
                     {claimButton}
@@ -585,6 +630,7 @@ export function QuestRow({
                             {issueLink}
                         </div>
                     )}
+                    {progress}
                 </div>
                 {claimButton}
                 <div className="ml-auto flex shrink-0 items-center gap-2.5">
@@ -617,6 +663,7 @@ export const QuestOverview: FC<QuestOverviewProps> = () => {
                 if (cancelled) return;
                 setState({
                     ...questData,
+                    progress: [],
                     loading: false,
                     // Flag the auto-check as in-flight so the indicator shows
                     // straight after the initial render, with no idle flash.
@@ -653,11 +700,14 @@ export const QuestOverview: FC<QuestOverviewProps> = () => {
                 const response = await apiClient.quests.check.$post();
                 if (cancelled) return;
                 if (response.ok) {
+                    const checkResult =
+                        (await response.json()) as QuestCheckResult;
                     const refreshed = await loadQuestData();
                     if (cancelled) return;
                     setState((current) => ({
                         ...current,
                         ...refreshed,
+                        progress: checkResult.progress,
                         checking: false,
                         loading: false,
                         error: null,
@@ -736,6 +786,9 @@ export const QuestOverview: FC<QuestOverviewProps> = () => {
     // quest (onboarding, GitHub, issue bounty, easter egg) is one card. Rewards
     // only tell us "did YOU earn it" + whether it has been claimed.
     const sections = useMemo(() => {
+        const progressByQuestId = new Map(
+            state.progress.map((progress) => [progress.questId, progress]),
+        );
         const byCat: Record<CategoryKey, QuestCard[]> = {
             setup: [],
             grow: [],
@@ -774,6 +827,14 @@ export const QuestOverview: FC<QuestOverviewProps> = () => {
                     reward?.balanceBucket ?? quest.balanceBucket ?? "tier",
                 status: deriveCardStatus(comingSoon, previewAll, reward),
                 earnedAmount: reward?.pollenAmount ?? undefined,
+                progress:
+                    reward && quest.goal
+                        ? {
+                              questId: quest.id,
+                              current: quest.goal.target,
+                              ...quest.goal,
+                          }
+                        : progressByQuestId.get(quest.id),
                 comingSoon,
             });
         }
@@ -790,7 +851,13 @@ export const QuestOverview: FC<QuestOverviewProps> = () => {
             });
         }
         return byCat;
-    }, [state.catalog, rewardedCatalogIds, rewardByKey, previewAll]);
+    }, [
+        state.catalog,
+        state.progress,
+        rewardedCatalogIds,
+        rewardByKey,
+        previewAll,
+    ]);
 
     // Rewards created by a maintainer or another non-catalog source still need
     // their own claim control. This is deliberately derived from the ledger —

--- a/enter.pollinations.ai/src/routes/quests.ts
+++ b/enter.pollinations.ai/src/routes/quests.ts
@@ -36,6 +36,12 @@ const questCatalogItemSchema = z.object({
     state: z.enum(["available", "completed", "coming_soon"]),
     rewardAmount: z.number(),
     balanceBucket: z.enum(["tier", "pack"]),
+    goal: z
+        .object({
+            target: z.number(),
+            unit: z.enum(["pollen", "users", "days"]),
+        })
+        .optional(),
     url: z.string().nullable(),
 });
 
@@ -62,6 +68,14 @@ const questCheckResponseSchema = z.object({
     success: z.boolean(),
     recorded: z.number(),
     rewardIds: z.array(z.string()),
+    progress: z.array(
+        z.object({
+            questId: z.string(),
+            current: z.number(),
+            target: z.number(),
+            unit: z.enum(["pollen", "users", "days"]),
+        }),
+    ),
 });
 
 const claimRewardResponseSchema = z.object({

--- a/enter.pollinations.ai/src/services/quest-checker.ts
+++ b/enter.pollinations.ai/src/services/quest-checker.ts
@@ -5,16 +5,16 @@ import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { QUEST_GROUPS } from "./quests/index.ts";
 import {
+    type QuestEvaluation,
     type QuestEvaluationContext,
+    type QuestProgress,
     type QuestUser,
-    type RewardProposal,
     toReward,
 } from "./quests/types.ts";
 
 const log = getLogger(["enter", "quest-checker"]);
 
-type QuestProposalSourceResult = {
-    proposals: RewardProposal[];
+type QuestEvaluationSourceResult = QuestEvaluation & {
     error?: string;
 };
 
@@ -22,6 +22,7 @@ export type QuestCheckResult = {
     success: boolean;
     recorded: number;
     rewardIds: string[];
+    progress: QuestProgress[];
 };
 
 export async function checkQuestsForUser(
@@ -50,7 +51,7 @@ export async function checkQuestsForUser(
 
     const ctx: QuestEvaluationContext = { db, env };
     const sourceResults = await Promise.all(
-        QUEST_GROUPS.map((group) => findGroupRewardProposals(ctx, group, user)),
+        QUEST_GROUPS.map((group) => evaluateGroup(ctx, group, user)),
     );
     const proposals = sourceResults.flatMap((entry) => entry.proposals);
     const rewardInputs = proposals.map(toReward);
@@ -74,6 +75,7 @@ export async function checkQuestsForUser(
         success: sourceResults.every((entry) => !entry.error),
         recorded: recorded.recorded,
         rewardIds: recorded.rewardIds,
+        progress: sourceResults.flatMap((entry) => entry.progress ?? []),
     };
 
     log.info("QUEST_CHECK_COMPLETE: userId={userId} result={result}", {
@@ -100,25 +102,23 @@ async function loadQuestUser(
     return rows[0] ?? null;
 }
 
-async function findGroupRewardProposals(
+async function evaluateGroup(
     ctx: QuestEvaluationContext,
     group: (typeof QUEST_GROUPS)[number],
     user: QuestUser,
-): Promise<QuestProposalSourceResult> {
+): Promise<QuestEvaluationSourceResult> {
     try {
         log.info("QUEST_GROUP_START: groupId={groupId} userId={userId}", {
             groupId: group.id,
             userId: user.id,
         });
-        const proposals = await group.findRewardProposalsForUser(ctx, user);
+        const evaluation = await group.evaluateUser(ctx, user);
         log.info("QUEST_GROUP_PROPOSALS: groupId={groupId} count={count}", {
             groupId: group.id,
-            count: proposals.length,
+            count: evaluation.proposals.length,
         });
 
-        return {
-            proposals,
-        };
+        return evaluation;
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         log.error(

--- a/enter.pollinations.ai/src/services/quests/definitions.ts
+++ b/enter.pollinations.ai/src/services/quests/definitions.ts
@@ -32,6 +32,11 @@ export type QuestCategory = (typeof QUEST_CATEGORIES)[number];
  */
 export type QuestScope = "perUser" | "perSubject" | "once";
 
+export type QuestGoal = {
+    target: number;
+    unit: "pollen" | "users" | "days";
+};
+
 /**
  * Quest board state. A BOARD flag, not a per-user status:
  *   - "available"   = open to everyone.
@@ -50,6 +55,8 @@ export type QuestDefinition = {
     scope: QuestScope;
     rewardAmount: number;
     balanceBucket: Bucket;
+    /** Optional measurable target for quests with meaningful partial progress. */
+    goal?: QuestGoal;
     /**
      * Optional static link for the quest (e.g. the GitHub quest board, the app
      * directory). Snapshotted onto each reward by toReward and shown on the

--- a/enter.pollinations.ai/src/services/quests/groups/account-setup.ts
+++ b/enter.pollinations.ai/src/services/quests/groups/account-setup.ts
@@ -2,10 +2,11 @@ import { sql } from "drizzle-orm";
 import { type QuestDefinition, rewardableQuests } from "../definitions.ts";
 import {
     type QuestCard,
+    type QuestEvaluation,
     type QuestEvaluationContext,
     type QuestUser,
     questToCard,
-    type RewardProposal,
+    toQuestProgress,
 } from "../types.ts";
 
 /**
@@ -100,7 +101,7 @@ const topUpSinceLaunchQuest: QuestDefinition = {
     balanceBucket: "tier",
 };
 
-const overHundredPollenSinceLaunchQuest: QuestDefinition = {
+const overHundredPollenSinceLaunchQuest = {
     id: "top_up_100_since_launch",
     title: "Top up 100 Pollen",
     description: `You have [topped up](/pollen#buy-pollen) 100 Pollen or more. _(from ${QUEST_REWARDS_LAUNCH_DATE_LABEL})_`,
@@ -108,7 +109,8 @@ const overHundredPollenSinceLaunchQuest: QuestDefinition = {
     scope: "perUser",
     rewardAmount: 50,
     balanceBucket: "tier",
-};
+    goal: { target: 100, unit: "pollen" },
+} satisfies QuestDefinition;
 
 const QUESTS = [
     firstApiKeyQuest,
@@ -134,10 +136,10 @@ export async function listQuestCards(
     return QUESTS.map((quest) => questToCard(quest));
 }
 
-export async function findRewardProposalsForUser(
+export async function evaluateUser(
     { db }: QuestEvaluationContext,
     user: QuestUser,
-): Promise<RewardProposal[]> {
+): Promise<QuestEvaluation> {
     const rewardableQuestIds = new Set(
         rewardableQuests(EVALUATED_QUESTS).map((quest) => quest.id),
     );
@@ -188,7 +190,8 @@ export async function findRewardProposalsForUser(
                 : [],
         ]);
 
-    return [
+    const totalPollen = topUpSummaryRows[0]?.totalPollen ?? 0;
+    const proposals = [
         ...apiKeyRows.map((row) => ({
             quest: firstApiKeyQuest,
             userId: row.userId,
@@ -211,7 +214,7 @@ export async function findRewardProposalsForUser(
               ]
             : []),
         ...(rewardableQuestIds.has(overHundredPollenSinceLaunchQuest.id) &&
-        (topUpSummaryRows[0]?.totalPollen ?? 0) >= 100
+        totalPollen >= overHundredPollenSinceLaunchQuest.goal.target
             ? [
                   {
                       quest: overHundredPollenSinceLaunchQuest,
@@ -220,4 +223,11 @@ export async function findRewardProposalsForUser(
               ]
             : []),
     ];
+
+    return {
+        proposals,
+        progress: [
+            toQuestProgress(overHundredPollenSinceLaunchQuest, totalPollen),
+        ],
+    };
 }

--- a/enter.pollinations.ai/src/services/quests/groups/app-growth.ts
+++ b/enter.pollinations.ai/src/services/quests/groups/app-growth.ts
@@ -4,10 +4,11 @@ import { fetchTinybirdRows, requireTinybirdReadToken } from "../../tinybird.ts";
 import { type QuestDefinition, rewardableQuests } from "../definitions.ts";
 import {
     type QuestCard,
+    type QuestEvaluation,
     type QuestEvaluationContext,
     type QuestUser,
     questToCard,
-    type RewardProposal,
+    toQuestProgress,
 } from "../types.ts";
 
 const log = getLogger(["enter", "quests", "app-growth"]);
@@ -57,7 +58,7 @@ const firstPaidSpendInAppQuest: QuestDefinition = {
     balanceBucket: "tier",
 };
 
-const tenAppUsersQuest: QuestDefinition = {
+const tenAppUsersQuest = {
     id: "app_users_10",
     title: "Your app is gaining users",
     description:
@@ -66,7 +67,8 @@ const tenAppUsersQuest: QuestDefinition = {
     scope: "perUser",
     rewardAmount: 15,
     balanceBucket: "tier",
-};
+    goal: { target: 10, unit: "users" },
+} satisfies QuestDefinition;
 
 const tenPollenAppUsageQuest: QuestDefinition = {
     id: "app_pollen_10",
@@ -106,10 +108,10 @@ export async function listQuestCards(
     return QUESTS.map((quest) => questToCard(quest));
 }
 
-export async function findRewardProposalsForUser(
+export async function evaluateUser(
     ctx: QuestEvaluationContext,
     user: QuestUser,
-): Promise<RewardProposal[]> {
+): Promise<QuestEvaluation> {
     const rewardableQuestIds = new Set(
         rewardableQuests(QUESTS).map((quest) => quest.id),
     );
@@ -120,7 +122,7 @@ export async function findRewardProposalsForUser(
                 userId: user.id,
             },
         );
-        return [];
+        return { proposals: [] };
     }
 
     const usageQuestIds = [
@@ -152,7 +154,7 @@ export async function findRewardProposalsForUser(
             ? [{ quest: firstPaidSpendInAppQuest, userId: user.id }]
             : []),
         ...(appReach &&
-        appReach.externalUsers >= 10 &&
+        appReach.externalUsers >= tenAppUsersQuest.goal.target &&
         rewardableQuestIds.has(tenAppUsersQuest.id)
             ? [{ quest: tenAppUsersQuest, userId: user.id }]
             : []),
@@ -178,7 +180,12 @@ export async function findRewardProposalsForUser(
             questIds: proposals.map((p) => p.quest.id),
         },
     );
-    return proposals;
+    return {
+        proposals,
+        progress: [
+            toQuestProgress(tenAppUsersQuest, appReach?.externalUsers ?? 0),
+        ],
+    };
 }
 
 async function loadAppUsage(

--- a/enter.pollinations.ai/src/services/quests/groups/github-contributions.ts
+++ b/enter.pollinations.ai/src/services/quests/groups/github-contributions.ts
@@ -6,10 +6,10 @@ import { graphql } from "@shared/github/client.ts";
 import type { QuestDefinition, QuestState } from "../definitions.ts";
 import {
     type QuestCard,
+    type QuestEvaluation,
     type QuestEvaluationContext,
     type QuestUser,
     questToCard,
-    type RewardProposal,
 } from "../types.ts";
 
 /**
@@ -260,11 +260,11 @@ async function hasMergedPr(token: string, user: QuestUser): Promise<boolean> {
     return data.search.nodes.some((pr) => pr.mergedAt !== null);
 }
 
-export async function findRewardProposalsForUser(
+export async function evaluateUser(
     ctx: QuestEvaluationContext,
     user: QuestUser,
-): Promise<RewardProposal[]> {
-    if (user.githubId === null) return [];
+): Promise<QuestEvaluation> {
+    if (user.githubId === null) return { proposals: [] };
 
     const token = await githubToken(ctx.env);
     const [issues, mergedPr] = await Promise.all([
@@ -287,8 +287,12 @@ export async function findRewardProposalsForUser(
             userId: user.id,
         }));
 
-    return [
-        ...issueProposals,
-        ...(mergedPr ? [{ quest: firstMergedPrQuest, userId: user.id }] : []),
-    ];
+    return {
+        proposals: [
+            ...issueProposals,
+            ...(mergedPr
+                ? [{ quest: firstMergedPrQuest, userId: user.id }]
+                : []),
+        ],
+    };
 }

--- a/enter.pollinations.ai/src/services/quests/groups/github-profile.ts
+++ b/enter.pollinations.ai/src/services/quests/groups/github-profile.ts
@@ -8,11 +8,12 @@ import { eq } from "drizzle-orm";
 import { type QuestDefinition, rewardableQuests } from "../definitions.ts";
 import type {
     QuestCard,
+    QuestEvaluation,
     QuestEvaluationContext,
+    QuestProgress,
     QuestUser,
-    RewardProposal,
 } from "../types.ts";
-import { questToCard } from "../types.ts";
+import { questToCard, toQuestProgress } from "../types.ts";
 
 /**
  * GitHub profile quests fetch the current user's linked GitHub profile, then
@@ -21,7 +22,6 @@ import { questToCard } from "../types.ts";
 
 const log = getLogger(["enter", "quest", "github-profile"]);
 
-const GITHUB_ACCOUNT_AGE_DAYS = 730;
 const PUBLIC_REPO_STAR_THRESHOLD = 20;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const REPO_OWNER = "pollinations";
@@ -176,7 +176,7 @@ function accountAgeDays(createdAt: Date | null, now: Date): number {
     return Math.floor((now.getTime() - createdAt.getTime()) / MS_PER_DAY);
 }
 
-const establishedGitHubAccountQuest: QuestDefinition = {
+const establishedGitHubAccountQuest = {
     id: "github_established",
     title: "Senior dev",
     description:
@@ -185,7 +185,8 @@ const establishedGitHubAccountQuest: QuestDefinition = {
     scope: "perSubject",
     rewardAmount: 3,
     balanceBucket: "tier",
-};
+    goal: { target: 730, unit: "days" },
+} satisfies QuestDefinition;
 
 const publicRepoStarsQuest: QuestDefinition = {
     id: "github_stars",
@@ -212,10 +213,10 @@ export async function listQuestCards(
     return QUESTS.map((quest) => questToCard(quest));
 }
 
-export async function findRewardProposalsForUser(
+export async function evaluateUser(
     ctx: QuestEvaluationContext,
     user: QuestUser,
-): Promise<RewardProposal[]> {
+): Promise<QuestEvaluation> {
     const rewardableQuestIds = new Set(
         rewardableQuests(QUESTS).map((quest) => quest.id),
     );
@@ -224,7 +225,7 @@ export async function findRewardProposalsForUser(
             "GITHUB_PROFILE_SKIPPED: userId={userId} reason=no_rewardable_quests",
             { userId: user.id },
         );
-        return [];
+        return { proposals: [] };
     }
 
     if (user.githubId === null) {
@@ -234,7 +235,7 @@ export async function findRewardProposalsForUser(
                 userId: user.id,
             },
         );
-        return [];
+        return { proposals: [] };
     }
 
     if (rewardableQuestIds.has(establishedGitHubAccountQuest.id)) {
@@ -253,23 +254,32 @@ export async function findRewardProposalsForUser(
         }
     }
 
-    if (rewardableQuestIds.size === 0) return [];
+    if (rewardableQuestIds.size === 0) {
+        return { proposals: [] };
+    }
 
     const now = new Date();
-    const proposals: RewardProposal[] = [];
+    const proposals: QuestEvaluation["proposals"] = [];
+    const progress: QuestProgress[] = [];
     const profile = await fetchGitHubProfile(ctx.env, user.githubId);
     if (!profile) {
         log.info(
             "GITHUB_PROFILE_NO_ACTIVITY: userId={userId} githubId={githubId}",
             { userId: user.id, githubId: user.githubId },
         );
-        return proposals;
+        return { proposals, progress };
     }
 
     if (rewardableQuestIds.has(establishedGitHubAccountQuest.id)) {
         const ageDays = accountAgeDays(profile.createdAt, now);
         const qualifies =
-            profile.createdAt !== null && ageDays >= GITHUB_ACCOUNT_AGE_DAYS;
+            profile.createdAt !== null &&
+            ageDays >= establishedGitHubAccountQuest.goal.target;
+        if (profile.createdAt !== null) {
+            progress.push(
+                toQuestProgress(establishedGitHubAccountQuest, ageDays),
+            );
+        }
         log.info(
             "GITHUB_PROFILE_QUEST_DECISION: userId={userId} githubId={githubId} createdAt={createdAt} ageDays={ageDays} thresholdDays={thresholdDays} qualifies={qualifies}",
             {
@@ -277,7 +287,7 @@ export async function findRewardProposalsForUser(
                 githubId: user.githubId,
                 createdAt: profile.createdAt?.toISOString() ?? null,
                 ageDays,
-                thresholdDays: GITHUB_ACCOUNT_AGE_DAYS,
+                thresholdDays: establishedGitHubAccountQuest.goal.target,
                 qualifies,
             },
         );
@@ -318,5 +328,5 @@ export async function findRewardProposalsForUser(
         }
     }
 
-    return proposals;
+    return { proposals, progress };
 }

--- a/enter.pollinations.ai/src/services/quests/groups/identity.ts
+++ b/enter.pollinations.ai/src/services/quests/groups/identity.ts
@@ -1,10 +1,10 @@
 import type { QuestDefinition } from "../definitions.ts";
 import {
     type QuestCard,
+    type QuestEvaluation,
     type QuestEvaluationContext,
     type QuestUser,
     questToCard,
-    type RewardProposal,
 } from "../types.ts";
 
 // elixpo (Ayushman Bhattacharya) joined the team as an intern — a one-off
@@ -34,10 +34,14 @@ export async function listQuestCards(
     return [questToCard(elixpoInternQuest)];
 }
 
-export async function findRewardProposalsForUser(
+export async function evaluateUser(
     _ctx: QuestEvaluationContext,
     user: QuestUser,
-): Promise<RewardProposal[]> {
-    if (user.githubId !== TARGET_GITHUB_ID) return [];
-    return [{ quest: elixpoInternQuest, userId: user.id }];
+): Promise<QuestEvaluation> {
+    return {
+        proposals:
+            user.githubId === TARGET_GITHUB_ID
+                ? [{ quest: elixpoInternQuest, userId: user.id }]
+                : [],
+    };
 }

--- a/enter.pollinations.ai/src/services/quests/groups/model-usage.ts
+++ b/enter.pollinations.ai/src/services/quests/groups/model-usage.ts
@@ -3,10 +3,10 @@ import { fetchTinybirdRows, requireTinybirdReadToken } from "../../tinybird.ts";
 import type { QuestDefinition } from "../definitions.ts";
 import {
     type QuestCard,
+    type QuestEvaluation,
     type QuestEvaluationContext,
     type QuestUser,
     questToCard,
-    type RewardProposal,
 } from "../types.ts";
 
 const log = getLogger(["enter", "quests", "model-usage"]);
@@ -69,10 +69,10 @@ export async function listQuestCards(
     return QUESTS.map((quest) => questToCard(quest));
 }
 
-export async function findRewardProposalsForUser(
+export async function evaluateUser(
     { env }: QuestEvaluationContext,
     user: QuestUser,
-): Promise<RewardProposal[]> {
+): Promise<QuestEvaluation> {
     const tinybirdOrigin = new URL(env.TINYBIRD_INGEST_URL).origin;
     const tinybirdToken = requireTinybirdReadToken(env);
     const rows = await fetchTinybirdRows<ModalityRow>(
@@ -102,7 +102,7 @@ export async function findRewardProposalsForUser(
         },
     );
 
-    const proposals: RewardProposal[] = [];
+    const proposals: QuestEvaluation["proposals"] = [];
     for (const row of matched) {
         if (row.usedText) {
             proposals.push({ quest: useTextModelQuest, userId: row.userId });
@@ -122,5 +122,5 @@ export async function findRewardProposalsForUser(
             questIds: proposals.map((p) => p.quest.id),
         },
     );
-    return proposals;
+    return { proposals };
 }

--- a/enter.pollinations.ai/src/services/quests/types.ts
+++ b/enter.pollinations.ai/src/services/quests/types.ts
@@ -3,6 +3,7 @@ import type * as schema from "@shared/db/better-auth.ts";
 import type { DrizzleD1Database } from "drizzle-orm/d1";
 import {
     type QuestDefinition,
+    type QuestGoal,
     type QuestState,
     questState,
 } from "./definitions.ts";
@@ -23,10 +24,10 @@ export type QuestUser = {
 export type QuestGroup = {
     id: string;
     listQuestCards(ctx: QuestEvaluationContext): Promise<QuestCard[]>;
-    findRewardProposalsForUser(
+    evaluateUser(
         ctx: QuestEvaluationContext,
         user: QuestUser,
-    ): Promise<RewardProposal[]>;
+    ): Promise<QuestEvaluation>;
 };
 
 export type RewardProposal = {
@@ -34,6 +35,23 @@ export type RewardProposal = {
     userId: string;
     idempotencySubject?: string;
 };
+
+export type QuestProgress = QuestGoal & {
+    questId: string;
+    current: number;
+};
+
+export type QuestEvaluation = {
+    proposals: RewardProposal[];
+    progress?: QuestProgress[];
+};
+
+export function toQuestProgress(
+    quest: QuestDefinition & { goal: QuestGoal },
+    current: number,
+): QuestProgress {
+    return { questId: quest.id, current, ...quest.goal };
+}
 
 export function toReward(proposal: RewardProposal): RecordRewardInput {
     const { quest, userId } = proposal;

--- a/enter.pollinations.ai/test/quests.test.ts
+++ b/enter.pollinations.ai/test/quests.test.ts
@@ -278,6 +278,7 @@ test("catalog returns quest definitions without ledger stats", async ({
             rewardAmount: number;
             balanceBucket: string;
             state: string;
+            goal?: { target: number; unit: string };
             availability?: unknown;
             stats?: unknown;
         }[];
@@ -322,6 +323,10 @@ test("catalog returns quest definitions without ledger stats", async ({
         rewardAmount: 50,
         balanceBucket: "tier",
     });
+    expect(byId.get(TOP_UP_100_SINCE_LAUNCH_QUEST_ID)?.goal).toEqual({
+        target: 100,
+        unit: "pollen",
+    });
     expectStableCatalogFields("app_listed", {
         state: "available",
         rewardAmount: 10,
@@ -348,6 +353,10 @@ test("catalog returns quest definitions without ledger stats", async ({
         rewardAmount: 3,
         balanceBucket: "tier",
     });
+    expect(byId.get("github_established")?.goal).toEqual({
+        target: 730,
+        unit: "days",
+    });
     expectStableCatalogFields("app_paid_request", {
         state: "available",
         rewardAmount: 15,
@@ -357,6 +366,10 @@ test("catalog returns quest definitions without ledger stats", async ({
         state: "available",
         rewardAmount: 15,
         balanceBucket: "tier",
+    });
+    expect(byId.get("app_users_10")?.goal).toEqual({
+        target: 10,
+        unit: "users",
     });
     expectStableCatalogFields("app_pollen_10", {
         state: "coming_soon",
@@ -681,7 +694,14 @@ test("top-up 100 quest records for exactly 100 paid checkout pollen", async ({
         createdAt: AFTER_QUEST_REWARDS_LAUNCH_DATE,
     });
 
-    await checkQuestsForUser(env, user.id);
+    const result = await checkQuestsForUser(env, user.id);
+
+    expect(result.progress).toContainEqual({
+        questId: TOP_UP_100_SINCE_LAUNCH_QUEST_ID,
+        current: 100,
+        target: 100,
+        unit: "pollen",
+    });
 
     const rewards = await db
         .select({ questId: schema.rewards.questId })
@@ -722,7 +742,14 @@ test("top-up quests ignore paid checkout pollen before quest launch", async ({
         )
         .run();
 
-    await checkQuestsForUser(env, user.id);
+    const result = await checkQuestsForUser(env, user.id);
+
+    expect(result.progress).toContainEqual({
+        questId: TOP_UP_100_SINCE_LAUNCH_QUEST_ID,
+        current: 0,
+        target: 100,
+        unit: "pollen",
+    });
 
     const rewards = await db
         .select({ questId: schema.rewards.questId })
@@ -810,7 +837,14 @@ test("top-up 100 quest only sums checkout pollen since quest launch", async ({
         createdAt: AFTER_QUEST_REWARDS_LAUNCH_DATE,
     });
 
-    await checkQuestsForUser(env, user.id);
+    const result = await checkQuestsForUser(env, user.id);
+
+    expect(result.progress).toContainEqual({
+        questId: TOP_UP_100_SINCE_LAUNCH_QUEST_ID,
+        current: 40,
+        target: 100,
+        unit: "pollen",
+    });
 
     const rewards = await db
         .select({ questId: schema.rewards.questId })
@@ -1096,7 +1130,14 @@ test("app milestones do not record below their thresholds", async ({
     ];
 
     await seedByopConnections(user.id, 9, "below-milestone");
-    await checkQuestsForUser(env, user.id);
+    const result = await checkQuestsForUser(env, user.id);
+
+    expect(result.progress).toContainEqual({
+        questId: "app_users_10",
+        current: 9,
+        target: 10,
+        unit: "users",
+    });
 
     const rewards = await db
         .select({ questId: schema.rewards.questId })
@@ -1182,7 +1223,7 @@ test("quest check continues after one group fails", async ({
         async listQuestCards() {
             return [];
         },
-        async findRewardProposalsForUser(): Promise<never> {
+        async evaluateUser(): Promise<never> {
             throw new Error("planned quest failure");
         },
     };
@@ -1302,7 +1343,14 @@ test("github established-account quest waits until the threshold", async ({
     await mocks.enable("github", "tinybird");
 
     mocks.github.state.requests = [];
-    await checkQuestsForUser(env, user.id);
+    const beforeThreshold = await checkQuestsForUser(env, user.id);
+
+    expect(beforeThreshold.progress).toContainEqual({
+        questId: "github_established",
+        current: 729,
+        target: 730,
+        unit: "days",
+    });
 
     let establishedRows = await db
         .select({ id: schema.rewards.id })


### PR DESCRIPTION
- Adds optional goals to measurable quests.
- Returns progress through the existing quest check response without new storage or endpoints.
- Shows exact values and progress bars for open, claimable, and completed quests.
- Covers top-up volume, app users, and GitHub account age.
- Keeps progress optional inside quest groups and an always-present array in the public API.

Checks:
- `npx biome check`
- `npx tsc --noEmit`
- `npx vitest run test/quests.test.ts --reporter=dot` (30 tests)
- staging deployment verified