### PR TITLE
refactor: drop the unreachable TS copy of the deduction ladder

### DIFF
--- a/shared/billing/balance.ts
+++ b/shared/billing/balance.ts
@@ -1,11 +1,7 @@
 import { eq } from "drizzle-orm";
 import type { DrizzleD1Database } from "drizzle-orm/d1";
 import { user as userTable } from "../db/better-auth.ts";
-import {
-    type BalanceBucket,
-    selectDeductionBucket,
-    type UserBalance,
-} from "./bucket-selection.ts";
+import type { BalanceBucket, UserBalance } from "./bucket-selection.ts";
 
 export type { UserBalance } from "./bucket-selection.ts";
 
@@ -69,16 +65,14 @@ export function payerBucketToMeter(bucket: BalanceBucket): {
 export function createBalanceCheckResult(
     balances: UserBalance,
     isPaidOnly = false,
-    amount?: number,
 ): BalanceCheckResult {
-    let source: BalanceBucket;
-    if (typeof amount === "number" && amount > 0) {
-        source = selectDeductionBucket(balances, amount, isPaidOnly);
-    } else if (isPaidOnly) {
-        source = "pack";
-    } else {
-        source = balances.tierBalance > 0 ? "tier" : "pack";
-    }
+    // Which bucket the charge is expected to land in, for the reported meter.
+    // The authoritative choice is the SQL ladder in atomicDeductUserBalance.
+    const source: BalanceBucket = isPaidOnly
+        ? "pack"
+        : balances.tierBalance > 0
+          ? "tier"
+          : "pack";
     return {
         ...payerBucketToMeter(source),
         balances: {

--- a/shared/billing/bucket-selection.ts
+++ b/shared/billing/bucket-selection.ts
@@ -20,14 +20,3 @@ export function canCoverEstimatedCharge(
         balances.tierBalance >= threshold || balances.packBalance >= threshold
     );
 }
-
-export function selectDeductionBucket(
-    balances: UserBalance,
-    amount: number,
-    isPaidOnly = false,
-): BalanceBucket {
-    if (isPaidOnly) return "pack";
-    if (balances.tierBalance >= amount) return "tier";
-    if (balances.packBalance > 0) return "pack";
-    return "tier";
-}


### PR DESCRIPTION
Dead code found while reviewing #13514. Independent of it — this predates the branch (arrived with #13320).

- `selectDeductionBucket` was reachable only through `createBalanceCheckResult`'s optional `amount` argument. That function has exactly one call site repo-wide (`gen.pollinations.ai/src/utils/generation-access.ts:53`) and it passes two arguments, so `amount` is always `undefined` and the branch never ran.
- It also duplicated the ladder `atomicDeductUserBalance` already encodes in SQL (`shared/billing/deduction.ts:34-39`) — paid-only → pack, tier covers → tier, pack > 0 → pack, else tier. That SQL is where the real deduction decision happens, so this was a second copy of a billing rule, free to drift from the one that runs.
- `createBalanceCheckResult` keeps the branch that actually executes: paid-only pays from pack, otherwise tier when it holds anything. That value feeds the reported meter (`selectedMeterSlug`), not the charge.

No behaviour change — every input reaching the live call site picks the same bucket as before. −17 lines.

`canCoverEstimatedCharge`, `getAvailableBalance`, and `payerBucketToMeter` all stay; each has live callers.

Tests: gen `byop-markup` + `tracking-observability` (53), `billing-deduction` + `community-endpoints` (63), enter `balance-check` (4). `tsc --noEmit` clean on gen and enter, biome clean.