### PR TITLE
refactor: one transcription formatter, and no invented subtitles

### DIFF
--- a/gen.pollinations.ai/src/audio/communityEndpoint.ts
+++ b/gen.pollinations.ai/src/audio/communityEndpoint.ts
@@ -17,13 +17,8 @@ import {
     buildTranscriptionResponse,
     type NormalizedSegment,
     type NormalizedWord,
+    UNDIARIZED_TRANSCRIPTION_RESPONSE_FORMATS,
 } from "../routes/transcription-response.ts";
-
-const COMMUNITY_TRANSCRIPTION_RESPONSE_FORMATS = [
-    "json",
-    "text",
-    "verbose_json",
-] as const;
 
 export type CommunityTranscriptionOptions = {
     file: File;
@@ -50,7 +45,7 @@ export async function callCommunityTranscriptionEndpoint(
     assertTranscriptionResponseFormat(
         responseFormat,
         endpoint.modelId,
-        COMMUNITY_TRANSCRIPTION_RESPONSE_FORMATS,
+        UNDIARIZED_TRANSCRIPTION_RESPONSE_FORMATS,
     );
 
     const bearerToken = await decryptSecret(

--- a/gen.pollinations.ai/src/routes/assemblyai-transcription.ts
+++ b/gen.pollinations.ai/src/routes/assemblyai-transcription.ts
@@ -6,10 +6,22 @@ import {
 } from "@shared/registry/usage-headers.ts";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import {
+    assertTranscriptionResponseFormat,
     buildTranscriptionResponse,
     type NormalizedDiarizedSegment,
     type NormalizedWord,
+    TRANSCRIPTION_RESPONSE_FORMATS,
 } from "./transcription-response.ts";
+
+/**
+ * AssemblyAI serves srt/vtt from its own rendered subtitle endpoint, so it
+ * supports the two formats the shared formatter cannot.
+ */
+const ASSEMBLYAI_RESPONSE_FORMATS = [
+    ...TRANSCRIPTION_RESPONSE_FORMATS,
+    "srt",
+    "vtt",
+] as const;
 
 const ASSEMBLYAI_API_BASE = "https://api.assemblyai.com";
 const ASSEMBLYAI_POLL_INTERVAL_MS = 2_000;
@@ -78,20 +90,11 @@ export async function transcribeWithAssemblyAi(opts: {
         });
     }
 
-    if (
-        ![
-            "json",
-            "text",
-            "verbose_json",
-            "srt",
-            "vtt",
-            "diarized_json",
-        ].includes(responseFormat)
-    ) {
-        throw new UpstreamError(400 as ContentfulStatusCode, {
-            message: `Unsupported response_format for AssemblyAI model: ${responseFormat}. Supported: json, text, verbose_json, srt, vtt, diarized_json`,
-        });
-    }
+    assertTranscriptionResponseFormat(
+        responseFormat,
+        "AssemblyAI model",
+        ASSEMBLYAI_RESPONSE_FORMATS,
+    );
     if (
         temperature !== undefined &&
         (!Number.isFinite(temperature) || temperature < 0 || temperature > 1)

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -51,6 +51,9 @@ import {
     assertTranscriptionResponseFormat,
     buildTranscriptionResponse,
     type NormalizedDiarizedSegment,
+    type NormalizedSegment,
+    type NormalizedWord,
+    UNDIARIZED_TRANSCRIPTION_RESPONSE_FORMATS,
 } from "./transcription-response.ts";
 
 const CreateSpeechRequestSchema = z
@@ -2785,7 +2788,7 @@ export async function handleTranscription(c: AudioContext): Promise<Response> {
         assertTranscriptionResponseFormat(
             responseFormat,
             "whisper model",
-            WHISPER_RESPONSE_FORMATS,
+            UNDIARIZED_TRANSCRIPTION_RESPONSE_FORMATS,
         );
 
         const whisperFormData = new FormData();
@@ -2821,12 +2824,23 @@ export async function handleTranscription(c: AudioContext): Promise<Response> {
             candidate.id,
             createAudioSecondsUsage(billedSeconds),
         );
-        return formatWhisperResponse(
-            whisper,
-            responseFormat,
+        return buildTranscriptionResponse({
+            normalized: {
+                text: whisper.text,
+                language: whisper.language || undefined,
+                // The billed seconds are the input-audio duration, which is
+                // what OpenAI's top-level duration means; keeping them one
+                // number makes body and usage headers agree.
+                duration: billedSeconds,
+                words: whisper.words ?? [],
+                segments: whisper.segments ?? [],
+                // OVH is not asked to diarize, so diarized_json is rejected
+                // by the undiarized format set rather than answered empty.
+                diarizedSegments: [],
+            },
+            responseFormat: responseFormat ?? "json",
             usageHeaders,
-            billedSeconds,
-        );
+        });
     });
     c.var.track.overrideResponseTracking(result.clone());
     return result;
@@ -3373,25 +3387,13 @@ export function parsePositiveInt(
     return n;
 }
 
-interface WhisperSegment {
-    start: number;
-    end: number;
-    text: string;
-}
-
 interface WhisperVerboseJson {
     text: string;
+    language?: string;
     usage?: { seconds?: number };
-    segments?: WhisperSegment[];
+    words?: NormalizedWord[];
+    segments?: NormalizedSegment[];
 }
-
-const WHISPER_RESPONSE_FORMATS = [
-    "json",
-    "text",
-    "verbose_json",
-    "srt",
-    "vtt",
-] as const;
 
 function extractWhisperUsage(json: WhisperVerboseJson, log: Logger): number {
     const seconds = json.usage?.seconds;
@@ -3402,72 +3404,4 @@ function extractWhisperUsage(json: WhisperVerboseJson, log: Logger): number {
     }
     log.debug("Whisper usage: {seconds}s", { seconds });
     return seconds;
-}
-
-/** Format SRT/VTT timestamps from seconds. SRT uses a comma, VTT a dot. */
-function formatTimestamp(seconds: number, sep: "," | "."): string {
-    const ms = Math.round(seconds * 1000);
-    const h = String(Math.floor(ms / 3_600_000)).padStart(2, "0");
-    const m = String(Math.floor((ms % 3_600_000) / 60_000)).padStart(2, "0");
-    const s = String(Math.floor((ms % 60_000) / 1000)).padStart(2, "0");
-    const msPart = String(ms % 1000).padStart(3, "0");
-    return `${h}:${m}:${s}${sep}${msPart}`;
-}
-
-function toSubtitles(segments: WhisperSegment[], kind: "srt" | "vtt"): string {
-    const sep = kind === "srt" ? "," : ".";
-    const cues = segments.map((seg, i) => {
-        const time = `${formatTimestamp(seg.start, sep)} --> ${formatTimestamp(seg.end, sep)}`;
-        const head = kind === "srt" ? `${i + 1}\n` : "";
-        return `${head}${time}\n${seg.text.trim()}`;
-    });
-    return kind === "vtt"
-        ? `WEBVTT\n\n${cues.join("\n\n")}\n`
-        : `${cues.join("\n\n")}\n`;
-}
-
-/**
- * Reformat OVH's verbose_json into the caller's requested response_format.
- * Mirrors the ElevenLabs scribe path so behaviour is consistent across backends.
- */
-export function formatWhisperResponse(
-    json: WhisperVerboseJson,
-    responseFormat: string | null,
-    usageHeaders: Record<string, string>,
-    billedSeconds: number,
-): Response {
-    assertTranscriptionResponseFormat(
-        responseFormat,
-        "whisper model",
-        WHISPER_RESPONSE_FORMATS,
-    );
-    // OVH reports a bare { seconds }; re-emit it in OpenAI's duration shape so
-    // whisper matches what buildTranscriptionResponse gives the other models.
-    const usage = { type: "duration" as const, seconds: billedSeconds };
-
-    if (responseFormat === "text") {
-        return new Response(json.text, {
-            headers: {
-                "Content-Type": "text/plain; charset=utf-8",
-                ...usageHeaders,
-            },
-        });
-    }
-
-    if (responseFormat === "srt" || responseFormat === "vtt") {
-        return new Response(toSubtitles(json.segments ?? [], responseFormat), {
-            headers: {
-                "Content-Type": "text/plain; charset=utf-8",
-                ...usageHeaders,
-            },
-        });
-    }
-
-    if (responseFormat === "verbose_json") {
-        const { usage: _ovhUsage, ...rest } = json;
-        return Response.json({ ...rest, usage }, { headers: usageHeaders });
-    }
-
-    // Default: json
-    return Response.json({ text: json.text, usage }, { headers: usageHeaders });
 }

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -3304,7 +3304,7 @@ export const audioRoutes = new Hono<Env>()
                                     ],
                                     default: "json",
                                     description:
-                                        "The format of the transcript output. Use `diarized_json` for OpenAI-compatible speaker segments on diarization-capable models.",
+                                        "The format of the transcript output. Support is model-dependent: `srt` and `vtt` require a model that renders subtitles, and `diarized_json` a diarization-capable one. Unsupported combinations return 400 naming the formats that model accepts.",
                                 },
                                 temperature: {
                                     type: "number",

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -2828,13 +2828,11 @@ export async function handleTranscription(c: AudioContext): Promise<Response> {
             normalized: {
                 text: whisper.text,
                 language: whisper.language || undefined,
-                // OVH rounds usage.seconds up to whole seconds, so it is
-                // not the audio length: a 0.9s file reports duration 0.904625
-                // and bills 1. Report the real length and charge the rounded
-                // one, which is what this route did before it shared the
-                // formatter.
-                duration: whisper.duration ?? billedSeconds,
-                billedSeconds,
+                // OVH rounds usage.seconds up to a whole second, so this
+                // can exceed the audio length by under a second. Reporting
+                // the billed figure keeps duration, usage and the usage
+                // headers on one number.
+                duration: billedSeconds,
                 words: whisper.words ?? [],
                 segments: whisper.segments ?? [],
                 // OVH is not asked to diarize, so diarized_json is rejected
@@ -3393,7 +3391,6 @@ export function parsePositiveInt(
 interface WhisperVerboseJson {
     text: string;
     language?: string;
-    duration?: number;
     usage?: { seconds?: number };
     words?: NormalizedWord[];
     segments?: NormalizedSegment[];

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -2828,10 +2828,13 @@ export async function handleTranscription(c: AudioContext): Promise<Response> {
             normalized: {
                 text: whisper.text,
                 language: whisper.language || undefined,
-                // The billed seconds are the input-audio duration, which is
-                // what OpenAI's top-level duration means; keeping them one
-                // number makes body and usage headers agree.
-                duration: billedSeconds,
+                // OVH rounds usage.seconds up to whole seconds, so it is
+                // not the audio length: a 0.9s file reports duration 0.904625
+                // and bills 1. Report the real length and charge the rounded
+                // one, which is what this route did before it shared the
+                // formatter.
+                duration: whisper.duration ?? billedSeconds,
+                billedSeconds,
                 words: whisper.words ?? [],
                 segments: whisper.segments ?? [],
                 // OVH is not asked to diarize, so diarized_json is rejected
@@ -3390,6 +3393,7 @@ export function parsePositiveInt(
 interface WhisperVerboseJson {
     text: string;
     language?: string;
+    duration?: number;
     usage?: { seconds?: number };
     words?: NormalizedWord[];
     segments?: NormalizedSegment[];

--- a/gen.pollinations.ai/src/routes/transcription-response.ts
+++ b/gen.pollinations.ai/src/routes/transcription-response.ts
@@ -75,14 +75,8 @@ export interface NormalizedTranscript {
     text: string;
     /** ISO-639-1 language code, or undefined if unknown. */
     language?: string;
-    /** Duration of the input audio in seconds. */
+    /** Duration in seconds. */
     duration: number;
-    /**
-     * Seconds billed, when the provider meters something other than the audio
-     * length: OVH whisper rounds up to whole seconds, so a 0.9s file bills 1.
-     * Defaults to duration, which is what every other provider bills.
-     */
-    billedSeconds?: number;
     words: NormalizedWord[];
     /**
      * Timed segments as reported upstream, empty when the provider reports
@@ -118,13 +112,10 @@ export function buildTranscriptionResponse(opts: {
 }): Response {
     const { normalized, responseFormat, usageHeaders } = opts;
     const { text, duration } = normalized;
-    // duration is the input audio; usage.seconds is what we charged for it.
-    // They are the same number unless the provider meters differently, and
-    // usage.seconds is the one that has to match the usage headers.
-    const usage = {
-        type: "duration" as const,
-        seconds: normalized.billedSeconds ?? duration,
-    };
+    // OpenAI defines usage.seconds and the top-level duration as the same
+    // quantity — "duration of the input audio" — so they are one number here.
+    // That is also what we bill, so the body and the usage headers agree.
+    const usage = { type: "duration" as const, seconds: duration };
 
     if (responseFormat === "text") {
         return new Response(text, {

--- a/gen.pollinations.ai/src/routes/transcription-response.ts
+++ b/gen.pollinations.ai/src/routes/transcription-response.ts
@@ -4,25 +4,31 @@ import type { ContentfulStatusCode } from "hono/utils/http-status";
 /**
  * Shared OpenAI-compatible transcription-response formatter.
  *
- * Providers (ElevenLabs Scribe, AssemblyAI, xAI) each normalize their upstream
- * payload into the seconds-based `NormalizedTranscript` intermediate below
- * — keeping their own grouping and unit conversion — then call
- * `buildTranscriptionResponse` to emit the four response branches
- * (text / verbose_json / diarized_json / json) identically.
+ * Providers (whisper, ElevenLabs Scribe, AssemblyAI, xAI, community
+ * endpoints) each normalize their upstream payload into the seconds-based
+ * `NormalizedTranscript` intermediate below — keeping their own grouping and
+ * unit conversion — then call `buildTranscriptionResponse` to emit every
+ * response branch identically.
  */
 
-/**
- * The formats `buildTranscriptionResponse` can emit. `srt`/`vtt` are absent
- * because building cues needs per-segment timings, which the normalized
- * intermediate does not carry — providers that support them (whisper,
- * AssemblyAI) handle those formats themselves.
- */
+/** The formats `buildTranscriptionResponse` can emit. */
 export const TRANSCRIPTION_RESPONSE_FORMATS = [
     "json",
     "text",
     "verbose_json",
     "diarized_json",
+    "srt",
+    "vtt",
 ] as const;
+
+/**
+ * For providers we never ask to diarize. diarized_json needs real speaker
+ * segments, so offering it would mean answering with an empty list.
+ */
+export const UNDIARIZED_TRANSCRIPTION_RESPONSE_FORMATS =
+    TRANSCRIPTION_RESPONSE_FORMATS.filter(
+        (format) => format !== "diarized_json",
+    );
 
 /**
  * No-op when the caller did not ask for a format; the default is json.
@@ -96,6 +102,107 @@ function toOpenAiDiarizedSegments(segments: NormalizedDiarizedSegment[]): {
     }));
 }
 
+/**
+ * OpenAI's TranscriptionSegment. Every field is required in the published
+ * type — openai-python builds a pydantic model from exactly these — so a
+ * partial segment makes a typed client raise rather than degrade. None of our
+ * providers report the decoder statistics, which therefore carry neutral
+ * placeholders: absent data, not measurements.
+ */
+interface OpenAiSegment {
+    id: number;
+    seek: number;
+    start: number;
+    end: number;
+    text: string;
+    tokens: number[];
+    temperature: number;
+    avg_logprob: number;
+    compression_ratio: number;
+    no_speech_prob: number;
+}
+
+/** Cue bounds for derived segments, following common subtitle practice. */
+const MAX_CUE_SECONDS = 7;
+const MAX_CUE_CHARS = 84;
+
+/**
+ * Group word timings into cues, breaking at sentence ends and capping length
+ * so an unpunctuated run still splits. Only used when the provider reports no
+ * segments of its own — OVH whisper answers `segments: []` even though it
+ * returns per-word timings, which is why asking it for subtitles used to
+ * produce an empty file.
+ */
+function deriveSegments(words: NormalizedWord[]): NormalizedSegment[] {
+    const segments: NormalizedSegment[] = [];
+    let start: number | null = null;
+    let parts: string[] = [];
+    words.forEach((word, index) => {
+        const token = word.word.trim();
+        if (!token) return;
+        if (start === null) start = word.start;
+        parts.push(token);
+        const text = parts.join(" ");
+        const isLast = index === words.length - 1;
+        const endsSentence = /[.!?。？！]["'\u201d\u2019)\]]?$/.test(token);
+        const isFull =
+            word.end - start >= MAX_CUE_SECONDS || text.length >= MAX_CUE_CHARS;
+        if (isLast || endsSentence || isFull) {
+            segments.push({ start, end: word.end, text });
+            start = null;
+            parts = [];
+        }
+    });
+    return segments;
+}
+
+function toOpenAiSegments(normalized: NormalizedTranscript): OpenAiSegment[] {
+    const timed = normalized.segments.length
+        ? normalized.segments
+        : deriveSegments(normalized.words);
+    // Nothing timed anywhere: one cue spanning the file, which is coarse but
+    // honest. Silence has no speech to caption, so it stays empty.
+    const source: NormalizedSegment[] = timed.length
+        ? timed
+        : normalized.text.trim()
+          ? [{ start: 0, end: normalized.duration, text: normalized.text }]
+          : [];
+    return source.map((segment, index) => ({
+        id: index,
+        seek: 0,
+        start: segment.start,
+        end: segment.end,
+        text: segment.text,
+        tokens: [],
+        temperature: 0,
+        avg_logprob: 0,
+        compression_ratio: 0,
+        no_speech_prob: 0,
+    }));
+}
+
+/** Format SRT/VTT timestamps from seconds. SRT uses a comma, VTT a dot. */
+function formatTimestamp(seconds: number, sep: "," | "."): string {
+    const ms = Math.round(seconds * 1000);
+    const h = String(Math.floor(ms / 3_600_000)).padStart(2, "0");
+    const m = String(Math.floor((ms % 3_600_000) / 60_000)).padStart(2, "0");
+    const s = String(Math.floor((ms % 60_000) / 1000)).padStart(2, "0");
+    const msPart = String(ms % 1000).padStart(3, "0");
+    return `${h}:${m}:${s}${sep}${msPart}`;
+}
+
+function toSubtitles(segments: OpenAiSegment[], kind: "srt" | "vtt"): string {
+    const sep = kind === "srt" ? "," : ".";
+    const cues = segments.map((seg, i) => {
+        const time = `${formatTimestamp(seg.start, sep)} --> ${formatTimestamp(seg.end, sep)}`;
+        const head = kind === "srt" ? `${i + 1}\n` : "";
+        return `${head}${time}\n${seg.text.trim()}`;
+    });
+    return kind === "vtt"
+        ? `WEBVTT\n\n${cues.join("\n\n")}\n`
+        : `${cues.join("\n\n")}\n`;
+}
+
 export function buildTranscriptionResponse(opts: {
     normalized: NormalizedTranscript;
     responseFormat: string;
@@ -124,24 +231,7 @@ export function buildTranscriptionResponse(opts: {
             language: normalized.language || "unknown",
             duration,
             words: normalized.words,
-            // Prefer what the provider measured. Inventing one file-spanning
-            // segment when it already sent real ones would hand the caller
-            // worse timings than the upstream produced.
-            segments: normalized.segments.length
-                ? normalized.segments.map((segment, index) => ({
-                      id: index,
-                      start: segment.start,
-                      end: segment.end,
-                      text: segment.text,
-                  }))
-                : [
-                      {
-                          id: 0,
-                          start: 0,
-                          end: duration,
-                          text,
-                      },
-                  ],
+            segments: toOpenAiSegments(normalized),
             usage,
         };
         return Response.json(body, { headers: usageHeaders });
@@ -157,6 +247,18 @@ export function buildTranscriptionResponse(opts: {
                 usage,
             },
             { headers: usageHeaders },
+        );
+    }
+
+    if (responseFormat === "srt" || responseFormat === "vtt") {
+        return new Response(
+            toSubtitles(toOpenAiSegments(normalized), responseFormat),
+            {
+                headers: {
+                    "Content-Type": "text/plain; charset=utf-8",
+                    ...usageHeaders,
+                },
+            },
         );
     }
 

--- a/gen.pollinations.ai/src/routes/transcription-response.ts
+++ b/gen.pollinations.ai/src/routes/transcription-response.ts
@@ -11,14 +11,17 @@ import type { ContentfulStatusCode } from "hono/utils/http-status";
  * response branch identically.
  */
 
-/** The formats `buildTranscriptionResponse` can emit. */
+/**
+ * The formats `buildTranscriptionResponse` can emit. srt/vtt are absent: cues
+ * need real segment boundaries and none of these providers report them, so a
+ * subtitle track here could only be invented. AssemblyAI serves those two
+ * formats from its own rendered subtitles instead.
+ */
 export const TRANSCRIPTION_RESPONSE_FORMATS = [
     "json",
     "text",
     "verbose_json",
     "diarized_json",
-    "srt",
-    "vtt",
 ] as const;
 
 /**
@@ -122,48 +125,11 @@ interface OpenAiSegment {
     no_speech_prob: number;
 }
 
-/** Cue bounds for derived segments, following common subtitle practice. */
-const MAX_CUE_SECONDS = 7;
-const MAX_CUE_CHARS = 84;
-
-/**
- * Group word timings into cues, breaking at sentence ends and capping length
- * so an unpunctuated run still splits. Only used when the provider reports no
- * segments of its own — OVH whisper answers `segments: []` even though it
- * returns per-word timings, which is why asking it for subtitles used to
- * produce an empty file.
- */
-function deriveSegments(words: NormalizedWord[]): NormalizedSegment[] {
-    const segments: NormalizedSegment[] = [];
-    let start: number | null = null;
-    let parts: string[] = [];
-    words.forEach((word, index) => {
-        const token = word.word.trim();
-        if (!token) return;
-        if (start === null) start = word.start;
-        parts.push(token);
-        const text = parts.join(" ");
-        const isLast = index === words.length - 1;
-        const endsSentence = /[.!?。？！]["'\u201d\u2019)\]]?$/.test(token);
-        const isFull =
-            word.end - start >= MAX_CUE_SECONDS || text.length >= MAX_CUE_CHARS;
-        if (isLast || endsSentence || isFull) {
-            segments.push({ start, end: word.end, text });
-            start = null;
-            parts = [];
-        }
-    });
-    return segments;
-}
-
 function toOpenAiSegments(normalized: NormalizedTranscript): OpenAiSegment[] {
-    const timed = normalized.segments.length
+    // One file-spanning placeholder when the provider reports no segments,
+    // and none at all for silence, which has nothing to describe.
+    const source: NormalizedSegment[] = normalized.segments.length
         ? normalized.segments
-        : deriveSegments(normalized.words);
-    // Nothing timed anywhere: one cue spanning the file, which is coarse but
-    // honest. Silence has no speech to caption, so it stays empty.
-    const source: NormalizedSegment[] = timed.length
-        ? timed
         : normalized.text.trim()
           ? [{ start: 0, end: normalized.duration, text: normalized.text }]
           : [];
@@ -179,28 +145,6 @@ function toOpenAiSegments(normalized: NormalizedTranscript): OpenAiSegment[] {
         compression_ratio: 0,
         no_speech_prob: 0,
     }));
-}
-
-/** Format SRT/VTT timestamps from seconds. SRT uses a comma, VTT a dot. */
-function formatTimestamp(seconds: number, sep: "," | "."): string {
-    const ms = Math.round(seconds * 1000);
-    const h = String(Math.floor(ms / 3_600_000)).padStart(2, "0");
-    const m = String(Math.floor((ms % 3_600_000) / 60_000)).padStart(2, "0");
-    const s = String(Math.floor((ms % 60_000) / 1000)).padStart(2, "0");
-    const msPart = String(ms % 1000).padStart(3, "0");
-    return `${h}:${m}:${s}${sep}${msPart}`;
-}
-
-function toSubtitles(segments: OpenAiSegment[], kind: "srt" | "vtt"): string {
-    const sep = kind === "srt" ? "," : ".";
-    const cues = segments.map((seg, i) => {
-        const time = `${formatTimestamp(seg.start, sep)} --> ${formatTimestamp(seg.end, sep)}`;
-        const head = kind === "srt" ? `${i + 1}\n` : "";
-        return `${head}${time}\n${seg.text.trim()}`;
-    });
-    return kind === "vtt"
-        ? `WEBVTT\n\n${cues.join("\n\n")}\n`
-        : `${cues.join("\n\n")}\n`;
 }
 
 export function buildTranscriptionResponse(opts: {
@@ -247,18 +191,6 @@ export function buildTranscriptionResponse(opts: {
                 usage,
             },
             { headers: usageHeaders },
-        );
-    }
-
-    if (responseFormat === "srt" || responseFormat === "vtt") {
-        return new Response(
-            toSubtitles(toOpenAiSegments(normalized), responseFormat),
-            {
-                headers: {
-                    "Content-Type": "text/plain; charset=utf-8",
-                    ...usageHeaders,
-                },
-            },
         );
     }
 

--- a/gen.pollinations.ai/src/routes/transcription-response.ts
+++ b/gen.pollinations.ai/src/routes/transcription-response.ts
@@ -75,8 +75,14 @@ export interface NormalizedTranscript {
     text: string;
     /** ISO-639-1 language code, or undefined if unknown. */
     language?: string;
-    /** Duration in seconds. */
+    /** Duration of the input audio in seconds. */
     duration: number;
+    /**
+     * Seconds billed, when the provider meters something other than the audio
+     * length: OVH whisper rounds up to whole seconds, so a 0.9s file bills 1.
+     * Defaults to duration, which is what every other provider bills.
+     */
+    billedSeconds?: number;
     words: NormalizedWord[];
     /**
      * Timed segments as reported upstream, empty when the provider reports
@@ -112,10 +118,13 @@ export function buildTranscriptionResponse(opts: {
 }): Response {
     const { normalized, responseFormat, usageHeaders } = opts;
     const { text, duration } = normalized;
-    // OpenAI defines usage.seconds and the top-level duration as the same
-    // quantity — "duration of the input audio" — so they are one number here.
-    // That is also what we bill, so the body and the usage headers agree.
-    const usage = { type: "duration" as const, seconds: duration };
+    // duration is the input audio; usage.seconds is what we charged for it.
+    // They are the same number unless the provider meters differently, and
+    // usage.seconds is the one that has to match the usage headers.
+    const usage = {
+        type: "duration" as const,
+        seconds: normalized.billedSeconds ?? duration,
+    };
 
     if (responseFormat === "text") {
         return new Response(text, {

--- a/gen.pollinations.ai/src/routes/transcription-response.ts
+++ b/gen.pollinations.ai/src/routes/transcription-response.ts
@@ -105,48 +105,6 @@ function toOpenAiDiarizedSegments(segments: NormalizedDiarizedSegment[]): {
     }));
 }
 
-/**
- * OpenAI's TranscriptionSegment. Every field is required in the published
- * type — openai-python builds a pydantic model from exactly these — so a
- * partial segment makes a typed client raise rather than degrade. None of our
- * providers report the decoder statistics, which therefore carry neutral
- * placeholders: absent data, not measurements.
- */
-interface OpenAiSegment {
-    id: number;
-    seek: number;
-    start: number;
-    end: number;
-    text: string;
-    tokens: number[];
-    temperature: number;
-    avg_logprob: number;
-    compression_ratio: number;
-    no_speech_prob: number;
-}
-
-function toOpenAiSegments(normalized: NormalizedTranscript): OpenAiSegment[] {
-    // One file-spanning placeholder when the provider reports no segments,
-    // and none at all for silence, which has nothing to describe.
-    const source: NormalizedSegment[] = normalized.segments.length
-        ? normalized.segments
-        : normalized.text.trim()
-          ? [{ start: 0, end: normalized.duration, text: normalized.text }]
-          : [];
-    return source.map((segment, index) => ({
-        id: index,
-        seek: 0,
-        start: segment.start,
-        end: segment.end,
-        text: segment.text,
-        tokens: [],
-        temperature: 0,
-        avg_logprob: 0,
-        compression_ratio: 0,
-        no_speech_prob: 0,
-    }));
-}
-
 export function buildTranscriptionResponse(opts: {
     normalized: NormalizedTranscript;
     responseFormat: string;
@@ -175,7 +133,24 @@ export function buildTranscriptionResponse(opts: {
             language: normalized.language || "unknown",
             duration,
             words: normalized.words,
-            segments: toOpenAiSegments(normalized),
+            // Prefer what the provider measured. Inventing one file-spanning
+            // segment when it already sent real ones would hand the caller
+            // worse timings than the upstream produced.
+            segments: normalized.segments.length
+                ? normalized.segments.map((segment, index) => ({
+                      id: index,
+                      start: segment.start,
+                      end: segment.end,
+                      text: segment.text,
+                  }))
+                : [
+                      {
+                          id: 0,
+                          start: 0,
+                          end: duration,
+                          text,
+                      },
+                  ],
             usage,
         };
         return Response.json(body, { headers: usageHeaders });

--- a/gen.pollinations.ai/test/whisper-format.test.ts
+++ b/gen.pollinations.ai/test/whisper-format.test.ts
@@ -78,93 +78,33 @@ describe("whisper through the shared transcription formatter", () => {
         ]);
     });
 
-    it("builds SRT cues from segments", async () => {
-        const res = format(WHISPER, "srt");
-        const srt = await res.text();
-        expect(res.headers.get("content-type")).toBe(
-            "text/plain; charset=utf-8",
-        );
-        expect(srt).toContain("1\n00:00:00,000 --> 00:00:01,500\nEl ciclo");
-        expect(srt).toContain("2\n00:00:01,500 --> 00:00:03,500\ndel agua");
-    });
-
-    it("builds VTT with a WEBVTT header and dot separators", async () => {
-        const res = format(WHISPER, "vtt");
-        const vtt = await res.text();
-        expect(vtt.startsWith("WEBVTT\n\n")).toBe(true);
-        expect(vtt).toContain("00:00:00.000 --> 00:00:01.500");
-    });
-
-    it("rejects unsupported Whisper response formats", () => {
-        expect(() =>
-            assertTranscriptionResponseFormat(
-                "diarized_json",
-                "whisper model",
-                UNDIARIZED_TRANSCRIPTION_RESPONSE_FORMATS,
-            ),
-        ).toThrow(
-            "Unsupported response_format for whisper model: diarized_json",
-        );
-    });
-});
-
-describe("subtitles when the provider reports no segments", () => {
-    // OVH answers segments: [] on every request while still returning word
-    // timings, which is why asking whisper for srt used to return an empty
-    // body (#13552).
-    const wordsOnly: NormalizedTranscript = {
-        text: "Hello world",
-        duration: 0.9,
-        words: [
-            { word: "Hello", start: 0, end: 0.26 },
-            { word: "world.", start: 0.26, end: 0.9 },
-        ],
-        segments: [],
-        diarizedSegments: [],
-    };
-
-    it("derives cues from word timings", async () => {
-        const srt = await format(wordsOnly, "srt").text();
-        expect(srt).toBe("1\n00:00:00,000 --> 00:00:00,900\nHello world.\n");
-    });
-
-    it("splits cues on sentence boundaries", async () => {
-        const twoSentences: NormalizedTranscript = {
-            ...wordsOnly,
-            text: "Hi there. Bye.",
-            duration: 4,
-            words: [
-                { word: "Hi", start: 0, end: 0.5 },
-                { word: "there.", start: 0.5, end: 1 },
-                { word: "Bye.", start: 3, end: 4 },
-            ],
-        };
-        const srt = await format(twoSentences, "srt").text();
-        expect(srt).toBe(
-            "1\n00:00:00,000 --> 00:00:01,000\nHi there.\n\n" +
-                "2\n00:00:03,000 --> 00:00:04,000\nBye.\n",
-        );
-    });
-
-    it("falls back to one file-spanning cue with neither segments nor words", async () => {
-        const bare: NormalizedTranscript = {
-            ...wordsOnly,
-            words: [],
-        };
-        const srt = await format(bare, "srt").text();
-        expect(srt).toBe("1\n00:00:00,000 --> 00:00:00,900\nHello world\n");
-    });
-
-    it("emits no cues for silence rather than an empty one", async () => {
+    it("describes silence with no segments rather than an empty one", async () => {
         const silent: NormalizedTranscript = {
-            ...wordsOnly,
+            ...WHISPER,
             text: "   ",
-            words: [],
+            segments: [],
         };
-        expect(await format(silent, "srt").text()).toBe("\n");
         const body = (await format(silent, "verbose_json").json()) as {
             segments: unknown[];
         };
         expect(body.segments).toEqual([]);
+    });
+
+    it.each([
+        "srt",
+        "vtt",
+        "diarized_json",
+    ])("rejects %s, which whisper cannot produce", (responseFormat) => {
+        // OVH answers segments: [] on every request, so subtitles could
+        // only be invented here; #13552 was that they came back empty.
+        expect(() =>
+            assertTranscriptionResponseFormat(
+                responseFormat,
+                "whisper model",
+                UNDIARIZED_TRANSCRIPTION_RESPONSE_FORMATS,
+            ),
+        ).toThrow(
+            `Unsupported response_format for whisper model: ${responseFormat}`,
+        );
     });
 });

--- a/gen.pollinations.ai/test/whisper-format.test.ts
+++ b/gen.pollinations.ai/test/whisper-format.test.ts
@@ -1,19 +1,40 @@
 import { describe, expect, it } from "vitest";
-import { formatWhisperResponse } from "../src/routes/audio.ts";
+import {
+    assertTranscriptionResponseFormat,
+    buildTranscriptionResponse,
+    type NormalizedTranscript,
+    UNDIARIZED_TRANSCRIPTION_RESPONSE_FORMATS,
+} from "../src/routes/transcription-response.ts";
 
-const VERBOSE = {
+/** OVH whisper, normalized the way the transcription route hands it over. */
+const WHISPER: NormalizedTranscript = {
     text: "El ciclo del agua",
-    usage: { seconds: 3.5 },
+    language: "es",
+    duration: 3.5,
+    words: [],
     segments: [
         { start: 0, end: 1.5, text: "El ciclo" },
         { start: 1.5, end: 3.5, text: " del agua" },
     ],
+    diarizedSegments: [],
 };
+
 const usageHeaders = { "x-usage-seconds": "3.5" };
 
-describe("formatWhisperResponse", () => {
+function format(
+    normalized: NormalizedTranscript,
+    responseFormat: string,
+): Response {
+    return buildTranscriptionResponse({
+        normalized,
+        responseFormat,
+        usageHeaders,
+    });
+}
+
+describe("whisper through the shared transcription formatter", () => {
     it("returns plain text for response_format=text (the #9028 bug)", async () => {
-        const res = formatWhisperResponse(VERBOSE, "text", usageHeaders, 3.5);
+        const res = format(WHISPER, "text");
         expect(res.headers.get("content-type")).toBe(
             "text/plain; charset=utf-8",
         );
@@ -22,7 +43,7 @@ describe("formatWhisperResponse", () => {
     });
 
     it("defaults to OpenAI-style { text } json", async () => {
-        const res = formatWhisperResponse(VERBOSE, null, usageHeaders, 3.5);
+        const res = format(WHISPER, "json");
         expect(res.headers.get("content-type")).toContain("application/json");
         expect(await res.json()).toEqual({
             text: "El ciclo del agua",
@@ -31,20 +52,34 @@ describe("formatWhisperResponse", () => {
     });
 
     it("re-emits OVH's bare usage in OpenAI's duration shape", async () => {
-        const res = formatWhisperResponse(
-            VERBOSE,
-            "verbose_json",
-            usageHeaders,
-            3.5,
-        );
+        const res = format(WHISPER, "verbose_json");
         const body = (await res.json()) as Record<string, unknown>;
         expect(body.usage).toEqual({ type: "duration", seconds: 3.5 });
         expect(body.text).toBe("El ciclo del agua");
         expect(body.segments).toHaveLength(2);
     });
 
+    it("fills every field OpenAI declares on a segment", async () => {
+        const res = format(WHISPER, "verbose_json");
+        const body = (await res.json()) as { segments: object[] };
+        // openai-python parses these into a pydantic model, so a segment
+        // missing any declared field makes a typed client raise.
+        expect(Object.keys(body.segments[0]).sort()).toEqual([
+            "avg_logprob",
+            "compression_ratio",
+            "end",
+            "id",
+            "no_speech_prob",
+            "seek",
+            "start",
+            "temperature",
+            "text",
+            "tokens",
+        ]);
+    });
+
     it("builds SRT cues from segments", async () => {
-        const res = formatWhisperResponse(VERBOSE, "srt", usageHeaders, 3.5);
+        const res = format(WHISPER, "srt");
         const srt = await res.text();
         expect(res.headers.get("content-type")).toBe(
             "text/plain; charset=utf-8",
@@ -54,7 +89,7 @@ describe("formatWhisperResponse", () => {
     });
 
     it("builds VTT with a WEBVTT header and dot separators", async () => {
-        const res = formatWhisperResponse(VERBOSE, "vtt", usageHeaders, 3.5);
+        const res = format(WHISPER, "vtt");
         const vtt = await res.text();
         expect(vtt.startsWith("WEBVTT\n\n")).toBe(true);
         expect(vtt).toContain("00:00:00.000 --> 00:00:01.500");
@@ -62,9 +97,74 @@ describe("formatWhisperResponse", () => {
 
     it("rejects unsupported Whisper response formats", () => {
         expect(() =>
-            formatWhisperResponse(VERBOSE, "diarized_json", usageHeaders, 3.5),
+            assertTranscriptionResponseFormat(
+                "diarized_json",
+                "whisper model",
+                UNDIARIZED_TRANSCRIPTION_RESPONSE_FORMATS,
+            ),
         ).toThrow(
             "Unsupported response_format for whisper model: diarized_json",
         );
+    });
+});
+
+describe("subtitles when the provider reports no segments", () => {
+    // OVH answers segments: [] on every request while still returning word
+    // timings, which is why asking whisper for srt used to return an empty
+    // body (#13552).
+    const wordsOnly: NormalizedTranscript = {
+        text: "Hello world",
+        duration: 0.9,
+        words: [
+            { word: "Hello", start: 0, end: 0.26 },
+            { word: "world.", start: 0.26, end: 0.9 },
+        ],
+        segments: [],
+        diarizedSegments: [],
+    };
+
+    it("derives cues from word timings", async () => {
+        const srt = await format(wordsOnly, "srt").text();
+        expect(srt).toBe("1\n00:00:00,000 --> 00:00:00,900\nHello world.\n");
+    });
+
+    it("splits cues on sentence boundaries", async () => {
+        const twoSentences: NormalizedTranscript = {
+            ...wordsOnly,
+            text: "Hi there. Bye.",
+            duration: 4,
+            words: [
+                { word: "Hi", start: 0, end: 0.5 },
+                { word: "there.", start: 0.5, end: 1 },
+                { word: "Bye.", start: 3, end: 4 },
+            ],
+        };
+        const srt = await format(twoSentences, "srt").text();
+        expect(srt).toBe(
+            "1\n00:00:00,000 --> 00:00:01,000\nHi there.\n\n" +
+                "2\n00:00:03,000 --> 00:00:04,000\nBye.\n",
+        );
+    });
+
+    it("falls back to one file-spanning cue with neither segments nor words", async () => {
+        const bare: NormalizedTranscript = {
+            ...wordsOnly,
+            words: [],
+        };
+        const srt = await format(bare, "srt").text();
+        expect(srt).toBe("1\n00:00:00,000 --> 00:00:00,900\nHello world\n");
+    });
+
+    it("emits no cues for silence rather than an empty one", async () => {
+        const silent: NormalizedTranscript = {
+            ...wordsOnly,
+            text: "   ",
+            words: [],
+        };
+        expect(await format(silent, "srt").text()).toBe("\n");
+        const body = (await format(silent, "verbose_json").json()) as {
+            segments: unknown[];
+        };
+        expect(body.segments).toEqual([]);
     });
 });

--- a/gen.pollinations.ai/test/whisper-format.test.ts
+++ b/gen.pollinations.ai/test/whisper-format.test.ts
@@ -59,6 +59,22 @@ describe("whisper through the shared transcription formatter", () => {
         expect(body.segments).toHaveLength(2);
     });
 
+    it("reports the audio length but bills the rounded seconds", async () => {
+        // OVH answers duration 0.904625 and usage.seconds 1 for the same
+        // file. duration is the input audio; usage is what we charged.
+        const rounded: NormalizedTranscript = {
+            ...WHISPER,
+            duration: 0.904625,
+            billedSeconds: 1,
+        };
+        const body = (await format(rounded, "verbose_json").json()) as {
+            duration: number;
+            usage: { seconds: number };
+        };
+        expect(body.duration).toBe(0.904625);
+        expect(body.usage.seconds).toBe(1);
+    });
+
     it("keeps a placeholder segment when the provider reports none", async () => {
         const noSegments: NormalizedTranscript = { ...WHISPER, segments: [] };
         const body = (await format(noSegments, "verbose_json").json()) as {

--- a/gen.pollinations.ai/test/whisper-format.test.ts
+++ b/gen.pollinations.ai/test/whisper-format.test.ts
@@ -59,22 +59,6 @@ describe("whisper through the shared transcription formatter", () => {
         expect(body.segments).toHaveLength(2);
     });
 
-    it("reports the audio length but bills the rounded seconds", async () => {
-        // OVH answers duration 0.904625 and usage.seconds 1 for the same
-        // file. duration is the input audio; usage is what we charged.
-        const rounded: NormalizedTranscript = {
-            ...WHISPER,
-            duration: 0.904625,
-            billedSeconds: 1,
-        };
-        const body = (await format(rounded, "verbose_json").json()) as {
-            duration: number;
-            usage: { seconds: number };
-        };
-        expect(body.duration).toBe(0.904625);
-        expect(body.usage.seconds).toBe(1);
-    });
-
     it("keeps a placeholder segment when the provider reports none", async () => {
         const noSegments: NormalizedTranscript = { ...WHISPER, segments: [] };
         const body = (await format(noSegments, "verbose_json").json()) as {

--- a/gen.pollinations.ai/test/whisper-format.test.ts
+++ b/gen.pollinations.ai/test/whisper-format.test.ts
@@ -59,35 +59,14 @@ describe("whisper through the shared transcription formatter", () => {
         expect(body.segments).toHaveLength(2);
     });
 
-    it("fills every field OpenAI declares on a segment", async () => {
-        const res = format(WHISPER, "verbose_json");
-        const body = (await res.json()) as { segments: object[] };
-        // openai-python parses these into a pydantic model, so a segment
-        // missing any declared field makes a typed client raise.
-        expect(Object.keys(body.segments[0]).sort()).toEqual([
-            "avg_logprob",
-            "compression_ratio",
-            "end",
-            "id",
-            "no_speech_prob",
-            "seek",
-            "start",
-            "temperature",
-            "text",
-            "tokens",
-        ]);
-    });
-
-    it("describes silence with no segments rather than an empty one", async () => {
-        const silent: NormalizedTranscript = {
-            ...WHISPER,
-            text: "   ",
-            segments: [],
-        };
-        const body = (await format(silent, "verbose_json").json()) as {
+    it("keeps a placeholder segment when the provider reports none", async () => {
+        const noSegments: NormalizedTranscript = { ...WHISPER, segments: [] };
+        const body = (await format(noSegments, "verbose_json").json()) as {
             segments: unknown[];
         };
-        expect(body.segments).toEqual([]);
+        expect(body.segments).toEqual([
+            { id: 0, start: 0, end: 3.5, text: "El ciclo del agua" },
+        ]);
     });
 
     it.each([


### PR DESCRIPTION
Follow-up to #13416. whisper kept its own copy of the transcription response formatter and AssemblyAI a third format validator, so fixes landed in one of three places — #13552 is what that cost.

**Src is net −58 lines. No behaviour is added; three copies become one.**

- `formatWhisperResponse` deleted; whisper normalizes like every other provider
- AssemblyAI's hand-rolled format check — an array plus a message listing the same six formats again, one edit from disagreeing — now goes through `assertTranscriptionResponseFormat`
- whisper's and the community path's allowlists were byte-identical and separately maintained; both take the shared undiarized set

**srt/vtt are removed rather than fixed.** OVH answers `segments: []` on every request, so `toSubtitles([])` emitted nothing — whisper `srt` returned 200 with a 1-byte body (verified against production). Deriving cues from word timings would have meant inventing cue length and break rules and shipping them as measurements. whisper, grok, scribe and community endpoints now return 400 naming what they do accept.

AssemblyAI keeps both formats: it renders subtitles upstream and `fetchAssemblyAiSubtitles` retrieves them, which is real data. The OpenAPI description now says format support is model-dependent.

**Also dropped:** whisper's raw-body passthrough, which carried `success: true`, `diarization: []` and those empty segments — no OpenAI fields among them.

Two things deliberately not done, both measured first:

- Segment payloads are unchanged from main. An earlier revision padded them to OpenAI's ten declared fields, justified by `openai-python` rejecting a partial segment — it does not. The client parses with `construct_type`, which skips validation, so absent fields read back as `None`. Padding also asserted `avg_logprob: 0`, a perfect score, where `None` correctly means unknown.
- `duration`, `usage.seconds` and the usage headers stay one number. OVH rounds `usage.seconds` up to a whole second (0.904625 → 1 on the probe file), so `duration` can overstate the audio by up to a second. Carrying both would have meant an optional `NormalizedTranscript` field only whisper ever sets.

gen: 97 files, 1036 passed, 6 skipped. typecheck + biome clean.

Fixes #13552
