### PR TITLE
refactor: share request identity between track and realtime

### DIFF
--- a/gen.pollinations.ai/src/middleware/track.ts
+++ b/gen.pollinations.ai/src/middleware/track.ts
@@ -174,24 +174,7 @@ export const track = (eventType: EventType) =>
             rawIp !== "unknown" ? stripIPv4MappedPrefix(rawIp) : undefined;
         const ipSubnet = truncateIpToSubnet(clientIp);
 
-        const apiKeyMetadata = c.var.auth.apiKey?.metadata as
-            | Record<string, unknown>
-            | undefined;
-        const byopClientKeyId = c.var.auth.apiKey?.byopClientKeyId;
-        const userTracking: UserData = {
-            userId: c.var.auth.user?.id,
-            userTier: c.var.auth.user?.tier,
-            apiKeyId: c.var.auth.apiKey?.id,
-            apiKeyType: apiKeyMetadata?.keyType as ApiKeyType,
-            apiKeyName: c.var.auth.apiKey?.name,
-            apiKeyCreatedVia: byopClientKeyId
-                ? "redirect-auth"
-                : (apiKeyMetadata?.createdVia as string | undefined),
-            apiKeyClientId: byopClientKeyId ?? undefined,
-            apiKeyCreatedForApp: c.var.auth.apiKey?.byopClientName ?? undefined,
-            apiKeyCreatedForUserId:
-                c.var.auth.apiKey?.byopClientUserId ?? undefined,
-        } satisfies UserData;
+        const userTracking = requestIdentity(c.var.auth);
 
         let responseOverride: Response | null = null;
         let pricingInput: PricingInput | undefined;
@@ -391,7 +374,7 @@ export const track = (eventType: EventType) =>
                         userId,
                         apiKeyId: c.var.auth?.apiKey?.id,
                         apiKeyPollenBalance: c.var.auth?.apiKey?.pollenBalance,
-                        byopClientKeyId,
+                        byopClientKeyId: c.var.auth?.apiKey?.byopClientKeyId,
                         modelPaidOnly: c.var.model?.definition.paidOnly,
                         // Only public endpoints pay their owner a reward: a
                         // private endpoint is owner-called (base cost billed to
@@ -842,7 +825,15 @@ async function* asyncIteratorStream<T>(
     }
 }
 
-type UserData = {
+/**
+ * Who made the request, in the shape the event carries it.
+ *
+ * Every path that emits a generation row builds this the same way, so a new
+ * identity column is added here once rather than in each emitter. Realtime
+ * settles from a socket rather than a response and so keeps its own event
+ * builder; it spreads this verbatim.
+ */
+export type UserData = {
     userId?: string;
     userTier?: string;
     apiKeyId?: string;
@@ -853,6 +844,28 @@ type UserData = {
     apiKeyCreatedForUserId?: string;
     apiKeyClientId?: string;
 };
+
+export function requestIdentity(auth: AuthVariables["auth"]): UserData {
+    const apiKeyMetadata = auth.apiKey?.metadata as
+        | Record<string, unknown>
+        | undefined;
+    const byopClientKeyId = auth.apiKey?.byopClientKeyId;
+    return {
+        userId: auth.user?.id,
+        userTier: auth.user?.tier,
+        apiKeyId: auth.apiKey?.id,
+        apiKeyType: apiKeyMetadata?.keyType as ApiKeyType,
+        apiKeyName: auth.apiKey?.name,
+        // A BYOP key is created by the redirect flow, whatever its metadata
+        // says it was created via.
+        apiKeyCreatedVia: byopClientKeyId
+            ? "redirect-auth"
+            : (apiKeyMetadata?.createdVia as string | undefined),
+        apiKeyClientId: byopClientKeyId ?? undefined,
+        apiKeyCreatedForApp: auth.apiKey?.byopClientName ?? undefined,
+        apiKeyCreatedForUserId: auth.apiKey?.byopClientUserId ?? undefined,
+    };
+}
 
 type BalanceData = {
     selectedMeterId?: string;

--- a/gen.pollinations.ai/src/routes/realtime.ts
+++ b/gen.pollinations.ai/src/routes/realtime.ts
@@ -34,7 +34,11 @@ import { drizzle } from "drizzle-orm/d1";
 import type { Context } from "hono";
 import { HTTPException } from "hono/http-exception";
 import type { Env } from "@/env.ts";
-import { reduceAdjustmentsToEventFields } from "@/middleware/track.ts";
+import {
+    reduceAdjustmentsToEventFields,
+    requestIdentity,
+    type UserData,
+} from "@/middleware/track.ts";
 import { RealtimeUsageSchema } from "@/schemas/realtime.ts";
 import { generateRandomId } from "@/util.ts";
 import { checkBalance } from "@/utils/generation-access.ts";
@@ -80,15 +84,9 @@ type RealtimeCacheUsage = {
     imageTokens: number;
 };
 type RealtimeBillingContext = {
-    userId: string;
-    userTier?: string;
-    apiKeyId?: string;
-    apiKeyName?: string;
-    apiKeyType?: "secret" | "publishable";
-    apiKeyCreatedVia?: string;
-    apiKeyCreatedForApp?: string;
-    apiKeyCreatedForUserId?: string;
-    apiKeyClientId?: string;
+    // Spread verbatim into the event, so an identity column added to UserData
+    // reaches a realtime row without touching this file.
+    identity: UserData & { userId: string };
     apiKeyPollenBalance?: number | null;
     byopClientKeyId?: string | null;
     modelRequested: string;
@@ -719,15 +717,7 @@ function createRealtimeTrackingEvent(args: {
         eventType: "generate.realtime",
         ipSubnet: args.tracking.ipSubnet,
         ipHash: args.tracking.ipHash,
-        userId: args.tracking.userId,
-        userTier: args.tracking.userTier,
-        apiKeyId: args.tracking.apiKeyId,
-        apiKeyName: args.tracking.apiKeyName,
-        apiKeyType: args.tracking.apiKeyType,
-        apiKeyCreatedVia: args.tracking.apiKeyCreatedVia,
-        apiKeyCreatedForApp: args.tracking.apiKeyCreatedForApp,
-        apiKeyCreatedForUserId: args.tracking.apiKeyCreatedForUserId,
-        apiKeyClientId: args.tracking.apiKeyClientId,
+        ...args.tracking.identity,
         referrerUrl: args.tracking.referrerUrl,
         referrerDomain: args.tracking.referrerDomain,
         modelRequested: args.tracking.modelRequested,
@@ -782,8 +772,8 @@ async function settleRealtimeSession(
             db,
             isBilledUsage: true,
             totalPrice: price.totalPrice,
-            userId: tracking.userId,
-            apiKeyId: tracking.apiKeyId,
+            userId: tracking.identity.userId,
+            apiKeyId: tracking.identity.apiKeyId,
             apiKeyPollenBalance: tracking.apiKeyPollenBalance,
             byopClientKeyId: tracking.byopClientKeyId,
             modelPaidOnly: tracking.modelDefinition.paidOnly,
@@ -795,7 +785,7 @@ async function settleRealtimeSession(
         tracking.rateLimitConsumed = true;
     }
 
-    const balances = await getUserBalance(db, tracking.userId);
+    const balances = await getUserBalance(db, tracking.identity.userId);
     await sendToTinybird(
         createRealtimeTrackingEvent({
             tracking,
@@ -1278,9 +1268,6 @@ async function createRealtimeBillingContext(
     c: Context<Env>,
 ): Promise<RealtimeBillingContext> {
     const user = c.var.auth.requireUser();
-    const apiKeyMetadata = c.var.auth.apiKey?.metadata as
-        | Record<string, unknown>
-        | undefined;
     const rawIp = getRealClientIp(c);
     const clientIp =
         rawIp !== "unknown" ? stripIPv4MappedPrefix(rawIp) : undefined;
@@ -1296,16 +1283,8 @@ async function createRealtimeBillingContext(
     }
 
     return {
-        userId: user.id,
-        userTier: user.tier,
-        apiKeyId: c.var.auth.apiKey?.id,
-        apiKeyName: c.var.auth.apiKey?.name,
-        apiKeyType: apiKeyMetadata?.keyType as "secret" | "publishable",
-        apiKeyCreatedVia: apiKeyMetadata?.createdVia as string | undefined,
-        apiKeyCreatedForApp: c.var.auth.apiKey?.byopClientName ?? undefined,
-        apiKeyCreatedForUserId:
-            c.var.auth.apiKey?.byopClientUserId ?? undefined,
-        apiKeyClientId: c.var.auth.apiKey?.byopClientKeyId ?? undefined,
+        // requireUser() above proves the id, which the optional field cannot.
+        identity: { ...requestIdentity(c.var.auth), userId: user.id },
         apiKeyPollenBalance: c.var.auth.apiKey?.pollenBalance,
         byopClientKeyId: c.var.auth.apiKey?.byopClientKeyId,
         modelRequested: modelInfo.requested,


### PR DESCRIPTION
- Extracts `requestIdentity(auth)` in `track.ts` — the single place auth maps to the identity columns of a generation event
- `RealtimeBillingContext` now nests that object and spreads it into the event, replacing 9 hand-mapped fields; a new identity column reaches realtime rows without touching `realtime.ts`
- **Behavior change:** realtime never applied the `redirect-auth` marker that `track.ts:186` applies for BYOP keys. BYOP realtime sessions have been missing from `app_byop_hostnames`, `app_byop_request_counts`, `app_top_weekly`, and `weekly_user_segment`; they will start appearing.
- These are the only two Tinybird event builders in the repo. Emit *timing* stays different (realtime settles once at socket teardown) — only the identity mapping is shared.

`npx vitest run test/realtime.test.ts test/tracking-observability.test.ts` → 71 passed. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)