### PR TITLE
refactor: one key-type predicate for the list and the edit dialog

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/keys/api-key-list.tsx
+++ b/enter.pollinations.ai/frontend/src/components/keys/api-key-list.tsx
@@ -23,26 +23,10 @@ import { ApiKeyDialog } from "./api-key-dialog.tsx";
 import { EditApiKeyDialog } from "./edit-api-key-dialog.tsx";
 import { DeleteConfirmation } from "./key-delete-confirmation.tsx";
 import { KeyDisplay } from "./key-display.tsx";
+import { isAppKey, isPublishableKey, readRedirectUris } from "./key-type.ts";
 import { LimitsBadge, shortLocale } from "./limits-badge.tsx";
 import { ModelsBadge } from "./models-badge.tsx";
 import type { ApiKey, ApiKeyManagerProps } from "./types.ts";
-
-function isPublishableKey(apiKey: ApiKey): boolean {
-    return apiKey.metadata?.keyType === "publishable";
-}
-
-function isAppKey(apiKey: ApiKey): boolean {
-    if (!isPublishableKey(apiKey)) return false;
-
-    const redirectUris = apiKey.metadata?.redirectUris;
-    const hasRedirectUris =
-        Array.isArray(redirectUris) &&
-        redirectUris.some(
-            (uri) => typeof uri === "string" && uri.trim().length > 0,
-        );
-
-    return hasRedirectUris || apiKey.metadata?.earningsEnabled === true;
-}
 
 export const ApiKeyList: FC<ApiKeyManagerProps> = ({
     apiKeys,
@@ -88,9 +72,7 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
         const plaintextKey = apiKey.metadata?.plaintextKey as
             | string
             | undefined;
-        const redirectUrisMeta = Array.isArray(apiKey.metadata?.redirectUris)
-            ? (apiKey.metadata?.redirectUris as string[])
-            : [];
+        const redirectUrisMeta = readRedirectUris(apiKey.metadata);
         const primaryRedirectUri = redirectUrisMeta[0] || "";
         const extraRedirectUriCount = Math.max(0, redirectUrisMeta.length - 1);
         const earningsEnabled = apiKey.metadata?.earningsEnabled === true;

--- a/enter.pollinations.ai/frontend/src/components/keys/edit-api-key-dialog.tsx
+++ b/enter.pollinations.ai/frontend/src/components/keys/edit-api-key-dialog.tsx
@@ -19,7 +19,7 @@ import { KeyPermissionsInputs, useKeyPermissions } from "./key-permissions.tsx";
 import {
     isAppKey,
     isPublishableKey,
-    readInitialRedirectUris,
+    readRedirectUris,
     shouldPostKeyMetadata,
 } from "./key-type.ts";
 import { PublishableKeySettings } from "./publishable-key-settings.tsx";
@@ -48,7 +48,7 @@ export const EditApiKeyDialog: FC<EditApiKeyDialogProps> = ({
     const appKey = isAppKey(apiKey);
     const plaintextKey = apiKey.metadata?.plaintextKey as string | undefined;
 
-    const initialRedirectUris = readInitialRedirectUris(apiKey.metadata);
+    const initialRedirectUris = readRedirectUris(apiKey.metadata);
     const initialEarningsEnabled = apiKey.metadata?.earningsEnabled === true;
     const [redirectUris, setRedirectUris] =
         useState<string[]>(initialRedirectUris);

--- a/enter.pollinations.ai/frontend/src/components/keys/key-type.ts
+++ b/enter.pollinations.ai/frontend/src/components/keys/key-type.ts
@@ -1,6 +1,12 @@
 import type { ApiKey } from "./types.ts";
 
-export function readInitialRedirectUris(
+/**
+ * Mirrors getRedirectUris in shared/auth/api-key-metadata.ts, the reader the
+ * OAuth allowlist check uses. Keep the two in step: a URI the UI counts but
+ * the server ignores (or the reverse) means a key is grouped and gated as
+ * something the server does not agree it is.
+ */
+export function readRedirectUris(
     metadata: Record<string, unknown> | null | undefined,
 ): string[] {
     const list = metadata?.redirectUris;
@@ -17,7 +23,7 @@ export function isPublishableKey(apiKey: ApiKey): boolean {
 export function isAppKey(apiKey: ApiKey): boolean {
     return (
         isPublishableKey(apiKey) &&
-        (readInitialRedirectUris(apiKey.metadata).length > 0 ||
+        (readRedirectUris(apiKey.metadata).length > 0 ||
             apiKey.metadata?.earningsEnabled === true)
     );
 }
@@ -30,7 +36,7 @@ export function shouldPostKeyMetadata(
     next: { redirectUris: string[]; earningsEnabled: boolean },
 ): boolean {
     if (!isPublishableKey(apiKey)) return false;
-    const initialUris = readInitialRedirectUris(apiKey.metadata);
+    const initialUris = readRedirectUris(apiKey.metadata);
     return (
         next.redirectUris.length !== initialUris.length ||
         next.redirectUris.some((v, i) => v !== initialUris[i]) ||

--- a/enter.pollinations.ai/test/key-type.test.ts
+++ b/enter.pollinations.ai/test/key-type.test.ts
@@ -1,8 +1,11 @@
 import {
+    isAppKey,
     isPublishableKey,
+    readRedirectUris,
     shouldPostKeyMetadata,
 } from "@frontend/components/keys/key-type.ts";
 import type { ApiKey } from "@frontend/components/keys/types.ts";
+import { getRedirectUris } from "@shared/auth/api-key-metadata.ts";
 import { describe, expect, it } from "vitest";
 
 function makeKey(metadata: Record<string, unknown> | null): ApiKey {
@@ -79,5 +82,57 @@ describe("shouldPostKeyMetadata", () => {
                 earningsEnabled: false,
             }),
         ).toBe(false);
+    });
+});
+
+// The key list groups cards with isAppKey and the edit dialog titles and gates
+// itself with the same predicate. They used to be two copies that disagreed on
+// whitespace-only URIs, so a key could sit under "API keys" while its dialog
+// called it an app key. One shared predicate is the fix; these pin it.
+describe("one shared predicate for list grouping and dialog gating", () => {
+    it("treats a whitespace-only redirect URI the same way everywhere", () => {
+        const key = makeKey({ keyType: "publishable", redirectUris: ["  "] });
+        expect(readRedirectUris(key.metadata)).toEqual(["  "]);
+        expect(isAppKey(key)).toBe(true);
+    });
+
+    it("agrees with the server's redirect-URI reader", () => {
+        for (const metadata of [
+            { redirectUris: ["https://a.example/cb"] },
+            { redirectUris: ["https://a.example/cb", "", null, 1] },
+            { redirectUris: ["  "] },
+            { redirectUris: "not-an-array" },
+            {},
+        ]) {
+            expect(readRedirectUris(metadata)).toEqual(
+                getRedirectUris(metadata),
+            );
+        }
+    });
+
+    it("drops non-string redirect URIs before they reach a card", () => {
+        const key = makeKey({
+            keyType: "publishable",
+            redirectUris: ["https://a.example/cb", null, 1, ""],
+        });
+        expect(readRedirectUris(key.metadata)).toEqual([
+            "https://a.example/cb",
+        ]);
+    });
+
+    it("counts an earnings-only key as an app key with no redirect URIs", () => {
+        const key = makeKey({ keyType: "publishable", earningsEnabled: true });
+        expect(readRedirectUris(key.metadata)).toEqual([]);
+        expect(isAppKey(key)).toBe(true);
+    });
+
+    it("never treats a secret key as an app key", () => {
+        const key = makeKey({
+            keyType: "secret",
+            redirectUris: ["https://a.example/cb"],
+            earningsEnabled: true,
+        });
+        expect(isPublishableKey(key)).toBe(false);
+        expect(isAppKey(key)).toBe(false);
     });
 });


### PR DESCRIPTION
Follow-up to #13078, which extracted the publishable/app-key predicates into `key-type.ts` but only migrated the edit dialog — `api-key-list.tsx` kept its own copies, and the two disagreed on whitespace-only redirect URIs.

- `api-key-list.tsx` imports the shared predicates instead of redeclaring them
- The card's redirect-URI reader is the shared one too, so a non-string entry in `metadata.redirectUris` can no longer reach the UI as a rendered URI
- `readInitialRedirectUris` → `readRedirectUris`; it is no longer specific to the dialog's initial state
- Test file moves to `key-type.test.ts` and pins the frontend reader against `getRedirectUris` in `shared/auth/api-key-metadata.ts`, so the UI and the OAuth allowlist check cannot drift apart

**No behaviour change for any key that can exist.** The old list predicate trimmed, `key-type.ts` does not — they only differ on a whitespace-only URI, which `validateRedirectUriFormat` (`shared/auth/api-key-creation.ts:70`) rejects at write time, so it is unreachable in stored metadata.

Test: `cd enter.pollinations.ai && npx vitest run test/key-type.test.ts`