### PR TITLE
docs: reframe pk_ keys as legacy, recommend App Keys for browsers

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/keys/api-key-dialog.tsx
+++ b/enter.pollinations.ai/frontend/src/components/keys/api-key-dialog.tsx
@@ -266,20 +266,13 @@ export const ApiKeyDialog: FC<ApiKeyDialogProps> = ({
 
                     {!simplified && !createdKey && (
                         <p className="text-xs text-theme-text-muted">
-                            Publishable keys (<code>pk_</code>) deprecated –
-                            create via{" "}
-                            <InlineLink
-                                href={genDocsUrl(
-                                    "#tag/-account/POST/account/keys",
-                                )}
-                            >
-                                API
-                            </InlineLink>{" "}
-                            or{" "}
-                            <InlineLink href="https://github.com/pollinations/pollinations/tree/main/packages/polli-cli">
-                                polli CLI
+                            Raw publishable keys (<code>pk_</code>) are
+                            legacy. For browsers, create an App Key on this
+                            dashboard and use{" "}
+                            <InlineLink href={genDocsUrl("#tag/byop")}>
+                                BYOP
                             </InlineLink>
-                            .
+                            — do not mint a raw <code>pk_</code> via the CLI.
                         </p>
                     )}
 

--- a/enter.pollinations.ai/frontend/src/components/keys/api-key-dialog.tsx
+++ b/enter.pollinations.ai/frontend/src/components/keys/api-key-dialog.tsx
@@ -266,9 +266,9 @@ export const ApiKeyDialog: FC<ApiKeyDialogProps> = ({
 
                     {!simplified && !createdKey && (
                         <p className="text-xs text-theme-text-muted">
-                            Raw publishable keys (<code>pk_</code>) are
-                            legacy. For browsers, create an App Key on this
-                            dashboard and use{" "}
+                            Raw publishable keys (<code>pk_</code>) are legacy.
+                            For browsers, create an App Key on this dashboard
+                            and use{" "}
                             <InlineLink href={genDocsUrl("#tag/byop")}>
                                 BYOP
                             </InlineLink>

--- a/enter.pollinations.ai/frontend/src/components/keys/api-key-list.tsx
+++ b/enter.pollinations.ai/frontend/src/components/keys/api-key-list.tsx
@@ -288,10 +288,10 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
                             </p>
                         )}
                         <p className="mt-1 text-sm">
-                            Publishable keys (<code>pk_</code>) are deprecated
-                            for direct API requests. Use Pollinations Auth
-                            (BYOP), where users sign in and spend their own
-                            Pollen.{" "}
+                            Raw publishable keys (<code>pk_</code>) are
+                            legacy for direct API requests. Use Pollinations
+                            Auth (BYOP), where users sign in and spend their
+                            own Pollen.{" "}
                             <InlineLink href={genDocsUrl("#tag/byop")}>
                                 Read the migration guide
                             </InlineLink>

--- a/enter.pollinations.ai/frontend/src/components/keys/api-key-list.tsx
+++ b/enter.pollinations.ai/frontend/src/components/keys/api-key-list.tsx
@@ -270,10 +270,10 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
                             </p>
                         )}
                         <p className="mt-1 text-sm">
-                            Raw publishable keys (<code>pk_</code>) are
-                            legacy for direct API requests. Use Pollinations
-                            Auth (BYOP), where users sign in and spend their
-                            own Pollen.{" "}
+                            Raw publishable keys (<code>pk_</code>) are legacy
+                            for direct API requests. Use Pollinations Auth
+                            (BYOP), where users sign in and spend their own
+                            Pollen.{" "}
                             <InlineLink href={genDocsUrl("#tag/byop")}>
                                 Read the migration guide
                             </InlineLink>

--- a/gen.pollinations.ai/src/docs/apidocs-recipes.md
+++ b/gen.pollinations.ai/src/docs/apidocs-recipes.md
@@ -1,11 +1,12 @@
 ## 🔐 Authentication
 
-Pollinations recognises two key types. Use the right one for the surface you're building.
+Pollinations recognises two prefixes. Use the right *kind* of `pk_` for the surface you're building.
 
 | Key type | Prefix | Where it goes | What it can do |
 |---|---|---|---|
 | Secret key | `sk_` | Server-only (env var, secrets manager) | Full account access. Can create child keys, list usage, run any model the account allows. **Never ship to a browser, mobile app, or repo.** |
-| Publishable key | `pk_` | Browsers, mobile apps, public clients | Calls models on behalf of the developer who created the key. Restricted to the permissions and budget set at creation. Safe to embed. |
+| App key (BYOP) | `pk_` with redirect URIs | OAuth `client_id` for web/mobile/CLI consent | Users authorize your app; you receive a scoped user `sk_`. Create at [enter.pollinations.ai/keys](https://enter.pollinations.ai/keys). This is the supported client path. |
+| Raw publishable key | `pk_` with no app / OAuth binding | Legacy only | Existing integrations only. Rate-limited to 1 pollen per IP per hour. **Do not mint new raw `pk_` keys, and do not embed them in new browser code.** |
 
 Both forms accept the same transports:
 
@@ -178,7 +179,7 @@ Each upload gets its own unique id — re-uploading the same bytes yields a new 
 
 ## 💡 Tips
 
-- **Use `pk_` keys in browsers.** Anywhere a `sk_` key could be read off the wire, use a publishable key with a tight budget and an allow-list of models.
+- **Do not put raw `pk_` keys in browsers.** For client apps, register an App Key and use [BYOP](https://github.com/pollinations/pollinations/blob/main/BRING_YOUR_OWN_POLLEN.md) so users authorize a scoped `sk_`. Raw `pk_` keys are legacy and rate-limited (1 pollen/IP/hour).
 - **One key per app.** Child keys scope budget and permissions independently — easier to audit, easier to revoke without touching production.
 - **Retry the same request after a timeout.** Keep the endpoint, body, query parameters, and seed unchanged. Your retry waits for the generation already in progress or receives the completed cached result instead of starting another generation.
 - **Watch `429` and `503`.** A `Retry-After` header tells you how long to back off. `502` from us means upstream provider — usually transient.

--- a/gen.pollinations.ai/src/docs/authentication.md
+++ b/gen.pollinations.ai/src/docs/authentication.md
@@ -5,9 +5,10 @@ All generation requests require an API key from [enter.pollinations.ai](https://
 | Type | Prefix | Use case | Rate limits | Description |
 |------|--------|----------|-------------|-------------|
 | Secret | `sk_` | Server-side apps | None | Personal developer key. Never expose in client-side code. |
-| App Key (BYOP) | `pk_` | Client-side & Frontend apps | None | Publishable key used in the **BYOP (Bring Your Own Pollen)** flow to authorize users' balances. |
+| App Key (BYOP) | `pk_` with redirect URIs | Client apps via OAuth / device flow | None on the App Key itself | Publishable App Key used as the BYOP `client_id`. Users authorize; your app receives a scoped `sk_`. |
+| Raw publishable | `pk_` with no app binding | Legacy direct spend | 1 pollen / IP / hour | Retained for existing integrations. Do not mint new ones. |
 
-> **Note:** Publishable Keys (`pk_`) for direct client-side requests have been replaced by the **BYOP (Bring Your Own Pollen)** auth flow. Frontend applications should use the OAuth authorization-code flow with PKCE to obtain a temporary user-authorized secret key (`sk_`). The legacy fragment redirect and device flow remain supported.
+> **Note:** Raw publishable keys (`pk_` used as a generation key in browsers) are **legacy**, not beta. New frontend and mobile apps should use the **BYOP (Bring Your Own Pollen)** flow: register an App Key at [enter.pollinations.ai/keys](https://enter.pollinations.ai/keys), then run the OAuth authorization-code flow with PKCE (or the device flow) to obtain a temporary user-authorized secret key (`sk_`). The legacy fragment redirect and device flow remain supported.
 
 Two ways to authenticate generation requests:
 


### PR DESCRIPTION
Fixes #11315

Docs and dashboard copy were still mixing three stories: Scalar said `pk_` was beta, recipes said raw `pk_` was safe to embed, and the dashboard said deprecated / mint via CLI.

Now:

- `sk_` = server-only
- App Key (`pk_` + redirect URIs) = BYOP client path
- raw `pk_` = legacy, 1 pollen/IP/hour, do not mint for new browser code

`APIDOCS.md` is left to the regen workflow after deploy, per repo rules.

Did not change key-creation behavior.