### PR TITLE
refactor: keep Z-Image fallback on one model identity

### DIFF
--- a/.claude/skills/model-management/SKILL.md
+++ b/.claude/skills/model-management/SKILL.md
@@ -106,6 +106,7 @@ Present the mandatory row and obtain explicit confirmation before editing. If a 
 ### 4. Implement the smallest complete change
 
 - Reuse existing handlers, transforms, provider configs, schemas, and generic fallback infrastructure.
+- Represent an automatic provider fallback for the same model as an internal provider route on the canonical registry entry, never as another public or hidden model. Provider routes may override serving provider cost and billing mechanics, but inherit the model's identity, permissions, capabilities, access, and user price.
 - Do not add speculative abstractions, compatibility shims, or fallbacks.
 - Expose a confirmed new public capability (per the API-change confirmation above) through two surfaces backed by one implementation: a Pollinations-native route outside `/v1` and a standard-compatible route under `/v1`.
 - Resolve the compatibility contract in this order: (1) current official OpenAI API; (2) if OpenAI defines no equivalent, the current published OpenRouter contract — a protocol-design reference here, not an inference-provider fallback; (3) if neither defines the capability, stop for an explicit API-contract decision. Document the exact reference checked.

--- a/.claude/skills/model-management/references/billing-verification.md
+++ b/.claude/skills/model-management/references/billing-verification.md
@@ -28,6 +28,7 @@ If upstream returns a new numeric billing field, extend the usage contract and o
 - Registry provider means configured primary route.
 - Selected/used provider means the backend that actually served a request.
 - For a fallback request, verify attempt attribution, selected provider, actual provider cost, and user price under the approved fallback economics.
+- For a same-model provider route, verify that provider cost follows the serving route while identity, permissions, and user price remain on the public model.
 - Provider-managed routing may obscure the physical backend; document the observable identity rather than inventing one.
 
 ## Cache behavior

--- a/.claude/skills/model-management/references/operating-policy.md
+++ b/.claude/skills/model-management/references/operating-policy.md
@@ -24,6 +24,7 @@ These are strategic defaults. The user's explicit, confirmed contract for a spec
 - Default to **no Pollinations fallback** for new routes.
 - Add or change a fallback only with explicit confirmation of the exact pair and proof of model identity, capabilities, parameters, permissions, billing, provider attribution, and economics.
 - Use the shared generic fallback system when an already-approved production pair needs migration; do not build a model-specific retry layer.
+- Distinguish model fallback from provider-route fallback. A different model remains a separate registry entry; another provider serving the same model belongs in `fallbackRoutes` on the canonical entry and must never create a second model ID or permission.
 - Provider-managed fallback is distinct from Pollinations fallback. Preserve the provider default unless its tradeoffs require a product decision, and disclose those tradeoffs before editing.
 - Never add a more expensive fallback when users are billed from the cheaper primary quote unless the economics are explicitly accepted.
 

--- a/enter.pollinations.ai/drizzle/0050_canonicalize-zimage-fal-permissions.sql
+++ b/enter.pollinations.ai/drizzle/0050_canonicalize-zimage-fal-permissions.sql
@@ -1,0 +1,37 @@
+-- zimage-fal is no longer a model identity. Fal is an internal provider route
+-- for zimage, so stored allowlists must grant the public canonical model only.
+-- Preserve unrelated permission data and model order while deduplicating a row
+-- that already contains both names.
+
+UPDATE apikey
+SET permissions = json_set(
+    permissions,
+    '$.models',
+    (
+        SELECT json_group_array(model_id ORDER BY position)
+        FROM (
+            SELECT model_id, MIN(position) AS position
+            FROM (
+                SELECT
+                    CASE
+                        WHEN model.type = 'text' AND model.value = 'zimage-fal'
+                            THEN 'zimage'
+                        ELSE model.value
+                    END AS model_id,
+                    CAST(model.key AS integer) AS position
+                FROM json_each(apikey.permissions, '$.models') AS model
+            )
+            GROUP BY model_id
+        )
+    )
+)
+WHERE CASE
+    WHEN instr(permissions, '"zimage-fal"') = 0 THEN 0
+    WHEN NOT json_valid(permissions) THEN 0
+    WHEN json_type(permissions, '$.models') != 'array' THEN 0
+    ELSE EXISTS (
+        SELECT 1
+        FROM json_each(permissions, '$.models') AS model
+        WHERE model.type = 'text' AND model.value = 'zimage-fal'
+    )
+END;

--- a/enter.pollinations.ai/drizzle/meta/_journal.json
+++ b/enter.pollinations.ai/drizzle/meta/_journal.json
@@ -351,6 +351,13 @@
       "when": 1786889023916,
       "tag": "0049_stormy_franklin_storm",
       "breakpoints": true
+    },
+    {
+      "idx": 50,
+      "version": "6",
+      "when": 1786980798641,
+      "tag": "0050_canonicalize-zimage-fal-permissions",
+      "breakpoints": true
     }
   ]
 }

--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -1819,13 +1819,5 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "completionImageTokens": 0.004,
     },
   },
-  "zimage-fal": {
-    "cost": {
-      "completionImageTokens": 0,
-    },
-    "price": {
-      "completionImageTokens": 0,
-    },
-  },
 }
 `;

--- a/enter.pollinations.ai/test/canonicalize-zimage-fal-permissions-migration.test.ts
+++ b/enter.pollinations.ai/test/canonicalize-zimage-fal-permissions-migration.test.ts
@@ -1,0 +1,112 @@
+import { env } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import migrationSql from "../drizzle/0050_canonicalize-zimage-fal-permissions.sql?raw";
+
+describe("canonicalize Z-Image Fal permissions migration", () => {
+    it("replaces zimage-fal with zimage without changing unrelated permissions", async () => {
+        await env.DB.prepare(`
+            CREATE TABLE zimage_route_migration_apikey (
+                id TEXT PRIMARY KEY,
+                permissions TEXT
+            )
+        `).run();
+        await env.DB.prepare(`
+            WITH RECURSIVE seq(x) AS (
+                VALUES(1)
+                UNION ALL
+                SELECT x + 1 FROM seq WHERE x < 10000
+            )
+            INSERT INTO zimage_route_migration_apikey
+            SELECT
+                printf('unaffected-%06d', x),
+                json_object('models', json_array('flux', 'openai'), 'role', 'keep')
+            FROM seq
+        `).run();
+        const rows = new Map<string, string | null>([
+            [
+                "alias-only",
+                JSON.stringify({ models: ["zimage-fal"], note: "keep" }),
+            ],
+            [
+                "old-and-new",
+                JSON.stringify({
+                    models: [
+                        "unknown-model",
+                        "zimage-fal",
+                        "owner/community-model",
+                        "zimage",
+                    ],
+                    account: ["profile"],
+                }),
+            ],
+            ["alias-elsewhere", JSON.stringify({ note: "zimage-fal" })],
+            ["missing-models", JSON.stringify({ note: "keep" })],
+            ["non-array", JSON.stringify({ models: "zimage-fal" })],
+            ["invalid-json", '{"models":["zimage-fal"]'],
+            ["unrestricted", null],
+        ]);
+        await env.DB.batch(
+            [...rows].map(([id, permissions]) =>
+                env.DB.prepare(
+                    "INSERT INTO zimage_route_migration_apikey VALUES (?, ?)",
+                ).bind(id, permissions),
+            ),
+        );
+
+        const statement = migrationSql.replace(
+            /\bapikey\b/g,
+            "zimage_route_migration_apikey",
+        );
+        await env.DB.prepare(statement).run();
+
+        const migrated = await env.DB.prepare(`
+            SELECT id, permissions
+            FROM zimage_route_migration_apikey
+            WHERE id NOT LIKE 'unaffected-%'
+            ORDER BY id
+        `).all<{ id: string; permissions: string | null }>();
+        const result = Object.fromEntries(
+            migrated.results.map((row) => [row.id, row.permissions]),
+        );
+        expect(JSON.parse(result["alias-only"] as string)).toEqual({
+            models: ["zimage"],
+            note: "keep",
+        });
+        expect(JSON.parse(result["old-and-new"] as string)).toEqual({
+            models: ["unknown-model", "zimage", "owner/community-model"],
+            account: ["profile"],
+        });
+        for (const id of [
+            "alias-elsewhere",
+            "missing-models",
+            "non-array",
+            "invalid-json",
+            "unrestricted",
+        ]) {
+            expect(result[id]).toBe(rows.get(id));
+        }
+
+        const changedUnaffectedKeys = await env.DB.prepare(`
+            SELECT count(*) AS count
+            FROM zimage_route_migration_apikey
+            WHERE id LIKE 'unaffected-%'
+              AND permissions != json_object(
+                  'models', json_array('flux', 'openai'), 'role', 'keep'
+              )
+        `).first<{ count: number }>();
+        expect(changedUnaffectedKeys?.count).toBe(0);
+
+        await env.DB.prepare(`
+            CREATE TABLE zimage_route_migration_snapshot AS
+            SELECT id, permissions FROM zimage_route_migration_apikey
+        `).run();
+        await env.DB.prepare(statement).run();
+        const changedOnSecondRun = await env.DB.prepare(`
+            SELECT count(*) AS count
+            FROM zimage_route_migration_apikey AS current
+            JOIN zimage_route_migration_snapshot AS snapshot USING (id)
+            WHERE current.permissions IS NOT snapshot.permissions
+        `).first<{ count: number }>();
+        expect(changedOnSecondRun?.count).toBe(0);
+    });
+});

--- a/gen.pollinations.ai/src/fallback.ts
+++ b/gen.pollinations.ai/src/fallback.ts
@@ -177,13 +177,38 @@ export function isRetryableFallbackError(
  * seam below does not depend on how any one handler reaches its provider.
  */
 export type FallbackCandidate = {
+    /** Public canonical model id. Provider routes keep the primary model id. */
     id: string;
+    /** Internal route selector; never accepted as a public model id. */
+    routeId?: string;
+    isFallback?: boolean;
     /** Always present alongside `communityEndpoint`: it is what prices it. */
     definition?: ModelDefinition;
     communityEndpoint?: CommunityEndpointRuntime;
     /** Serving registry entry. Absent on the model the caller asked for. */
     entry?: GenerationModelEntry;
 };
+
+function definitionForProviderRoute(
+    model: ModelDefinition,
+    route: NonNullable<ModelDefinition["fallbackRoutes"]>[number],
+): ModelDefinition {
+    return {
+        ...model,
+        provider: route.provider,
+        cost: route.cost,
+        billing: route.billing,
+        // Serving cost belongs to the selected route. Public price still comes
+        // from the model the caller requested, so public cost variants and
+        // billing rules must not leak into the route's provider cost.
+        costVariants: undefined,
+        costVariantMetadata: undefined,
+        defaultCostVariantLabel: undefined,
+        selectCostVariant: undefined,
+        fallbacks: undefined,
+        fallbackRoutes: undefined,
+    };
+}
 
 type PrimaryModel = {
     resolved: string;
@@ -209,9 +234,24 @@ export function fallbackCandidates(
             communityEndpoint: model?.communityEndpoint,
         },
     ];
+    const primaryDefinition = model?.definition;
+    if (primaryDefinition) {
+        for (const route of primaryDefinition.fallbackRoutes ?? []) {
+            candidates.push({
+                id: model?.resolved ?? "",
+                routeId: route.id,
+                isFallback: true,
+                definition: definitionForProviderRoute(
+                    primaryDefinition,
+                    route,
+                ),
+            });
+        }
+    }
     for (const entry of model?.fallbackEntries ?? []) {
         candidates.push({
             id: entry.id,
+            isFallback: true,
             definition: entry.definition,
             communityEndpoint: entry.communityEndpoint,
             entry,

--- a/gen.pollinations.ai/src/image/createAndReturnImages.ts
+++ b/gen.pollinations.ai/src/image/createAndReturnImages.ts
@@ -34,7 +34,6 @@ import {
 } from "./models/seedreamReplicateModel.ts";
 import { callWanImageAPI } from "./models/wanImageModel.ts";
 import { callXaiImageAPI } from "./models/xaiModel.ts";
-import { callZImageFalAPI } from "./models/zImageFalModel.ts";
 import type { ImageParams } from "./params.ts";
 import { sanitizeString } from "./util.ts";
 import { closestByRatio } from "./utils/aspectRatio.ts";
@@ -821,9 +820,6 @@ const generateImage = async (
 
         case "flux":
             return await callSelfHostedServer(prompt, safeParams, "flux");
-
-        case "zimage-fal":
-            return await callZImageFalAPI(prompt, safeParams);
 
         default:
             // zimage is the only model that reaches the default branch

--- a/gen.pollinations.ai/src/image/handler.ts
+++ b/gen.pollinations.ai/src/image/handler.ts
@@ -1,6 +1,7 @@
 import { remapUpstreamStatus, UpstreamError } from "@shared/error.ts";
 import { IMMUTABLE_CACHE_CONTROL } from "@shared/http/cache-control.ts";
 import { DEFAULT_IMAGE_MODEL } from "@shared/registry/image.ts";
+import type { ModelDefinition } from "@shared/registry/registry.ts";
 import { FALLBACK_TARGET_HEADER } from "@shared/registry/usage-headers.ts";
 import type { Context } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
@@ -30,6 +31,7 @@ import {
 import { getImageEnv, syncImageEnv } from "./env.ts";
 import { HttpError } from "./httpError.ts";
 import { setKleinVpcBinding } from "./models/fluxKleinModel.ts";
+import { callZImageFalAPI } from "./models/zImageFalModel.ts";
 import { type ImageParams, ImageParamsSchema } from "./params.ts";
 import { sanitizeString, sleep } from "./util.ts";
 import {
@@ -418,6 +420,7 @@ async function generateMediaWithFallback(
     result: ImageGenerationResult | VideoGenerationResult;
     params: RuntimeImageParams;
     servedEntry?: GenerationModelEntry;
+    servedDefinition?: ModelDefinition;
     servedIndex: number;
 }> {
     const { result, candidate, index } = await withModelFallback(
@@ -442,23 +445,27 @@ async function generateMediaWithFallback(
                 assertNonEmptyMedia(generated.buffer, "Video provider");
                 return { result: generated, params };
             }
-            const hiddenFallback = attempt.entry?.definition.hidden === true;
+            if (attempt.routeId) {
+                if (attempt.id !== "zimage" || attempt.routeId !== "fal") {
+                    throw new Error(
+                        `Unsupported provider route: ${attempt.id}/${attempt.routeId}`,
+                    );
+                }
+                const generated = await callZImageFalAPI(prompt, {
+                    ...safeParams,
+                    model: "zimage",
+                });
+                assertNonEmptyMedia(generated.buffer, "Fal image provider");
+                return { result: generated, params: safeParams };
+            }
             const generated = await generateImageResult(
                 c,
                 prompt,
                 params,
-                (hiddenFallback
-                    ? safeParams.model
-                    : params.model) as ImageParams["model"],
+                params.model as ImageParams["model"],
             );
             assertNonEmptyMedia(generated.buffer, "Image provider");
-            // Hidden static fallbacks are internal routes for the same public
-            // service. Keep their id out of filenames and EXIF metadata while
-            // servedEntry still carries their provider and cost to tracking.
-            return {
-                result: generated,
-                params: hiddenFallback ? safeParams : params,
-            };
+            return { result: generated, params };
         },
         c.var.track?.failedCalls,
         (attempt) =>
@@ -467,6 +474,7 @@ async function generateMediaWithFallback(
     return {
         ...result,
         servedEntry: candidate.entry,
+        ...(candidate.routeId && { servedDefinition: candidate.definition }),
         servedIndex: index,
     };
 }
@@ -544,7 +552,7 @@ export async function generateImageOrVideoResponse(
     });
 
     try {
-        const { result, params, servedEntry, servedIndex } =
+        const { result, params, servedEntry, servedDefinition, servedIndex } =
             await generateMediaWithFallback(c, originalPrompt, safeParams);
         const headers = mediaHeaders(
             originalPrompt,
@@ -553,6 +561,9 @@ export async function generateImageOrVideoResponse(
             result.mimeType || detectMimeType(result.buffer),
         );
         if (servedEntry) c.set("servedModelEntry", servedEntry);
+        if (servedDefinition) {
+            c.set("servedModelDefinition", servedDefinition);
+        }
         if (servedIndex > 0) {
             // Same shape text emits, so tracking has one fallback marker.
             headers.set(

--- a/gen.pollinations.ai/src/image/models/zImageFalModel.ts
+++ b/gen.pollinations.ai/src/image/models/zImageFalModel.ts
@@ -73,7 +73,7 @@ export async function callZImageFalAPI(
         isMature: result.has_nsfw_concepts?.[0] ?? false,
         isChild: false,
         trackingData: {
-            actualModel: "zimage-fal",
+            actualModel: "zimage",
             usage: { completionImageTokens: 1 },
         },
     };

--- a/gen.pollinations.ai/src/middleware/model.ts
+++ b/gen.pollinations.ai/src/middleware/model.ts
@@ -46,6 +46,8 @@ export type ModelVariables = {
      * caller pays does not — that stays the listing they asked for.
      */
     servedModelEntry?: GenerationModelEntry;
+    /** Serving provider route definition when the public model id is unchanged. */
+    servedModelDefinition?: ModelDefinition;
     formData?: FormData;
 };
 
@@ -203,17 +205,13 @@ export function resolveModel(
             c.var.auth?.user?.id,
             options?.supportedEndpoint,
         );
-        // Hidden registry fallbacks are provider implementations of the public
-        // model the caller selected, so they inherit that model's permission.
-        // Visible and community targets remain independently scoped: a key can
-        // never be served — or billed for — a model it could not call directly.
+        // Provider routes are part of the selected model and never enter this
+        // list. Distinct registry/community fallback models remain independently
+        // scoped: a key cannot be served a model it could not call directly.
         const allowedModels = c.var.auth?.apiKey?.permissions?.models;
         if (allowedModels && resolved.fallbackEntries) {
             resolved.fallbackEntries = resolved.fallbackEntries.filter(
-                (entry) =>
-                    (entry.definition.hidden === true &&
-                        !entry.communityEndpoint) ||
-                    allowedModels.includes(entry.id),
+                (entry) => allowedModels.includes(entry.id),
             );
         }
         c.set("model", resolved);

--- a/gen.pollinations.ai/src/middleware/track.ts
+++ b/gen.pollinations.ai/src/middleware/track.ts
@@ -332,8 +332,9 @@ export const track = (eventType: EventType) =>
                             isBilledUsage: false,
                             isFinal: false,
                             fallbackUsed:
+                                call.candidate.isFallback === true ||
                                 model !==
-                                requestTracking.resolvedModelRequested,
+                                    requestTracking.resolvedModelRequested,
                             modelUsed: model,
                             modelProviderUsed:
                                 call.candidate.definition?.provider ??
@@ -348,11 +349,13 @@ export const track = (eventType: EventType) =>
                     });
                 }
                 const servedEntry = c.var.servedModelEntry;
+                const servedDefinition = c.var.servedModelDefinition;
                 const responseTracking = await trackResponse(
                     eventType,
                     requestTracking,
                     response,
-                    servedEntry?.definition ??
+                    servedDefinition ??
+                        servedEntry?.definition ??
                         terminalAttempt?.candidate.definition,
                     terminalAttemptModel ?? servedEntry?.id,
                     pricingInput,

--- a/gen.pollinations.ai/test/fallback.test.ts
+++ b/gen.pollinations.ai/test/fallback.test.ts
@@ -1,5 +1,9 @@
 import { communityEndpointPrices } from "@shared/community-endpoints.ts";
-import type { ModelDefinition } from "@shared/registry/registry.ts";
+import {
+    getModels,
+    type ModelDefinition,
+    resolveModelName,
+} from "@shared/registry/registry.ts";
 import { FALLBACK_TARGET_HEADER } from "@shared/registry/usage-headers.ts";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -66,6 +70,62 @@ function communityEntry(
 }
 
 describe("registry fallback linking", () => {
+    it("keeps the retired Fal id as an alias, not a model", () => {
+        expect(resolveModelName("zimage-fal")).toBe("zimage");
+        expect(getModels()).not.toContain("zimage-fal");
+    });
+
+    it("keeps provider routes on the public model identity", () => {
+        const primary = registryEntry("primary", ["other-model"], 4);
+        primary.definition.fallbackRoutes = [
+            {
+                id: "backup-provider",
+                provider: "backup",
+                cost: { completionTextTokens: 2 },
+            },
+        ];
+        const otherModel = registryEntry("other-model", [], 1);
+        primary.fallbackEntries = [otherModel];
+
+        const candidates = fallbackCandidates({
+            resolved: primary.id,
+            definition: primary.definition,
+            fallbackEntries: primary.fallbackEntries,
+        });
+
+        expect(
+            candidates.map(({ id, routeId, definition, isFallback }) => ({
+                id,
+                routeId,
+                provider: definition?.provider,
+                cost: definition?.cost,
+                isFallback,
+            })),
+        ).toEqual([
+            {
+                id: "primary",
+                routeId: undefined,
+                provider: "test",
+                cost: { completionTextTokens: 4 },
+                isFallback: undefined,
+            },
+            {
+                id: "primary",
+                routeId: "backup-provider",
+                provider: "backup",
+                cost: { completionTextTokens: 2 },
+                isFallback: true,
+            },
+            {
+                id: "other-model",
+                routeId: undefined,
+                provider: "test",
+                cost: { completionTextTokens: 1 },
+                isFallback: true,
+            },
+        ]);
+    });
+
     it("uses registry declarations without applying community price rules", () => {
         const primary = registryEntry("primary", ["target-alias", "target"]);
         const target = registryEntry("target", ["primary"], 10);

--- a/gen.pollinations.ai/test/image/zImageFalFallback.test.ts
+++ b/gen.pollinations.ai/test/image/zImageFalFallback.test.ts
@@ -3,7 +3,10 @@ import {
     env,
     waitOnExecutionContext,
 } from "cloudflare:test";
-import { test as baseTest } from "@shared/test/fixtures/index.ts";
+import {
+    test as baseTest,
+    createTestApiKey,
+} from "@shared/test/fixtures/index.ts";
 import {
     createFetchMock,
     teardownFetchMock,
@@ -89,9 +92,12 @@ async function fetchWorker(path: string, init: RequestInit) {
 }
 
 test("uses Fal only after the Vast Z-Image pool exhausts its 503s", async ({
-    paidApiKey,
     mocks,
 }) => {
+    const { key } = await createTestApiKey({
+        allowedModels: ["zimage"],
+        user: { packBalance: 100 },
+    });
     const existing = await env.KV.list({ prefix: "image:server:test:zimage:" });
     await Promise.all(existing.keys.map((key) => env.KV.delete(key.name)));
 
@@ -111,13 +117,13 @@ test("uses Fal only after the Vast Z-Image pool exhausts its 503s", async ({
 
     const { response, wait } = await fetchWorker(
         "/image/a%20red%20apple?model=zimage&width=1024&height=1024&seed=42",
-        { headers: { authorization: `Bearer ${paidApiKey}` } },
+        { headers: { authorization: `Bearer ${key}` } },
     );
 
     const failureBody =
         response.status === 200 ? "" : await response.clone().text();
     expect(response.status, failureBody).toBe(200);
-    expect(response.headers.get("x-model-used")).toBe("zimage-fal");
+    expect(response.headers.get("x-model-used")).toBe("zimage");
     expect(response.headers.get("x-fallback-target")).toBe("config.targets[1]");
     await response.arrayBuffer();
     expect(mocks.fal.state.falRequests).toEqual([
@@ -144,7 +150,7 @@ test("uses Fal only after the Vast Z-Image pool exhausts its 503s", async ({
     });
     expect(mocks.tinybird.state.events[1]).toMatchObject({
         modelRequested: "zimage",
-        modelUsed: "zimage-fal",
+        modelUsed: "zimage",
         modelProviderUsed: "fal",
         responseStatus: 200,
         fallbackUsed: true,

--- a/gen.pollinations.ai/test/image/zImageFalModel.test.ts
+++ b/gen.pollinations.ai/test/image/zImageFalModel.test.ts
@@ -8,7 +8,7 @@ const IMAGE_URL = "https://fal.media/zimage-output.jpg";
 const JPEG_BYTES = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
 
 const params: ImageParams = {
-    model: "zimage-fal",
+    model: "zimage",
     width: 1024,
     height: 768,
     dimensionsExplicit: true,
@@ -80,7 +80,7 @@ describe("callZImageFalAPI", () => {
         expect(result.buffer).toEqual(Buffer.from(JPEG_BYTES));
         expect(result.mimeType).toBe("image/jpeg");
         expect(result.trackingData).toEqual({
-            actualModel: "zimage-fal",
+            actualModel: "zimage",
             usage: { completionImageTokens: 1 },
         });
     });

--- a/gen.pollinations.ai/test/model-permissions.test.ts
+++ b/gen.pollinations.ai/test/model-permissions.test.ts
@@ -69,6 +69,20 @@ test("canonicalizes aliases in new model permissions", async () => {
     expect(body.map((model) => model.name)).toEqual(["nanobanana-2"]);
 });
 
+test("canonicalizes the retired Z-Image Fal id in new permissions", async () => {
+    const { key } = await createTestApiKey({
+        allowedModels: ["zimage-fal"],
+        user: { packBalance: 100 },
+    });
+    const response = await fetchWorker("/image/models", {
+        headers: { Authorization: `Bearer ${key}` },
+    });
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { name: string }[];
+    expect(body.map((model) => model.name)).toEqual(["zimage"]);
+});
+
 test("empty model permissions deny access and return an empty catalog", async () => {
     const { key } = await createTestApiKey({
         allowedModels: [],

--- a/operations/infrastructure/gpu/zimage/README.md
+++ b/operations/infrastructure/gpu/zimage/README.md
@@ -43,7 +43,8 @@ for Fal while still bounding worst-case queue growth.
 Deploy the gen fallback before enabling this queue limit on production workers.
 After updating a worker, verify local saturation returns 503, normal generation
 still succeeds, and production telemetry attributes any overflow to
-`zimage-fal`. Only then drain and destroy a redundant Vast connector.
+model `zimage` with provider `fal` and `fallback_used=true`. Only then drain
+and destroy a redundant Vast connector.
 
 The setup defaults to `HEARTBEAT_ENABLED=false`, which prevents registry
 registration but does not isolate a connector in the shared named tunnel.

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -351,57 +351,47 @@ export const IMAGE_SERVICES = {
         outputModalities: ["image"],
     },
     "zimage": {
-        aliases: ["z-image", "z-image-turbo"],
+        aliases: ["z-image", "z-image-turbo", "zimage-fal"],
         provider: "vast",
-        fallbacks: ["zimage-fal"],
         // Fal is capacity insurance only: do not move provider errors or bad
         // requests away from the Pollinations-operated Vast pool.
         fallbackOnStatusCodes: [503],
+        fallbackRoutes: [
+            {
+                id: "fal",
+                provider: "fal",
+                // Fal bills $0.005 per output megapixel. The token line stays
+                // at zero and the adjustment records the exact provider cost;
+                // the caller keeps the public Z-Image flat price.
+                cost: {
+                    completionImageTokens: 0,
+                },
+                billing: {
+                    adjustments: [
+                        {
+                            id: "fal.zimage.output_megapixels.v1",
+                            description: "Fal output image megapixels",
+                            kind: "image",
+                            unit: "megapixel",
+                            unitCost: 0.005,
+                            publicPricing: {
+                                label: "Output megapixels",
+                                quantity: 1,
+                                unit: "megapixel",
+                            },
+                            countUnits: (_output, input) =>
+                                Math.max(0, input?.megapixels ?? 0),
+                        },
+                    ],
+                },
+            },
+        ],
         brand: "Alibaba",
         category: "image",
         addedDate: new Date("2025-12-08").getTime(),
         priceMultiplier: 1,
         cost: {
             completionImageTokens: 0.004, // per image
-        },
-        title: "Z-Image Turbo",
-        description:
-            "Instant, budget-friendly images with crisp upscaled output",
-        inputModalities: ["text"],
-        outputModalities: ["image"],
-    },
-    "zimage-fal": {
-        aliases: [],
-        provider: "fal",
-        brand: "Alibaba",
-        category: "image",
-        addedDate: new Date("2026-08-10").getTime(),
-        paidOnly: true,
-        hidden: true,
-        priceMultiplier: 1,
-        // Fal bills $0.005 per output megapixel. The token line stays at zero;
-        // the adjustment below records the exact provider cost while the
-        // caller keeps the public zimage flat price when this serves as fallback.
-        cost: {
-            completionImageTokens: 0,
-        },
-        billing: {
-            adjustments: [
-                {
-                    id: "fal.zimage.output_megapixels.v1",
-                    description: "Fal output image megapixels",
-                    kind: "image",
-                    unit: "megapixel",
-                    unitCost: 0.005,
-                    publicPricing: {
-                        label: "Output megapixels",
-                        quantity: 1,
-                        unit: "megapixel",
-                    },
-                    countUnits: (_output, input) =>
-                        Math.max(0, input?.megapixels ?? 0),
-                },
-            ],
         },
         title: "Z-Image Turbo",
         description:

--- a/shared/registry/registry.ts
+++ b/shared/registry/registry.ts
@@ -143,13 +143,26 @@ export type BillingAdjustment = {
     price: number;
 };
 
+/**
+ * An internal provider route for the same public model. Routes have their own
+ * provider cost but never their own model identity, permissions, or user price.
+ */
+export type ProviderRouteDefinition = {
+    id: string;
+    provider: string;
+    cost: CostDefinition;
+    billing?: BillingRules;
+};
+
 export type ModelDefinition = {
     aliases: string[];
     provider: string;
-    /** Ordered model ids to try when this model's upstream fails. */
+    /** Ordered distinct model ids to try when this model's upstream fails. */
     fallbacks?: string[];
     /** Override the shared fallback status list for this model. Network failures always retry. */
     fallbackOnStatusCodes?: number[];
+    /** Ordered internal provider routes to try before falling back to another model. */
+    fallbackRoutes?: ProviderRouteDefinition[];
     brand: string;
     category: Category;
     cost: CostDefinition;


### PR DESCRIPTION
- Removes `zimage-fal` as a hidden model and represents Fal as an internal provider route of `zimage`, used only after Vast returns 503.
- Preserves the public `zimage` identity, model permission, and 0.004 Pollen price while recording Fal as the serving provider and its 0.005/MP provider cost.
- Keeps `zimage-fal` as a compatibility alias and migrates stored allowlists to `zimage`, preserving order, unrelated permissions, unknown/community IDs, and idempotence.
- Reuses the existing shared fallback pipeline; community-model fallbacks remain distinct models with their existing permissions, pricing, ownership, and rewards.
- Validated with Gen and Enter typechecks, Biome, migration/pricing tests, end-to-end scoped-key fallback billing, and the broader registry, tracking, community reward, model catalog, Flux, and Portkey fallback suites.