### PR TITLE
chore: promote main to production

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/auth/authorize.tsx
+++ b/enter.pollinations.ai/frontend/src/components/auth/authorize.tsx
@@ -36,6 +36,7 @@ import { useKeyPermissions } from "../keys/key-permissions.tsx";
 import { PollenBudgetInput } from "../keys/pollen-budget-input.tsx";
 import { computeCategoryModalities } from "../models/model-categories.ts";
 import { useModelCategories } from "../models/use-model-categories.ts";
+import { useOwnCommunityModels } from "../models/use-own-community-models.ts";
 import { AppAttribution } from "./app-attribution.tsx";
 
 type Attribution = {
@@ -112,7 +113,10 @@ export function Authorize() {
     );
     const { setAccountPermissions } = keyPermissions;
 
-    const modelCategories = useModelCategories();
+    // The minted key is the signed-in user's, so it reaches their own private
+    // models just as their dashboard keys do — but the anonymous catalog omits
+    // them, so the consent screen has to learn them separately.
+    const modelCategories = useModelCategories(useOwnCommunityModels(!!user));
     const modalities = computeCategoryModalities(
         keyPermissions.permissions.allowedModels,
         modelCategories,

--- a/enter.pollinations.ai/frontend/src/components/keys/api-key-list.tsx
+++ b/enter.pollinations.ai/frontend/src/components/keys/api-key-list.tsx
@@ -23,26 +23,10 @@ import { ApiKeyDialog } from "./api-key-dialog.tsx";
 import { EditApiKeyDialog } from "./edit-api-key-dialog.tsx";
 import { DeleteConfirmation } from "./key-delete-confirmation.tsx";
 import { KeyDisplay } from "./key-display.tsx";
+import { isAppKey, isPublishableKey, readRedirectUris } from "./key-type.ts";
 import { LimitsBadge, shortLocale } from "./limits-badge.tsx";
 import { ModelsBadge } from "./models-badge.tsx";
 import type { ApiKey, ApiKeyManagerProps } from "./types.ts";
-
-function isPublishableKey(apiKey: ApiKey): boolean {
-    return apiKey.metadata?.keyType === "publishable";
-}
-
-function isAppKey(apiKey: ApiKey): boolean {
-    if (!isPublishableKey(apiKey)) return false;
-
-    const redirectUris = apiKey.metadata?.redirectUris;
-    const hasRedirectUris =
-        Array.isArray(redirectUris) &&
-        redirectUris.some(
-            (uri) => typeof uri === "string" && uri.trim().length > 0,
-        );
-
-    return hasRedirectUris || apiKey.metadata?.earningsEnabled === true;
-}
 
 export const ApiKeyList: FC<ApiKeyManagerProps> = ({
     apiKeys,
@@ -88,9 +72,7 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
         const plaintextKey = apiKey.metadata?.plaintextKey as
             | string
             | undefined;
-        const redirectUrisMeta = Array.isArray(apiKey.metadata?.redirectUris)
-            ? (apiKey.metadata?.redirectUris as string[])
-            : [];
+        const redirectUrisMeta = readRedirectUris(apiKey.metadata);
         const primaryRedirectUri = redirectUrisMeta[0] || "";
         const extraRedirectUriCount = Math.max(0, redirectUrisMeta.length - 1);
         const earningsEnabled = apiKey.metadata?.earningsEnabled === true;

--- a/enter.pollinations.ai/frontend/src/components/keys/edit-api-key-dialog.tsx
+++ b/enter.pollinations.ai/frontend/src/components/keys/edit-api-key-dialog.tsx
@@ -16,6 +16,12 @@ import {
 import type { FC } from "react";
 import { useState } from "react";
 import { KeyPermissionsInputs, useKeyPermissions } from "./key-permissions.tsx";
+import {
+    isAppKey,
+    isPublishableKey,
+    readInitialRedirectUris,
+    shouldPostKeyMetadata,
+} from "./key-type.ts";
 import { PublishableKeySettings } from "./publishable-key-settings.tsx";
 import type { ApiKey, ApiKeyUpdateParams } from "./types.ts";
 
@@ -25,35 +31,8 @@ interface EditApiKeyDialogProps {
     onClose: () => void;
 }
 
-function readInitialRedirectUris(
-    metadata: Record<string, unknown> | null | undefined,
-): string[] {
-    const list = metadata?.redirectUris;
-    if (Array.isArray(list)) {
-        return list.filter((v): v is string => typeof v === "string" && !!v);
-    }
-    return [];
-}
-
-function sameRedirectUris(a: string[], b: string[]): boolean {
-    if (a.length !== b.length) return false;
-    return a.every((v, i) => v === b[i]);
-}
-
 function cleanRedirectUris(uris: string[]): string[] {
     return uris.map((v) => v.trim()).filter((v) => v !== "");
-}
-
-function isPublishableKey(apiKey: ApiKey): boolean {
-    return apiKey.metadata?.keyType === "publishable";
-}
-
-function isAppKey(apiKey: ApiKey): boolean {
-    return (
-        isPublishableKey(apiKey) &&
-        (readInitialRedirectUris(apiKey.metadata).length > 0 ||
-            apiKey.metadata?.earningsEnabled === true)
-    );
 }
 
 export const EditApiKeyDialog: FC<EditApiKeyDialogProps> = ({
@@ -95,34 +74,21 @@ export const EditApiKeyDialog: FC<EditApiKeyDialogProps> = ({
         setIsSubmitting(true);
         setError(null);
         try {
-            const { expiryDays, ...permissions } = keyPermissions.permissions;
-            await onUpdate(apiKey.id, {
-                name,
-                ...permissions,
-                expiresAt: expiryDays
-                    ? new Date(Date.now() + expiryDays * 24 * 60 * 60 * 1000)
-                    : null,
-            });
-
-            // Save app settings only for keys that belong in the App section.
-            if (appKey) {
-                const cleaned = cleanRedirectUris(redirectUris);
-                if (
-                    sameRedirectUris(cleaned, initialRedirectUris) &&
-                    earningsEnabled === initialEarningsEnabled
-                ) {
-                    onClose();
-                    return;
-                }
-                const metadataBody = {
+            // Metadata must post before onUpdate: onUpdate ends in
+            // router.invalidate(), which would refetch the key list before this
+            // write lands and close the dialog onto a stale card.
+            const cleaned = cleanRedirectUris(redirectUris);
+            if (
+                shouldPostKeyMetadata(apiKey, {
                     redirectUris: cleaned,
                     earningsEnabled,
-                };
+                })
+            ) {
                 const metaRes = await apiClient["api-keys"][
                     ":id"
                 ].metadata.$post({
                     param: { id: apiKey.id },
-                    json: metadataBody,
+                    json: { redirectUris: cleaned, earningsEnabled },
                 });
                 if (!metaRes.ok) {
                     const err = await metaRes.json().catch(() => null);
@@ -132,6 +98,15 @@ export const EditApiKeyDialog: FC<EditApiKeyDialogProps> = ({
                     );
                 }
             }
+
+            const { expiryDays, ...permissions } = keyPermissions.permissions;
+            await onUpdate(apiKey.id, {
+                name,
+                ...permissions,
+                expiresAt: expiryDays
+                    ? new Date(Date.now() + expiryDays * 24 * 60 * 60 * 1000)
+                    : null,
+            });
 
             onClose();
         } catch (error) {
@@ -222,7 +197,7 @@ export const EditApiKeyDialog: FC<EditApiKeyDialogProps> = ({
                         />
                     </Field.Root>
 
-                    {appKey && (
+                    {isPublishable && (
                         <PublishableKeySettings
                             redirectUris={redirectUris}
                             onRedirectUrisChange={setRedirectUris}

--- a/enter.pollinations.ai/frontend/src/components/keys/edit-api-key-dialog.tsx
+++ b/enter.pollinations.ai/frontend/src/components/keys/edit-api-key-dialog.tsx
@@ -19,7 +19,7 @@ import { KeyPermissionsInputs, useKeyPermissions } from "./key-permissions.tsx";
 import {
     isAppKey,
     isPublishableKey,
-    readInitialRedirectUris,
+    readRedirectUris,
     shouldPostKeyMetadata,
 } from "./key-type.ts";
 import { PublishableKeySettings } from "./publishable-key-settings.tsx";
@@ -48,7 +48,7 @@ export const EditApiKeyDialog: FC<EditApiKeyDialogProps> = ({
     const appKey = isAppKey(apiKey);
     const plaintextKey = apiKey.metadata?.plaintextKey as string | undefined;
 
-    const initialRedirectUris = readInitialRedirectUris(apiKey.metadata);
+    const initialRedirectUris = readRedirectUris(apiKey.metadata);
     const initialEarningsEnabled = apiKey.metadata?.earningsEnabled === true;
     const [redirectUris, setRedirectUris] =
         useState<string[]>(initialRedirectUris);

--- a/enter.pollinations.ai/frontend/src/components/keys/key-permissions.tsx
+++ b/enter.pollinations.ai/frontend/src/components/keys/key-permissions.tsx
@@ -1,6 +1,7 @@
 import type { FC } from "react";
 import { useState } from "react";
 import { useModelCategories } from "../models/use-model-categories.ts";
+import { useOwnCommunityModels } from "../models/use-own-community-models.ts";
 import { AccountPermissionsInput } from "./account-permissions-input.tsx";
 import { ExpiryDaysInput } from "./expiry-days-input.tsx";
 import { PollenBudgetInput } from "./pollen-budget-input.tsx";
@@ -61,7 +62,10 @@ export const KeyPermissionsInputs: FC<KeyPermissionsInputsProps> = ({
         setExpiryDays,
         setAccountPermissions,
     } = value;
-    const modelCategories = useModelCategories();
+    // A dashboard key belongs to the account, so it can call that account's own
+    // private models. Offer them here too, or a key already scoped to one shows
+    // up as granting nothing and loses the grant on the next edit.
+    const modelCategories = useModelCategories(useOwnCommunityModels());
 
     return (
         <div className="space-y-6">

--- a/enter.pollinations.ai/frontend/src/components/keys/key-type.ts
+++ b/enter.pollinations.ai/frontend/src/components/keys/key-type.ts
@@ -1,0 +1,39 @@
+import type { ApiKey } from "./types.ts";
+
+export function readInitialRedirectUris(
+    metadata: Record<string, unknown> | null | undefined,
+): string[] {
+    const list = metadata?.redirectUris;
+    if (Array.isArray(list)) {
+        return list.filter((v): v is string => typeof v === "string" && !!v);
+    }
+    return [];
+}
+
+export function isPublishableKey(apiKey: ApiKey): boolean {
+    return apiKey.metadata?.keyType === "publishable";
+}
+
+export function isAppKey(apiKey: ApiKey): boolean {
+    return (
+        isPublishableKey(apiKey) &&
+        (readInitialRedirectUris(apiKey.metadata).length > 0 ||
+            apiKey.metadata?.earningsEnabled === true)
+    );
+}
+
+// Must mirror isPublishableKey, the predicate that decides whether the
+// settings fields render — if this gate is narrower than that one, edits
+// to a visible field get silently dropped.
+export function shouldPostKeyMetadata(
+    apiKey: ApiKey,
+    next: { redirectUris: string[]; earningsEnabled: boolean },
+): boolean {
+    if (!isPublishableKey(apiKey)) return false;
+    const initialUris = readInitialRedirectUris(apiKey.metadata);
+    return (
+        next.redirectUris.length !== initialUris.length ||
+        next.redirectUris.some((v, i) => v !== initialUris[i]) ||
+        next.earningsEnabled !== (apiKey.metadata?.earningsEnabled === true)
+    );
+}

--- a/enter.pollinations.ai/frontend/src/components/keys/key-type.ts
+++ b/enter.pollinations.ai/frontend/src/components/keys/key-type.ts
@@ -1,6 +1,12 @@
 import type { ApiKey } from "./types.ts";
 
-export function readInitialRedirectUris(
+/**
+ * Mirrors getRedirectUris in shared/auth/api-key-metadata.ts, the reader the
+ * OAuth allowlist check uses. Keep the two in step: a URI the UI counts but
+ * the server ignores (or the reverse) means a key is grouped and gated as
+ * something the server does not agree it is.
+ */
+export function readRedirectUris(
     metadata: Record<string, unknown> | null | undefined,
 ): string[] {
     const list = metadata?.redirectUris;
@@ -17,7 +23,7 @@ export function isPublishableKey(apiKey: ApiKey): boolean {
 export function isAppKey(apiKey: ApiKey): boolean {
     return (
         isPublishableKey(apiKey) &&
-        (readInitialRedirectUris(apiKey.metadata).length > 0 ||
+        (readRedirectUris(apiKey.metadata).length > 0 ||
             apiKey.metadata?.earningsEnabled === true)
     );
 }
@@ -30,7 +36,7 @@ export function shouldPostKeyMetadata(
     next: { redirectUris: string[]; earningsEnabled: boolean },
 ): boolean {
     if (!isPublishableKey(apiKey)) return false;
-    const initialUris = readInitialRedirectUris(apiKey.metadata);
+    const initialUris = readRedirectUris(apiKey.metadata);
     return (
         next.redirectUris.length !== initialUris.length ||
         next.redirectUris.some((v, i) => v !== initialUris[i]) ||

--- a/enter.pollinations.ai/frontend/src/components/models/use-model-categories.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/use-model-categories.ts
@@ -6,13 +6,18 @@ import {
 } from "./model-categories.ts";
 
 /**
- * The public model catalog, grouped into categories.
+ * The public model catalog, plus any models the caller supplies that the
+ * catalog omits — the signed-in user's own non-public ones — grouped into
+ * categories. Callers pass only models the catalog leaves out, so the two
+ * sources never describe the same model twice.
  *
  * The consent screen and the permission picker have to agree on this list: one
  * renders the summary of what is being granted and the other renders the
  * checkboxes, so a divergence would describe two different grants.
  */
-export function useModelCategories(): ModelCategoryGroup[] {
+export function useModelCategories(
+    extraModels?: ApiModelInfo[],
+): ModelCategoryGroup[] {
     const [catalogModels, setCatalogModels] = useState<ApiModelInfo[]>([]);
 
     useEffect(() => {
@@ -32,7 +37,11 @@ export function useModelCategories(): ModelCategoryGroup[] {
     }, []);
 
     return useMemo(
-        () => getModelCategoriesFromCatalog(catalogModels),
-        [catalogModels],
+        () =>
+            getModelCategoriesFromCatalog([
+                ...catalogModels,
+                ...(extraModels ?? []),
+            ]),
+        [catalogModels, extraModels],
     );
 }

--- a/enter.pollinations.ai/frontend/src/components/models/use-own-community-models.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/use-own-community-models.ts
@@ -1,0 +1,57 @@
+import { useEffect, useState } from "react";
+import { apiClient } from "../../api.ts";
+import type { ApiModelInfo } from "./model-catalog.ts";
+
+/**
+ * The signed-in account's own community models that the anonymous catalog
+ * omits, in catalog form, so pickers can offer them.
+ *
+ * Public ones are dropped because the catalog already lists them, with pricing
+ * and capabilities this five-field projection cannot reconstruct.
+ *
+ * Returns an empty list until loaded, and on failure, so a picker degrades to
+ * the public catalog rather than blocking.
+ */
+export function useOwnCommunityModels(enabled = true): ApiModelInfo[] {
+    const [models, setModels] = useState<ApiModelInfo[]>([]);
+
+    useEffect(() => {
+        if (!enabled) return;
+        let cancelled = false;
+
+        void (async () => {
+            try {
+                const response = await apiClient.account["my-models"].$get();
+                if (!response.ok) return;
+                const { data } = await response.json();
+                if (cancelled) return;
+                setModels(
+                    data
+                        .filter(
+                            (model) =>
+                                !model.disabled &&
+                                model.visibility !== "public",
+                        )
+                        .map((model) => ({
+                            name: model.modelId,
+                            title: model.title,
+                            category:
+                                model.modality === "image"
+                                    ? ("image" as const)
+                                    : ("text" as const),
+                            community: true,
+                            agent: model.delegatesGeneration,
+                        })),
+                );
+            } catch {
+                // Leave the picker on the public catalog alone.
+            }
+        })();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [enabled]);
+
+    return models;
+}

--- a/enter.pollinations.ai/src/routes/community-endpoints.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints.ts
@@ -163,6 +163,17 @@ type FallbackPrimary = {
 };
 
 /**
+ * Whether a stored row generates through something else — always for an agent,
+ * and for an external endpoint that was granted delegation.
+ */
+function rowDelegatesGeneration(row: {
+    agentId: string | null;
+    delegatesGeneration: boolean;
+}): boolean {
+    return row.agentId !== null || row.delegatesGeneration;
+}
+
+/**
  * Why `target` may not serve as a fallback for `primary`, or null when it may.
  *
  * The candidate list the dashboard offers and the validation the write path
@@ -181,7 +192,7 @@ function fallbackTargetRejection(
     if (target.disabledAt !== null) {
         return `Fallback target ${modelId} must be active`;
     }
-    if (target.agentId !== null || target.delegatesGeneration) {
+    if (rowDelegatesGeneration(target)) {
         return `Fallback target ${modelId} cannot delegate generation`;
     }
     if (
@@ -444,6 +455,9 @@ const CommunityEndpointResponseSchema = z.object({
     inputModalities: z.array(InputModalitySchema),
     baseUrl: z.string(),
     agentId: z.string().nullable(),
+    // Derived, not the stored column: true for every agent as well. Clients get
+    // the answer rather than the two columns it is computed from.
+    delegatesGeneration: z.boolean(),
     upstreamModel: z.string(),
     visibility: VisibilitySchema,
     perUserRpm: PerUserRpmSchema,
@@ -600,6 +614,7 @@ function toResponse(
         ),
         baseUrl,
         agentId: row.agentId,
+        delegatesGeneration: rowDelegatesGeneration(row),
         upstreamModel: row.upstreamModel,
         visibility: row.visibility,
         perUserRpm: row.perUserRpm,

--- a/enter.pollinations.ai/src/routes/quest-grants.ts
+++ b/enter.pollinations.ai/src/routes/quest-grants.ts
@@ -19,6 +19,8 @@ const grantRewardsSchema = z.object({
         .regex(/^[a-z0-9][a-z0-9_-]{0,99}$/),
     title: z.string().trim().min(1).max(200),
     pollenAmount: z.number().positive().max(MAX_REWARD_AMOUNT),
+    // "pack" grants paid pollen, the only bucket paid-only requests can spend.
+    balanceBucket: z.enum(["tier", "pack"]).default("tier"),
     sourceUrl: z
         .url()
         .refine((value) =>
@@ -68,7 +70,7 @@ export const questGrantAdminRoutes = new Hono<Env>().post(
                 idempotencyKey: `quest:${questId}:user:${user.id}`,
                 userId: user.id,
                 amount: input.pollenAmount,
-                bucket: "tier",
+                bucket: input.balanceBucket,
                 questId,
                 title: input.title,
                 url: input.sourceUrl,
@@ -77,6 +79,7 @@ export const questGrantAdminRoutes = new Hono<Env>().post(
 
         return c.json({
             campaignId: input.campaignId,
+            balanceBucket: input.balanceBucket,
             matched: matched.length,
             recorded: result.recorded,
             missing: requested.filter((login) => !usersByLogin.has(login)),

--- a/enter.pollinations.ai/test/edit-api-key-dialog.test.ts
+++ b/enter.pollinations.ai/test/edit-api-key-dialog.test.ts
@@ -1,0 +1,83 @@
+import {
+    isPublishableKey,
+    shouldPostKeyMetadata,
+} from "@frontend/components/keys/key-type.ts";
+import type { ApiKey } from "@frontend/components/keys/types.ts";
+import { describe, expect, it } from "vitest";
+
+function makeKey(metadata: Record<string, unknown> | null): ApiKey {
+    return {
+        id: "key_1",
+        createdAt: new Date().toISOString(),
+        permissions: null,
+        metadata,
+    };
+}
+
+// The edit dialog renders the redirect-URI / earnings fields when
+// isPublishableKey is true, so anything it renders must also pass
+// shouldPostKeyMetadata or the save silently drops the edit.
+describe("publishable key settings gate", () => {
+    it("renders and saves for a publishable key with no redirect URIs or earnings", () => {
+        const key = makeKey({ keyType: "publishable" });
+        expect(isPublishableKey(key)).toBe(true);
+        expect(
+            shouldPostKeyMetadata(key, {
+                redirectUris: ["https://myapp.com/callback"],
+                earningsEnabled: false,
+            }),
+        ).toBe(true);
+    });
+
+    it("renders and saves for a publishable key that is also an app key", () => {
+        const key = makeKey({
+            keyType: "publishable",
+            redirectUris: ["https://myapp.com/callback"],
+        });
+        expect(isPublishableKey(key)).toBe(true);
+        expect(
+            shouldPostKeyMetadata(key, {
+                redirectUris: ["https://myapp.com/other"],
+                earningsEnabled: false,
+            }),
+        ).toBe(true);
+    });
+
+    it("neither renders nor saves for a secret key", () => {
+        const key = makeKey({ keyType: "secret" });
+        expect(isPublishableKey(key)).toBe(false);
+        expect(
+            shouldPostKeyMetadata(key, {
+                redirectUris: ["https://myapp.com/callback"],
+                earningsEnabled: true,
+            }),
+        ).toBe(false);
+    });
+
+    it("neither renders nor saves for a key with no metadata", () => {
+        const key = makeKey(null);
+        expect(isPublishableKey(key)).toBe(false);
+    });
+});
+
+describe("shouldPostKeyMetadata", () => {
+    const plainPublishable = makeKey({ keyType: "publishable" });
+
+    it("posts enabled earnings on a publishable non-app key", () => {
+        expect(
+            shouldPostKeyMetadata(plainPublishable, {
+                redirectUris: [],
+                earningsEnabled: true,
+            }),
+        ).toBe(true);
+    });
+
+    it("skips the post when nothing changed", () => {
+        expect(
+            shouldPostKeyMetadata(plainPublishable, {
+                redirectUris: [],
+                earningsEnabled: false,
+            }),
+        ).toBe(false);
+    });
+});

--- a/enter.pollinations.ai/test/key-type.test.ts
+++ b/enter.pollinations.ai/test/key-type.test.ts
@@ -1,8 +1,11 @@
 import {
+    isAppKey,
     isPublishableKey,
+    readRedirectUris,
     shouldPostKeyMetadata,
 } from "@frontend/components/keys/key-type.ts";
 import type { ApiKey } from "@frontend/components/keys/types.ts";
+import { getRedirectUris } from "@shared/auth/api-key-metadata.ts";
 import { describe, expect, it } from "vitest";
 
 function makeKey(metadata: Record<string, unknown> | null): ApiKey {
@@ -79,5 +82,57 @@ describe("shouldPostKeyMetadata", () => {
                 earningsEnabled: false,
             }),
         ).toBe(false);
+    });
+});
+
+// The key list groups cards with isAppKey and the edit dialog titles and gates
+// itself with the same predicate. They used to be two copies that disagreed on
+// whitespace-only URIs, so a key could sit under "API keys" while its dialog
+// called it an app key. One shared predicate is the fix; these pin it.
+describe("one shared predicate for list grouping and dialog gating", () => {
+    it("treats a whitespace-only redirect URI the same way everywhere", () => {
+        const key = makeKey({ keyType: "publishable", redirectUris: ["  "] });
+        expect(readRedirectUris(key.metadata)).toEqual(["  "]);
+        expect(isAppKey(key)).toBe(true);
+    });
+
+    it("agrees with the server's redirect-URI reader", () => {
+        for (const metadata of [
+            { redirectUris: ["https://a.example/cb"] },
+            { redirectUris: ["https://a.example/cb", "", null, 1] },
+            { redirectUris: ["  "] },
+            { redirectUris: "not-an-array" },
+            {},
+        ]) {
+            expect(readRedirectUris(metadata)).toEqual(
+                getRedirectUris(metadata),
+            );
+        }
+    });
+
+    it("drops non-string redirect URIs before they reach a card", () => {
+        const key = makeKey({
+            keyType: "publishable",
+            redirectUris: ["https://a.example/cb", null, 1, ""],
+        });
+        expect(readRedirectUris(key.metadata)).toEqual([
+            "https://a.example/cb",
+        ]);
+    });
+
+    it("counts an earnings-only key as an app key with no redirect URIs", () => {
+        const key = makeKey({ keyType: "publishable", earningsEnabled: true });
+        expect(readRedirectUris(key.metadata)).toEqual([]);
+        expect(isAppKey(key)).toBe(true);
+    });
+
+    it("never treats a secret key as an app key", () => {
+        const key = makeKey({
+            keyType: "secret",
+            redirectUris: ["https://a.example/cb"],
+            earningsEnabled: true,
+        });
+        expect(isPublishableKey(key)).toBe(false);
+        expect(isAppKey(key)).toBe(false);
     });
 });

--- a/enter.pollinations.ai/test/quest-grants.test.ts
+++ b/enter.pollinations.ai/test/quest-grants.test.ts
@@ -42,6 +42,7 @@ test("admin grant records one claimable reward per user and campaign", async ({
     expect(grant.status).toBe(200);
     expect(await grant.json()).toEqual({
         campaignId: request.campaignId,
+        balanceBucket: "tier",
         matched: 1,
         recorded: 1,
         missing: ["missing-user"],
@@ -87,6 +88,68 @@ test("admin grant records one claimable reward per user and campaign", async ({
             },
         ],
     });
+});
+
+test("a pack grant credits paid pollen when claimed", async ({
+    sessionToken,
+}) => {
+    const db = drizzle(env.DB, { schema });
+    const [user] = await db
+        .select({
+            id: schema.user.id,
+            githubUsername: schema.user.githubUsername,
+            packBalance: schema.user.packBalance,
+        })
+        .from(schema.user)
+        .limit(1);
+
+    const grant = await SELF.fetch(`${baseUrl}/admin/quest-grants`, {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${env.PLN_ENTER_TOKEN}`,
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+            campaignId: "paid-bonus-2026-08",
+            title: "Paid pollen bonus",
+            pollenAmount: 5,
+            balanceBucket: "pack",
+            githubUsernames: [user?.githubUsername ?? ""],
+        }),
+    });
+    expect(grant.status).toBe(200);
+    expect(await grant.json()).toMatchObject({
+        balanceBucket: "pack",
+        recorded: 1,
+    });
+
+    const [reward] = await db
+        .select()
+        .from(schema.rewards)
+        .where(eq(schema.rewards.questId, "grant:paid-bonus-2026-08"));
+    expect(reward).toMatchObject({ balanceBucket: "pack", claimedAt: null });
+
+    const claim = await SELF.fetch(
+        `${baseUrl}/quests/rewards/${reward?.id}/claim`,
+        {
+            method: "POST",
+            headers: { Cookie: `better-auth.session_token=${sessionToken}` },
+        },
+    );
+    expect(claim.status).toBe(200);
+    expect(await claim.json()).toMatchObject({
+        claimed: true,
+        newBalance: (user?.packBalance ?? 0) + 5,
+    });
+
+    const [credited] = await db
+        .select({
+            tierBalance: schema.user.tierBalance,
+            packBalance: schema.user.packBalance,
+        })
+        .from(schema.user)
+        .where(eq(schema.user.id, user?.id ?? ""));
+    expect(credited?.packBalance).toBe((user?.packBalance ?? 0) + 5);
 });
 
 test("admin grant rejects requests without the admin token", async () => {

--- a/gen.pollinations.ai/src/middleware/track.ts
+++ b/gen.pollinations.ai/src/middleware/track.ts
@@ -174,24 +174,7 @@ export const track = (eventType: EventType) =>
             rawIp !== "unknown" ? stripIPv4MappedPrefix(rawIp) : undefined;
         const ipSubnet = truncateIpToSubnet(clientIp);
 
-        const apiKeyMetadata = c.var.auth.apiKey?.metadata as
-            | Record<string, unknown>
-            | undefined;
-        const byopClientKeyId = c.var.auth.apiKey?.byopClientKeyId;
-        const userTracking: UserData = {
-            userId: c.var.auth.user?.id,
-            userTier: c.var.auth.user?.tier,
-            apiKeyId: c.var.auth.apiKey?.id,
-            apiKeyType: apiKeyMetadata?.keyType as ApiKeyType,
-            apiKeyName: c.var.auth.apiKey?.name,
-            apiKeyCreatedVia: byopClientKeyId
-                ? "redirect-auth"
-                : (apiKeyMetadata?.createdVia as string | undefined),
-            apiKeyClientId: byopClientKeyId ?? undefined,
-            apiKeyCreatedForApp: c.var.auth.apiKey?.byopClientName ?? undefined,
-            apiKeyCreatedForUserId:
-                c.var.auth.apiKey?.byopClientUserId ?? undefined,
-        } satisfies UserData;
+        const userTracking = requestIdentity(c.var.auth);
 
         let responseOverride: Response | null = null;
         let pricingInput: PricingInput | undefined;
@@ -391,7 +374,7 @@ export const track = (eventType: EventType) =>
                         userId,
                         apiKeyId: c.var.auth?.apiKey?.id,
                         apiKeyPollenBalance: c.var.auth?.apiKey?.pollenBalance,
-                        byopClientKeyId,
+                        byopClientKeyId: c.var.auth?.apiKey?.byopClientKeyId,
                         modelPaidOnly: c.var.model?.definition.paidOnly,
                         // Only public endpoints pay their owner a reward: a
                         // private endpoint is owner-called (base cost billed to
@@ -842,7 +825,15 @@ async function* asyncIteratorStream<T>(
     }
 }
 
-type UserData = {
+/**
+ * Who made the request, in the shape the event carries it.
+ *
+ * Every path that emits a generation row builds this the same way, so a new
+ * identity column is added here once rather than in each emitter. Realtime
+ * settles from a socket rather than a response and so keeps its own event
+ * builder; it spreads this verbatim.
+ */
+export type UserData = {
     userId?: string;
     userTier?: string;
     apiKeyId?: string;
@@ -853,6 +844,28 @@ type UserData = {
     apiKeyCreatedForUserId?: string;
     apiKeyClientId?: string;
 };
+
+export function requestIdentity(auth: AuthVariables["auth"]): UserData {
+    const apiKeyMetadata = auth.apiKey?.metadata as
+        | Record<string, unknown>
+        | undefined;
+    const byopClientKeyId = auth.apiKey?.byopClientKeyId;
+    return {
+        userId: auth.user?.id,
+        userTier: auth.user?.tier,
+        apiKeyId: auth.apiKey?.id,
+        apiKeyType: apiKeyMetadata?.keyType as ApiKeyType,
+        apiKeyName: auth.apiKey?.name,
+        // A BYOP key is created by the redirect flow, whatever its metadata
+        // says it was created via.
+        apiKeyCreatedVia: byopClientKeyId
+            ? "redirect-auth"
+            : (apiKeyMetadata?.createdVia as string | undefined),
+        apiKeyClientId: byopClientKeyId ?? undefined,
+        apiKeyCreatedForApp: auth.apiKey?.byopClientName ?? undefined,
+        apiKeyCreatedForUserId: auth.apiKey?.byopClientUserId ?? undefined,
+    };
+}
 
 type BalanceData = {
     selectedMeterId?: string;

--- a/gen.pollinations.ai/src/routes/realtime.ts
+++ b/gen.pollinations.ai/src/routes/realtime.ts
@@ -34,7 +34,11 @@ import { drizzle } from "drizzle-orm/d1";
 import type { Context } from "hono";
 import { HTTPException } from "hono/http-exception";
 import type { Env } from "@/env.ts";
-import { reduceAdjustmentsToEventFields } from "@/middleware/track.ts";
+import {
+    reduceAdjustmentsToEventFields,
+    requestIdentity,
+    type UserData,
+} from "@/middleware/track.ts";
 import { RealtimeUsageSchema } from "@/schemas/realtime.ts";
 import { generateRandomId } from "@/util.ts";
 import { checkBalance } from "@/utils/generation-access.ts";
@@ -80,15 +84,9 @@ type RealtimeCacheUsage = {
     imageTokens: number;
 };
 type RealtimeBillingContext = {
-    userId: string;
-    userTier?: string;
-    apiKeyId?: string;
-    apiKeyName?: string;
-    apiKeyType?: "secret" | "publishable";
-    apiKeyCreatedVia?: string;
-    apiKeyCreatedForApp?: string;
-    apiKeyCreatedForUserId?: string;
-    apiKeyClientId?: string;
+    // Spread verbatim into the event, so an identity column added to UserData
+    // reaches a realtime row without touching this file.
+    identity: UserData & { userId: string };
     apiKeyPollenBalance?: number | null;
     byopClientKeyId?: string | null;
     modelRequested: string;
@@ -719,15 +717,7 @@ function createRealtimeTrackingEvent(args: {
         eventType: "generate.realtime",
         ipSubnet: args.tracking.ipSubnet,
         ipHash: args.tracking.ipHash,
-        userId: args.tracking.userId,
-        userTier: args.tracking.userTier,
-        apiKeyId: args.tracking.apiKeyId,
-        apiKeyName: args.tracking.apiKeyName,
-        apiKeyType: args.tracking.apiKeyType,
-        apiKeyCreatedVia: args.tracking.apiKeyCreatedVia,
-        apiKeyCreatedForApp: args.tracking.apiKeyCreatedForApp,
-        apiKeyCreatedForUserId: args.tracking.apiKeyCreatedForUserId,
-        apiKeyClientId: args.tracking.apiKeyClientId,
+        ...args.tracking.identity,
         referrerUrl: args.tracking.referrerUrl,
         referrerDomain: args.tracking.referrerDomain,
         modelRequested: args.tracking.modelRequested,
@@ -782,8 +772,8 @@ async function settleRealtimeSession(
             db,
             isBilledUsage: true,
             totalPrice: price.totalPrice,
-            userId: tracking.userId,
-            apiKeyId: tracking.apiKeyId,
+            userId: tracking.identity.userId,
+            apiKeyId: tracking.identity.apiKeyId,
             apiKeyPollenBalance: tracking.apiKeyPollenBalance,
             byopClientKeyId: tracking.byopClientKeyId,
             modelPaidOnly: tracking.modelDefinition.paidOnly,
@@ -795,7 +785,7 @@ async function settleRealtimeSession(
         tracking.rateLimitConsumed = true;
     }
 
-    const balances = await getUserBalance(db, tracking.userId);
+    const balances = await getUserBalance(db, tracking.identity.userId);
     await sendToTinybird(
         createRealtimeTrackingEvent({
             tracking,
@@ -1278,9 +1268,6 @@ async function createRealtimeBillingContext(
     c: Context<Env>,
 ): Promise<RealtimeBillingContext> {
     const user = c.var.auth.requireUser();
-    const apiKeyMetadata = c.var.auth.apiKey?.metadata as
-        | Record<string, unknown>
-        | undefined;
     const rawIp = getRealClientIp(c);
     const clientIp =
         rawIp !== "unknown" ? stripIPv4MappedPrefix(rawIp) : undefined;
@@ -1296,16 +1283,8 @@ async function createRealtimeBillingContext(
     }
 
     return {
-        userId: user.id,
-        userTier: user.tier,
-        apiKeyId: c.var.auth.apiKey?.id,
-        apiKeyName: c.var.auth.apiKey?.name,
-        apiKeyType: apiKeyMetadata?.keyType as "secret" | "publishable",
-        apiKeyCreatedVia: apiKeyMetadata?.createdVia as string | undefined,
-        apiKeyCreatedForApp: c.var.auth.apiKey?.byopClientName ?? undefined,
-        apiKeyCreatedForUserId:
-            c.var.auth.apiKey?.byopClientUserId ?? undefined,
-        apiKeyClientId: c.var.auth.apiKey?.byopClientKeyId ?? undefined,
+        // requireUser() above proves the id, which the optional field cannot.
+        identity: { ...requestIdentity(c.var.auth), userId: user.id },
         apiKeyPollenBalance: c.var.auth.apiKey?.pollenBalance,
         byopClientKeyId: c.var.auth.apiKey?.byopClientKeyId,
         modelRequested: modelInfo.requested,

--- a/operations/model-monitor/src/App.jsx
+++ b/operations/model-monitor/src/App.jsx
@@ -9,7 +9,6 @@ import {
     ExternalLinkButton,
     GitHubIcon,
     Heading,
-    IconButton,
     Surface,
     TabButton,
     Table,
@@ -20,50 +19,8 @@ import {
     TableRow,
 } from "@pollinations/ui";
 import { ModalityChip } from "@pollinations/ui/gen";
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
 import { useModelMonitor } from "./hooks/useModelMonitor";
-
-const FAVORITES_KEY = "model-monitor-favorites";
-
-function loadFavorites() {
-    try {
-        const raw = localStorage.getItem(FAVORITES_KEY);
-        const parsed = raw ? JSON.parse(raw) : [];
-        return Array.isArray(parsed) ? parsed : [];
-    } catch {
-        return [];
-    }
-}
-
-function saveFavorites(list) {
-    try {
-        localStorage.setItem(FAVORITES_KEY, JSON.stringify(list));
-    } catch {
-        // storage full or blocked — silently ignore
-    }
-}
-
-function modelKey(model) {
-    return `${model.type}-${model.name}`;
-}
-
-function StarIcon({ filled }) {
-    return (
-        <svg
-            viewBox="0 0 24 24"
-            className="h-4 w-4"
-            fill={filled ? "currentColor" : "none"}
-            stroke="currentColor"
-            strokeWidth={2}
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            role="img"
-            aria-label={filled ? "Favorited" : "Not favorited"}
-        >
-            <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
-        </svg>
-    );
-}
 
 const WINDOW_OPTIONS = [
     { key: "7d", label: "7d" },
@@ -87,31 +44,6 @@ const MODEL_SCOPES = [
     { key: "official", title: "Official" },
     { key: "community", title: "Community" },
 ];
-
-const FILTER_KEY = "model-monitor-filter";
-
-function loadFilterState() {
-    try {
-        const raw = localStorage.getItem(FILTER_KEY);
-        if (!raw) return null;
-        const { scope, type } = JSON.parse(raw);
-        const validScope = MODEL_SCOPES.some((s) => s.key === scope)
-            ? scope
-            : null;
-        const validType = MODEL_TYPES.some((t) => t.key === type) ? type : null;
-        return { scope: validScope, type: validType };
-    } catch {
-        return null;
-    }
-}
-
-function saveFilterState(filter) {
-    try {
-        localStorage.setItem(FILTER_KEY, JSON.stringify(filter));
-    } catch {
-        // storage full or blocked — silently ignore
-    }
-}
 
 const LOW_SAMPLE_REQUESTS = 10;
 
@@ -175,7 +107,7 @@ function getLatencyColor(latencySec) {
 }
 
 function computeHealthStatus(stats) {
-    if (!stats?.total_requests) return "on";
+    if (!stats || !stats.total_requests) return "on";
     const success = stats.status_2xx || 0;
     const total5xx = stats.errors_5xx || 0;
     // 4xx are client errors and don't count. Judge purely on the 5xx share of
@@ -463,32 +395,9 @@ function App() {
         useModelMonitor(aggregationWindow);
 
     const [sort, setSort] = useState({ key: "requests", asc: false });
-    const [initialFilter] = useState(loadFilterState);
-    const [scopeFilter, setScopeFilter] = useState(
-        initialFilter?.scope ?? "official",
-    );
-    const [typeFilter, setTypeFilter] = useState(initialFilter?.type ?? null);
-    const [favorites, setFavorites] = useState(loadFavorites);
-    const [favoritesOnly, setFavoritesOnly] = useState(false);
+    const [scopeFilter, setScopeFilter] = useState("official");
+    const [typeFilter, setTypeFilter] = useState(null);
     const catalogUnavailable = endpointStatus.catalog === false;
-
-    useEffect(() => {
-        saveFavorites(favorites);
-    }, [favorites]);
-
-    useEffect(() => {
-        saveFilterState({ scope: scopeFilter, type: typeFilter });
-    }, [scopeFilter, typeFilter]);
-
-    const toggleFavorite = useCallback((key) => {
-        setFavorites((prev) => {
-            const next = prev.includes(key)
-                ? prev.filter((k) => k !== key)
-                : [...prev, key];
-            if (next.length === 0) setFavoritesOnly(false);
-            return next;
-        });
-    }, []);
 
     const handleSort = (key) => {
         setSort((prev) => ({
@@ -503,10 +412,6 @@ function App() {
     );
 
     const sortedModels = [...observedModels].sort((a, b) => {
-        const aFav = favorites.includes(modelKey(a));
-        const bFav = favorites.includes(modelKey(b));
-        if (aFav !== bFav) return aFav ? -1 : 1;
-
         const dir = sort.asc ? 1 : -1;
         switch (sort.key) {
             case "type":
@@ -619,11 +524,9 @@ function App() {
     const scopedModels = sortedModels.filter(
         (model) => modelScope(model) === scopeFilter,
     );
-    const filteredModels = scopedModels
-        .filter((model) => (typeFilter ? model.type === typeFilter : true))
-        .filter((model) =>
-            favoritesOnly ? favorites.includes(modelKey(model)) : true,
-        );
+    const filteredModels = typeFilter
+        ? scopedModels.filter((model) => model.type === typeFilter)
+        : scopedModels;
 
     const handleScopeChange = (scope) => {
         setScopeFilter(scope);
@@ -701,32 +604,10 @@ function App() {
                     />
                 </div>
 
-                {favorites.length > 0 && (
-                    <div className="flex items-center gap-2">
-                        <Button
-                            type="button"
-                            size="sm"
-                            intent={favoritesOnly ? "info" : undefined}
-                            aria-pressed={favoritesOnly}
-                            aria-label={`Show favorites only (${favorites.length})`}
-                            onClick={() => setFavoritesOnly((prev) => !prev)}
-                        >
-                            <span className="inline-flex items-center gap-1">
-                                <StarIcon filled={favoritesOnly} />
-                                Favorites
-                                <span className="ml-0.5 tabular-nums opacity-70">
-                                    {favorites.length}
-                                </span>
-                            </span>
-                        </Button>
-                    </div>
-                )}
-
                 <Surface variant="card" className="p-0">
                     <Table>
                         <TableHead>
                             <tr>
-                                <TableHeaderCell className="w-8" />
                                 <SortableTh
                                     label="Type"
                                     sortKey="type"
@@ -816,14 +697,12 @@ function App() {
                             {filteredModels.length === 0 ? (
                                 <TableRow>
                                     <TableCell
-                                        colSpan={adminMode ? 12 : 11}
+                                        colSpan={adminMode ? 11 : 10}
                                         align="center"
                                         className="py-8 text-theme-text-muted"
                                     >
                                         {lastUpdated
-                                            ? favoritesOnly
-                                                ? "No favorited models match the current filter"
-                                                : "No traffic in this window"
+                                            ? "No traffic in this window"
                                             : "Loading models..."}
                                     </TableCell>
                                 </TableRow>
@@ -855,31 +734,9 @@ function App() {
 
                                     return (
                                         <TableRow
-                                            key={modelKey(model)}
+                                            key={`${model.type}-${model.name}`}
                                             intent={rowIntent(health)}
                                         >
-                                            <TableCell className="w-8">
-                                                <IconButton
-                                                    title={
-                                                        favorites.includes(
-                                                            modelKey(model),
-                                                        )
-                                                            ? "Remove from favorites"
-                                                            : "Add to favorites"
-                                                    }
-                                                    onClick={() =>
-                                                        toggleFavorite(
-                                                            modelKey(model),
-                                                        )
-                                                    }
-                                                >
-                                                    <StarIcon
-                                                        filled={favorites.includes(
-                                                            modelKey(model),
-                                                        )}
-                                                    />
-                                                </IconButton>
-                                            </TableCell>
                                             <TableCell>
                                                 <ModalityChip
                                                     modality={model.type}

--- a/packages/polli-cli/README.md
+++ b/packages/polli-cli/README.md
@@ -94,7 +94,7 @@ polli usage --history        # recent requests
 polli usage --daily          # daily spend
 polli quests mine --completed # completed and earned quests
 polli agents list            # managed prompt agents
-polli my-models list         # invite-only community text models
+polli my-models list         # invite-only community text and image models
 ```
 
 Manage agents with API-shaped JSON config files:

--- a/packages/polli-cli/SKILL.md
+++ b/packages/polli-cli/SKILL.md
@@ -157,10 +157,11 @@ polli quests --claimable # only rewards ready to claim
 polli my-models list
 polli my-models models --base-url https://api.example.com/v1 --bearer-token "$UPSTREAM_KEY"
 polli my-models create --name my-model --title "My Model" --base-url https://api.example.com/v1 --bearer-token "$UPSTREAM_KEY" --upstream-model gpt-4.1-mini
+polli my-models create --name my-image --title "My Image" --modality image --image-pricing request --completion-image-price 0.01 --base-url https://api.example.com/v1 --bearer-token "$UPSTREAM_KEY" --upstream-model flux
 polli my-models update <id> --description "Updated description"
 polli my-models delete <id>
 ```
-`my-models` manages owned community text models for invite-only accounts. It requires `communityEndpointsAllowed: true` plus a key with `account:keys`, or an authenticated dashboard session through the API. Use `account:usage` for narrow read-only usage and `polli quests`; use both permissions when a client needs both read-only account state and admin operations. Quest claiming is dashboard-only; `polli quests` is read-only and account-aware.
+`my-models` manages owned community text and image models for invite-only accounts. It requires `communityEndpointsAllowed: true` plus a key with `account:keys`, or an authenticated dashboard session through the API. Use `account:usage` for narrow read-only usage and `polli quests`; use both permissions when a client needs both read-only account state and admin operations. Quest claiming is dashboard-only; `polli quests` is read-only and account-aware.
 
 ### Register an image my-model
 ```bash

--- a/packages/polli-cli/SKILL.md
+++ b/packages/polli-cli/SKILL.md
@@ -162,6 +162,17 @@ polli my-models delete <id>
 ```
 `my-models` manages owned community text models for invite-only accounts. It requires `communityEndpointsAllowed: true` plus a key with `account:keys`, or an authenticated dashboard session through the API. Use `account:usage` for narrow read-only usage and `polli quests`; use both permissions when a client needs both read-only account state and admin operations. Quest claiming is dashboard-only; `polli quests` is read-only and account-aware.
 
+### Register an image my-model
+```bash
+polli my-models test --modality image --base-url https://api.example.com/v1 --bearer-token "$UPSTREAM_KEY" --model image-v1
+polli my-models create --name my-image --title "My Image" --modality image --image-pricing request --completion-image-price 0.01 --input-modalities text,image --base-url https://api.example.com/v1 --bearer-token "$UPSTREAM_KEY" --upstream-model image-v1
+```
+Test before creating. The probe reports the pricing mode it detected and the input modalities it found, including whether the endpoint accepts image edits; pass those back as `--input-modalities text,image` to advertise edit support. `polli my-models list` shows them in the `inputs` column.
+
+Two billing modes: `--image-pricing request` charges `--completion-image-price` per generated image, while `--image-pricing tokens` bills returned token usage per 1M through `--prompt-text-price`, `--prompt-image-price`, and `--completion-image-price`.
+
+`--modality` is fixed at creation — `update` cannot change it.
+
 ### Manage agents
 
 ```bash

--- a/packages/polli-cli/package.json
+++ b/packages/polli-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollinations/cli",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "The Pollinations CLI — for humans, AI agents, and everything in between",
   "type": "module",
   "bin": {

--- a/packages/polli-cli/src/commands/my-models.test.ts
+++ b/packages/polli-cli/src/commands/my-models.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { modelBody } from "./my-models.js";
+
+describe("modelBody", () => {
+    it("builds image model registration fields supported by the API", () => {
+        expect(
+            modelBody(
+                {
+                    name: "image-provider",
+                    title: "Image Provider",
+                    baseUrl: "https://example.com/v1",
+                    bearerToken: "upstream-token",
+                    modality: "image",
+                    imagePricing: "request",
+                    inputModalities: "text,image",
+                    completionImagePrice: "0.01",
+                },
+                true,
+            ),
+        ).toEqual({
+            name: "image-provider",
+            title: "Image Provider",
+            baseUrl: "https://example.com/v1",
+            bearerToken: "upstream-token",
+            modality: "image",
+            imagePricing: "request",
+            inputModalities: ["text", "image"],
+            completionImagePrice: 0.01,
+        });
+    });
+
+    it("keeps modality out of updates while allowing image pricing changes", () => {
+        expect(
+            modelBody(
+                {
+                    imagePricing: "tokens",
+                    promptImagePrice: "0.000001",
+                    completionImagePrice: "0.02",
+                    modality: "image",
+                },
+                false,
+            ),
+        ).toEqual({
+            imagePricing: "tokens",
+            promptImagePrice: 0.000001,
+            completionImagePrice: 0.02,
+        });
+    });
+});

--- a/packages/polli-cli/src/commands/my-models.ts
+++ b/packages/polli-cli/src/commands/my-models.ts
@@ -21,6 +21,10 @@ const PRICE_FLAGS = [
         "Completion reasoning token price",
     ],
     ["--completion-audio-price <number>", "Completion audio token price"],
+    [
+        "--completion-image-price <number>",
+        "Generated-image price (per image when --image-pricing request; per token when --image-pricing tokens)",
+    ],
 ] as const;
 
 const PRICE_OPTION_KEYS = [
@@ -32,6 +36,7 @@ const PRICE_OPTION_KEYS = [
     "completionTextPrice",
     "completionReasoningPrice",
     "completionAudioPrice",
+    "completionImagePrice",
 ] as const;
 
 type PriceOptionKey = (typeof PRICE_OPTION_KEYS)[number];
@@ -42,6 +47,12 @@ interface MyModel {
     name: string;
     title: string;
     description: string | null;
+    modality: "text" | "image";
+    imagePricing: "request" | "tokens";
+    completionImagePrice: number;
+    // How a publisher confirms an image model registered as edit-capable:
+    // /account/my-models/test detects these from generation and edit probes.
+    inputModalities: string[];
     baseUrl: string;
     upstreamModel: string;
     visibility: "private" | "public";
@@ -73,7 +84,10 @@ function readPriceOptions(opts: Record<string, unknown>) {
     return prices;
 }
 
-function modelBody(opts: Record<string, unknown>, includeRequired: boolean) {
+export function modelBody(
+    opts: Record<string, unknown>,
+    includeRequired: boolean,
+) {
     const body: Record<string, unknown> = {
         ...readPriceOptions(opts),
     };
@@ -96,6 +110,22 @@ function modelBody(opts: Record<string, unknown>, includeRequired: boolean) {
             fail("--visibility must be 'private' or 'public'");
         }
         body.visibility = opts.visibility;
+    }
+
+    // Create only. UpdateEndpointSchema has no modality — a model's family
+    // is fixed at registration, so update must not send this field.
+    if (includeRequired && opts.modality !== undefined) {
+        if (opts.modality !== "text" && opts.modality !== "image") {
+            fail("--modality must be 'text' or 'image'");
+        }
+        body.modality = opts.modality;
+    }
+
+    if (opts.imagePricing !== undefined) {
+        if (opts.imagePricing !== "request" && opts.imagePricing !== "tokens") {
+            fail("--image-pricing must be 'request' or 'tokens'");
+        }
+        body.imagePricing = opts.imagePricing;
     }
 
     // An empty string clears the list, which is why this checks for the flag
@@ -146,6 +176,14 @@ function printModels(models: MyModel[]) {
             id: chalk.dim(model.id),
             model: chalk.hex("#a78bfa").bold(model.modelId),
             title: model.title,
+            modality: model.modality,
+            // Price and billing mode read as one unit, so they share a cell
+            // rather than widening an already wide table by two columns.
+            image_price:
+                model.modality === "image"
+                    ? `${model.completionImagePrice}/${model.imagePricing === "tokens" ? "token" : "req"}`
+                    : "-",
+            inputs: model.inputModalities?.join(", ") || "-",
             visibility: model.visibility,
             upstream: model.upstreamModel,
             base_url: model.baseUrl,
@@ -156,6 +194,9 @@ function printModels(models: MyModel[]) {
             "id",
             "model",
             "title",
+            "modality",
+            "image_price",
+            "inputs",
             "visibility",
             "upstream",
             "base_url",
@@ -200,6 +241,14 @@ const create = addPriceOptions(
         .option(
             "--input-modalities <types>",
             "Comma-separated accepted inputs: text,image,audio,video",
+        )
+        .option(
+            "--modality <modality>",
+            "Model family: text (default) or image",
+        )
+        .option(
+            "--image-pricing <mode>",
+            "Image billing: request (per image, default) or tokens",
         ),
 ).action(async (opts) => {
     const key = requireKey();
@@ -240,6 +289,12 @@ const update = addPriceOptions(
         .option(
             "--input-modalities <types>",
             "Comma-separated accepted inputs: text,image,audio,video",
+        )
+        // No --modality here on purpose: UpdateEndpointSchema has no modality
+        // field, so a registered model's family is fixed at creation.
+        .option(
+            "--image-pricing <mode>",
+            "Image billing: request (per image) or tokens",
         ),
 ).action(async (id, opts) => {
     const key = requireKey();
@@ -317,8 +372,16 @@ const test = new Command("test")
     .requiredOption("--base-url <url>", "OpenAI-compatible base URL")
     .requiredOption("--bearer-token <token>", "Upstream bearer token")
     .requiredOption("--model <model>", "Upstream model id")
+    .option("--modality <modality>", "Model family: text (default) or image")
     .action(async (opts) => {
         const key = requireKey();
+        if (
+            opts.modality !== undefined &&
+            opts.modality !== "text" &&
+            opts.modality !== "image"
+        ) {
+            fail("--modality must be 'text' or 'image'");
+        }
         try {
             const res = await gen<Record<string, unknown>>(
                 "/account/my-models/test",
@@ -329,6 +392,9 @@ const test = new Command("test")
                         baseUrl: opts.baseUrl,
                         bearerToken: opts.bearerToken,
                         model: opts.model,
+                        ...(opts.modality !== undefined && {
+                            modality: opts.modality,
+                        }),
                     },
                 },
             );
@@ -339,7 +405,7 @@ const test = new Command("test")
     });
 
 export const myModelsCommand = new Command("my-models")
-    .description("Manage private and published community text models")
+    .description("Manage private and published community text and image models")
     .addCommand(list)
     .addCommand(create)
     .addCommand(update)


### PR DESCRIPTION
Promotes main to production.

- Adds `balanceBucket` to the admin quest-grant endpoint (#13509), so contributor bonuses can pay paid Pollen
- Plus 7 other merged changes: key-type predicate refactor, publishable-key redirect URI fix, model-monitor favorites revert, polli-cli image modality flags, private-model permission picker fix, my-model docs, shared request identity