### PR TITLE
refactor: single model-catalog hook for the permissions picker

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/auth/authorize.tsx
+++ b/enter.pollinations.ai/frontend/src/components/auth/authorize.tsx
@@ -34,12 +34,8 @@ import { AccountPermissionsInput } from "../keys/account-permissions-input.tsx";
 import { ExpiryDaysInput } from "../keys/expiry-days-input.tsx";
 import { useKeyPermissions } from "../keys/key-permissions.tsx";
 import { PollenBudgetInput } from "../keys/pollen-budget-input.tsx";
-import { fetchModelCatalog } from "../models/model-catalog.ts";
-import {
-    computeCategoryModalities,
-    getModelCategoriesFromCatalog,
-    type ModelCategoryGroup,
-} from "../models/model-categories.ts";
+import { computeCategoryModalities } from "../models/model-categories.ts";
+import { useModelCategories } from "../models/use-model-categories.ts";
 import { AppAttribution } from "./app-attribution.tsx";
 
 type Attribution = {
@@ -102,9 +98,6 @@ export function Authorize() {
     >("pending");
     const [totalBalance, setTotalBalance] = useState<number | null>(null);
     const [permissionsExpanded, setPermissionsExpanded] = useState(false);
-    const [modelCategories, setModelCategories] = useState<
-        ModelCategoryGroup[]
-    >([]);
 
     const parsedRedirectUrl = redirect_url ? safeParseUrl(redirect_url) : null;
     const redirectHostname = parsedRedirectUrl?.hostname ?? "";
@@ -119,6 +112,7 @@ export function Authorize() {
     );
     const { setAccountPermissions } = keyPermissions;
 
+    const modelCategories = useModelCategories();
     const modalities = computeCategoryModalities(
         keyPermissions.permissions.allowedModels,
         modelCategories,
@@ -147,24 +141,6 @@ export function Authorize() {
 
     const isMobile = window.innerWidth < 768;
     useScrollLock(!isMobile);
-
-    useEffect(() => {
-        let cancelled = false;
-
-        fetchModelCatalog()
-            .then((models) => {
-                if (!cancelled) {
-                    setModelCategories(getModelCategoriesFromCatalog(models));
-                }
-            })
-            .catch(() => {
-                if (!cancelled) setModelCategories([]);
-            });
-
-        return () => {
-            cancelled = true;
-        };
-    }, []);
 
     useEffect(() => {
         setRedirectValidationState("unchecked");
@@ -797,6 +773,7 @@ export function Authorize() {
                                 visiblePermissions={visibleOptionalPermissions}
                                 showApiName={false}
                                 modelsInitiallyExpanded
+                                modelCategories={modelCategories}
                             />
                         </Collapsible>
                     </div>

--- a/enter.pollinations.ai/frontend/src/components/keys/account-permissions-input.tsx
+++ b/enter.pollinations.ai/frontend/src/components/keys/account-permissions-input.tsx
@@ -1,12 +1,10 @@
 import { ButtonGroup, Collapsible, cn } from "@pollinations/ui";
 import { ModalityTab } from "@pollinations/ui/gen";
 import type { FC } from "react";
-import { useEffect, useMemo, useState } from "react";
-import { fetchModelCatalog } from "../models/model-catalog.ts";
-import {
-    getModelCategoriesFromCatalog,
-    type ModelCategoryGroup,
-    type ModelCategoryModel,
+import { useMemo, useState } from "react";
+import type {
+    ModelCategoryGroup,
+    ModelCategoryModel,
 } from "../models/model-categories.ts";
 import { normalizeAllowedModelSelection } from "./model-selection.ts";
 import { PERMISSION_UI_THEME } from "./permission-ui.ts";
@@ -28,6 +26,12 @@ type AccountPermissionsInputProps = {
     showApiName?: boolean;
     /** Whether the Models section starts expanded. Always collapsible. */
     modelsInitiallyExpanded?: boolean;
+    /**
+     * The models on offer. The owning screen supplies these so that whatever
+     * else it renders from the same list — the authorize screen summarises the
+     * grant above this picker — cannot describe a different set of models.
+     */
+    modelCategories: ModelCategoryGroup[];
 };
 
 export const ACCOUNT_PERMISSIONS: readonly AccountPermissionOption[] = [
@@ -62,6 +66,7 @@ export const AccountPermissionsInput: FC<AccountPermissionsInputProps> = ({
     visiblePermissions,
     showApiName = true,
     modelsInitiallyExpanded = false,
+    modelCategories,
 }) => {
     const { row: rowTheme } = PERMISSION_UI_THEME;
     const permissionOptions =
@@ -71,9 +76,6 @@ export const AccountPermissionsInput: FC<AccountPermissionsInputProps> = ({
                   visiblePermissions.includes(p.id),
               );
     const isUnrestricted = allowedModels === null;
-    const [modelCategories, setModelCategories] = useState<
-        ModelCategoryGroup[]
-    >([]);
 
     const handleToggle = (permissionId: string) => {
         if (disabled) return;
@@ -89,24 +91,6 @@ export const AccountPermissionsInput: FC<AccountPermissionsInputProps> = ({
             onChange([...currentPermissions, permissionId]);
         }
     };
-
-    useEffect(() => {
-        let cancelled = false;
-
-        fetchModelCatalog()
-            .then((models) => {
-                if (!cancelled) {
-                    setModelCategories(getModelCategoriesFromCatalog(models));
-                }
-            })
-            .catch(() => {
-                if (!cancelled) setModelCategories([]);
-            });
-
-        return () => {
-            cancelled = true;
-        };
-    }, []);
 
     const allModelIds = useMemo(
         () =>

--- a/enter.pollinations.ai/frontend/src/components/keys/api-key-dialog.tsx
+++ b/enter.pollinations.ai/frontend/src/components/keys/api-key-dialog.tsx
@@ -213,11 +213,7 @@ export const ApiKeyDialog: FC<ApiKeyDialogProps> = ({
                             <li>
                                 Use that key for API requests paid with the
                                 user&apos;s Pollen.{" "}
-                                <InlineLink
-                                    href={genDocsUrl(
-                                        "#tag/bring-your-own-pollen",
-                                    )}
-                                >
+                                <InlineLink href={genDocsUrl("#tag/byop")}>
                                     Read the guide
                                 </InlineLink>
                             </li>

--- a/enter.pollinations.ai/frontend/src/components/keys/api-key-list.tsx
+++ b/enter.pollinations.ai/frontend/src/components/keys/api-key-list.tsx
@@ -292,9 +292,7 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
                             for direct API requests. Use Pollinations Auth
                             (BYOP), where users sign in and spend their own
                             Pollen.{" "}
-                            <InlineLink
-                                href={genDocsUrl("#tag/bring-your-own-pollen")}
-                            >
+                            <InlineLink href={genDocsUrl("#tag/byop")}>
                                 Read the migration guide
                             </InlineLink>
                             .
@@ -385,11 +383,7 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
                             <span>
                                 Turn on earnings to receive a share of pollen
                                 users spend in your app.{" "}
-                                <InlineLink
-                                    href={genDocsUrl(
-                                        "#tag/bring-your-own-pollen",
-                                    )}
-                                >
+                                <InlineLink href={genDocsUrl("#tag/byop")}>
                                     Read the guide
                                 </InlineLink>
                             </span>

--- a/enter.pollinations.ai/frontend/src/components/keys/key-permissions.tsx
+++ b/enter.pollinations.ai/frontend/src/components/keys/key-permissions.tsx
@@ -1,5 +1,6 @@
 import type { FC } from "react";
 import { useState } from "react";
+import { useModelCategories } from "../models/use-model-categories.ts";
 import { AccountPermissionsInput } from "./account-permissions-input.tsx";
 import { ExpiryDaysInput } from "./expiry-days-input.tsx";
 import { PollenBudgetInput } from "./pollen-budget-input.tsx";
@@ -60,6 +61,7 @@ export const KeyPermissionsInputs: FC<KeyPermissionsInputsProps> = ({
         setExpiryDays,
         setAccountPermissions,
     } = value;
+    const modelCategories = useModelCategories();
 
     return (
         <div className="space-y-6">
@@ -84,6 +86,7 @@ export const KeyPermissionsInputs: FC<KeyPermissionsInputsProps> = ({
                 allowedModels={permissions.allowedModels}
                 onModelsChange={setAllowedModels}
                 modelsInitiallyExpanded={modelsInitiallyExpanded}
+                modelCategories={modelCategories}
             />
         </div>
     );

--- a/enter.pollinations.ai/frontend/src/components/models/use-model-categories.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/use-model-categories.ts
@@ -1,0 +1,38 @@
+import { useEffect, useMemo, useState } from "react";
+import { type ApiModelInfo, fetchModelCatalog } from "./model-catalog.ts";
+import {
+    getModelCategoriesFromCatalog,
+    type ModelCategoryGroup,
+} from "./model-categories.ts";
+
+/**
+ * The public model catalog, grouped into categories.
+ *
+ * The consent screen and the permission picker have to agree on this list: one
+ * renders the summary of what is being granted and the other renders the
+ * checkboxes, so a divergence would describe two different grants.
+ */
+export function useModelCategories(): ModelCategoryGroup[] {
+    const [catalogModels, setCatalogModels] = useState<ApiModelInfo[]>([]);
+
+    useEffect(() => {
+        let cancelled = false;
+
+        fetchModelCatalog()
+            .then((models) => {
+                if (!cancelled) setCatalogModels(models);
+            })
+            .catch(() => {
+                if (!cancelled) setCatalogModels([]);
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    return useMemo(
+        () => getModelCategoriesFromCatalog(catalogModels),
+        [catalogModels],
+    );
+}


### PR DESCRIPTION
Split out of #13464 — no behaviour change.

- `authorize.tsx` and `account-permissions-input.tsx` each ran the same `fetchModelCatalog` effect, and both render on the authorize screen at once. Extracted into `useModelCategories()`.
- `AccountPermissionsInput` now takes `modelCategories` as a prop, so the grant summary above the picker and the checkbox list render from one array instead of two independent fetches.
- Fixes three dead Scalar anchors: `#tag/bring-your-own-pollen` → `#tag/byop` (the tag is `byop`; `dashboard-shell.tsx` already links it correctly).

Two call sites updated; `key-permissions.tsx` calls the hook itself.