### PR TITLE
fix: cover a zero-cost model with a zero balance

### DIFF
--- a/gen.pollinations.ai/src/byop-markup.test.ts
+++ b/gen.pollinations.ai/src/byop-markup.test.ts
@@ -225,7 +225,7 @@ describe("BYOP markup", () => {
         });
     });
 
-    it("rejects regular preflight when neither bucket is above the model estimate", async () => {
+    it("rejects regular preflight when both buckets are below the model estimate", async () => {
         const vars = {
             auth: {
                 user: { id: "preflight-payer" },
@@ -236,8 +236,8 @@ describe("BYOP markup", () => {
             },
             balance: {
                 getBalance: async () => ({
-                    tierBalance: 1,
-                    packBalance: 1,
+                    tierBalance: 0.5,
+                    packBalance: 0.5,
                 }),
             },
             model: testModel(),
@@ -275,6 +275,30 @@ describe("BYOP markup", () => {
         });
     });
 
+    it("allows a zero-cost model when every balance is zero", async () => {
+        const vars = {
+            auth: {
+                user: { id: "preflight-payer" },
+                apiKey: { id: "sk-test", pollenBalance: 0 },
+            },
+            balance: {
+                getBalance: async () => ({
+                    tierBalance: 0,
+                    packBalance: 0,
+                }),
+            },
+            model: testModel(),
+            log: fakeLog(),
+        } as unknown as Parameters<typeof checkBalance>[0];
+
+        await checkBalance(vars, fakeStatsEnv(0));
+
+        expect(vars.balance.balanceCheckResult?.balances).toEqual({
+            "v1:meter:tier": 0,
+            "v1:meter:pack": 0,
+        });
+    });
+
     it("requires paid-only preflight to have pack balance above the model estimate", async () => {
         const vars = {
             auth: {
@@ -298,11 +322,11 @@ describe("BYOP markup", () => {
         });
     });
 
-    it("rejects finite API key budgets that are not above the model estimate", async () => {
+    it("rejects finite API key budgets below the model estimate", async () => {
         const vars = {
             auth: {
                 user: { id: "preflight-payer" },
-                apiKey: { id: "sk-test", pollenBalance: 1 },
+                apiKey: { id: "sk-test", pollenBalance: 0.5 },
             },
             balance: {
                 getBalance: async () => ({

--- a/gen.pollinations.ai/src/utils/generation-access.ts
+++ b/gen.pollinations.ai/src/utils/generation-access.ts
@@ -1,6 +1,5 @@
 import { createBalanceCheckResult } from "@shared/billing/balance.ts";
 import { canCoverEstimatedCharge } from "@shared/billing/bucket-selection.ts";
-import { isFreeCommunityEndpoint } from "@shared/community-endpoints.ts";
 import { getModelStats } from "@shared/utils/model-stats.ts";
 import { createMiddleware } from "hono/factory";
 import { HTTPException } from "hono/http-exception";
@@ -32,18 +31,9 @@ export async function checkBalance(
         await getModelStats(env.KV, log),
         model.resolved,
     );
-    const communityEndpoint = model.communityEndpoint;
-    const isFreeCommunityModel =
-        communityEndpoint !== undefined &&
-        isFreeCommunityEndpoint(communityEndpoint);
-
     const apiKeyBudget = auth.apiKey?.pollenBalance;
     const requiredBudget = Math.max(0, estimatedCost);
-    if (
-        !isFreeCommunityModel &&
-        typeof apiKeyBudget === "number" &&
-        apiKeyBudget <= requiredBudget
-    ) {
+    if (typeof apiKeyBudget === "number" && apiKeyBudget < requiredBudget) {
         throw new HTTPException(402, {
             message: `API key budget too low. This request costs ~${estimatedCost.toFixed(4)} pollen, but this key has ${Math.max(0, apiKeyBudget).toFixed(4)}.`,
         });
@@ -51,10 +41,7 @@ export async function checkBalance(
 
     const userBalance = await balance.getBalance(auth.user.id);
 
-    if (
-        !isFreeCommunityModel &&
-        !canCoverEstimatedCharge(userBalance, estimatedCost, isPaidOnly)
-    ) {
+    if (!canCoverEstimatedCharge(userBalance, estimatedCost, isPaidOnly)) {
         const available = isPaidOnly
             ? userBalance.packBalance
             : Math.max(userBalance.tierBalance, userBalance.packBalance);

--- a/shared/billing/bucket-selection.ts
+++ b/shared/billing/bucket-selection.ts
@@ -11,8 +11,14 @@ export function canCoverEstimatedCharge(
     isPaidOnly = false,
 ): boolean {
     const threshold = Math.max(0, estimatedCost);
+    // Paid-only stays strict: the flag means "must hold paid balance", a
+    // positive-balance requirement rather than a cost-coverage one. A paid-only
+    // model is never free, so no zero-balance caller needs to get through.
     if (isPaidOnly) return balances.packBalance > threshold;
-    return balances.tierBalance > threshold || balances.packBalance > threshold;
+    // Cost coverage, so a zero-priced model is covered by a zero balance.
+    return (
+        balances.tierBalance >= threshold || balances.packBalance >= threshold
+    );
 }
 
 export function selectDeductionBucket(


### PR DESCRIPTION
- Preflight compares balance against the estimate with `>=`, so a zero-priced model is covered by a zero balance. The old strict `>` degenerated to "balance must be strictly positive" whenever the estimate was 0 — rejecting exactly the users a free model exists for.
- Drops the `isFreeCommunityEndpoint` special case in `checkBalance`. It existed only to defeat that floor: Tinybird already reports 0 for free endpoints, since `public_model_stats` averages only `total_price > 0` rows.
- Keeps paid-only strict. `paidOnly` means "must hold paid balance" — a positive-balance requirement, not cost coverage — and a paid-only model is never free.
- Updates the two preflight tests that encoded the old boundary (balance *equal* to the estimate now passes) and adds one for zero cost at zero balance.

Groundwork for #13353: once community models can set `paidOnly`, the balance gate needs one path rather than a free-model bypass that would silently ignore the flag.

Note: a caller at exactly 0 can now issue one request against a model with no priced-success history (estimate 0), going negative and blocked thereafter. Not new exposure — anyone holding dust already cleared `> 0` on every model, and deduction is post-response in `waitUntil` either way.