### PR TITLE
feat: grant paid pollen through quest rewards

### DIFF
--- a/enter.pollinations.ai/src/routes/quest-grants.ts
+++ b/enter.pollinations.ai/src/routes/quest-grants.ts
@@ -19,6 +19,8 @@ const grantRewardsSchema = z.object({
         .regex(/^[a-z0-9][a-z0-9_-]{0,99}$/),
     title: z.string().trim().min(1).max(200),
     pollenAmount: z.number().positive().max(MAX_REWARD_AMOUNT),
+    // "pack" grants paid pollen, the only bucket paid-only requests can spend.
+    balanceBucket: z.enum(["tier", "pack"]).default("tier"),
     sourceUrl: z
         .url()
         .refine((value) =>
@@ -68,7 +70,7 @@ export const questGrantAdminRoutes = new Hono<Env>().post(
                 idempotencyKey: `quest:${questId}:user:${user.id}`,
                 userId: user.id,
                 amount: input.pollenAmount,
-                bucket: "tier",
+                bucket: input.balanceBucket,
                 questId,
                 title: input.title,
                 url: input.sourceUrl,
@@ -77,6 +79,7 @@ export const questGrantAdminRoutes = new Hono<Env>().post(
 
         return c.json({
             campaignId: input.campaignId,
+            balanceBucket: input.balanceBucket,
             matched: matched.length,
             recorded: result.recorded,
             missing: requested.filter((login) => !usersByLogin.has(login)),

--- a/enter.pollinations.ai/test/quest-grants.test.ts
+++ b/enter.pollinations.ai/test/quest-grants.test.ts
@@ -42,6 +42,7 @@ test("admin grant records one claimable reward per user and campaign", async ({
     expect(grant.status).toBe(200);
     expect(await grant.json()).toEqual({
         campaignId: request.campaignId,
+        balanceBucket: "tier",
         matched: 1,
         recorded: 1,
         missing: ["missing-user"],
@@ -87,6 +88,68 @@ test("admin grant records one claimable reward per user and campaign", async ({
             },
         ],
     });
+});
+
+test("a pack grant credits paid pollen when claimed", async ({
+    sessionToken,
+}) => {
+    const db = drizzle(env.DB, { schema });
+    const [user] = await db
+        .select({
+            id: schema.user.id,
+            githubUsername: schema.user.githubUsername,
+            packBalance: schema.user.packBalance,
+        })
+        .from(schema.user)
+        .limit(1);
+
+    const grant = await SELF.fetch(`${baseUrl}/admin/quest-grants`, {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${env.PLN_ENTER_TOKEN}`,
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+            campaignId: "paid-bonus-2026-08",
+            title: "Paid pollen bonus",
+            pollenAmount: 5,
+            balanceBucket: "pack",
+            githubUsernames: [user?.githubUsername ?? ""],
+        }),
+    });
+    expect(grant.status).toBe(200);
+    expect(await grant.json()).toMatchObject({
+        balanceBucket: "pack",
+        recorded: 1,
+    });
+
+    const [reward] = await db
+        .select()
+        .from(schema.rewards)
+        .where(eq(schema.rewards.questId, "grant:paid-bonus-2026-08"));
+    expect(reward).toMatchObject({ balanceBucket: "pack", claimedAt: null });
+
+    const claim = await SELF.fetch(
+        `${baseUrl}/quests/rewards/${reward?.id}/claim`,
+        {
+            method: "POST",
+            headers: { Cookie: `better-auth.session_token=${sessionToken}` },
+        },
+    );
+    expect(claim.status).toBe(200);
+    expect(await claim.json()).toMatchObject({
+        claimed: true,
+        newBalance: (user?.packBalance ?? 0) + 5,
+    });
+
+    const [credited] = await db
+        .select({
+            tierBalance: schema.user.tierBalance,
+            packBalance: schema.user.packBalance,
+        })
+        .from(schema.user)
+        .where(eq(schema.user.id, user?.id ?? ""));
+    expect(credited?.packBalance).toBe((user?.packBalance ?? 0) + 5);
 });
 
 test("admin grant rejects requests without the admin token", async () => {


### PR DESCRIPTION
- Adds `balanceBucket` (`tier` | `pack`, default `tier`) to the admin quest-grant request, so a bonus can pay paid Pollen
- Echoes the granted bucket in the response, so an operator can confirm which balance a money-moving grant hit
- No other change needed: the reward ledger stores the bucket, `claimReward()` already credits `pack_balance`, and `rewardIconKind()` already renders pack rewards with the paid icon
- Paid Pollen is the only bucket paid-only requests can spend, which is what a contributor bonus in `pack` actually unlocks

Checks:
- `npx vitest run test/quest-grants.test.ts test/quests.test.ts` — 33 passed, including a new pack grant → claim → `pack_balance` credit
- `npx biome check` clean; `tsc --noEmit` clean for Worker code