### PR TITLE
refactor: retire GPT Realtime 2

### DIFF
--- a/MODEL_SLUGS.md
+++ b/MODEL_SLUGS.md
@@ -230,7 +230,6 @@ Only the names are changing. Model behavior and pricing stay the same.
 | GPT Image 1.5 | `gptimage-large` | `openai/gpt-image-1.5` |
 | GPT Image 2 | `gpt-image-2` | `openai/gpt-image-2` |
 | GPT Live Transcribe | `gpt-live-transcribe` | `openai/gpt-live-transcribe` |
-| GPT Realtime 2 | `gpt-realtime-2` | `openai/gpt-realtime-2` |
 | GPT Realtime 2.1 | `gpt-realtime-2.1` | `openai/gpt-realtime-2.1` |
 | GPT Realtime 2.1 Mini | `gpt-realtime-2.1-mini` | `openai/gpt-realtime-2.1-mini` |
 | GPT Transcribe | `gpt-transcribe` | `openai/gpt-transcribe` |
@@ -246,6 +245,8 @@ Only the names are changing. Model behavior and pricing stay the same.
 | Text Embedding 3 Large | `openai-3-large` | `openai/text-embedding-3-large` |
 | Text Embedding 3 Small | `openai-3-small` | `openai/text-embedding-3-small` |
 | Whisper Large V3 | `whisper` | `openai/whisper-large-v3` |
+
+GPT Realtime 2 retired on August 31, 2026. `gpt-realtime-2` remains a compatibility alias for GPT Realtime 2.1; it will not receive a separate namespaced ID.
 
 ## Perplexity
 

--- a/enter.pollinations.ai/drizzle/0056_canonicalize_gpt_realtime_2_permission.sql
+++ b/enter.pollinations.ai/drizzle/0056_canonicalize_gpt_realtime_2_permission.sql
@@ -1,0 +1,51 @@
+-- GPT Realtime 2 now resolves to GPT Realtime 2.1. Replace the retired
+-- canonical ID in restricted API-key allowlists so authorization continues to
+-- match the resolved canonical model. Preserve unrelated permissions and model
+-- order, and collapse only duplicates between the retired and replacement IDs.
+-- Read-only audit on 2026-08-31: 1,011 production keys and 0 staging keys.
+-- No stored OpenAI-prefixed aliases were found.
+--
+-- Prefilter with instr() inside CASE so JSON functions only inspect rows that
+-- can contain the retired ID. json() preserves the array subtype across
+-- json_set(), and aggregate ORDER BY preserves the original array order.
+
+UPDATE apikey
+SET permissions = json_set(
+    permissions,
+    '$.models',
+    json((
+        SELECT json_group_array(model_id ORDER BY position)
+        FROM (
+            SELECT
+                CASE
+                    WHEN model.type = 'text'
+                      AND model.value IN ('gpt-realtime-2', 'gpt-realtime-2.1')
+                        THEN 'gpt-realtime-2.1'
+                    ELSE model.value
+                END AS model_id,
+                CAST(model.key AS integer) AS position
+            FROM json_each(apikey.permissions, '$.models') AS model
+            WHERE NOT (
+                model.type = 'text'
+                AND model.value IN ('gpt-realtime-2', 'gpt-realtime-2.1')
+                AND EXISTS (
+                    SELECT 1
+                    FROM json_each(apikey.permissions, '$.models') AS earlier
+                    WHERE CAST(earlier.key AS integer) < CAST(model.key AS integer)
+                      AND earlier.type = 'text'
+                      AND earlier.value IN ('gpt-realtime-2', 'gpt-realtime-2.1')
+                )
+            )
+        )
+    ))
+)
+WHERE CASE
+    WHEN instr(permissions, '"gpt-realtime-2"') = 0 THEN 0
+    WHEN NOT json_valid(permissions) THEN 0
+    WHEN json_type(permissions, '$.models') != 'array' THEN 0
+    ELSE EXISTS (
+        SELECT 1
+        FROM json_each(permissions, '$.models') AS model
+        WHERE model.type = 'text' AND model.value = 'gpt-realtime-2'
+    )
+END;

--- a/enter.pollinations.ai/drizzle/meta/_journal.json
+++ b/enter.pollinations.ai/drizzle/meta/_journal.json
@@ -393,6 +393,13 @@
       "when": 1787648526176,
       "tag": "0055_rare_doctor_spectrum",
       "breakpoints": true
+    },
+    {
+      "idx": 56,
+      "version": "6",
+      "when": 1788172800000,
+      "tag": "0056_canonicalize_gpt_realtime_2_permission",
+      "breakpoints": true
     }
   ]
 }

--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -573,24 +573,6 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.00000005,
     },
   },
-  "gpt-realtime-2": {
-    "cost": {
-      "completionAudioTokens": 0.000064,
-      "completionTextTokens": 0.000024,
-      "promptAudioTokens": 0.000032,
-      "promptCachedTokens": 0.0000004,
-      "promptImageTokens": 0.000005,
-      "promptTextTokens": 0.000004,
-    },
-    "price": {
-      "completionAudioTokens": 0.000048,
-      "completionTextTokens": 0.000018,
-      "promptAudioTokens": 0.000024,
-      "promptCachedTokens": 0.0000003,
-      "promptImageTokens": 0.00000375,
-      "promptTextTokens": 0.000003,
-    },
-  },
   "gpt-realtime-2.1": {
     "cost": {
       "completionAudioTokens": 0.000064,

--- a/enter.pollinations.ai/test/canonicalize-gpt-realtime-2-permission-migration.test.ts
+++ b/enter.pollinations.ai/test/canonicalize-gpt-realtime-2-permission-migration.test.ts
@@ -1,0 +1,169 @@
+import { env } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import migrationSql from "../drizzle/0056_canonicalize_gpt_realtime_2_permission.sql?raw";
+
+describe("canonicalize GPT Realtime 2 permission migration", () => {
+    it("replaces the retired ID without changing unrelated permissions", async () => {
+        await env.DB.prepare(`
+            CREATE TABLE gpt_realtime_2_permission_apikey (
+                id TEXT PRIMARY KEY,
+                permissions TEXT
+            )
+        `).run();
+        await env.DB.prepare(`
+            WITH RECURSIVE seq(x) AS (
+                VALUES(1)
+                UNION ALL
+                SELECT x + 1 FROM seq WHERE x < 10000
+            )
+            INSERT INTO gpt_realtime_2_permission_apikey
+            SELECT
+                printf('unaffected-%06d', x),
+                json_object('models', json_array('flux'), 'note', 'keep')
+            FROM seq
+        `).run();
+        const edgeRows = new Map<string, string | null>([
+            [
+                "retired-only",
+                JSON.stringify({
+                    models: ["gpt-realtime-2", "flux"],
+                    note: "keep",
+                }),
+            ],
+            [
+                "retired-before-canonical",
+                JSON.stringify({
+                    models: [
+                        "unknown-model",
+                        "gpt-realtime-2",
+                        "owner/community-model",
+                        "gpt-realtime-2.1",
+                    ],
+                    account: ["profile"],
+                }),
+            ],
+            [
+                "canonical-before-retired",
+                JSON.stringify({
+                    models: ["gpt-realtime-2.1", "flux", "gpt-realtime-2"],
+                }),
+            ],
+            [
+                "repeated-retired",
+                JSON.stringify({
+                    models: ["gpt-realtime-2", "gpt-realtime-2", "openai"],
+                }),
+            ],
+            [
+                "unrelated-duplicates",
+                JSON.stringify({
+                    models: ["gpt-realtime-2", "flux", "flux"],
+                }),
+            ],
+            [
+                "alias-elsewhere",
+                JSON.stringify({ models: ["flux"], note: "gpt-realtime-2" }),
+            ],
+            ["missing-models", JSON.stringify({ note: "gpt-realtime-2" })],
+            ["non-array", JSON.stringify({ models: "gpt-realtime-2" })],
+            ["invalid-json", '{"models":["gpt-realtime-2"]'],
+            ["unrestricted", null],
+        ]);
+        await env.DB.batch(
+            [...edgeRows].map(([id, permissions]) =>
+                env.DB.prepare(
+                    "INSERT INTO gpt_realtime_2_permission_apikey VALUES (?, ?)",
+                ).bind(id, permissions),
+            ),
+        );
+
+        const statement = migrationSql.replace(
+            /\bapikey\b/g,
+            "gpt_realtime_2_permission_apikey",
+        );
+        const runMigration = () => env.DB.prepare(statement).run();
+        await runMigration();
+
+        const rows = await env.DB.prepare(`
+            SELECT id, permissions
+            FROM gpt_realtime_2_permission_apikey
+            WHERE id NOT LIKE 'unaffected-%'
+            ORDER BY id
+        `).all<{ id: string; permissions: string | null }>();
+        const permissions = Object.fromEntries(
+            rows.results.map((row) => [row.id, row.permissions]),
+        );
+
+        expect(JSON.parse(permissions["retired-only"] as string)).toEqual({
+            models: ["gpt-realtime-2.1", "flux"],
+            note: "keep",
+        });
+        expect(
+            JSON.parse(permissions["retired-before-canonical"] as string),
+        ).toEqual({
+            models: [
+                "unknown-model",
+                "gpt-realtime-2.1",
+                "owner/community-model",
+            ],
+            account: ["profile"],
+        });
+        expect(
+            JSON.parse(permissions["canonical-before-retired"] as string),
+        ).toEqual({ models: ["gpt-realtime-2.1", "flux"] });
+        expect(JSON.parse(permissions["repeated-retired"] as string)).toEqual({
+            models: ["gpt-realtime-2.1", "openai"],
+        });
+        expect(
+            JSON.parse(permissions["unrelated-duplicates"] as string),
+        ).toEqual({ models: ["gpt-realtime-2.1", "flux", "flux"] });
+        for (const id of [
+            "alias-elsewhere",
+            "missing-models",
+            "non-array",
+            "invalid-json",
+            "unrestricted",
+        ]) {
+            expect(permissions[id]).toBe(edgeRows.get(id));
+        }
+
+        const retiredAfter = await env.DB.prepare(`
+            SELECT count(*) AS count
+            FROM gpt_realtime_2_permission_apikey AS api_key
+            JOIN json_each(
+                CASE WHEN json_valid(api_key.permissions) THEN api_key.permissions END,
+                '$.models'
+            ) AS model
+            WHERE json_type(
+                CASE WHEN json_valid(api_key.permissions) THEN api_key.permissions END,
+                '$.models'
+            ) = 'array'
+              AND model.type = 'text'
+              AND model.value = 'gpt-realtime-2'
+        `).first<{ count: number }>();
+        expect(retiredAfter?.count).toBe(0);
+
+        const changedUnaffected = await env.DB.prepare(`
+            SELECT count(*) AS count
+            FROM gpt_realtime_2_permission_apikey
+            WHERE id LIKE 'unaffected-%'
+              AND permissions != json_object(
+                  'models', json_array('flux'), 'note', 'keep'
+              )
+        `).first<{ count: number }>();
+        expect(changedUnaffected?.count).toBe(0);
+
+        await env.DB.prepare(`
+            CREATE TABLE gpt_realtime_2_permission_snapshot AS
+            SELECT id, permissions FROM gpt_realtime_2_permission_apikey
+        `).run();
+        await runMigration();
+        const changedOnSecondRun = await env.DB.prepare(`
+            SELECT count(*) AS count
+            FROM gpt_realtime_2_permission_apikey AS current
+            JOIN gpt_realtime_2_permission_snapshot AS snapshot USING (id)
+            WHERE current.permissions IS NOT snapshot.permissions
+        `).first<{ count: number }>();
+        expect(changedOnSecondRun?.count).toBe(0);
+    });
+});

--- a/enter.pollinations.ai/test/integration/api-keys.test.ts
+++ b/enter.pollinations.ai/test/integration/api-keys.test.ts
@@ -906,7 +906,12 @@ describe("API Key Management", () => {
         }) => {
             const created = await createApiKeyViaApi(sessionToken, {
                 name: "key-with-alias-and-unknown-model",
-                allowedModels: ["flux", "nanobanana2", "retired-model"],
+                allowedModels: [
+                    "flux",
+                    "nanobanana2",
+                    "gpt-realtime-2",
+                    "retired-model",
+                ],
             });
 
             const response = await SELF.fetch(
@@ -924,6 +929,7 @@ describe("API Key Management", () => {
             expect(listed?.permissions?.models).toEqual([
                 "flux",
                 "nanobanana-2",
+                "gpt-realtime-2.1",
             ]);
 
             const db = drizzle(env.DB, { schema });
@@ -933,6 +939,7 @@ describe("API Key Management", () => {
             expect(JSON.parse(stored?.permissions ?? "{}").models).toEqual([
                 "flux",
                 "nanobanana-2",
+                "gpt-realtime-2.1",
                 "retired-model",
             ]);
         });

--- a/gen.pollinations.ai/src/routes/realtime.ts
+++ b/gen.pollinations.ai/src/routes/realtime.ts
@@ -68,12 +68,6 @@ const REALTIME_ROUTES = {
         deployment: "gpt-realtime-2-1-mini",
         apiKeyEnv: "AZURE_MYCELI_PROD_EASTUS2_API_KEY",
     },
-    "gpt-realtime-2": {
-        endpoint:
-            "https://myceli-prod-swedencentral.openai.azure.com/openai/v1/realtime",
-        deployment: "gpt-realtime-2",
-        apiKeyEnv: "AZURE_MYCELI_PROD_SWEDEN_API_KEY",
-    },
     "gpt-live-transcribe": {
         endpoint:
             "https://myceli-prod-swedencentral.openai.azure.com/openai/v1/realtime",

--- a/gen.pollinations.ai/src/schemas/realtime.ts
+++ b/gen.pollinations.ai/src/schemas/realtime.ts
@@ -1,13 +1,19 @@
 import {
     DEFAULT_REALTIME_MODEL,
     REALTIME_MODEL_NAMES,
+    REALTIME_SERVICES,
 } from "@shared/registry/realtime.ts";
 import { z } from "zod";
+
+const VALID_REALTIME_MODELS = [
+    ...REALTIME_MODEL_NAMES,
+    ...Object.values(REALTIME_SERVICES).flatMap((service) => service.aliases),
+] as const;
 
 export const RealtimeRequestQueryParamsSchema = z
     .object({
         model: z
-            .enum(REALTIME_MODEL_NAMES as [string, ...string[]])
+            .enum(VALID_REALTIME_MODELS as unknown as [string, ...string[]])
             .optional()
             .default(DEFAULT_REALTIME_MODEL)
             .meta({

--- a/gen.pollinations.ai/test/realtime.test.ts
+++ b/gen.pollinations.ai/test/realtime.test.ts
@@ -124,7 +124,7 @@ function mockRealtimeProvider(initialMessage?: string, estimatedCost = 0) {
                         estimatedCost > 0
                             ? [
                                   {
-                                      model: "gpt-realtime-2",
+                                      model: "gpt-realtime-2.1",
                                       avg_cost_usd: estimatedCost,
                                   },
                               ]
@@ -245,7 +245,7 @@ async function waitForTinybirdRequests(
 
 async function openPaidRealtimeSession({
     name,
-    model = "gpt-realtime-2",
+    model = "gpt-realtime-2.1",
     referrer,
     initialProviderMessage,
     byopClientKeyId,
@@ -479,7 +479,7 @@ test("proxies OpenAI-compatible realtime WebSockets on both public routes", asyn
 test("forwards the initial Azure session event after listeners are attached", async () => {
     const initialProviderMessage = JSON.stringify({
         type: "session.created",
-        session: { model: "gpt-realtime-2" },
+        session: { model: "gpt-realtime-2-1" },
     });
     const session = await openPaidRealtimeSession({
         name: "azure-realtime-initial-event-key",
@@ -1291,7 +1291,7 @@ test("deducts aggregate session usage from paid pack balance on close", async ()
     expect(user?.packBalance).toBeCloseTo(1 - expectedCharge, 8);
     expect(telemetry.eventType).toBe("generate.realtime");
     expect(telemetry.responseStatus).toBe(200);
-    expect(telemetry.resolvedModelRequested).toBe("gpt-realtime-2");
+    expect(telemetry.resolvedModelRequested).toBe("gpt-realtime-2.1");
     expect(telemetry.modelProviderUsed).toBe("azure");
     expect(telemetry.tokenCountPromptText).toBe(200);
     expect(telemetry.tokenCountPromptCached).toBe(40);
@@ -1405,7 +1405,7 @@ test.each([
     const expectedCharge = expectedCost * 0.75;
     const user = await waitForPackBalanceBelow(session.userId, 1);
     expect(user?.packBalance).toBeCloseTo(1 - expectedCharge, 8);
-    expect(telemetry.resolvedModelRequested).toBe(model);
+    expect(telemetry.resolvedModelRequested).toBe("gpt-realtime-2.1");
     expect(telemetry.tokenCountPromptText).toBe(60);
     expect(telemetry.tokenCountPromptCached).toBe(60);
     expect(telemetry.tokenCountPromptAudio).toBe(70);
@@ -1626,13 +1626,12 @@ test("includes realtime model in OpenAI-compatible model discovery", async ({
     };
     const realtimeModels = publicBody.data.filter((model) =>
         [
-            "gpt-realtime-2",
             "gpt-realtime-2.1",
             "gpt-realtime-2.1-mini",
             "gpt-live-transcribe",
         ].includes(model.id),
     );
-    expect(realtimeModels).toHaveLength(4);
+    expect(realtimeModels).toHaveLength(3);
     for (const model of realtimeModels) {
         expect(model.supported_endpoints).toContain("/v1/realtime");
     }
@@ -1659,6 +1658,11 @@ test("includes realtime model in OpenAI-compatible model discovery", async ({
     const scribeRealtime = richModels.find(
         (model) => model.name === "scribe-realtime",
     );
+    expect(
+        richModels.find((model) => model.name === "gpt-realtime-2.1"),
+    ).toMatchObject({
+        aliases: ["openai/gpt-realtime-2.1", "gpt-realtime-2"],
+    });
     expect(scribeRealtime).toMatchObject({
         aliases: ["elevenlabs/scribe-v2-realtime"],
         brand: "ElevenLabs",

--- a/shared/registry/realtime.ts
+++ b/shared/registry/realtime.ts
@@ -31,7 +31,7 @@ const OPENAI_REALTIME_COST = {
 export const REALTIME_SERVICES = {
     [DEFAULT_REALTIME_MODEL]: {
         ...OPENAI_REALTIME_BASE,
-        aliases: ["openai/gpt-realtime-2.1"],
+        aliases: ["openai/gpt-realtime-2.1", "gpt-realtime-2"],
         addedDate: new Date("2026-07-16").getTime(),
         cost: OPENAI_REALTIME_COST,
         billing: OPENAI_REALTIME_CACHE_BILLING,
@@ -70,16 +70,6 @@ export const REALTIME_SERVICES = {
             "marin",
             "cedar",
         ],
-    },
-    "gpt-realtime-2": {
-        ...OPENAI_REALTIME_BASE,
-        aliases: ["openai/gpt-realtime-2"],
-        addedDate: new Date("2026-05-23").getTime(),
-        cost: OPENAI_REALTIME_COST,
-        billing: OPENAI_REALTIME_CACHE_BILLING,
-        title: "GPT Realtime 2",
-        description: "Live voice conversations with instant, reasoned replies",
-        contextLength: 128000,
     },
     "scribe-realtime": {
         aliases: ["elevenlabs/scribe-v2-realtime"],


### PR DESCRIPTION
- Removes `gpt-realtime-2` as a separate canonical model and its Azure route.
- Keeps `gpt-realtime-2` working as an alias of canonical `gpt-realtime-2.1`; routing, billing, permissions, and telemetry resolve to 2.1.
- Migrates 1,011 production restricted-key allowlists to `gpt-realtime-2.1` before worker deployment; staging has none. The migration is idempotent and preserves unrelated permissions.
- Keeps the existing 2.1 provider, pricing, and no-fallback contract unchanged. No secret or provider-deployment mutation.

### Retirement verification

- Direct Azure WebSocket checks on August 31: both the old deployment and replacement accepted handshakes. The replacement is healthy; Azure's delayed shutdown does not block this change because the public old ID resolves to 2.1.
- Microsoft schedule: https://learn.microsoft.com/en-us/azure/foundry/openai/concepts/model-retirement-schedule?view=foundry-classic

### Validation

- Realtime: 41/41
- Registry/catalog/pricing: 63/63
- Migration + API-key canonicalization: 2/2
- Gen and Enter typechecks; Biome: clean
