### PR TITLE
fix: harden DreamShaper Vast deployment

### DIFF
--- a/operations/infrastructure/gpu/GPU_INSTANCES.md
+++ b/operations/infrastructure/gpu/GPU_INSTANCES.md
@@ -1,6 +1,6 @@
 # GPU Instances
 
-Last updated: 2026-08-11
+Last updated: 2026-08-19
 
 ## Capacity Summary
 
@@ -9,14 +9,14 @@ Last updated: 2026-08-11
 | Flux (FP4) | 2 | 2x RTX PRO 4000 Blackwell | Vast.ai | $0.460000/hr all-in | **ACTIVE — two production, Vast-only** |
 | Z-Image | 1 | RTX 5090 | Vast.ai | $0.351111/hr all-in | **ACTIVE — one production with Fal spillover** |
 | Klein 4B | 1 | RTX 3090 | Vast.ai | $0.150000/hr all-in | **ACTIVE — Vast production** |
-| DreamShaper 8 LCM (`dreamshaper`, alias `sana`) | 2 | 2x RTX 3090 | Vast.ai | $0.303333/hr all-in | **ACTIVE — production** |
+| DreamShaper 8 LCM (`dreamshaper`, alias `sana`) | 2 | 2x RTX 4070 | Vast.ai | $0.196889/hr all-in | **ACTIVE — production** |
 | LTX-2 + ACE-Step | 0 active routes | GH200 (historical) | Lambda Labs | Verify provider account | **RETIRED from production** |
 
-At capture time, the six running Vast instances cost **$1.264444/hr** in total
-(**$910.40 per 30-day month**).
+At capture time, the six running Vast instances cost **$1.158000/hr** in total
+(**$833.76 per 30-day month**).
 All six are production workers; there is no isolated canary left running.
 
-Live verification on 2026-08-11 confirmed that all six instances are in both
+Live verification on 2026-08-19 confirmed that all six instances are in both
 `actual_status=running` and `intended_status=running`, every model server and
 named tunnel is healthy, and the registry contains both Flux hostnames, the
 shared Z-Image hostname, and both DreamShaper hostnames. Klein is not in the
@@ -37,7 +37,7 @@ exists after the routing change deploys.
 
 | Worker | Vast instance | Machine / region | GPU | All-in rate | Status |
 |--------|---------------|------------------|-----|-------------|--------|
-| dreamshaper-vast-01 | 46607014 | 4749 / Oregon, US | RTX 3090 | $0.150000/hr | ACTIVE — named tunnel `dreamshaper-canary-46600159.myceli.ai` |
+| dreamshaper-vast-01 | 48108043 | 94288 / New Zealand | RTX 4070 | $0.103000/hr | ACTIVE — named tunnel `dreamshaper-canary-46600159.myceli.ai` |
 | dreamshaper-vast-02 | 47789794 | 100803 / Romania, RO | RTX 4070 | $0.093889/hr | ACTIVE — named tunnel `dreamshaper-canary-47789794.myceli.ai` |
 
 Config: `Lykon/dreamshaper-8` + fused `lcm-lora-sdv1-5`, `LCMScheduler`, TAESD
@@ -51,36 +51,40 @@ gen retries the other registered DreamShaper hostname. With three processes,
 each GPU admits at most six in-flight requests instead of accumulating an
 unbounded local backlog.
 
-Instance `46607014` replaced `46307858` on 2026-08-02 and reduced the slot from
-`$0.175556/hr` to `$0.150000/hr`, saving **$0.025556/hr** or about
-**$18.40 per 30-day month**. The Oregon host has Vast reliability `0.9977` and
-preserves regional and machine diversity from the California replica.
+Instance `48108043` replaced `46607014` on 2026-08-19 and reduced the slot from
+`$0.150000/hr` to `$0.103000/hr`, saving **$0.047000/hr** or **$33.84 per
+30-day month** in Vast credits. The New Zealand host had Vast reliability
+`0.9977049` when rented and preserves machine and regional diversity from the
+Romania replica.
 
-Qualification passed authentication, fixed-seed byte parity, caller-step
-override protection, 512x512 and clamped dimension limits, public tunnel
-parity, and a genuine Vast stop/start. A 20.69-second concurrency-8 run served
-210 images with zero errors at **10.15 img/s** and **1.54s p95**. After
-promotion the host served 358 attributed production generations with zero
-5xx, OOM, CUDA, worker, or tunnel failures before the old instance was
-destroyed.
+Qualification passed authentication, fixed-seed byte parity, 512x512 and
+clamped dimension limits, output quality, queue shedding, and restart
+recovery. At 200 RPM the RTX 4070 served 60/60 requests after restart. At 300
+RPM it served 60/60 before restart and 29/30 in a later short probe, shedding
+the remaining request for cross-worker retry. In the final post-cutover window
+it served 58 production requests with zero backend errors at **0.23s mean**
+and **0.40s p95** generation time; five queue-full responses were retried on
+the other DreamShaper worker.
 
-The canary also exposed a reusable restart failure: quitting the `screen`
-session can leave Uvicorn child workers holding port 8766. `setup-vast.sh` now
-uses `fuser` to terminate the existing listener before relaunching, preventing
-an `Address already in use` restart loop.
+The canary exposed two reusable deployment requirements. Prefer the smaller
+`nvidia/cuda:12.8.1-cudnn-runtime-ubuntu24.04` image; the previous Vast
+development image repeatedly stalled before container creation. Also, killing
+only the port listener is insufficient for multi-worker Uvicorn: detached
+supervisors, spawned workers, and the resource tracker can survive and race the
+replacement process. `setup-vast.sh` now terminates the dedicated supervisor
+and every Python process in the DreamShaper venv before port cleanup.
 
 **Run several uvicorn workers per card.** A single process plateaued at
 **~4.3 img/s with the GPU only 26-45% busy** — the ceiling is the Python path
 (global lock, JPEG + base64 per response), not the GPU or the step count.
-Dropping 3 steps to 2 changed nothing, which proved it. With `WORKERS=3` each
-3090 sustains **~8 img/s** at concurrency 8 (GPU still only ~36%, so there is
-more left). The model is ~2.5 GB, so three copies fit easily in 24 GB.
+Dropping 3 steps to 2 changed nothing, which proved it. With `WORKERS=3`, the
+validated RTX 4070 sustained the expected 200 RPM per-worker load with zero
+errors. The model is small enough for three copies on its 12 GB card.
 
-Measured capacity is ~16 img/s across both cards against a 5.72 img/s peak, so
-either card can carry production alone. **Never size this from a single-client
-benchmark** — the first rollout did, sized one card at 6.18 img/s, and produced
-a latency climb to 57s in production before the GH200 was put back in the pool
-as emergency capacity.
+The two-card pool covers the measured 5.72 img/s peak and uses cross-worker 503
+retry for short bursts. **Never size this from a single-client benchmark** —
+the first rollout did, sized one card at 6.18 img/s, and produced a latency
+climb to 57s in production before emergency capacity was restored.
 
 Two traps that fail silently:
 

--- a/operations/infrastructure/gpu/dreamshaper/README.md
+++ b/operations/infrastructure/gpu/dreamshaper/README.md
@@ -61,13 +61,13 @@ Requires a **named** Cloudflare tunnel, not a quick tunnel (quick tunnels caused
 outage #12254). Point the public hostname at `http://localhost:8766` and pass
 the hostname so heartbeats advertise the stable URL rather than a raw IP:
 
-Provision a Vast SSH instance with at least 60 GB of disk and configure the
+Provision a Vast SSH instance with at least 30 GB of disk and configure the
 startup hook at rent time:
 
 ```bash
 vastai create instance <OFFER> \
-  --image vastai/base-image:cuda-12.8.1-cudnn-devel-ubuntu24.04-py312 \
-  --disk 60 --ssh --label dreamshaper-vast-NN \
+  --image nvidia/cuda:12.8.1-cudnn-runtime-ubuntu24.04 \
+  --disk 30 --ssh --label dreamshaper-vast-NN \
   --onstart-cmd 'if [ -x /root/onstart.sh ]; then /root/onstart.sh; fi'
 vastai attach ssh <INSTANCE> ~/.ssh/id_ed25519.pub
 
@@ -86,15 +86,24 @@ PLN_GPU_TOKEN=... CLOUDFLARED_TUNNEL_TOKEN=... \
   HEARTBEAT_ENABLED=true GIT_BRANCH=main bash setup-vast.sh
 ```
 
+Use the NVIDIA runtime image above. DreamShaper installs the pinned PyTorch
+CUDA wheel and does not compile CUDA extensions, so the larger development
+image is unnecessary. During the 2026-08-19 replacement, the previous Vast
+development image repeatedly stalled before container creation while this
+runtime image booted successfully. `setup-vast.sh` creates `/workspace` when
+the image does not provide it.
+
 Env: `MODEL_ID`, `LCM_LORA`, `TINY_VAE`, `NUM_INFERENCE_STEPS`,
 `GUIDANCE_SCALE`, `MAX_DIM` (768), `MAX_PIXELS` (512²), `PORT` (8766),
 `REGISTER_URL`, `SERVICE_TYPE` (`sana`), `HEARTBEAT_ENABLED`,
 `TUNNEL_ENABLED`, `WORKERS` (3), and `QUEUE_LIMIT` (2 per worker process).
 
 Vast executes `/root/onstart.sh`, not `/workspace/onstart.sh`, after a container
-restart. The startup script terminates any listener still holding port 8766
-before relaunching Uvicorn; quitting the parent `screen` session alone can
-leave worker children alive and cause an `Address already in use` loop.
+restart. The startup script terminates the detached supervisor and every
+Python process in the dedicated DreamShaper venv before clearing port 8766 and
+relaunching Uvicorn. Killing only the listener is insufficient: spawned
+workers and the resource tracker can survive their parent and cause an
+`Address already in use` loop.
 
 **Ordering matters when replacing sana.** Before this change `sana` was reached
 through a hardcoded backend URL that bypassed the registry pool. Deploy and

--- a/operations/infrastructure/gpu/dreamshaper/SERVERS.md
+++ b/operations/infrastructure/gpu/dreamshaper/SERVERS.md
@@ -1,6 +1,6 @@
 # Sana compatibility route
 
-Last updated: 2026-08-15
+Last updated: 2026-08-19
 
 ## Current deployment
 
@@ -11,7 +11,7 @@ for compatibility.
 
 | Worker | Vast instance | Machine / region | GPU | All-in rate | Registered hostname |
 |--------|---------------|------------------|-----|-------------|---------------------|
-| dreamshaper-vast-01 | 46607014 | 4749 / Oregon, US | RTX 3090 | $0.150000/hr | `dreamshaper-canary-46600159.myceli.ai` |
+| dreamshaper-vast-01 | 48108043 | 94288 / New Zealand | RTX 4070 | $0.103000/hr | `dreamshaper-canary-46600159.myceli.ai` |
 | dreamshaper-vast-02 | 47789794 | 100803 / Romania, RO | RTX 4070 | $0.093889/hr | `dreamshaper-canary-47789794.myceli.ai` |
 
 The route is:

--- a/operations/infrastructure/gpu/dreamshaper/setup-vast.sh
+++ b/operations/infrastructure/gpu/dreamshaper/setup-vast.sh
@@ -35,6 +35,7 @@ if ! command -v cloudflared >/dev/null || \
     dpkg -i /tmp/cloudflared.deb >/dev/null
 fi
 
+install -d -m 755 "$(dirname "$WORK_DIR")"
 if [ -d "$WORK_DIR/.git" ]; then
     git -C "$WORK_DIR" fetch --depth 1 origin "$GIT_BRANCH"
     git -C "$WORK_DIR" checkout FETCH_HEAD
@@ -104,8 +105,21 @@ set -euo pipefail
 PORT=$PORT
 
 screen -wipe >/dev/null 2>&1 || true
+# Stop the detached supervisor before its Uvicorn children, otherwise the
+# loop can relaunch the parent while cleanup is still in progress.
+pkill -TERM -f "/root/run-dreamshaper.sh" 2>/dev/null || true
 screen -S dreamshaper -X quit 2>/dev/null || true
 screen -S cloudflared -X quit 2>/dev/null || true
+# Uvicorn's spawned workers and resource tracker can outlive their parent.
+# This venv is dedicated to DreamShaper, so terminate every process using it.
+pkill -TERM -f "$VENV/bin/python" 2>/dev/null || true
+for _ in 1 2 3 4 5; do
+    if ! pgrep -f "$VENV/bin/python" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+done
+pkill -KILL -f "$VENV/bin/python" 2>/dev/null || true
 fuser -k -TERM \"\$PORT/tcp\" >/dev/null 2>&1 || true
 for _ in 1 2 3 4 5; do
     if ! fuser \"\$PORT/tcp\" >/dev/null 2>&1; then


### PR DESCRIPTION
- Replaces DreamShaper instance 46607014 with RTX 4070 instance 48108043, reducing the slot from $0.150/hr to $0.103/hr.
- Uses the smaller NVIDIA CUDA runtime image with 30 GB storage and creates the workspace parent directory.
- Stops the detached supervisor and all DreamShaper venv processes before restart, preventing orphaned Uvicorn workers from rebinding port 8766.
- Updates the live fleet inventory, deployment runbook, capacity evidence, and total Vast burn.

Validation: DreamShaper tests pass; shell syntax and diff checks pass; 60/60 requests passed at 200 RPM; post-cutover production served 58 requests with zero backend errors at 0.40s p95.