### PR TITLE
chore: promote main to production

### DIFF
--- a/enter.pollinations.ai/observability/endpoints/weekly_usage_stats.pipe
+++ b/enter.pollinations.ai/observability/endpoints/weekly_usage_stats.pipe
@@ -1,6 +1,7 @@
 DESCRIPTION >
     Weekly usage statistics - tokens, requests, revenue breakdown by week.
-    Includes per-user averages for depth metrics.
+    Includes per-user averages for depth metrics, and the community-model share
+    of users and successful requests.
     Optimized: single-pass query with uniq() instead of uniqExact() for ~10x speed.
     Supports start_date param for single-week queries to avoid Tinybird timeouts.
 
@@ -21,7 +22,37 @@ SQL >
         sum(total_cost) AS cost_usd,
         uniq(user_id) AS active_users,
         if(active_users > 0, total_tokens / active_users, 0) AS tokens_per_user,
-        if(active_users > 0, total_requests / active_users, 0) AS requests_per_user
+        if(active_users > 0, total_requests / active_users, 0) AS requests_per_user,
+        -- Community models: endpoints registered by users, which the registry
+        -- gives provider 'community'. Managed agents are community endpoints
+        -- too, so their top-level runs are inside these numbers until the
+        -- is_agent attribution column exists.
+        uniqIf(user_id, model_provider_used = 'community') AS community_users,
+        countIf(response_status >= 200 AND response_status < 300) AS successful_requests,
+        countIf(
+            model_provider_used = 'community'
+            AND response_status >= 200 AND response_status < 300
+        ) AS community_successful_requests,
+        countIf(model_provider_used = 'community' AND response_status >= 500)
+            AS community_server_errors_5xx,
+        round(community_users * 100.0 / nullIf(active_users, 0), 1)
+            AS community_user_pct,
+        round(
+            community_successful_requests * 100.0
+            / nullIf(successful_requests, 0),
+            1
+        ) AS community_request_pct,
+        -- 2xx / (2xx + 5xx), matching weekly_health_stats: 4xx is the caller's
+        -- error (auth, balance, rate limit, bad input) and must not read as an
+        -- endpoint being down.
+        round(
+            community_successful_requests * 100.0
+            / nullIf(
+                community_successful_requests + community_server_errors_5xx,
+                0
+            ),
+            2
+        ) AS community_availability
     FROM generation_event_v2
     WHERE
         {% if defined(start_date) %}

--- a/operations/kpi/package.json
+++ b/operations/kpi/package.json
@@ -7,6 +7,7 @@
         "decrypt-vars": "sops decrypt secrets/env.json --output-type dotenv > .dev.vars",
         "predev": "npm run build --prefix ../../packages/ui",
         "dev": "vite",
+        "test": "vitest run",
         "prebuild": "npm run build --prefix ../../packages/ui",
         "build": "vite build",
         "deploy": "npm run build && npx wrangler deploy",

--- a/operations/kpi/src/App.jsx
+++ b/operations/kpi/src/App.jsx
@@ -9,8 +9,10 @@ import {
     Surface,
     Text,
 } from "@pollinations/ui";
+import { useState } from "react";
 import { FunnelBars } from "./components/FunnelBars";
 import { KPITrendTable } from "./components/KPITrendTable";
+import { KpiExplorer } from "./components/KpiExplorer";
 import { LineChart } from "./components/LineChart";
 import { RetentionTable } from "./components/RetentionTable";
 import { Trend } from "./components/Trend";
@@ -90,7 +92,24 @@ function LoadingScreen({ done, active }) {
     );
 }
 
+const EXPLORER_ID = "kpi-explorer";
+
 export default function App() {
+    // Which unit each cycling row is showing, and which row the explorer plots.
+    // Both live here so the chart follows the table.
+    const [viewIndex, setViewIndex] = useState({});
+    const [explored, setExplored] = useState("registrations");
+
+    const cycleView = (key) =>
+        setViewIndex((prev) => ({ ...prev, [key]: (prev[key] ?? 0) + 1 }));
+
+    const graphKpi = (key) => {
+        setExplored(key);
+        document
+            .getElementById(EXPLORER_ID)
+            ?.scrollIntoView({ behavior: "smooth", block: "center" });
+    };
+
     const {
         loading,
         done,
@@ -240,7 +259,12 @@ export default function App() {
                     />
                 </div>
 
-                <KPITrendTable weeklyData={weeklyData} />
+                <KPITrendTable
+                    weeklyData={weeklyData}
+                    viewIndex={viewIndex}
+                    onCycle={cycleView}
+                    onGraph={graphKpi}
+                />
 
                 <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
                     <LineChart
@@ -268,6 +292,13 @@ export default function App() {
                             },
                         ]}
                         dualAxis
+                    />
+                    <KpiExplorer
+                        id={EXPLORER_ID}
+                        weeks={historyWeeks}
+                        selected={explored}
+                        viewIndex={viewIndex}
+                        onSelect={setExplored}
                     />
                     <FunnelBars
                         title={`Conversion funnel · ${weekLabel(currentWeek?.week)}`}

--- a/operations/kpi/src/App.jsx
+++ b/operations/kpi/src/App.jsx
@@ -27,6 +27,9 @@ const EXPORT_COLUMNS = [
     ["tokens", "Tokens"],
     ["revenue", "Revenue"],
     ["packPurchases", "Pack purchases"],
+    ["communityUserPct", "Community models user %"],
+    ["communityRequestPct", "Community models request %"],
+    ["communityAvailability", "Community models availability %"],
 ];
 
 function exportCsv(weeklyData) {

--- a/operations/kpi/src/components/KPITrendTable.jsx
+++ b/operations/kpi/src/components/KPITrendTable.jsx
@@ -10,153 +10,27 @@ import {
     TableRow,
     Text,
 } from "@pollinations/ui";
-import { useState } from "react";
 import {
     calcChange,
     currentWeekStart,
     formatValue,
     weekLabel,
 } from "../lib/format";
+import { KPIS, kpiValue, kpiView } from "../lib/kpis";
 
-const KPIS = [
-    {
-        key: "registrations",
-        name: "New registrations",
-        category: "Acquisition",
-        tooltip:
-            "Count of new user accounts created during the week. Source: D1 database (user.created_at)",
-    },
-    {
-        key: "activations",
-        name: "Activated (D7)",
-        category: "Acquisition",
-        tooltip:
-            "Users who made at least one API request within 7 days of registration. Source: D1 + Tinybird (generation_event_v2)",
-    },
-    {
-        key: "activationRate",
-        name: "D7 activation rate",
-        category: "Acquisition",
-        format: "percent",
-        calc: (w) => (w.activations / w.registrations) * 100,
-        tooltip:
-            "Activated users / new registrations × 100. What share of signups become real users within 7 days.",
-    },
-    {
-        key: "wau",
-        name: "WAU",
-        category: "Usage",
-        tooltip:
-            "Weekly active users: unique users with at least one API request this week. Source: Tinybird (generation_event_v2)",
-    },
-    {
-        key: "tokens",
-        category: "Usage",
-        format: "compact",
-        views: [
-            {
-                name: "Total tokens",
-                tooltip:
-                    "Sum of prompt + completion tokens consumed. Source: Tinybird (weekly_usage_stats)",
-            },
-            {
-                name: "Tokens/user",
-                calc: (w) => w.tokens / w.wau,
-                tooltip:
-                    "Total tokens / WAU. Usage depth — how much each active user consumes on average.",
-            },
-        ],
-    },
-    {
-        key: "revenue",
-        category: "Revenue",
-        format: "currency",
-        views: [
-            {
-                name: "Revenue",
-                tooltip:
-                    "Gross USD from Pollen pack purchases. Source: Stripe checkout events in Tinybird.",
-            },
-            {
-                name: "ARPA",
-                calc: (w) => w.revenue / w.wau,
-                tooltip:
-                    "Weekly revenue / WAU. Average revenue per active user — monetization efficiency.",
-            },
-        ],
-    },
-    {
-        key: "packPurchases",
-        category: "Revenue",
-        views: [
-            {
-                name: "Pack purchases",
-                tooltip:
-                    "Completed Pollen pack purchases this week. Source: Stripe checkout events in Tinybird.",
-            },
-            {
-                name: "Purchase rate",
-                format: "percent",
-                calc: (w) => (w.packPurchases / w.wau) * 100,
-                tooltip:
-                    "Pack purchases / WAU × 100. Share of active users who bought a pack this week.",
-            },
-        ],
-    },
-    {
-        key: "grossMargin",
-        name: "Gross margin",
-        category: "Efficiency",
-        format: "percent",
-        calc: (w) =>
-            w.revenue > 0
-                ? ((w.revenue - (w.costUsd || 0)) / w.revenue) * 100
-                : null,
-        tooltip:
-            "(Revenue − COGS) / revenue × 100. COGS is compute cost from generation_event_v2.total_cost (GPU, tokens, providers).",
-    },
-    {
-        key: "availability",
-        name: "Service availability",
-        category: "Health",
-        format: "percent",
-        tooltip:
-            "(Total − 5xx) / total × 100. User errors (4xx) do not count as downtime.",
-    },
-    {
-        key: "byopUserPct",
-        name: "BYOP user %",
-        category: "Segments",
-        format: "percent",
-        tooltip:
-            "Share of active users from BYOP apps (app key attribution or hostname heuristic).",
-    },
-    {
-        key: "byopPollenPct",
-        name: "BYOP Pollen %",
-        category: "Segments",
-        format: "percent",
-        tooltip:
-            "Share of Pollen consumed by apps that bring their own Pollen.",
-    },
-    {
-        key: "appSubmissions",
-        name: "App submissions",
-        category: "Community",
-        tooltip:
-            "Issues opened this week with the APP-SUBMISSION label on pollinations/pollinations.",
-    },
-];
-
-function kpiValue(kpi, week) {
-    return kpi.calc ? kpi.calc(week) : week[kpi.key];
+/** Three rising bars — marks the row you can send to the explorer chart. */
+function ChartIcon() {
+    return (
+        <svg viewBox="0 0 12 12" className="h-3 w-3" aria-hidden="true">
+            <title>Graph</title>
+            <rect x="1" y="7" width="2.5" height="4" fill="currentColor" />
+            <rect x="4.75" y="4" width="2.5" height="7" fill="currentColor" />
+            <rect x="8.5" y="1" width="2.5" height="10" fill="currentColor" />
+        </svg>
+    );
 }
 
-export function KPITrendTable({ weeklyData }) {
-    // Some rows are the same measure in another unit — tokens/user tracks total
-    // tokens at r = +0.996 while WAU stays flat — so they share one row and
-    // cycle on click instead of each taking a line of their own.
-    const [viewIndex, setViewIndex] = useState({});
+export function KPITrendTable({ weeklyData, viewIndex, onCycle, onGraph }) {
     const partialWeekStart = currentWeekStart();
     const partialWeek = weeklyData.find((w) => w.week === partialWeekStart);
     const fullWeeks = weeklyData.filter((w) => w.week !== partialWeekStart);
@@ -207,9 +81,7 @@ export function KPITrendTable({ weeklyData }) {
                         {KPIS.map((row) => {
                             const views = row.views;
                             const index = viewIndex[row.key] ?? 0;
-                            const kpi = views
-                                ? { ...row, ...views[index % views.length] }
-                                : row;
+                            const kpi = kpiView(row, index);
                             const change = calcChange(
                                 lastFull ? kpiValue(kpi, lastFull) : null,
                                 previousFull
@@ -231,13 +103,7 @@ export function KPITrendTable({ weeklyData }) {
                                                     type="button"
                                                     title={`Show ${views[(index + 1) % views.length].name}`}
                                                     onClick={() =>
-                                                        setViewIndex(
-                                                            (prev) => ({
-                                                                ...prev,
-                                                                [row.key]:
-                                                                    index + 1,
-                                                            }),
-                                                        )
+                                                        onCycle(row.key)
                                                     }
                                                     className="flex items-center gap-1 underline decoration-dotted underline-offset-2 hover:text-theme-text-link"
                                                 >
@@ -250,6 +116,15 @@ export function KPITrendTable({ weeklyData }) {
                                                 kpi.name
                                             )}
                                             <InfoTip text={kpi.tooltip} />
+                                            <button
+                                                type="button"
+                                                aria-label={`Graph ${kpi.name}`}
+                                                title={`Graph ${kpi.name}`}
+                                                onClick={() => onGraph(row.key)}
+                                                className="ml-1 text-theme-text-muted hover:text-theme-text-link"
+                                            >
+                                                <ChartIcon />
+                                            </button>
                                         </span>
                                         <Text
                                             as="span"

--- a/operations/kpi/src/components/KpiExplorer.jsx
+++ b/operations/kpi/src/components/KpiExplorer.jsx
@@ -1,0 +1,49 @@
+import { KPIS, kpiValue, kpiView } from "../lib/kpis";
+import { LineChart } from "./LineChart";
+
+/**
+ * Plots whichever KPI row the reader picked — from the selector here, or from
+ * the graph button on a table row. Rows that cycle through units follow the
+ * unit the table is currently showing.
+ */
+export function KpiExplorer({ id, weeks, selected, viewIndex, onSelect }) {
+    const row = KPIS.find((item) => item.key === selected) ?? KPIS[0];
+    const kpi = kpiView(row, viewIndex[row.key] ?? 0);
+
+    // Pipes reach back different distances, so trim to the span this metric
+    // actually covers instead of leaving a long empty run-up.
+    const points = weeks.map((week) => ({
+        week: week.week,
+        value: kpiValue(kpi, week),
+    }));
+    const first = points.findIndex((point) => Number.isFinite(point.value));
+    const last = points.findLastIndex((point) => Number.isFinite(point.value));
+    const data = first === -1 ? [] : points.slice(first, last + 1);
+
+    const selector = (
+        <select
+            aria-label="KPI to graph"
+            value={row.key}
+            onChange={(event) => onSelect(event.target.value)}
+            className="rounded-lg bg-theme-bg-subtle px-2.5 py-1.5 font-medium text-sm text-theme-text-strong hover:bg-theme-bg-hover"
+        >
+            {KPIS.map((item) => (
+                <option key={item.key} value={item.key}>
+                    {kpiView(item, viewIndex[item.key] ?? 0).name}
+                </option>
+            ))}
+        </select>
+    );
+
+    return (
+        <div id={id}>
+            <LineChart
+                title="Graph any KPI"
+                data={data}
+                series={[{ key: "value", label: kpi.name }]}
+                format={kpi.format}
+                action={selector}
+            />
+        </div>
+    );
+}

--- a/operations/kpi/src/components/LineChart.jsx
+++ b/operations/kpi/src/components/LineChart.jsx
@@ -28,47 +28,95 @@ function useElementWidth() {
     return [ref, width];
 }
 
-/** Snap a step to 1/2/5 × 10^n so ticks land on read-off values. */
+const LADDER = [1, 2, 2.5, 5, 10];
+
+/** Snap a step to 1/2/2.5/5/10 × 10^n so ticks land on read-off values. */
 function niceStep(span) {
     if (!(span > 0)) return 1;
     const magnitude = 10 ** Math.floor(Math.log10(span));
     const normalized = span / magnitude;
-    const step =
-        normalized <= 1 ? 1 : normalized <= 2 ? 2 : normalized <= 5 ? 5 : 10;
-    return step * magnitude;
+    return LADDER.find((rung) => normalized <= rung) * magnitude;
 }
 
-/** The next step up the 1/2/5 ladder. */
+/**
+ * The ladder rung nearest a target step, rather than the next one up. Rounding
+ * up always would cost gridlines: a span wanting 240K would jump to 500K and
+ * leave the plot with two lines on it.
+ */
+const LADDER_EDGES = [1.5, 2.25, 3.55, 7.1];
+function nearestStep(span) {
+    if (!(span > 0)) return 1;
+    const magnitude = 10 ** Math.floor(Math.log10(span));
+    const normalized = span / magnitude;
+    const rung = LADDER_EDGES.findIndex((edge) => normalized < edge);
+    return LADDER[rung === -1 ? LADDER.length - 1 : rung] * magnitude;
+}
+
+/** The next step up the ladder. */
 function widerStep(step) {
     const magnitude = 10 ** Math.floor(Math.log10(step));
     const normalized = step / magnitude;
-    return (normalized < 1.5 ? 2 : normalized < 3.5 ? 5 : 10) * magnitude;
+    const next = LADDER.find((rung) => rung > normalized * 1.001) ?? 10;
+    return next * magnitude;
+}
+
+/** The window the data occupies, with a little air above and below. */
+function dataWindow(values) {
+    const rawMin = Math.min(...values);
+    const rawMax = Math.max(...values);
+    const span = rawMax - rawMin || Math.abs(rawMax) || 1;
+    const min = rawMin - span * 0.08;
+    return {
+        // Air below, but a series that never goes negative keeps a floor of
+        // zero rather than dipping into it. Gross margin does go negative.
+        min: rawMin >= 0 ? Math.max(0, min) : min,
+        max: rawMax + span * 0.08,
+    };
 }
 
 /**
  * Fit the axis to the data rather than to zero — twelve weeks of WAU sitting
- * between 6k and 7k is a flat line on a zero baseline. The floor is clamped at
- * zero so a series that genuinely reaches it still reads as reaching it.
+ * between 6k and 7k is a flat line on a zero baseline.
  *
- * Always returns exactly TICKS intervals, so two axes on the same plot put
- * their labels on the same gridlines.
+ * The bounds are the data window itself, and the ticks are the round numbers
+ * that fall inside it. Snapping the bounds outward to round numbers instead is
+ * what strands half the plot: a series topping out at 1.24M gets rounded up to
+ * a 2.5M ceiling and then draws in the bottom half of the card.
  */
 function niceScale(values) {
     if (values.length === 0) return { lo: 0, hi: 1, ticks: [0, 1] };
-    const rawMin = Math.min(...values);
-    const rawMax = Math.max(...values);
-    const span = rawMax - rawMin || Math.abs(rawMax) || 1;
-    const min = Math.max(0, rawMin - span * 0.08);
-    const max = rawMax + span * 0.08;
+    const { min, max } = dataWindow(values);
+    const step = nearestStep((max - min) / TICKS);
+    const ticks = [];
+    for (
+        let tick = Math.ceil(min / step) * step;
+        tick <= max + step * 1e-9;
+        tick += step
+    )
+        ticks.push(tick);
+    return { lo: min, hi: max, step, ticks };
+}
 
+/**
+ * Same idea, but every axis gets exactly TICKS intervals starting on a round
+ * number, so two scales on one plot put their labels on shared gridlines.
+ * Only the dual-axis chart needs this; it trades some fit for that alignment.
+ */
+function alignedScale(values) {
+    if (values.length === 0) return { lo: 0, hi: 1, ticks: [0, 1] };
+    const { min, max } = dataWindow(values);
     let step = niceStep((max - min) / TICKS);
-    let lo = Math.max(0, Math.floor(min / step) * step);
+    const floorAt = (size) => {
+        const value = Math.floor(min / size) * size;
+        return min >= 0 ? Math.max(0, value) : value;
+    };
+    let lo = floorAt(step);
     while (lo + step * TICKS < max) {
         step = widerStep(step);
-        lo = Math.max(0, Math.floor(min / step) * step);
+        lo = floorAt(step);
     }
     const ticks = Array.from({ length: TICKS + 1 }, (_, i) => lo + step * i);
-    return { lo, hi: lo + step * TICKS, ticks };
+    return { lo, hi: lo + step * TICKS, step, ticks };
 }
 
 /**
@@ -84,6 +132,7 @@ export function LineChart({
     series,
     format = "number",
     dualAxis = false,
+    action,
 }) {
     const [ref, width] = useElementWidth();
     const [hover, setHover] = useState(null);
@@ -101,7 +150,7 @@ export function LineChart({
     // One scale per axis. Both end up with TICKS intervals, so the right-hand
     // labels land on the same gridlines as the left-hand ones.
     const scales = dual
-        ? series.map((item) => niceScale(valuesOf(item)))
+        ? series.map((item) => alignedScale(valuesOf(item)))
         : [niceScale(series.flatMap(valuesOf))];
     const scaleOf = (index) => scales[dual ? index : 0];
 
@@ -154,9 +203,16 @@ export function LineChart({
         if (previous && label.y - previous.y < 13) label.y = previous.y + 13;
     });
 
-    // Axis ticks wear the format of the series they belong to.
+    // Axis ticks wear the format of the series they belong to. Percentages get
+    // as many decimals as the step needs — availability sits between 99% and
+    // 100%, and whole-number ticks there would all read the same.
     const axisLabel = (tick, seriesIndex) => {
+        const scale = scaleOf(seriesIndex);
         const tickFormat = dual ? formatOf(series[seriesIndex]) : format;
+        if (tickFormat === "percent") {
+            const decimals = scale.step >= 1 ? 0 : scale.step >= 0.1 ? 1 : 2;
+            return `${tick.toFixed(decimals)}%`;
+        }
         return formatValue(
             tick,
             tickFormat === "currency" ? "currency" : "compact",
@@ -167,9 +223,12 @@ export function LineChart({
 
     return (
         <Surface className="flex flex-col gap-3">
-            <Heading as="h3" size="card">
-                {title}
-            </Heading>
+            <div className="flex flex-wrap items-center justify-between gap-2">
+                <Heading as="h3" size="card">
+                    {title}
+                </Heading>
+                {action}
+            </div>
 
             {series.length > 1 && (
                 <div className="flex flex-wrap gap-x-4 gap-y-1">
@@ -371,8 +430,7 @@ export function LineChart({
             ) : (
                 scales[0].lo > 0 && (
                     <Text as="p" size="micro" tone="muted">
-                        Axis starts at {formatValue(scales[0].lo, format)}, not
-                        zero.
+                        Axis starts at {axisLabel(scales[0].lo, 0)}, not zero.
                     </Text>
                 )
             )}

--- a/operations/kpi/src/hooks/useKpiData.js
+++ b/operations/kpi/src/hooks/useKpiData.js
@@ -113,6 +113,9 @@ export function useKpiData() {
                 textRequests: row.text_requests,
                 imageRequests: row.image_requests,
                 costUsd: row.cost_usd,
+                communityUserPct: row.community_user_pct,
+                communityRequestPct: row.community_request_pct,
+                communityAvailability: row.community_availability,
             }));
             mergeInto(weekMap, raw.revenue, (row) => ({
                 revenue: row.revenue,

--- a/operations/kpi/src/lib/kpis.js
+++ b/operations/kpi/src/lib/kpis.js
@@ -134,6 +134,31 @@ export const KPIS = [
             "Share of Pollen consumed by apps that bring their own Pollen.",
     },
     {
+        key: "communityModels",
+        category: "Ecosystem",
+        format: "percent",
+        views: [
+            {
+                key: "communityUserPct",
+                name: "Community models · users",
+                tooltip:
+                    "Unique users making at least one final community-model request / weekly active users × 100. Status is ignored on the numerator, so a user whose only community call returned 4xx or 5xx still counts. Managed agents are community endpoints too, so their callers are included until agent attribution exists.",
+            },
+            {
+                key: "communityRequestPct",
+                name: "Community models · requests",
+                tooltip:
+                    "Successful (2xx) final community-model requests / all successful (2xx) final requests × 100. 4xx and 5xx are excluded from both sides. Final rows only, so a fallback-rescued request counts once, as one success. Includes top-level managed-agent runs until agent attribution exists.",
+            },
+            {
+                key: "communityAvailability",
+                name: "Community models · availability",
+                tooltip:
+                    "Community-model 2xx / (2xx + 5xx) × 100. 4xx is excluded from the denominator — auth, balance, rate-limit and bad-input errors are the caller's, not an endpoint being down. Includes top-level managed-agent runs until agent attribution exists.",
+            },
+        ],
+    },
+    {
         key: "appSubmissions",
         name: "App submissions",
         category: "Community",

--- a/operations/kpi/src/lib/kpis.js
+++ b/operations/kpi/src/lib/kpis.js
@@ -1,0 +1,152 @@
+// The KPI catalogue. Rows with `views` are the same measure in another
+// unit and cycle in place; the rest have a single definition.
+export const KPIS = [
+    {
+        key: "registrations",
+        name: "New registrations",
+        category: "Acquisition",
+        tooltip:
+            "Count of new user accounts created during the week. Source: D1 database (user.created_at)",
+    },
+    {
+        key: "activations",
+        category: "Acquisition",
+        views: [
+            {
+                name: "Activated (D7)",
+                tooltip:
+                    "Users who made at least one API request within 7 days of registration. Source: D1 + Tinybird (generation_event_v2)",
+            },
+            {
+                name: "D7 activation rate",
+                format: "percent",
+                calc: (w) => (w.activations / w.registrations) * 100,
+                tooltip:
+                    "Activated users / new registrations × 100. What share of signups become real users within 7 days.",
+            },
+        ],
+    },
+    {
+        key: "wau",
+        name: "WAU",
+        category: "Usage",
+        tooltip:
+            "Weekly active users: unique users with at least one API request this week. Source: Tinybird (generation_event_v2)",
+    },
+    {
+        key: "tokens",
+        category: "Usage",
+        format: "compact",
+        views: [
+            {
+                name: "Total tokens",
+                tooltip:
+                    "Sum of prompt + completion tokens consumed. Source: Tinybird (weekly_usage_stats)",
+            },
+            {
+                name: "Tokens/user",
+                calc: (w) => w.tokens / w.wau,
+                tooltip:
+                    "Total tokens / WAU. Usage depth — how much each active user consumes on average.",
+            },
+        ],
+    },
+    {
+        key: "revenue",
+        category: "Revenue",
+        format: "currency",
+        views: [
+            {
+                name: "Revenue",
+                tooltip:
+                    "Gross USD from Pollen pack purchases. Source: Stripe checkout events in Tinybird.",
+            },
+            {
+                name: "ARPA",
+                calc: (w) => w.revenue / w.wau,
+                tooltip:
+                    "Weekly revenue / WAU. Average revenue per active user — monetization efficiency.",
+            },
+        ],
+    },
+    {
+        key: "packPurchases",
+        category: "Revenue",
+        views: [
+            {
+                name: "Pack purchases",
+                tooltip:
+                    "Completed Pollen pack purchases this week. Source: Stripe checkout events in Tinybird.",
+            },
+            {
+                name: "Purchase rate",
+                format: "percent",
+                calc: (w) => (w.packPurchases / w.wau) * 100,
+                tooltip:
+                    "Pack purchases / WAU × 100. Share of active users who bought a pack this week.",
+            },
+        ],
+    },
+    {
+        key: "grossMargin",
+        name: "Gross margin",
+        category: "Efficiency",
+        format: "percent",
+        calc: (w) =>
+            w.revenue > 0
+                ? ((w.revenue - (w.costUsd || 0)) / w.revenue) * 100
+                : null,
+        tooltip:
+            "(Revenue − COGS) / revenue × 100. COGS is compute cost from generation_event_v2.total_cost (GPU, tokens, providers).",
+    },
+    {
+        key: "availability",
+        category: "Health",
+        views: [
+            {
+                name: "Service availability",
+                format: "percent",
+                tooltip:
+                    "(Total − 5xx) / total × 100. User errors (4xx) do not count as downtime.",
+            },
+            {
+                name: "5xx errors",
+                calc: (w) => w.serverErrors5xx,
+                tooltip:
+                    "Server errors behind the availability figure. 90% availability reads mild; the same week in raw failed requests does not.",
+            },
+        ],
+    },
+    {
+        key: "byopUserPct",
+        name: "BYOP user %",
+        category: "Segments",
+        format: "percent",
+        tooltip:
+            "Share of active users from BYOP apps (app key attribution or hostname heuristic).",
+    },
+    {
+        key: "byopPollenPct",
+        name: "BYOP Pollen %",
+        category: "Segments",
+        format: "percent",
+        tooltip:
+            "Share of Pollen consumed by apps that bring their own Pollen.",
+    },
+    {
+        key: "appSubmissions",
+        name: "App submissions",
+        category: "Community",
+        tooltip:
+            "Issues opened this week with the APP-SUBMISSION label on pollinations/pollinations.",
+    },
+];
+
+export function kpiValue(kpi, week) {
+    return kpi.calc ? kpi.calc(week) : week[kpi.key];
+}
+
+/** The active definition of a row, given how many times it has been cycled. */
+export function kpiView(row, index = 0) {
+    return row.views ? { ...row, ...row.views[index % row.views.length] } : row;
+}

--- a/operations/kpi/test/kpis.test.js
+++ b/operations/kpi/test/kpis.test.js
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { formatValue } from "../src/lib/format";
+import { KPIS, kpiValue, kpiView } from "../src/lib/kpis";
+
+const community = KPIS.find((row) => row.key === "communityModels");
+
+// One week as the dashboard sees it, after useKpiData maps the usage pipe.
+const week = {
+    week: "2026-08-10",
+    communityUserPct: 12.4,
+    communityRequestPct: 3.6,
+    communityAvailability: 98.75,
+};
+
+describe("community models row", () => {
+    it("cycles through all three views and back", () => {
+        const names = [0, 1, 2, 3].map((i) => kpiView(community, i).name);
+        expect(names).toEqual([
+            "Community models · users",
+            "Community models · requests",
+            "Community models · availability",
+            "Community models · users",
+        ]);
+    });
+
+    it("reads a different field in each view", () => {
+        const values = [0, 1, 2].map((i) =>
+            kpiValue(kpiView(community, i), week),
+        );
+        expect(values).toEqual([12.4, 3.6, 98.75]);
+    });
+
+    it("formats every view as a percentage", () => {
+        const shown = [0, 1, 2].map((i) => {
+            const view = kpiView(community, i);
+            return formatValue(kpiValue(view, week), view.format);
+        });
+        expect(shown).toEqual(["12%", "4%", "99%"]);
+    });
+
+    it("gives each view its own tooltip naming the 4xx treatment", () => {
+        const tooltips = community.views.map((view) => view.tooltip);
+        expect(new Set(tooltips).size).toBe(3);
+        for (const tooltip of tooltips) expect(tooltip).toMatch(/4xx/);
+    });
+
+    it("reads as missing, not zero, before the pipe ships the fields", () => {
+        const before = { week: "2026-05-04" };
+        for (const index of [0, 1, 2]) {
+            const view = kpiView(community, index);
+            expect(kpiValue(view, before)).toBeUndefined();
+            expect(formatValue(kpiValue(view, before), view.format)).toBe("—");
+        }
+    });
+});

--- a/operations/kpi/vitest.config.js
+++ b/operations/kpi/vitest.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+// Its own config, not vite.config.js: that one loads the Cloudflare plugin and
+// would boot a Worker for tests that only exercise plain modules.
+export default defineConfig({
+    test: { include: ["test/**/*.test.js"], environment: "node" },
+});


### PR DESCRIPTION
Promotes two KPI dashboard PRs. Nothing else is in the gap.

- #13568 — graph any KPI from the trend table; axis now fits the data
- #13570 — community-models row (users ⇄ requests ⇄ availability) + CSV columns

The `weekly_usage_stats` pipe is already live in Tinybird prod (deployment 164), so the row populates as soon as the worker's 6-hour response cache turns over.