### PR TITLE
feat: add Nemotron 3.5 Lightning via Fireworks

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -1157,6 +1157,18 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.0000005,
     },
   },
+  "nemotron-3.5-lightning": {
+    "cost": {
+      "completionTextTokens": 0.0000002,
+      "promptCachedTokens": 0.00000001,
+      "promptTextTokens": 0.00000005,
+    },
+    "price": {
+      "completionTextTokens": 0.0000002,
+      "promptCachedTokens": 0.00000001,
+      "promptTextTokens": 0.00000005,
+    },
+  },
   "nova": {
     "cost": {
       "completionTextTokens": 0.00000275,

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -368,6 +368,13 @@ const models: ModelDefinition[] = [
         transform: createReasoningEffortTransform("toggle"),
     },
     {
+        name: "nemotron-3.5-lightning",
+        config: portkeyConfig[
+            "accounts/fireworks/models/nemotron-lightning-3p5-30b-a3b"
+        ],
+        transform: pipe(stripCacheControl, fireworksThinking),
+    },
+    {
         name: "mimo-v2.5",
         config: portkeyConfig["xiaomi/mimo-v2.5"],
         transform: stripCacheControl,

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -405,6 +405,10 @@ export const portkeyConfig: PortkeyConfigMap = {
         createFireworksModelConfig({
             model: "accounts/fireworks/models/muse-glimmer-30b",
         }),
+    "accounts/fireworks/models/nemotron-lightning-3p5-30b-a3b": () =>
+        createFireworksModelConfig({
+            model: "accounts/fireworks/models/nemotron-lightning-3p5-30b-a3b",
+        }),
 
     // -- Vercel AI Gateway (Meta) --------------------------------------------
     "meta/muse-spark-1.2": () =>

--- a/gen.pollinations.ai/test/text/transforms/createReasoningEffortTransform.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/createReasoningEffortTransform.test.ts
@@ -90,6 +90,7 @@ describe("reasoning_effort model wiring", () => {
         "qwen3.8-2.4t-a95b",
         "longcat",
         "nemotron",
+        "nemotron-3.5-lightning",
         "minimax",
         "muse-glimmer",
     ])("disables thinking via reasoning_effort=none on %s", async (modelName) => {

--- a/gen.pollinations.ai/test/text/transforms/stripCacheControl.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/stripCacheControl.test.ts
@@ -45,9 +45,8 @@ describe("stripCacheControl", () => {
 });
 
 describe("stripCacheControl model wiring", () => {
-    // Azure-deployed Grok rejects cache_control like its sibling Azure/strict
-    // OpenAI-compatible models; all grok entries must carry the transform so
-    // multi-turn history isn't dropped (see issue #10722).
+    // Strict OpenAI-compatible providers reject Anthropic-style cache_control
+    // annotations, so affected models must strip them without dropping history.
     it.each([
         "grok",
         "nemotron-3.5-lightning",

--- a/gen.pollinations.ai/test/text/transforms/stripCacheControl.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/stripCacheControl.test.ts
@@ -48,9 +48,12 @@ describe("stripCacheControl model wiring", () => {
     // Azure-deployed Grok rejects cache_control like its sibling Azure/strict
     // OpenAI-compatible models; all grok entries must carry the transform so
     // multi-turn history isn't dropped (see issue #10722).
-    it("wires cache_control stripping onto grok", async () => {
-        const transform = findModelByName("grok")?.transform;
-        if (!transform) throw new Error("grok transform missing");
+    it.each([
+        "grok",
+        "nemotron-3.5-lightning",
+    ])("wires cache_control stripping onto %s", async (modelName) => {
+        const transform = findModelByName(modelName)?.transform;
+        if (!transform) throw new Error(`${modelName} transform missing`);
 
         const { messages: result } = await transform(
             [

--- a/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
+++ b/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
@@ -96,6 +96,21 @@ describe("resolveModelConfig", () => {
         expect(result.options.provider).toBeUndefined();
     });
 
+    it("routes Nemotron 3.5 Lightning directly to Fireworks without fallback", () => {
+        const result = resolveModelConfig(messages, {
+            model: "nemotron-3.5-lightning",
+        });
+
+        expect(result.options.model).toBe(
+            "accounts/fireworks/models/nemotron-lightning-3p5-30b-a3b",
+        );
+        expect(result.options.modelConfig).toMatchObject({
+            provider: "openai",
+            "custom-host": "https://api.fireworks.ai/inference/v1",
+        });
+        expect(result.options.provider).toBeUndefined();
+    });
+
     it("routes Step Flash directly to DeepInfra without fallback", () => {
         const result = resolveModelConfig(messages, { model: "step-flash" });
 

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -1381,6 +1381,30 @@ export const TEXT_SERVICES = {
         contextLength: 262144,
         isSpecialized: false,
     },
+    "nemotron-3.5-lightning": {
+        aliases: [],
+        provider: "fireworks",
+        brand: "NVIDIA",
+        category: "text",
+        addedDate: new Date("2026-08-19").getTime(),
+        paidOnly: false,
+        priceMultiplier: 1,
+        cost: {
+            // Fireworks, verified 2026-08-19: $0.05/$0.01/$0.20 per million.
+            promptTextTokens: perMillion(0.05),
+            promptCachedTokens: perMillion(0.01),
+            completionTextTokens: perMillion(0.2),
+        },
+        title: "NVIDIA Nemotron 3.5 Lightning",
+        description:
+            "Fast open-weight reasoning for high-volume agent tasks, tool use and structured output",
+        inputModalities: ["text"],
+        outputModalities: ["text"],
+        tools: true,
+        reasoning: true,
+        contextLength: 262144,
+        isSpecialized: false,
+    },
     "mimo-v2.5": {
         aliases: ["mimo", "mimo-2.5"],
         provider: "openrouter",


### PR DESCRIPTION
## Summary

- Adds canonical `nemotron-3.5-lightning` with no aliases.
- Routes directly to Fireworks `accounts/fireworks/models/nemotron-lightning-3p5-30b-a3b` with no fallback.
- Declares the verified Fireworks rates: $0.05/M prompt, $0.01/M cached prompt, and $0.20/M completion tokens.
- Keeps the service Quest-accessible (`paidOnly: false`), at multiplier `1`, with no Pollinations GPU.
- Preserves existing `nemotron`, which remains the separate Nemotron 3 Ultra service.

## Verification

- Direct Fireworks: text, streaming, reasoning on/off, tools, JSON schema, prompt cache, errors, and 5/5 burst.
- Local Pollinations E2E: `/v1/chat/completions`, `/text`, `/models`, `/v1/models`, streaming, tools and follow-up, JSON schema, parameters, cache annotations, output cache, Quest-only access, model permissions, errors, exact wallet billing, staging Tinybird billing, and 5/5 burst.
- Gen: 83 focused tests and typecheck passed.
- Enter: 83 pricing/variant/snapshot tests and production build passed.
- Biome and `git diff --check` passed.

After merge, run one paid production route, cache, wallet, Tinybird, and provider-activity reconciliation before considering the task complete.
