### PR TITLE
fix(enter): drop duplicate redirectUri validation on metadata update

### DIFF
--- a/enter.pollinations.ai/src/routes/api-keys.ts
+++ b/enter.pollinations.ai/src/routes/api-keys.ts
@@ -192,25 +192,12 @@ const CreateApiKeySchema = z.object({
  * Schema for updating metadata on an API key.
  * Only caller-owned fields are accepted. Server-controlled fields like
  * keyType, createdVia, and plaintextKey cannot be modified after creation.
+ * redirectUris stay plain strings here; the handler calls
+ * validateRedirectUriFormat so the precise error message is returned.
  */
-const UrlWithSchemeSchema = z.string().refine(
-    (val) => {
-        try {
-            validateRedirectUriFormat(val);
-            return true;
-        } catch {
-            return false;
-        }
-    },
-    {
-        message:
-            "Must be an https:// redirect URI with no fragment, or http:// on a loopback host",
-    },
-);
-
 const UpdateMetadataSchema = z.object({
     description: z.string().optional(),
-    redirectUris: z.array(UrlWithSchemeSchema).optional(),
+    redirectUris: z.array(z.string()).optional(),
     earningsEnabled: z.boolean().optional(),
 });
 


### PR DESCRIPTION
Fixes #11451

The metadata-update route validated `redirectUris` twice: Zod `UrlWithSchemeSchema` at the request boundary, then `validateRedirectUriFormat` again in the handler. Anything invalid never reached the second check.

This keeps the handler loop as the single check (same idiom as create) so the precise `HTTPException` message is what the client gets.

**Verify**
- `npx vitest run test/integration/api-keys.test.ts` — 36/36 pass
- includes `rejects unsafe redirectUris during metadata updates` (still 400)