### PR TITLE
fix: route Kontext to Azure East US

### DIFF
--- a/gen.pollinations.ai/src/image/models/azureFluxKontextModel.ts
+++ b/gen.pollinations.ai/src/image/models/azureFluxKontextModel.ts
@@ -34,13 +34,13 @@ export async function callAzureFluxKontext(
     safeParams: ImageParams,
     userInfo: AuthResult,
 ): Promise<ImageGenerationResult> {
-    const apiKey = getImageEnv("AZURE_MYCELI_PROD_SWEDEN_API_KEY");
+    const apiKey = getImageEnv("AZURE_MYCELI_PROD_API_KEY");
     const baseUrl =
-        "https://myceli-prod-swedencentral.cognitiveservices.azure.com/openai/deployments/FLUX.1-Kontext-pro";
+        "https://myceli-prod-eastus.services.ai.azure.com/openai/deployments/FLUX.1-Kontext-pro";
 
     if (!apiKey) {
         throw new Error(
-            "AZURE_MYCELI_PROD_SWEDEN_API_KEY not found in environment variables",
+            "AZURE_MYCELI_PROD_API_KEY not found in environment variables",
         );
     }
 
@@ -68,7 +68,7 @@ export async function callAzureFluxKontext(
         prompt: sanitizeString(prompt),
         size: size,
         n: 1,
-        model: "flux.1-kontext-pro",
+        model: "FLUX.1-Kontext-pro",
     };
 
     logCloudflare("Calling Azure Flux Kontext API with params:", requestBody);
@@ -81,7 +81,7 @@ export async function callAzureFluxKontext(
 
         // Add the prompt
         formData.append("prompt", sanitizeString(prompt));
-        formData.append("model", "flux.1-kontext-pro");
+        formData.append("model", "FLUX.1-Kontext-pro");
 
         // Handle images based on their type
         try {


### PR DESCRIPTION
- Routes `kontext` to the supported `myceli-prod-eastus` FLUX.1 Kontext deployment.
- Uses the existing East US production credential and Azure’s documented `services.ai.azure.com` endpoint.
- Sends the canonical `FLUX.1-Kontext-pro` model identifier for generation and editing.
- Fixes the outage caused by Azure retaining a stale Sweden deployment while no longer supporting the model in that region.
- Verified with live generation and edit requests (both HTTP 200), TypeScript typecheck, and 52 focused image tests.