### PR TITLE
refactor: one timeout for community endpoints, 300s

### DIFF
--- a/enter.pollinations.ai/src/services/community-endpoint-openai.ts
+++ b/enter.pollinations.ai/src/services/community-endpoint-openai.ts
@@ -1,4 +1,5 @@
 import {
+    COMMUNITY_ENDPOINT_TIMEOUT_MS,
     type CommunityEndpointImagePricing,
     communityChatCompletionsUrl,
     communityEndpointErrorDetail,
@@ -34,7 +35,6 @@ export type CommunityEndpointTestResult = {
     inputModalities?: ModelInputModality[];
 };
 
-const REQUEST_TIMEOUT_MS = 90_000;
 const MAX_IMAGE_BYTES = 20 * 1024 * 1024;
 
 function authorizationHeaders(bearerToken: string): HeadersInit {
@@ -56,7 +56,7 @@ async function fetchJson(url: string, init: RequestInit): Promise<unknown> {
         response = await fetch(url, {
             ...init,
             redirect: "manual",
-            signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+            signal: AbortSignal.timeout(COMMUNITY_ENDPOINT_TIMEOUT_MS),
         });
     } catch {
         throw new Error("Endpoint request timed out or could not connect");
@@ -287,7 +287,7 @@ async function fetchImageBytes(
     try {
         response = await fetch(url, {
             redirect: "manual",
-            signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+            signal: AbortSignal.timeout(COMMUNITY_ENDPOINT_TIMEOUT_MS),
         });
     } catch {
         throw new Error("Endpoint image URL timed out or could not connect");

--- a/gen.pollinations.ai/src/image/communityEndpoint.ts
+++ b/gen.pollinations.ai/src/image/communityEndpoint.ts
@@ -1,5 +1,6 @@
 import { Buffer } from "node:buffer";
 import {
+    COMMUNITY_ENDPOINT_TIMEOUT_MS,
     type CommunityEndpointRuntime,
     communityEndpointErrorDetail,
     communityImageEditsUrl,
@@ -25,7 +26,6 @@ import {
 
 type CommunityImageParams = Omit<ImageParams, "model"> & { model: string };
 
-const REQUEST_TIMEOUT_MS = 120_000;
 const MAX_IMAGE_BYTES = 20 * 1024 * 1024;
 
 export async function callCommunityImageEndpoint(
@@ -106,7 +106,7 @@ async function imageEditFormData(
     for (const [index, imageUrl] of safeParams.image.entries()) {
         const { buffer, mimeType } = await downloadUserImage(
             imageUrl,
-            AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+            AbortSignal.timeout(COMMUNITY_ENDPOINT_TIMEOUT_MS),
         );
         const extension = mimeType.split("/")[1];
         formData.append(
@@ -186,7 +186,7 @@ async function fetchWithTimeout(
         return await fetch(input, {
             ...init,
             redirect: "manual",
-            signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+            signal: AbortSignal.timeout(COMMUNITY_ENDPOINT_TIMEOUT_MS),
         });
     } catch (error) {
         throw new HttpError(

--- a/shared/community-endpoints.ts
+++ b/shared/community-endpoints.ts
@@ -39,6 +39,12 @@ export const MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS = 50;
 export const MAX_COMMUNITY_PRICE_PER_TOKEN =
     MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS / 1_000_000;
 export const MAX_COMMUNITY_PRICE_PER_IMAGE = 0.25;
+// How long we wait on a self-hosted community endpoint before giving up. Kept
+// generous because these are hobby GPUs, and in line with the text providers
+// (Portkey and Azure both use 290s). Workers impose no wall-clock limit of
+// their own, so without this a hung endpoint would hang until the caller
+// disconnects.
+export const COMMUNITY_ENDPOINT_TIMEOUT_MS = 300_000;
 const BEARER_PREFIX = /^Bearer(?:\s+|$)/i;
 
 export type CommunityEndpointModality =


### PR DESCRIPTION
- Adds `COMMUNITY_ENDPOINT_TIMEOUT_MS = 300_000` to `shared/community-endpoints.ts`.
- Image generation used **120s**, the enter registration probe **90s**, with no shared source. Both now read the constant.
- 300s matches what the text paths already run: `generateTextPortkey.ts:30` and `azureResponsesClient.ts:16` are both 290s.

Why keep a timeout at all: Workers impose **no wall-clock limit** on an invocation — [the runtime caps CPU time, not duration, and there is no per-subrequest timeout](https://developers.cloudflare.com/workers/platform/limits/). So without an explicit signal a hung community endpoint hangs for as long as the caller holds the connection. The 524 proxy read timeout is an *origin* limit and does not bound a Worker.

The timeout is also load-bearing for failover: it throws 502, and 502 is in `FALLBACK_ON_STATUS_CODES` (`gen.pollinations.ai/src/fallback.ts:22`), so a hung endpoint fails over to the next declared community fallback.

Follow-up: `gen.pollinations.ai/src/audio/communityEndpoint.ts` on #13416 declares its own `REQUEST_TIMEOUT_MS = 300_000` — same value, should point at this constant once that lands.

Note `gen.pollinations.ai/src/image/availableServers.ts:191` warns that a timeout signal once broke every pool request despite passing locally. That was about *adding* one where there was none; this only changes existing values. Still worth a smoke test of a community image generation after deploy.
