### PR TITLE
feat: show connected accounts on the account page

### DIFF
--- a/enter.pollinations.ai/frontend/src/routes/_dashboard.account.tsx
+++ b/enter.pollinations.ai/frontend/src/routes/_dashboard.account.tsx
@@ -1,6 +1,7 @@
 import {
     Alert,
     Button,
+    Chip,
     CopyButton,
     Dialog,
     FieldStack,
@@ -103,6 +104,23 @@ function AccountPage() {
                             </>
                         )}
                     </CopyButton>
+                </Surface>
+            </Section>
+
+            <Section title="Connected accounts" framed>
+                <Surface variant="card" className="flex items-center gap-3">
+                    <GitHubIcon className="h-6 w-6 shrink-0 text-theme-text-strong" />
+                    <div className="min-w-0 flex-1">
+                        <Text tone="strong" weight="semibold">
+                            GitHub
+                        </Text>
+                        <Text size="sm" tone="muted" className="truncate">
+                            {githubUsername ? `@${githubUsername}` : user.email}
+                        </Text>
+                    </div>
+                    <Chip intent="neutral" size="sm">
+                        Connected
+                    </Chip>
                 </Surface>
             </Section>
 


### PR DESCRIPTION
Stacked on #13471 — restores the Connected accounts section that PR removed.

- Adds back the section listing the GitHub identity the account signs in with
- Base is `codex/account-settings`; retarget to `main` once #13471 merges

**Do not merge yet.** GitHub is the only sign-in today, so the list has exactly one row and tells the user nothing they can't see on their profile. Merge when a second provider (Discord, etc.) is connectable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)