### PR TITLE
fix: offer an account's own private models in the permission picker

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/auth/authorize.tsx
+++ b/enter.pollinations.ai/frontend/src/components/auth/authorize.tsx
@@ -36,6 +36,7 @@ import { useKeyPermissions } from "../keys/key-permissions.tsx";
 import { PollenBudgetInput } from "../keys/pollen-budget-input.tsx";
 import { computeCategoryModalities } from "../models/model-categories.ts";
 import { useModelCategories } from "../models/use-model-categories.ts";
+import { useOwnCommunityModels } from "../models/use-own-community-models.ts";
 import { AppAttribution } from "./app-attribution.tsx";
 
 type Attribution = {
@@ -112,7 +113,10 @@ export function Authorize() {
     );
     const { setAccountPermissions } = keyPermissions;
 
-    const modelCategories = useModelCategories();
+    // The minted key is the signed-in user's, so it reaches their own private
+    // models just as their dashboard keys do — but the anonymous catalog omits
+    // them, so the consent screen has to learn them separately.
+    const modelCategories = useModelCategories(useOwnCommunityModels(!!user));
     const modalities = computeCategoryModalities(
         keyPermissions.permissions.allowedModels,
         modelCategories,

--- a/enter.pollinations.ai/frontend/src/components/keys/key-permissions.tsx
+++ b/enter.pollinations.ai/frontend/src/components/keys/key-permissions.tsx
@@ -1,6 +1,7 @@
 import type { FC } from "react";
 import { useState } from "react";
 import { useModelCategories } from "../models/use-model-categories.ts";
+import { useOwnCommunityModels } from "../models/use-own-community-models.ts";
 import { AccountPermissionsInput } from "./account-permissions-input.tsx";
 import { ExpiryDaysInput } from "./expiry-days-input.tsx";
 import { PollenBudgetInput } from "./pollen-budget-input.tsx";
@@ -61,7 +62,10 @@ export const KeyPermissionsInputs: FC<KeyPermissionsInputsProps> = ({
         setExpiryDays,
         setAccountPermissions,
     } = value;
-    const modelCategories = useModelCategories();
+    // A dashboard key belongs to the account, so it can call that account's own
+    // private models. Offer them here too, or a key already scoped to one shows
+    // up as granting nothing and loses the grant on the next edit.
+    const modelCategories = useModelCategories(useOwnCommunityModels());
 
     return (
         <div className="space-y-6">

--- a/enter.pollinations.ai/frontend/src/components/models/use-model-categories.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/use-model-categories.ts
@@ -6,13 +6,18 @@ import {
 } from "./model-categories.ts";
 
 /**
- * The public model catalog, grouped into categories.
+ * The public model catalog, plus any models the caller supplies that the
+ * catalog omits — the signed-in user's own non-public ones — grouped into
+ * categories. Callers pass only models the catalog leaves out, so the two
+ * sources never describe the same model twice.
  *
  * The consent screen and the permission picker have to agree on this list: one
  * renders the summary of what is being granted and the other renders the
  * checkboxes, so a divergence would describe two different grants.
  */
-export function useModelCategories(): ModelCategoryGroup[] {
+export function useModelCategories(
+    extraModels?: ApiModelInfo[],
+): ModelCategoryGroup[] {
     const [catalogModels, setCatalogModels] = useState<ApiModelInfo[]>([]);
 
     useEffect(() => {
@@ -32,7 +37,11 @@ export function useModelCategories(): ModelCategoryGroup[] {
     }, []);
 
     return useMemo(
-        () => getModelCategoriesFromCatalog(catalogModels),
-        [catalogModels],
+        () =>
+            getModelCategoriesFromCatalog([
+                ...catalogModels,
+                ...(extraModels ?? []),
+            ]),
+        [catalogModels, extraModels],
     );
 }

--- a/enter.pollinations.ai/frontend/src/components/models/use-own-community-models.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/use-own-community-models.ts
@@ -1,0 +1,57 @@
+import { useEffect, useState } from "react";
+import { apiClient } from "../../api.ts";
+import type { ApiModelInfo } from "./model-catalog.ts";
+
+/**
+ * The signed-in account's own community models that the anonymous catalog
+ * omits, in catalog form, so pickers can offer them.
+ *
+ * Public ones are dropped because the catalog already lists them, with pricing
+ * and capabilities this five-field projection cannot reconstruct.
+ *
+ * Returns an empty list until loaded, and on failure, so a picker degrades to
+ * the public catalog rather than blocking.
+ */
+export function useOwnCommunityModels(enabled = true): ApiModelInfo[] {
+    const [models, setModels] = useState<ApiModelInfo[]>([]);
+
+    useEffect(() => {
+        if (!enabled) return;
+        let cancelled = false;
+
+        void (async () => {
+            try {
+                const response = await apiClient.account["my-models"].$get();
+                if (!response.ok) return;
+                const { data } = await response.json();
+                if (cancelled) return;
+                setModels(
+                    data
+                        .filter(
+                            (model) =>
+                                !model.disabled &&
+                                model.visibility !== "public",
+                        )
+                        .map((model) => ({
+                            name: model.modelId,
+                            title: model.title,
+                            category:
+                                model.modality === "image"
+                                    ? ("image" as const)
+                                    : ("text" as const),
+                            community: true,
+                            agent: model.delegatesGeneration,
+                        })),
+                );
+            } catch {
+                // Leave the picker on the public catalog alone.
+            }
+        })();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [enabled]);
+
+    return models;
+}

--- a/enter.pollinations.ai/src/routes/community-endpoints.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints.ts
@@ -163,6 +163,17 @@ type FallbackPrimary = {
 };
 
 /**
+ * Whether a stored row generates through something else — always for an agent,
+ * and for an external endpoint that was granted delegation.
+ */
+function rowDelegatesGeneration(row: {
+    agentId: string | null;
+    delegatesGeneration: boolean;
+}): boolean {
+    return row.agentId !== null || row.delegatesGeneration;
+}
+
+/**
  * Why `target` may not serve as a fallback for `primary`, or null when it may.
  *
  * The candidate list the dashboard offers and the validation the write path
@@ -181,7 +192,7 @@ function fallbackTargetRejection(
     if (target.disabledAt !== null) {
         return `Fallback target ${modelId} must be active`;
     }
-    if (target.agentId !== null || target.delegatesGeneration) {
+    if (rowDelegatesGeneration(target)) {
         return `Fallback target ${modelId} cannot delegate generation`;
     }
     if (
@@ -444,6 +455,9 @@ const CommunityEndpointResponseSchema = z.object({
     inputModalities: z.array(InputModalitySchema),
     baseUrl: z.string(),
     agentId: z.string().nullable(),
+    // Derived, not the stored column: true for every agent as well. Clients get
+    // the answer rather than the two columns it is computed from.
+    delegatesGeneration: z.boolean(),
     upstreamModel: z.string(),
     visibility: VisibilitySchema,
     perUserRpm: PerUserRpmSchema,
@@ -600,6 +614,7 @@ function toResponse(
         ),
         baseUrl,
         agentId: row.agentId,
+        delegatesGeneration: rowDelegatesGeneration(row),
         upstreamModel: row.upstreamModel,
         visibility: row.visibility,
         perUserRpm: row.perUserRpm,


### PR DESCRIPTION
- Adds `useOwnCommunityModels`, so the key permission picker and the OAuth consent screen list the account's own non-public community models alongside the public catalog
- `getVisibleModelIdsForUser` already lets a key call its owner's own models at any visibility; only the picker's *anonymous* catalog fetch hid them, so such a grant rendered as empty and was silently dropped on the next edit
- Exposes `delegatesGeneration` on the community endpoint response as a derived flag (true for agents too), so clients read the answer rather than recombining `agentId` and the stored column
- Split out of #13464 — no dependency on app visibility

Verified: `biome check` clean, `tsc --noEmit` clean in enter + gen, enter model/community tests pass (18).