### PR TITLE
 Closing Issue #10733 (Expose BYOP app details from /account/key #10733)

### DIFF
--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -1609,6 +1609,32 @@ export const accountRoutes = new Hono<Env>()
                                         .describe(
                                             "Publishable app key that minted this key via the BYOP authorize flow. Server-attested; clients cannot forge.",
                                         ),
+                                    byopApp: z
+                                        .object({
+                                            keyId: z
+                                                .string()
+                                                .describe(
+                                                    "Public app key / client id",
+                                                ),
+                                            name: z
+                                                .string()
+                                                .nullable()
+                                                .describe("App name"),
+                                            user: z
+                                                .object({
+                                                    id: z
+                                                        .string()
+                                                        .describe(
+                                                            "App user identity",
+                                                        ),
+                                                })
+                                                .nullable()
+                                                .describe("App user identity"),
+                                        })
+                                        .nullable()
+                                        .describe(
+                                            "BYOP app attribution for keys minted through BYOP, or null for non-BYOP keys.",
+                                        ),
                                 }),
                             ),
                         },
@@ -1702,6 +1728,15 @@ export const accountRoutes = new Hono<Env>()
                 // params — so user and BYOP app ids cannot be spoofed.
                 userId: c.var.auth.user?.id ?? null,
                 byopClientKeyId: apiKey.byopClientKeyId ?? null,
+                byopApp: apiKey.byopClientKeyId
+                    ? {
+                          keyId: apiKey.byopClientKeyId,
+                          name: apiKey.byopClientName ?? null,
+                          user: apiKey.byopClientUserId
+                              ? { id: apiKey.byopClientUserId }
+                              : null,
+                      }
+                    : null,
             });
         },
     )

--- a/enter.pollinations.ai/test/account-key.test.ts
+++ b/enter.pollinations.ai/test/account-key.test.ts
@@ -26,212 +26,250 @@ test("GET /api/account/key - returns 401 with invalid API key", async () => {
     expect(text).toBeTruthy();
 });
 
-test(
-    "GET /api/account/key - returns key status for secret key",
-    { timeout: 30000 },
-    async ({ apiKey, mocks }) => {
-        await mocks.enable("tinybird");
+test("GET /api/account/key - returns key status for secret key", {
+    timeout: 30000,
+}, async ({ apiKey, mocks }) => {
+    await mocks.enable("tinybird");
 
-        const response = await SELF.fetch(`http://localhost:3000${endpoint}`, {
-            headers: {
-                Authorization: `Bearer ${apiKey}`,
+    const response = await SELF.fetch(`http://localhost:3000${endpoint}`, {
+        headers: {
+            Authorization: `Bearer ${apiKey}`,
+        },
+    });
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.valid).toBe(true);
+    expect(data.type).toBe("secret");
+    expect(data.name).toBeTruthy();
+    expect(data).toHaveProperty("expiresAt");
+    expect(data).toHaveProperty("expiresIn");
+    expect(data).toHaveProperty("permissions");
+    expect(data).toHaveProperty("pollenBudget");
+    expect(data).toHaveProperty("rateLimitEnabled");
+    expect(data.byopApp).toBeNull();
+});
+
+test("GET /api/account/key - accepts an agent run token", {
+    timeout: 30000,
+}, async ({ apiKey, mocks }) => {
+    await mocks.enable("tinybird");
+    const parent = await authenticateApiKeyRequest({
+        request: new Request("http://localhost", {
+            headers: { Authorization: `Bearer ${apiKey}` },
+        }),
+        env,
+    });
+    expect(parent?.user?.id).toBeTruthy();
+
+    const runToken = await signAgentRunToken({
+        secret: env.BETTER_AUTH_SECRET,
+        parentApiKeyId: parent?.apiKey.id as string,
+        runId: crypto.randomUUID(),
+    });
+    const response = await SELF.fetch(`http://localhost:3000${endpoint}`, {
+        headers: { Authorization: `Bearer ${runToken}` },
+    });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data).toMatchObject({
+        valid: true,
+        type: "secret",
+        userId: parent?.user?.id,
+        byopClientKeyId: parent?.apiKey.byopClientKeyId ?? null,
+    });
+    // A run token never carries account scope, only generation access.
+    expect(data.permissions.account).toBeNull();
+});
+
+test("GET /api/account/key - returns key status for publishable key", {
+    timeout: 30000,
+}, async ({ pubApiKey, mocks }) => {
+    await mocks.enable("tinybird");
+
+    const response = await SELF.fetch(`http://localhost:3000${endpoint}`, {
+        headers: {
+            Authorization: `Bearer ${pubApiKey}`,
+        },
+    });
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.valid).toBe(true);
+    expect(data.type).toBe("publishable");
+    expect(data.rateLimitEnabled).toBe(true);
+});
+
+test("GET /api/account/key - shows permissions for restricted key", {
+    timeout: 30000,
+}, async ({ restrictedApiKey, mocks }) => {
+    await mocks.enable("tinybird");
+
+    const response = await SELF.fetch(`http://localhost:3000${endpoint}`, {
+        headers: {
+            Authorization: `Bearer ${restrictedApiKey}`,
+        },
+    });
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.permissions).toBeDefined();
+    expect(data.permissions.models).toEqual(["openai-fast", "flux"]);
+});
+
+test("GET /api/account/key - omits retired models from permissions", {
+    timeout: 30000,
+}, async ({ sessionToken, mocks }) => {
+    await mocks.enable("tinybird");
+    const created = await createApiKeyViaApi(sessionToken, {
+        name: "current-key-with-retired-model",
+        allowedModels: ["openai-fast", "retired-model"],
+    });
+
+    const response = await SELF.fetch(`http://localhost:3000${endpoint}`, {
+        headers: {
+            Authorization: `Bearer ${created.key}`,
+        },
+    });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.permissions.models).toEqual(["openai-fast"]);
+});
+
+test("GET /api/account/key - shows pollenBudget for budgeted key", {
+    timeout: 30000,
+}, async ({ budgetedApiKey, mocks }) => {
+    await mocks.enable("tinybird");
+
+    const response = await SELF.fetch(`http://localhost:3000${endpoint}`, {
+        headers: {
+            Authorization: `Bearer ${budgetedApiKey.key}`,
+        },
+    });
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.pollenBudget).toBeDefined();
+    expect(typeof data.pollenBudget).toBe("number");
+    expect(data.pollenBudget).toBe(100); // Initial budget from fixture
+});
+
+test("GET /api/account/key - works with query parameter", {
+    timeout: 30000,
+}, async ({ apiKey, mocks }) => {
+    await mocks.enable("tinybird");
+
+    const response = await SELF.fetch(
+        `http://localhost:3000${endpoint}?key=${apiKey}`,
+    );
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.valid).toBe(true);
+});
+
+test("GET /api/account/key - calculates expiresIn correctly", {
+    timeout: 30000,
+}, async ({ apiKey, mocks }) => {
+    await mocks.enable("tinybird");
+
+    const response = await SELF.fetch(`http://localhost:3000${endpoint}`, {
+        headers: {
+            Authorization: `Bearer ${apiKey}`,
+        },
+    });
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    if (data.expiresAt) {
+        expect(data.expiresIn).toBeDefined();
+        expect(typeof data.expiresIn).toBe("number");
+
+        // Verify expiresIn is calculated correctly
+        const expiresAtMs = new Date(data.expiresAt).getTime();
+        const nowMs = Date.now();
+        const expectedExpiresIn = Math.floor((expiresAtMs - nowMs) / 1000);
+
+        // Allow for some time drift during test execution (5 seconds)
+        expect(Math.abs(data.expiresIn - expectedExpiresIn)).toBeLessThan(5);
+    }
+});
+
+test("GET /api/account/key - returns null for keys without expiry", {
+    timeout: 30000,
+}, async ({ apiKey, mocks }) => {
+    await mocks.enable("tinybird");
+
+    const response = await SELF.fetch(`http://localhost:3000${endpoint}`, {
+        headers: {
+            Authorization: `Bearer ${apiKey}`,
+        },
+    });
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    // Most test keys don't have expiry set
+    if (!data.expiresAt) {
+        expect(data.expiresAt).toBeNull();
+        expect(data.expiresIn).toBeNull();
+    }
+});
+
+test("GET /api/account/key - returns BYOP app attribution for keys minted through BYOP", {
+    timeout: 30000,
+}, async ({ sessionToken, mocks }) => {
+    await mocks.enable("tinybird");
+
+    const appResponse = await SELF.fetch("http://localhost:3000/api/api-keys", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            Cookie: `better-auth.session_token=${sessionToken}`,
+        },
+        body: JSON.stringify({
+            name: "test-byop-app",
+            type: "publishable",
+            metadata: {
+                redirectUris: ["https://byop.example/callback"],
             },
-        });
-        expect(response.status).toBe(200);
+        }),
+    });
+    expect(appResponse.status).toBe(200);
+    const appKey = await appResponse.json();
 
-        const data = await response.json();
-        expect(data.valid).toBe(true);
-        expect(data.type).toBe("secret");
-        expect(data.name).toBeTruthy();
-        expect(data).toHaveProperty("expiresAt");
-        expect(data).toHaveProperty("expiresIn");
-        expect(data).toHaveProperty("permissions");
-        expect(data).toHaveProperty("pollenBudget");
-        expect(data).toHaveProperty("rateLimitEnabled");
-    },
-);
-
-test(
-    "GET /api/account/key - accepts an agent run token",
-    { timeout: 30000 },
-    async ({ apiKey, mocks }) => {
-        await mocks.enable("tinybird");
-        const parent = await authenticateApiKeyRequest({
-            request: new Request("http://localhost", {
-                headers: { Authorization: `Bearer ${apiKey}` },
-            }),
-            env,
-        });
-        expect(parent?.user?.id).toBeTruthy();
-
-        const runToken = await signAgentRunToken({
-            secret: env.BETTER_AUTH_SECRET,
-            parentApiKeyId: parent?.apiKey.id as string,
-            runId: crypto.randomUUID(),
-        });
-        const response = await SELF.fetch(`http://localhost:3000${endpoint}`, {
-            headers: { Authorization: `Bearer ${runToken}` },
-        });
-
-        expect(response.status).toBe(200);
-        const data = await response.json();
-        expect(data).toMatchObject({
-            valid: true,
+    const keyResponse = await SELF.fetch("http://localhost:3000/api/api-keys", {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            Cookie: `better-auth.session_token=${sessionToken}`,
+        },
+        body: JSON.stringify({
+            name: "minted-byop-key",
             type: "secret",
-            userId: parent?.user?.id,
-            byopClientKeyId: parent?.apiKey.byopClientKeyId ?? null,
-        });
-        // A run token never carries account scope, only generation access.
-        expect(data.permissions.account).toBeNull();
-    },
-);
-
-test(
-    "GET /api/account/key - returns key status for publishable key",
-    { timeout: 30000 },
-    async ({ pubApiKey, mocks }) => {
-        await mocks.enable("tinybird");
-
-        const response = await SELF.fetch(`http://localhost:3000${endpoint}`, {
-            headers: {
-                Authorization: `Bearer ${pubApiKey}`,
+            metadata: {
+                requestedClientId: appKey.key,
+                redirectUri: "https://byop.example/callback",
             },
-        });
-        expect(response.status).toBe(200);
+        }),
+    });
+    expect(keyResponse.status).toBe(200);
+    const mintedKey = await keyResponse.json();
 
-        const data = await response.json();
-        expect(data.valid).toBe(true);
-        expect(data.type).toBe("publishable");
-        expect(data.rateLimitEnabled).toBe(true);
-    },
-);
+    const response = await SELF.fetch(`http://localhost:3000${endpoint}`, {
+        headers: {
+            Authorization: `Bearer ${mintedKey.key}`,
+        },
+    });
+    expect(response.status).toBe(200);
 
-test(
-    "GET /api/account/key - shows permissions for restricted key",
-    { timeout: 30000 },
-    async ({ restrictedApiKey, mocks }) => {
-        await mocks.enable("tinybird");
-
-        const response = await SELF.fetch(`http://localhost:3000${endpoint}`, {
-            headers: {
-                Authorization: `Bearer ${restrictedApiKey}`,
-            },
-        });
-        expect(response.status).toBe(200);
-
-        const data = await response.json();
-        expect(data.permissions).toBeDefined();
-        expect(data.permissions.models).toEqual(["openai-fast", "flux"]);
-    },
-);
-
-test(
-    "GET /api/account/key - omits retired models from permissions",
-    { timeout: 30000 },
-    async ({ sessionToken, mocks }) => {
-        await mocks.enable("tinybird");
-        const created = await createApiKeyViaApi(sessionToken, {
-            name: "current-key-with-retired-model",
-            allowedModels: ["openai-fast", "retired-model"],
-        });
-
-        const response = await SELF.fetch(`http://localhost:3000${endpoint}`, {
-            headers: {
-                Authorization: `Bearer ${created.key}`,
-            },
-        });
-
-        expect(response.status).toBe(200);
-        const data = await response.json();
-        expect(data.permissions.models).toEqual(["openai-fast"]);
-    },
-);
-
-test(
-    "GET /api/account/key - shows pollenBudget for budgeted key",
-    { timeout: 30000 },
-    async ({ budgetedApiKey, mocks }) => {
-        await mocks.enable("tinybird");
-
-        const response = await SELF.fetch(`http://localhost:3000${endpoint}`, {
-            headers: {
-                Authorization: `Bearer ${budgetedApiKey.key}`,
-            },
-        });
-        expect(response.status).toBe(200);
-
-        const data = await response.json();
-        expect(data.pollenBudget).toBeDefined();
-        expect(typeof data.pollenBudget).toBe("number");
-        expect(data.pollenBudget).toBe(100); // Initial budget from fixture
-    },
-);
-
-test(
-    "GET /api/account/key - works with query parameter",
-    { timeout: 30000 },
-    async ({ apiKey, mocks }) => {
-        await mocks.enable("tinybird");
-
-        const response = await SELF.fetch(
-            `http://localhost:3000${endpoint}?key=${apiKey}`,
-        );
-        expect(response.status).toBe(200);
-
-        const data = await response.json();
-        expect(data.valid).toBe(true);
-    },
-);
-
-test(
-    "GET /api/account/key - calculates expiresIn correctly",
-    { timeout: 30000 },
-    async ({ apiKey, mocks }) => {
-        await mocks.enable("tinybird");
-
-        const response = await SELF.fetch(`http://localhost:3000${endpoint}`, {
-            headers: {
-                Authorization: `Bearer ${apiKey}`,
-            },
-        });
-        expect(response.status).toBe(200);
-
-        const data = await response.json();
-        if (data.expiresAt) {
-            expect(data.expiresIn).toBeDefined();
-            expect(typeof data.expiresIn).toBe("number");
-
-            // Verify expiresIn is calculated correctly
-            const expiresAtMs = new Date(data.expiresAt).getTime();
-            const nowMs = Date.now();
-            const expectedExpiresIn = Math.floor((expiresAtMs - nowMs) / 1000);
-
-            // Allow for some time drift during test execution (5 seconds)
-            expect(Math.abs(data.expiresIn - expectedExpiresIn)).toBeLessThan(
-                5,
-            );
-        }
-    },
-);
-
-test(
-    "GET /api/account/key - returns null for keys without expiry",
-    { timeout: 30000 },
-    async ({ apiKey, mocks }) => {
-        await mocks.enable("tinybird");
-
-        const response = await SELF.fetch(`http://localhost:3000${endpoint}`, {
-            headers: {
-                Authorization: `Bearer ${apiKey}`,
-            },
-        });
-        expect(response.status).toBe(200);
-
-        const data = await response.json();
-        // Most test keys don't have expiry set
-        if (!data.expiresAt) {
-            expect(data.expiresAt).toBeNull();
-            expect(data.expiresIn).toBeNull();
-        }
-    },
-);
+    const data = await response.json();
+    expect(data.valid).toBe(true);
+    expect(data.byopClientKeyId).toBe(appKey.id);
+    expect(data.byopApp).toEqual({
+        keyId: appKey.id,
+        name: "test-byop-app",
+        user: { id: expect.any(String) },
+    });
+});

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -691,6 +691,13 @@ export interface KeyInfo {
     };
     pollenBudget?: number | null;
     rateLimitEnabled?: boolean;
+    userId?: string | null;
+    byopClientKeyId?: string | null;
+    byopApp?: {
+        keyId: string;
+        name: string | null;
+        user: { id: string } | null;
+    } | null;
 }
 
 /** Detailed key record returned by GET /account/keys (list) */


### PR DESCRIPTION
Added BYOP app attribution to GET /account/key for keys minted through BYOP.
Includes public app key id, app name, and app user identity (user object).
Keeps non-BYOP keys simple with byopApp: null and reuses auth middleware fields.

PR created by @NamanSoni78
This PR is for Closer of issue "Ship bounty #10733: Expose BYOP app details from /account/key"
Thank You Pollination 😁