### PR TITLE
fix: polish pollen price and signed-out footer

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/layout/dashboard-shell.tsx
+++ b/enter.pollinations.ai/frontend/src/components/layout/dashboard-shell.tsx
@@ -64,6 +64,7 @@ type DashboardShellProps = PropsWithChildren<{
     onSignOut?: () => void;
     accountArea?: ReactNode;
     walletArea?: ReactNode;
+    showFooterLinks?: boolean;
 }>;
 
 type BrandLink = {
@@ -146,6 +147,7 @@ export const DashboardShell: FC<DashboardShellProps> = ({
     onSignOut,
     accountArea,
     walletArea,
+    showFooterLinks = true,
     children,
 }) => {
     const [isDrawerOpen, setIsDrawerOpen] = useState(false);
@@ -298,6 +300,7 @@ export const DashboardShell: FC<DashboardShellProps> = ({
             supportLinks={supportLinks}
             accountArea={effectiveAccountArea}
             walletArea={walletArea}
+            showFooterLinks={showFooterLinks}
             onNavigate={closeDrawer}
         />
     );
@@ -389,6 +392,7 @@ type DashboardRailProps = {
     supportLinks: readonly SupportLink[];
     accountArea?: ReactNode;
     walletArea?: ReactNode;
+    showFooterLinks: boolean;
     onNavigate: () => void;
 };
 
@@ -399,6 +403,7 @@ const DashboardRail: FC<DashboardRailProps> = ({
     supportLinks,
     accountArea,
     walletArea,
+    showFooterLinks,
     onNavigate,
 }) => (
     <aside
@@ -448,7 +453,10 @@ const DashboardRail: FC<DashboardRailProps> = ({
         <div className="flex shrink-0 flex-col gap-2 border-t border-theme-text-strong/10 pt-4">
             {walletArea && <div className="px-1">{walletArea}</div>}
             {accountArea}
-            <DashboardFooter links={footerLinks} note="© 2026 Myceli.AI" />
+            <DashboardFooter
+                links={showFooterLinks ? footerLinks : []}
+                note="© 2026 Myceli.AI"
+            />
         </div>
     </aside>
 );
@@ -571,19 +579,21 @@ const DashboardFooter: FC<{
     note?: ReactNode;
 }> = ({ links, note }) => (
     <>
-        <div className="flex flex-wrap gap-x-2 gap-y-1 px-3 text-xs leading-snug text-theme-text-muted">
-            {links.map((link) => (
-                <a
-                    key={link.href}
-                    href={link.href}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="transition-colors hover:text-theme-text-strong"
-                >
-                    {link.label}
-                </a>
-            ))}
-        </div>
+        {links.length > 0 && (
+            <div className="flex flex-wrap gap-x-2 gap-y-1 px-3 text-xs leading-snug text-theme-text-muted">
+                {links.map((link) => (
+                    <a
+                        key={link.href}
+                        href={link.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="transition-colors hover:text-theme-text-strong"
+                    >
+                        {link.label}
+                    </a>
+                ))}
+            </div>
+        )}
         <div className="flex items-center justify-between gap-2 pl-3 text-xs leading-none text-theme-text-muted">
             <span>{note}</span>
             {/* accent on the toggle's active icon, over the neutral rail */}

--- a/enter.pollinations.ai/frontend/src/components/pollen/pollen-balance.tsx
+++ b/enter.pollinations.ai/frontend/src/components/pollen/pollen-balance.tsx
@@ -286,7 +286,7 @@ export const BuyPollenPanel: FC<BuyPollenPanelProps> = ({
         <>
             <Surface>
                 {selectedPack && (
-                    <div className="flex w-full flex-col items-start gap-4 pb-10 sm:flex-row sm:items-center sm:gap-4 sm:pb-20">
+                    <div className="flex w-full flex-col items-start gap-4 sm:flex-row sm:items-center sm:gap-4 sm:pb-20">
                         <div className="w-full min-w-0 flex-1 pb-20 sm:pb-0">
                             <PollenPackSlider
                                 value={selectedPack.amountUsd}

--- a/enter.pollinations.ai/frontend/src/components/pollen/pollen-pack-controls.tsx
+++ b/enter.pollinations.ai/frontend/src/components/pollen/pollen-pack-controls.tsx
@@ -113,38 +113,25 @@ export const PollenPackSlider: FC<PollenPackSliderProps> = ({
                                     {isSelected && (
                                         <span
                                             className={cn(
-                                                "absolute top-full mt-1 inline-flex items-center whitespace-nowrap",
+                                                "absolute top-full mt-1 inline-flex flex-col whitespace-nowrap",
                                                 isFirst
-                                                    ? "left-0"
+                                                    ? "left-0 items-start text-left"
                                                     : isLast
-                                                      ? "right-0"
-                                                      : "left-1/2 -translate-x-1/2",
+                                                      ? "right-0 items-end text-right"
+                                                      : "left-1/2 -translate-x-1/2 items-center text-center",
                                             )}
                                         >
                                             <Chip size="sm">
-                                                <span
-                                                    className={cn(
-                                                        "inline-flex flex-col leading-tight",
-                                                        isFirst
-                                                            ? "text-left"
-                                                            : isLast
-                                                              ? "text-right"
-                                                              : "text-center",
-                                                    )}
-                                                >
-                                                    <span className="text-sm">
-                                                        {selectedBadgeLabel ??
-                                                            `$${pack.amountUsd}`}
-                                                    </span>
-                                                    {selectedBadgeDetail && (
-                                                        <span className="text-xs font-normal leading-none text-theme-text-muted">
-                                                            {
-                                                                selectedBadgeDetail
-                                                            }
-                                                        </span>
-                                                    )}
+                                                <span className="text-sm">
+                                                    {selectedBadgeLabel ??
+                                                        `$${pack.amountUsd}`}
                                                 </span>
                                             </Chip>
+                                            {selectedBadgeDetail && (
+                                                <span className="mt-0.5 text-xs font-normal leading-none text-theme-text-muted">
+                                                    {selectedBadgeDetail}
+                                                </span>
+                                            )}
                                         </span>
                                     )}
                                 </span>

--- a/enter.pollinations.ai/frontend/src/routes/_dashboard.tsx
+++ b/enter.pollinations.ai/frontend/src/routes/_dashboard.tsx
@@ -1,4 +1,4 @@
-import { Button, GitHubIcon, InlineLink, Text } from "@pollinations/ui";
+import { Button, GitHubIcon, InlineLink } from "@pollinations/ui";
 import { createFileRoute, Outlet } from "@tanstack/react-router";
 import { useState } from "react";
 import { apiClient } from "../api.ts";
@@ -120,6 +120,7 @@ function DashboardLayout() {
             githubAvatarUrl={data.user?.image || ""}
             onSignOut={data.user ? handleSignOut : undefined}
             accountArea={data.user ? undefined : <SignedOutAccountArea />}
+            showFooterLinks={Boolean(data.user)}
             walletArea={
                 data.user ? (
                     <SidebarWallet
@@ -151,11 +152,7 @@ export function SignedOutAccountArea() {
                 <GitHubIcon className="h-4 w-4 shrink-0" />
                 {isSigningIn ? "Signing in..." : "Sign in with GitHub"}
             </Button>
-            <Text
-                size="micro"
-                tone="muted"
-                className="px-1 text-center leading-[1.35]"
-            >
+            <p className="px-1 text-center text-micro font-normal leading-[1.35] text-theme-text-muted">
                 By continuing, you agree to the{" "}
                 <InlineLink
                     href="https://pollinations.ai/terms"
@@ -171,7 +168,7 @@ export function SignedOutAccountArea() {
                     Privacy Policy
                 </InlineLink>
                 .
-            </Text>
+            </p>
             {error && (
                 <p className="px-2 text-xs text-intent-danger-text">{error}</p>
             )}

--- a/enter.pollinations.ai/frontend/src/routes/sign-in.tsx
+++ b/enter.pollinations.ai/frontend/src/routes/sign-in.tsx
@@ -60,6 +60,7 @@ function SignInPage() {
         <DashboardShell
             navItems={SIGNED_OUT_NAV_ITEMS}
             accountArea={<SignedOutAccountArea />}
+            showFooterLinks={false}
         >
             <NewsFaq />
         </DashboardShell>


### PR DESCRIPTION
- Fixes the price badge overflow by keeping the total inside the pill and rendering the fee beneath it.
- Removes the extra mobile-only bottom padding below the Buy button while preserving desktop spacing.
- Hides duplicate Terms, Privacy, and Refunds footer links for signed-out users.
- Makes the consent copy inherit the GitHub sign-in font at the existing micro size.
- Validated with Biome, the Enter frontend production build, and TypeScript.