### PR TITLE
feat: add a community-models row to the KPI table

### DIFF
--- a/enter.pollinations.ai/observability/endpoints/weekly_usage_stats.pipe
+++ b/enter.pollinations.ai/observability/endpoints/weekly_usage_stats.pipe
@@ -1,6 +1,7 @@
 DESCRIPTION >
     Weekly usage statistics - tokens, requests, revenue breakdown by week.
-    Includes per-user averages for depth metrics.
+    Includes per-user averages for depth metrics, and the community-model share
+    of users and successful requests.
     Optimized: single-pass query with uniq() instead of uniqExact() for ~10x speed.
     Supports start_date param for single-week queries to avoid Tinybird timeouts.
 
@@ -21,7 +22,37 @@ SQL >
         sum(total_cost) AS cost_usd,
         uniq(user_id) AS active_users,
         if(active_users > 0, total_tokens / active_users, 0) AS tokens_per_user,
-        if(active_users > 0, total_requests / active_users, 0) AS requests_per_user
+        if(active_users > 0, total_requests / active_users, 0) AS requests_per_user,
+        -- Community models: endpoints registered by users, which the registry
+        -- gives provider 'community'. Managed agents are community endpoints
+        -- too, so their top-level runs are inside these numbers until the
+        -- is_agent attribution column exists.
+        uniqIf(user_id, model_provider_used = 'community') AS community_users,
+        countIf(response_status >= 200 AND response_status < 300) AS successful_requests,
+        countIf(
+            model_provider_used = 'community'
+            AND response_status >= 200 AND response_status < 300
+        ) AS community_successful_requests,
+        countIf(model_provider_used = 'community' AND response_status >= 500)
+            AS community_server_errors_5xx,
+        round(community_users * 100.0 / nullIf(active_users, 0), 1)
+            AS community_user_pct,
+        round(
+            community_successful_requests * 100.0
+            / nullIf(successful_requests, 0),
+            1
+        ) AS community_request_pct,
+        -- 2xx / (2xx + 5xx), matching weekly_health_stats: 4xx is the caller's
+        -- error (auth, balance, rate limit, bad input) and must not read as an
+        -- endpoint being down.
+        round(
+            community_successful_requests * 100.0
+            / nullIf(
+                community_successful_requests + community_server_errors_5xx,
+                0
+            ),
+            2
+        ) AS community_availability
     FROM generation_event_v2
     WHERE
         {% if defined(start_date) %}

--- a/operations/kpi/package.json
+++ b/operations/kpi/package.json
@@ -7,6 +7,7 @@
         "decrypt-vars": "sops decrypt secrets/env.json --output-type dotenv > .dev.vars",
         "predev": "npm run build --prefix ../../packages/ui",
         "dev": "vite",
+        "test": "vitest run",
         "prebuild": "npm run build --prefix ../../packages/ui",
         "build": "vite build",
         "deploy": "npm run build && npx wrangler deploy",

--- a/operations/kpi/src/App.jsx
+++ b/operations/kpi/src/App.jsx
@@ -27,6 +27,9 @@ const EXPORT_COLUMNS = [
     ["tokens", "Tokens"],
     ["revenue", "Revenue"],
     ["packPurchases", "Pack purchases"],
+    ["communityUserPct", "Community models user %"],
+    ["communityRequestPct", "Community models request %"],
+    ["communityAvailability", "Community models availability %"],
 ];
 
 function exportCsv(weeklyData) {

--- a/operations/kpi/src/hooks/useKpiData.js
+++ b/operations/kpi/src/hooks/useKpiData.js
@@ -113,6 +113,9 @@ export function useKpiData() {
                 textRequests: row.text_requests,
                 imageRequests: row.image_requests,
                 costUsd: row.cost_usd,
+                communityUserPct: row.community_user_pct,
+                communityRequestPct: row.community_request_pct,
+                communityAvailability: row.community_availability,
             }));
             mergeInto(weekMap, raw.revenue, (row) => ({
                 revenue: row.revenue,

--- a/operations/kpi/src/lib/kpis.js
+++ b/operations/kpi/src/lib/kpis.js
@@ -134,6 +134,31 @@ export const KPIS = [
             "Share of Pollen consumed by apps that bring their own Pollen.",
     },
     {
+        key: "communityModels",
+        category: "Ecosystem",
+        format: "percent",
+        views: [
+            {
+                key: "communityUserPct",
+                name: "Community models · users",
+                tooltip:
+                    "Unique users making at least one final community-model request / weekly active users × 100. Status is ignored on the numerator, so a user whose only community call returned 4xx or 5xx still counts. Managed agents are community endpoints too, so their callers are included until agent attribution exists.",
+            },
+            {
+                key: "communityRequestPct",
+                name: "Community models · requests",
+                tooltip:
+                    "Successful (2xx) final community-model requests / all successful (2xx) final requests × 100. 4xx and 5xx are excluded from both sides. Final rows only, so a fallback-rescued request counts once, as one success. Includes top-level managed-agent runs until agent attribution exists.",
+            },
+            {
+                key: "communityAvailability",
+                name: "Community models · availability",
+                tooltip:
+                    "Community-model 2xx / (2xx + 5xx) × 100. 4xx is excluded from the denominator — auth, balance, rate-limit and bad-input errors are the caller's, not an endpoint being down. Includes top-level managed-agent runs until agent attribution exists.",
+            },
+        ],
+    },
+    {
         key: "appSubmissions",
         name: "App submissions",
         category: "Community",

--- a/operations/kpi/test/kpis.test.js
+++ b/operations/kpi/test/kpis.test.js
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { formatValue } from "../src/lib/format";
+import { KPIS, kpiValue, kpiView } from "../src/lib/kpis";
+
+const community = KPIS.find((row) => row.key === "communityModels");
+
+// One week as the dashboard sees it, after useKpiData maps the usage pipe.
+const week = {
+    week: "2026-08-10",
+    communityUserPct: 12.4,
+    communityRequestPct: 3.6,
+    communityAvailability: 98.75,
+};
+
+describe("community models row", () => {
+    it("cycles through all three views and back", () => {
+        const names = [0, 1, 2, 3].map((i) => kpiView(community, i).name);
+        expect(names).toEqual([
+            "Community models · users",
+            "Community models · requests",
+            "Community models · availability",
+            "Community models · users",
+        ]);
+    });
+
+    it("reads a different field in each view", () => {
+        const values = [0, 1, 2].map((i) =>
+            kpiValue(kpiView(community, i), week),
+        );
+        expect(values).toEqual([12.4, 3.6, 98.75]);
+    });
+
+    it("formats every view as a percentage", () => {
+        const shown = [0, 1, 2].map((i) => {
+            const view = kpiView(community, i);
+            return formatValue(kpiValue(view, week), view.format);
+        });
+        expect(shown).toEqual(["12%", "4%", "99%"]);
+    });
+
+    it("gives each view its own tooltip naming the 4xx treatment", () => {
+        const tooltips = community.views.map((view) => view.tooltip);
+        expect(new Set(tooltips).size).toBe(3);
+        for (const tooltip of tooltips) expect(tooltip).toMatch(/4xx/);
+    });
+
+    it("reads as missing, not zero, before the pipe ships the fields", () => {
+        const before = { week: "2026-05-04" };
+        for (const index of [0, 1, 2]) {
+            const view = kpiView(community, index);
+            expect(kpiValue(view, before)).toBeUndefined();
+            expect(formatValue(kpiValue(view, before), view.format)).toBe("—");
+        }
+    });
+});

--- a/operations/kpi/vitest.config.js
+++ b/operations/kpi/vitest.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+// Its own config, not vite.config.js: that one loads the Cloudflare plugin and
+// would boot a Worker for tests that only exercise plain modules.
+export default defineConfig({
+    test: { include: ["test/**/*.test.js"], environment: "node" },
+});


### PR DESCRIPTION
Community-models half of the ecosystem KPI request. No agent metrics and no `is_agent` schema change — that lands separately.

- Extends `weekly_usage_stats.pipe` with `community_user_pct`, `community_request_pct`, `community_availability` as single-pass conditional aggregates on the existing `model_provider_used = 'community'` column. No datasource change.
- Availability is `2xx / (2xx + 5xx)`, same formula as `weekly_health_stats` — 4xx is the caller's error, not downtime.
- Every division guarded with `nullIf(..., 0)`, so a week with no community traffic is blank rather than 0%.
- One cycleable **Community models** row (users ⇄ requests ⇄ availability) in the trend table, reusing the existing dotted-underline ⇄ behaviour. Three CSV columns added.
- Adds `vitest` to `operations/kpi` (already resolvable from the repo root, no new install) with tests for cycling, per-view field, percent formatting, and blank-not-zero before the pipe ships.

Known limitation, stated in all three tooltips: managed agents are community endpoints, so their top-level runs are inside these numbers until `is_agent` exists.

**Not deployed.** The pipe change needs Tinybird staging validation and deploy before the column shows numbers; until then the row renders `—`.

Stacked on #13568 — merge that first.