### PR TITLE
feat(account): add accountBalance breakdown without changing balance

### DIFF
--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -4,6 +4,10 @@ import {
     createApiKeyForUser,
 } from "@shared/auth/api-key-creation.ts";
 import { parseMetadata } from "@shared/auth/api-key-metadata.ts";
+import {
+    getAvailableBalance,
+    getUserBalance,
+} from "@shared/billing/balance.ts";
 import { isCommunityEndpointOwnerAllowed } from "@shared/community-endpoints.ts";
 import * as schema from "@shared/db/better-auth.ts";
 import {
@@ -663,9 +667,11 @@ const profileResponseSchema = z.object({
 const accountBalanceSchema = z.object({
     total: z
         .number()
-        .describe("Quest Pollen + paid Pollen remaining on the account"),
-    tier: z.number().describe("Quest Pollen remaining"),
-    paid: z.number().describe("Paid Pollen remaining"),
+        .describe(
+            "Quest Pollen + paid Pollen the account can spend on a regular model. Paid-only models spend `paid` alone, so use that field for them rather than this total.",
+        ),
+    tier: z.number().describe("Quest Pollen remaining, never below 0"),
+    paid: z.number().describe("Paid Pollen remaining, never below 0"),
 });
 
 const balanceResponseSchema = z.object({
@@ -971,19 +977,19 @@ export const accountRoutes = new Hono<Env>()
                 | { total: number; tier: number; paid: number }
                 | undefined;
             if (canViewAccount) {
-                const db = drizzle(c.env.DB);
-                const users = await db
-                    .select({
-                        tierBalance: userTable.tierBalance,
-                        packBalance: userTable.packBalance,
-                    })
-                    .from(userTable)
-                    .where(eq(userTable.id, user.id))
-                    .limit(1);
-
-                const tier = users[0]?.tierBalance ?? 0;
-                const paid = users[0]?.packBalance ?? 0;
-                accountBalance = { total: tier + paid, tier, paid };
+                // Same helper the billing path uses, so a bucket that has gone
+                // negative is clamped here exactly as it is when spending is
+                // authorized — a raw tier + pack sum would under-report the
+                // Pollen the account can actually spend.
+                const balances = await getUserBalance(
+                    drizzle(c.env.DB),
+                    user.id,
+                );
+                accountBalance = {
+                    total: getAvailableBalance(balances),
+                    tier: Math.max(0, balances.tierBalance),
+                    paid: Math.max(0, balances.packBalance),
+                };
             }
 
             // Budgeted keys keep seeing their remaining budget in `balance`.

--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -660,11 +660,24 @@ const profileResponseSchema = z.object({
         ),
 });
 
+const accountBalanceSchema = z.object({
+    total: z
+        .number()
+        .describe("Quest Pollen + paid Pollen remaining on the account"),
+    tier: z.number().describe("Quest Pollen remaining"),
+    paid: z.number().describe("Paid Pollen remaining"),
+});
+
 const balanceResponseSchema = z.object({
     balance: z
         .number()
         .describe(
-            "Remaining pollen balance (sum of Quest Pollen + paid balance)",
+            "Pollen remaining for this caller. Budgeted API keys see the key's remaining budget here, not the account total. Sessions and unbudgeted keys see the account total (Quest Pollen + paid).",
+        ),
+    accountBalance: accountBalanceSchema
+        .optional()
+        .describe(
+            "Full account balances. Included only when the caller can view account usage (dashboard session or `account:usage`). Omitted for budgeted keys that lack that permission so the account wallet is not leaked.",
         ),
 });
 
@@ -922,7 +935,7 @@ export const accountRoutes = new Hono<Env>()
             tags: ["👤 Account"],
             summary: "Get Balance",
             description:
-                "Returns the pollen balance visible to the caller. API keys with a budget always see their remaining budget (no scope needed). Full account balance requires the read-only `account:usage` permission.",
+                "Returns the pollen balance visible to the caller. API keys with a budget always see their remaining budget in `balance` (no scope needed). When the caller can view account usage (`account:usage` or a dashboard session), the response also includes `accountBalance: { total, tier, paid }`. Unbudgeted keys without `account:usage` get 403. Key-scoped usage is `GET /account/key/usage`; account-wide usage is `GET /account/usage`.",
             responses: {
                 200: {
                     description: "Pollen balance",
@@ -943,34 +956,43 @@ export const accountRoutes = new Hono<Env>()
             await c.var.auth.requireAuthorization();
             const user = c.var.auth.requireUser();
             const apiKey = c.var.auth.apiKey;
+            const keyBudget = apiKey?.pollenBalance ?? null;
+            const canViewAccount = hasAccountPermission(apiKey, "usage");
 
-            // Keys with a budget always see their own budget — no scope needed.
-            if (apiKey?.pollenBalance != null) {
-                return c.json({ balance: apiKey.pollenBalance });
-            }
-
-            // Beyond that, reading account balance requires usage or admin.
-            if (!hasAccountPermission(apiKey, "usage")) {
+            // Unbudgeted keys cannot see any balance without account:usage.
+            if (keyBudget == null && !canViewAccount) {
                 throw new HTTPException(403, {
                     message:
                         "API key does not have 'account:usage' permission and no budget of its own. Add `account:usage` or set a budget on the key.",
                 });
             }
 
-            const db = drizzle(c.env.DB);
-            const users = await db
-                .select({
-                    tierBalance: userTable.tierBalance,
-                    packBalance: userTable.packBalance,
-                })
-                .from(userTable)
-                .where(eq(userTable.id, user.id))
-                .limit(1);
+            let accountBalance:
+                | { total: number; tier: number; paid: number }
+                | undefined;
+            if (canViewAccount) {
+                const db = drizzle(c.env.DB);
+                const users = await db
+                    .select({
+                        tierBalance: userTable.tierBalance,
+                        packBalance: userTable.packBalance,
+                    })
+                    .from(userTable)
+                    .where(eq(userTable.id, user.id))
+                    .limit(1);
 
-            const tierBalance = users[0]?.tierBalance ?? 0;
-            const packBalance = users[0]?.packBalance ?? 0;
+                const tier = users[0]?.tierBalance ?? 0;
+                const paid = users[0]?.packBalance ?? 0;
+                accountBalance = { total: tier + paid, tier, paid };
+            }
 
-            return c.json({ balance: tierBalance + packBalance });
+            // Budgeted keys keep seeing their remaining budget in `balance`.
+            const balance =
+                keyBudget != null ? keyBudget : (accountBalance?.total ?? 0);
+
+            return c.json(
+                accountBalance ? { balance, accountBalance } : { balance },
+            );
         },
     )
     .get(

--- a/enter.pollinations.ai/test/account-balance.test.ts
+++ b/enter.pollinations.ai/test/account-balance.test.ts
@@ -1,0 +1,184 @@
+import { env, SELF } from "cloudflare:test";
+import { user as userTable } from "@shared/db/better-auth.ts";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import { describe, expect } from "vitest";
+import { createApiKeyViaApi, test } from "./fixtures.ts";
+
+type BalanceBody = {
+    balance: number;
+    accountBalance?: { total: number; tier: number; paid: number };
+};
+
+const TIER = 10.5;
+const PAID = 25.25;
+const TOTAL = TIER + PAID;
+
+async function setAccountBalances(userId: string) {
+    const db = drizzle(env.DB);
+    await db
+        .update(userTable)
+        .set({ tierBalance: TIER, packBalance: PAID })
+        .where(eq(userTable.id, userId));
+}
+
+async function sessionUserId(sessionToken: string): Promise<string> {
+    const sessionResponse = await SELF.fetch(
+        "http://localhost:3000/api/auth/get-session",
+        { headers: { Cookie: `better-auth.session_token=${sessionToken}` } },
+    );
+    const session = (await sessionResponse.json()) as { user: { id: string } };
+    return session.user.id;
+}
+
+async function createKey(
+    sessionToken: string,
+    options: {
+        name: string;
+        pollenBudget?: number | null;
+        accountPermissions?: string[] | null;
+    },
+) {
+    const response = await SELF.fetch(
+        "http://localhost:3000/api/account/keys",
+        {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Cookie: `better-auth.session_token=${sessionToken}`,
+            },
+            body: JSON.stringify(options),
+        },
+    );
+    if (!response.ok) {
+        throw new Error(`Failed to create API key: ${await response.text()}`);
+    }
+    return (await response.json()) as { id: string; key: string };
+}
+
+async function getBalance(headers: Record<string, string>) {
+    return SELF.fetch("http://localhost:3000/api/account/balance", {
+        headers,
+    });
+}
+
+describe("GET /api/account/balance", () => {
+    test("session sees account total in balance plus accountBalance breakdown", async ({
+        sessionToken,
+        mocks,
+    }) => {
+        await mocks.enable("tinybird");
+        const userId = await sessionUserId(sessionToken);
+        await setAccountBalances(userId);
+
+        const res = await getBalance({
+            Cookie: `better-auth.session_token=${sessionToken}`,
+        });
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({
+            balance: TOTAL,
+            accountBalance: { total: TOTAL, tier: TIER, paid: PAID },
+        });
+    });
+
+    test("budgeted key without account:usage sees only the key budget", async ({
+        sessionToken,
+        mocks,
+    }) => {
+        await mocks.enable("tinybird");
+        const userId = await sessionUserId(sessionToken);
+        await setAccountBalances(userId);
+
+        const created = await createKey(sessionToken, {
+            name: "budget-only",
+            pollenBudget: 7,
+        });
+        const res = await getBalance({
+            Authorization: `Bearer ${created.key}`,
+        });
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as BalanceBody;
+        expect(body.balance).toBe(7);
+        expect(body.accountBalance).toBeUndefined();
+    });
+
+    test("budgeted key with account:usage keeps key budget and adds accountBalance", async ({
+        sessionToken,
+        mocks,
+    }) => {
+        await mocks.enable("tinybird");
+        const userId = await sessionUserId(sessionToken);
+        await setAccountBalances(userId);
+
+        const created = await createKey(sessionToken, {
+            name: "budget-and-usage",
+            pollenBudget: 7,
+            accountPermissions: ["usage"],
+        });
+        const res = await getBalance({
+            Authorization: `Bearer ${created.key}`,
+        });
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({
+            balance: 7,
+            accountBalance: { total: TOTAL, tier: TIER, paid: PAID },
+        });
+    });
+
+    test("unbudgeted key with account:usage sees the account total", async ({
+        sessionToken,
+        mocks,
+    }) => {
+        await mocks.enable("tinybird");
+        const userId = await sessionUserId(sessionToken);
+        await setAccountBalances(userId);
+
+        const created = await createKey(sessionToken, {
+            name: "usage-only",
+            accountPermissions: ["usage"],
+        });
+        const res = await getBalance({
+            Authorization: `Bearer ${created.key}`,
+        });
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({
+            balance: TOTAL,
+            accountBalance: { total: TOTAL, tier: TIER, paid: PAID },
+        });
+    });
+
+    test("unbudgeted key without account:usage is 403", async ({
+        sessionToken,
+        mocks,
+    }) => {
+        await mocks.enable("tinybird");
+        const created = await createApiKeyViaApi(sessionToken, {
+            name: "no-scope-no-budget",
+        });
+        const res = await getBalance({
+            Authorization: `Bearer ${created.key}`,
+        });
+        expect(res.status).toBe(403);
+    });
+
+    test("publishable key with a zero budget does not leak accountBalance", async ({
+        sessionToken,
+        mocks,
+    }) => {
+        await mocks.enable("tinybird");
+        const userId = await sessionUserId(sessionToken);
+        await setAccountBalances(userId);
+
+        const created = await createApiKeyViaApi(sessionToken, {
+            name: "raw-pk",
+            type: "publishable",
+        });
+        const res = await getBalance({
+            Authorization: `Bearer ${created.key}`,
+        });
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as BalanceBody;
+        expect(body.balance).toBe(0);
+        expect(body.accountBalance).toBeUndefined();
+    });
+});

--- a/enter.pollinations.ai/test/account-balance.test.ts
+++ b/enter.pollinations.ai/test/account-balance.test.ts
@@ -181,4 +181,28 @@ describe("GET /api/account/balance", () => {
         expect(body.balance).toBe(0);
         expect(body.accountBalance).toBeUndefined();
     });
+    // A pack balance can go negative after a settlement overshoots. Spending
+    // still draws on Quest Pollen in that state, so the reported total must
+    // not be reduced by the overdraft.
+    test("an overdrawn pack balance does not eat the reported total", async ({
+        sessionToken,
+        mocks,
+    }) => {
+        await mocks.enable("tinybird");
+        const userId = await sessionUserId(sessionToken);
+        const db = drizzle(env.DB);
+        await db
+            .update(userTable)
+            .set({ tierBalance: 10, packBalance: -5 })
+            .where(eq(userTable.id, userId));
+
+        const res = await getBalance({
+            Cookie: `better-auth.session_token=${sessionToken}`,
+        });
+        expect(res.status).toBe(200);
+        expect(await res.json()).toEqual({
+            balance: 10,
+            accountBalance: { total: 10, tier: 10, paid: 0 },
+        });
+    });
 });

--- a/gen.pollinations.ai/src/docs/account.md
+++ b/gen.pollinations.ai/src/docs/account.md
@@ -9,8 +9,9 @@ Self-service endpoints for the authenticated user. All endpoints require authent
 | `GET /account/profile` | GitHub username, image, and community model access |
 | `GET /account/balance` | Current pollen balance |
 | `GET /account/quests` | Read-only quest status |
-| `GET /account/usage` | Per-request usage history with costs |
+| `GET /account/usage` | Per-request usage history with costs (account-wide) |
 | `GET /account/usage/daily` | Daily aggregated usage for dashboards |
+| `GET /account/key/usage` | Usage history for the calling API key only |
 | `/account/my-models` | Private community model registration and allowlisted public publishing |
 | `GET /account/key` | API key validity, type, and permissions |
 
@@ -20,7 +21,16 @@ Returns user profile. `githubUsername`, `image`, and `communityEndpointsAllowed`
 
 ### GET /account/balance
 
-Returns remaining pollen. If the API key has a budget, returns key budget instead. Full account balance requires `account:usage`.
+`balance` is the amount visible to this caller and is kept stable for existing clients:
+
+- Budgeted API keys always get the key's remaining budget in `balance` (no extra scope).
+- Sessions and unbudgeted keys get the account total (Quest Pollen + paid) in `balance`. That path requires `account:usage` for API keys.
+
+When the caller can view account usage (dashboard session or `account:usage`), the response also includes `accountBalance: { total, tier, paid }` so clients can see Quest Pollen vs paid Pollen. Budgeted keys without `account:usage` do **not** receive `accountBalance` — that would leak the owner's wallet.
+
+### GET /account/key/usage
+
+Usage history for the API key used in the request. No extra scope — a key can always read its own usage. For account-wide usage across all keys, use `GET /account/usage` with `account:usage`.
 
 ### GET /account/quests
 

--- a/gen.pollinations.ai/src/routes/docs-samples.ts
+++ b/gen.pollinations.ai/src/routes/docs-samples.ts
@@ -539,11 +539,6 @@ export const RESPONSE_EXAMPLES: Record<string, unknown> = {
     },
     "get /account/balance": {
         balance: 42.5,
-        accountBalance: {
-            total: 42.5,
-            tier: 12.5,
-            paid: 30,
-        },
     },
     "get /account/profile": {
         githubUsername: "janedeveloper",

--- a/gen.pollinations.ai/src/routes/docs-samples.ts
+++ b/gen.pollinations.ai/src/routes/docs-samples.ts
@@ -539,6 +539,11 @@ export const RESPONSE_EXAMPLES: Record<string, unknown> = {
     },
     "get /account/balance": {
         balance: 42.5,
+        accountBalance: {
+            total: 42.5,
+            tier: 12.5,
+            paid: 30,
+        },
     },
     "get /account/profile": {
         githubUsername: "janedeveloper",

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -585,7 +585,20 @@ export interface AccountProfile {
 
 /** Account balance */
 export interface AccountBalance {
+    /**
+     * Pollen remaining for this caller. Budgeted API keys see the key budget
+     * here, not the account total.
+     */
     balance: number;
+    /**
+     * Full account balances. Present only when the caller can view account
+     * usage (session or `account:usage`).
+     */
+    accountBalance?: {
+        total: number;
+        tier: number;
+        paid: number;
+    };
 }
 
 /** Usage record */


### PR DESCRIPTION
Fixes #11160

`GET /account/balance` still returns the same `balance` number:

- budgeted key → remaining key budget
- session / unbudgeted key with `account:usage` → account total
- unbudgeted key without `account:usage` → 403

When the caller can view account usage, the response now also includes `accountBalance: { total, tier, paid }`. Budgeted keys without that permission do **not** get the split, so a child key cannot read the owner wallet.

Also documented existing `GET /account/key/usage` as key-scoped vs account-wide `/account/usage`.

**Verify**
- `npx vitest run test/account-balance.test.ts` — 6/6
- session + breakdown
- budgeted key, no leak
- budgeted key + `account:usage` keeps `balance` as the key budget
- unbudgeted + usage
- unbudgeted without usage → 403
- publishable zero-budget key does not leak `accountBalance`