### PR TITLE
docs(polli-cli): note that prices only apply to public models

### DIFF
--- a/packages/polli-cli/SKILL.md
+++ b/packages/polli-cli/SKILL.md
@@ -171,6 +171,8 @@ Test before creating. The probe reports the pricing mode it detected and the inp
 
 Two billing modes: `--image-pricing request` charges `--completion-image-price` per generated image, while `--image-pricing tokens` bills returned token usage per 1M through `--prompt-text-price`, `--prompt-image-price`, and `--completion-image-price`.
 
+Prices only apply to `--visibility public` models. A private model is owner-only and always free, so every price flag above is stored as `0` until you publish — and making a published model private clears its prices again.
+
 `--modality` is fixed at creation — `update` cannot change it.
 
 ### Manage agents


### PR DESCRIPTION
Follow-up to #13386.

The image-model example documents `--completion-image-price 0.01` on a `create` that defaults to `--visibility private`. On that path `community-endpoints.ts` replaces every price with `communityEndpointPrices({})` — all zeros — so anyone copying the example gets a silently free model.

- Adds one line stating prices only apply to public models, and that making a published model private clears them again.
