### PR TITLE
refactor: drop the dead conditional visibility write on update

### DIFF
--- a/enter.pollinations.ai/src/routes/community-endpoints.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints.ts
@@ -1233,9 +1233,6 @@ export const communityEndpointsRoutes = new Hono<Env>()
                     c.env.BETTER_AUTH_SECRET,
                 );
             }
-            if (input.visibility !== undefined) {
-                update.visibility = input.visibility;
-            }
             if (endpoint.agentId !== null) {
                 update.perUserRpm = null;
             } else if (input.perUserRpm !== undefined) {


### PR DESCRIPTION
Found while reviewing #13514. Independent of it — pre-existing code.

The my-models update handler set `update.visibility` conditionally, then overwrote it unconditionally 70 lines further down:

```ts
const effectiveVisibility = input.visibility ?? endpoint.visibility;
// ...
update.visibility = effectiveVisibility;
```

That second write subsumes the first — when `input.visibility` is set the two write the same value, and when it is not, the conditional never fired. The persisted row is identical either way.

The one thing that could have made the first write load-bearing: `update` is spread into `communityEndpointPricesForModality({ ...endpoint, ...update }, ...)` in between. It isn't — that function takes `source: Partial<CommunityEndpointPrices>` (`shared/community-endpoints.ts:210`) and only indexes `source[field.key]` for keys in `COMMUNITY_ENDPOINT_PRICE_FIELDS`. Visibility is never read. Nothing else between the two writes reads it either, and the unconditional write sits immediately before the DB update, with only `enforcePublishingAccess` in between (which throws rather than falling through).

−3 lines, no behaviour change. The comment on the surviving write already explains why it is unconditional.

Tests: gen `community-endpoints` (57), enter `community-endpoint-openai` + `-price-input` + `-rpm-input` (18). `tsc --noEmit` clean, biome clean.