### PR TITLE
feat: let the KPI graph select any variant, not just the cycled one

### DIFF
--- a/operations/kpi/src/App.jsx
+++ b/operations/kpi/src/App.jsx
@@ -101,7 +101,7 @@ export default function App() {
     // Which unit each cycling row is showing, and which row the explorer plots.
     // Both live here so the chart follows the table.
     const [viewIndex, setViewIndex] = useState({});
-    const [explored, setExplored] = useState("registrations");
+    const [explored, setExplored] = useState("registrations:0");
 
     const cycleView = (key) =>
         setViewIndex((prev) => ({ ...prev, [key]: (prev[key] ?? 0) + 1 }));
@@ -300,7 +300,6 @@ export default function App() {
                         id={EXPLORER_ID}
                         weeks={historyWeeks}
                         selected={explored}
-                        viewIndex={viewIndex}
                         onSelect={setExplored}
                     />
                     <FunnelBars

--- a/operations/kpi/src/components/KPITrendTable.jsx
+++ b/operations/kpi/src/components/KPITrendTable.jsx
@@ -16,7 +16,7 @@ import {
     formatValue,
     weekLabel,
 } from "../lib/format";
-import { KPIS, kpiValue, kpiView } from "../lib/kpis";
+import { KPIS, kpiValue, kpiView, kpiViewId } from "../lib/kpis";
 
 /** Three rising bars — marks the row you can send to the explorer chart. */
 function ChartIcon() {
@@ -120,7 +120,11 @@ export function KPITrendTable({ weeklyData, viewIndex, onCycle, onGraph }) {
                                                 type="button"
                                                 aria-label={`Graph ${kpi.name}`}
                                                 title={`Graph ${kpi.name}`}
-                                                onClick={() => onGraph(row.key)}
+                                                onClick={() =>
+                                                    onGraph(
+                                                        kpiViewId(row, index),
+                                                    )
+                                                }
                                                 className="ml-1 text-theme-text-muted hover:text-theme-text-link"
                                             >
                                                 <ChartIcon />

--- a/operations/kpi/src/components/KpiExplorer.jsx
+++ b/operations/kpi/src/components/KpiExplorer.jsx
@@ -1,14 +1,13 @@
-import { KPIS, kpiValue, kpiView } from "../lib/kpis";
+import { KPI_VIEWS, kpiValue, kpiViewById } from "../lib/kpis";
 import { LineChart } from "./LineChart";
 
 /**
- * Plots whichever KPI row the reader picked — from the selector here, or from
- * the graph button on a table row. Rows that cycle through units follow the
- * unit the table is currently showing.
+ * Plots whichever KPI the reader picked — from the selector here, or from the
+ * graph button on a table row. Rows that cycle through units contribute one
+ * entry per unit, so every variant is selectable without touching the table.
  */
-export function KpiExplorer({ id, weeks, selected, viewIndex, onSelect }) {
-    const row = KPIS.find((item) => item.key === selected) ?? KPIS[0];
-    const kpi = kpiView(row, viewIndex[row.key] ?? 0);
+export function KpiExplorer({ id, weeks, selected, onSelect }) {
+    const kpi = kpiViewById(selected);
 
     // Pipes reach back different distances, so trim to the span this metric
     // actually covers instead of leaving a long empty run-up.
@@ -20,17 +19,26 @@ export function KpiExplorer({ id, weeks, selected, viewIndex, onSelect }) {
     const last = points.findLastIndex((point) => Number.isFinite(point.value));
     const data = first === -1 ? [] : points.slice(first, last + 1);
 
+    // Categories keep a ~19-entry list readable, in catalogue order.
+    const categories = [...new Set(KPI_VIEWS.map((view) => view.category))];
+
     const selector = (
         <select
             aria-label="KPI to graph"
-            value={row.key}
+            value={kpi.id}
             onChange={(event) => onSelect(event.target.value)}
             className="rounded-lg bg-theme-bg-subtle px-2.5 py-1.5 font-medium text-sm text-theme-text-strong hover:bg-theme-bg-hover"
         >
-            {KPIS.map((item) => (
-                <option key={item.key} value={item.key}>
-                    {kpiView(item, viewIndex[item.key] ?? 0).name}
-                </option>
+            {categories.map((category) => (
+                <optgroup key={category} label={category}>
+                    {KPI_VIEWS.filter((view) => view.category === category).map(
+                        (view) => (
+                            <option key={view.id} value={view.id}>
+                                {view.name}
+                            </option>
+                        ),
+                    )}
+                </optgroup>
             ))}
         </select>
     );

--- a/operations/kpi/src/lib/kpis.js
+++ b/operations/kpi/src/lib/kpis.js
@@ -175,3 +175,22 @@ export function kpiValue(kpi, week) {
 export function kpiView(row, index = 0) {
     return row.views ? { ...row, ...row.views[index % row.views.length] } : row;
 }
+
+/** The id the explorer uses to name one specific view of one row. */
+export function kpiViewId(row, index = 0) {
+    return `${row.key}:${row.views ? index % row.views.length : 0}`;
+}
+
+// Every view of every row as its own entry. The table cycles units in place to
+// stay compact; the graph has room to list them all, so a variant is reachable
+// there without cycling the table to it first.
+export const KPI_VIEWS = KPIS.flatMap((row) =>
+    (row.views ?? [null]).map((_, index) => ({
+        id: kpiViewId(row, index),
+        ...kpiView(row, index),
+    })),
+);
+
+export function kpiViewById(id) {
+    return KPI_VIEWS.find((view) => view.id === id) ?? KPI_VIEWS[0];
+}

--- a/operations/kpi/test/kpis.test.js
+++ b/operations/kpi/test/kpis.test.js
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { formatValue } from "../src/lib/format";
-import { KPIS, kpiValue, kpiView } from "../src/lib/kpis";
+import {
+    KPI_VIEWS,
+    KPIS,
+    kpiValue,
+    kpiView,
+    kpiViewById,
+    kpiViewId,
+} from "../src/lib/kpis";
 
 const community = KPIS.find((row) => row.key === "communityModels");
 
@@ -51,5 +58,49 @@ describe("community models row", () => {
             expect(kpiValue(view, before)).toBeUndefined();
             expect(formatValue(kpiValue(view, before), view.format)).toBe("—");
         }
+    });
+});
+
+describe("explorer view list", () => {
+    it("offers every view of every row, not one per row", () => {
+        const expected = KPIS.reduce(
+            (total, row) => total + (row.views?.length ?? 1),
+            0,
+        );
+        expect(KPI_VIEWS).toHaveLength(expected);
+        expect(KPI_VIEWS.length).toBeGreaterThan(KPIS.length);
+    });
+
+    it("gives each view a unique id that resolves back to it", () => {
+        const ids = KPI_VIEWS.map((view) => view.id);
+        expect(new Set(ids).size).toBe(ids.length);
+        for (const view of KPI_VIEWS)
+            expect(kpiViewById(view.id).name).toBe(view.name);
+    });
+
+    it("lists all three community variants separately", () => {
+        const names = KPI_VIEWS.filter((view) =>
+            view.id.startsWith("communityModels:"),
+        ).map((view) => view.name);
+        expect(names).toEqual([
+            "Community models · users",
+            "Community models · requests",
+            "Community models · availability",
+        ]);
+    });
+
+    it("sends a cycled table row to the variant it is showing", () => {
+        // The table's graph button passes kpiViewId(row, index); index 2 on the
+        // community row must land on availability, not back on users.
+        expect(kpiViewById(kpiViewId(community, 2)).name).toBe(
+            "Community models · availability",
+        );
+        expect(kpiViewById(kpiViewId(community, 4)).name).toBe(
+            "Community models · requests",
+        );
+    });
+
+    it("falls back to the first view for an unknown id", () => {
+        expect(kpiViewById("nope:9").id).toBe(KPI_VIEWS[0].id);
     });
 });


### PR DESCRIPTION
The explorer listed one entry per row and showed whichever unit the table was cycled to, so graphing **Community models · availability** meant cycling the table row twice first.

The table cycles in place because it is short of width. The dropdown is not, so it now lists every view of every row — 19 entries, grouped by category.

- `KPI_VIEWS` / `kpiViewId` / `kpiViewById` added to the catalogue
- Explorer selects by view id; no longer reads the table's `viewIndex`
- The table's graph button passes the view the row is currently showing, so that jump still lands on the right variant

10 tests pass, including that every view has a unique id resolving back to itself and that a cycled row jumps to its own variant.