### PR TITLE
fix: prevent zero billing when OpenRouter omits usage

### DIFF
--- a/gen.pollinations.ai/src/middleware/track.ts
+++ b/gen.pollinations.ai/src/middleware/track.ts
@@ -128,6 +128,11 @@ type ResponseTrackingData = {
     errorTracking?: ErrorData;
 };
 
+const OPENROUTER_GENERATION_ENDPOINT =
+    "https://openrouter.ai/api/v1/generation";
+const OPENROUTER_USAGE_RECOVERY_DELAYS_MS = [0, 5_000, 10_000] as const;
+const OPENROUTER_GENERATION_LOOKUP_TIMEOUT_MS = 5_000;
+
 export type TrackVariables = {
     track: {
         modelRequested: string | null;
@@ -339,6 +344,7 @@ export const track = (eventType: EventType) =>
                         terminalAttempt?.candidate.definition,
                     terminalAttemptModel ?? servedEntry?.id,
                     pricingInput,
+                    c.env.OPENROUTER_API_KEY,
                 );
                 if (responseTracking.cacheHit) {
                     await c.var.frontendKeyRateLimit?.consumePollen(0);
@@ -584,6 +590,7 @@ export async function trackResponse(
     servedModelDefinition?: ModelDefinition,
     terminalAttemptModel?: string,
     pricingInput?: PricingInput,
+    openRouterApiKey?: string,
 ): Promise<ResponseTrackingData> {
     const log = getLogger(["hono", "track", "response"]);
     const { resolvedModelRequested } = requestTracking;
@@ -649,12 +656,47 @@ export async function trackResponse(
         return notBilled({ modelUsed: resolvedModelRequested });
     }
 
-    const { modelUsage, output, contentFilterResults } =
+    let { modelUsage, output, contentFilterResults } =
         await extractUsageAndContentFilterResults(
             eventType,
             requestTracking,
             response,
         );
+
+    const servedCostDefinition =
+        servedModelDefinition?.cost ?? requestTracking.modelCostDefinition;
+    const needsOpenRouterUsageRecovery =
+        eventType === "generate.text" &&
+        modelProviderUsed === "openrouter" &&
+        hasPositiveRate(servedCostDefinition) &&
+        !hasPositiveUsage(modelUsage?.usage);
+
+    if (needsOpenRouterUsageRecovery) {
+        const generationId =
+            response.headers.get("x-generation-id") ??
+            findOpenRouterGenerationId(output);
+        const recoveredUsage =
+            generationId && openRouterApiKey
+                ? await recoverOpenRouterUsage(generationId, openRouterApiKey)
+                : null;
+
+        if (recoveredUsage) {
+            modelUsage = {
+                model: modelCalled,
+                usage: recoveredUsage,
+                output,
+            };
+            log.info(
+                "Recovered missing OpenRouter usage for model {model} from generation metadata",
+                { model: modelCalled },
+            );
+        } else {
+            // An all-zero object is not usable billing evidence for a paid
+            // OpenRouter request. Treat it like absent usage so the request is
+            // never silently recorded as successfully billed at zero.
+            modelUsage = null;
+        }
+    }
     if (!modelUsage) {
         log.error("Failed to extract model usage for model {model}", {
             model: resolvedModelRequested,
@@ -732,6 +774,107 @@ export async function trackResponse(
         usage: modelUsage.usage,
         contentFilterResults,
     };
+}
+
+function hasPositiveRate(definition: CostDefinition): boolean {
+    return Object.values(definition).some(
+        (rate) => typeof rate === "number" && rate > 0,
+    );
+}
+
+function hasPositiveUsage(usage?: Usage): boolean {
+    return Object.values(usage ?? {}).some(
+        (value) => typeof value === "number" && value > 0,
+    );
+}
+
+function findOpenRouterGenerationId(output: unknown): string | null {
+    if (!output || typeof output !== "object") return null;
+
+    const directId = (output as { id?: unknown }).id;
+    if (isOpenRouterGenerationId(directId)) return directId;
+
+    const streamEvents = (output as { streamEvents?: unknown }).streamEvents;
+    if (!Array.isArray(streamEvents)) return null;
+    for (const event of streamEvents) {
+        if (!event || typeof event !== "object") continue;
+        const eventId = (event as { id?: unknown }).id;
+        if (isOpenRouterGenerationId(eventId)) return eventId;
+    }
+    return null;
+}
+
+function isOpenRouterGenerationId(value: unknown): value is string {
+    return (
+        typeof value === "string" &&
+        value.startsWith("gen-") &&
+        value.length <= 255
+    );
+}
+
+const OpenRouterGenerationSchema = z.object({
+    data: z.object({
+        tokens_prompt: z.number().int().nonnegative(),
+        tokens_completion: z.number().int().nonnegative(),
+        native_tokens_cached: z.number().int().nonnegative().nullish(),
+        native_tokens_reasoning: z.number().int().nonnegative().nullish(),
+    }),
+});
+
+async function recoverOpenRouterUsage(
+    generationId: string,
+    apiKey: string,
+): Promise<Usage | null> {
+    const url = new URL(OPENROUTER_GENERATION_ENDPOINT);
+    url.searchParams.set("id", generationId);
+
+    for (const delayMs of OPENROUTER_USAGE_RECOVERY_DELAYS_MS) {
+        if (delayMs > 0) {
+            await new Promise((resolve) => setTimeout(resolve, delayMs));
+        }
+
+        try {
+            const response = await fetch(url, {
+                headers: { Authorization: `Bearer ${apiKey}` },
+                signal: AbortSignal.timeout(
+                    OPENROUTER_GENERATION_LOOKUP_TIMEOUT_MS,
+                ),
+            });
+            if (response.status === 401 || response.status === 403) return null;
+            if (!response.ok) continue;
+
+            const parsed = OpenRouterGenerationSchema.safeParse(
+                await response.json(),
+            );
+            if (!parsed.success) continue;
+
+            const promptTokens = parsed.data.data.tokens_prompt;
+            const completionTokens = parsed.data.data.tokens_completion;
+            if (promptTokens + completionTokens === 0) continue;
+
+            const cachedTokens = Math.min(
+                parsed.data.data.native_tokens_cached ?? 0,
+                promptTokens,
+            );
+            const reasoningTokens = Math.min(
+                parsed.data.data.native_tokens_reasoning ?? 0,
+                completionTokens,
+            );
+            return {
+                promptTextTokens: promptTokens - cachedTokens,
+                ...(cachedTokens > 0
+                    ? { promptCachedTokens: cachedTokens }
+                    : {}),
+                completionTextTokens: completionTokens - reasoningTokens,
+                ...(reasoningTokens > 0
+                    ? { completionReasoningTokens: reasoningTokens }
+                    : {}),
+            };
+        } catch {
+            // A recovery lookup must never fail the successful generation.
+        }
+    }
+    return null;
 }
 
 // Portkey reports the served target as "config.targets[N]" via the

--- a/gen.pollinations.ai/test/tracking-observability.test.ts
+++ b/gen.pollinations.ai/test/tracking-observability.test.ts
@@ -1944,6 +1944,17 @@ describe("trackResponse missing usage", () => {
             headers: { "content-type": "text/event-stream" },
         });
 
+    const openRouterGeneration = (overrides = {}) =>
+        Response.json({
+            data: {
+                tokens_prompt: 12,
+                tokens_completion: 7,
+                native_tokens_cached: 2,
+                native_tokens_reasoning: 3,
+                ...overrides,
+            },
+        });
+
     it("marks a text response that carried no billable usage at all", async () => {
         const tracking = await trackResponse(
             "generate.text",
@@ -1966,6 +1977,149 @@ describe("trackResponse missing usage", () => {
         );
         expect(tracking.isBilledUsage).toBe(true);
         expect(tracking.errorTracking).toBeUndefined();
+    });
+
+    it("recovers paid OpenRouter usage from generation metadata", async () => {
+        const fetchSpy = vi
+            .spyOn(globalThis, "fetch")
+            .mockResolvedValue(openRouterGeneration());
+        const response = Response.json(
+            { id: "gen-recovery-test", choices: [] },
+            { headers: { "x-model-used": "gemini-fast" } },
+        );
+
+        const tracking = await trackResponse(
+            "generate.text",
+            requestTrackingFixture(false, "gemini-fast"),
+            response,
+            undefined,
+            undefined,
+            undefined,
+            "test-openrouter-key",
+        );
+
+        expect(fetchSpy).toHaveBeenCalledOnce();
+        const [input, init] = fetchSpy.mock.calls[0];
+        expect(String(input)).toBe(
+            "https://openrouter.ai/api/v1/generation?id=gen-recovery-test",
+        );
+        expect(new Headers(init?.headers).get("authorization")).toBe(
+            "Bearer test-openrouter-key",
+        );
+        expect(tracking.isBilledUsage).toBe(true);
+        expect(tracking.errorTracking).toBeUndefined();
+        expect(tracking.usage).toEqual({
+            promptTextTokens: 10,
+            promptCachedTokens: 2,
+            completionTextTokens: 4,
+            completionReasoningTokens: 3,
+        });
+        expect(tracking.cost?.totalCost).toBeGreaterThan(0);
+        expect(tracking.price?.totalPrice).toBeGreaterThan(0);
+    });
+
+    it("recovers a streamed OpenRouter generation by its event id", async () => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+            openRouterGeneration({
+                native_tokens_cached: 0,
+                native_tokens_reasoning: 0,
+            }),
+        );
+        const response = new Response(
+            [
+                `data: ${JSON.stringify({ id: "gen-stream-recovery-test", model: "google/gemini", choices: [] })}`,
+                "data: [DONE]",
+                "",
+            ].join("\n\n"),
+            {
+                headers: {
+                    "content-type": "text/event-stream",
+                    "x-model-used": "gemini-fast",
+                },
+            },
+        );
+
+        const tracking = await trackResponse(
+            "generate.text",
+            requestTrackingFixture(true, "gemini-fast"),
+            response,
+            undefined,
+            undefined,
+            undefined,
+            "test-openrouter-key",
+        );
+
+        expect(tracking.usage).toEqual({
+            promptTextTokens: 12,
+            completionTextTokens: 7,
+        });
+        expect(tracking.errorTracking).toBeUndefined();
+    });
+
+    it("does not classify a genuinely free community model as missing usage", async () => {
+        const fetchSpy = vi.spyOn(globalThis, "fetch");
+        const paidDefinition = getRegistryModelDefinition("gemini-fast");
+        const freeDefinition = {
+            ...paidDefinition,
+            provider: "community",
+            cost: {},
+            priceMultiplier: 1,
+        };
+        const response = Response.json(
+            { id: "community-response", choices: [] },
+            { headers: { "x-model-used": "owner/free-model" } },
+        );
+
+        const tracking = await trackResponse(
+            "generate.text",
+            {
+                ...requestTrackingFixture(false, "gemini-fast"),
+                modelRequested: "owner/free-model",
+                resolvedModelRequested: "owner/free-model",
+                modelProvider: "community",
+                modelDefinition: freeDefinition,
+                modelCostDefinition: {},
+                modelPriceDefinition: {},
+            },
+            response,
+            freeDefinition,
+            "owner/free-model",
+            undefined,
+            "test-openrouter-key",
+        );
+
+        expect(fetchSpy).not.toHaveBeenCalled();
+        expect(tracking.errorTracking).toBeUndefined();
+        expect(tracking.cost?.totalCost).toBe(0);
+        expect(tracking.price?.totalPrice).toBe(0);
+    });
+
+    it("marks unrecoverable paid OpenRouter zero usage as missing", async () => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+            Response.json(
+                { error: { message: "Unauthorized" } },
+                { status: 401 },
+            ),
+        );
+        const response = Response.json(
+            { id: "gen-unavailable-test", choices: [] },
+            { headers: { "x-model-used": "gemini-fast" } },
+        );
+
+        const tracking = await trackResponse(
+            "generate.text",
+            requestTrackingFixture(false, "gemini-fast"),
+            response,
+            undefined,
+            undefined,
+            undefined,
+            "test-openrouter-key",
+        );
+
+        expect(tracking.isBilledUsage).toBe(false);
+        expect(tracking.errorTracking).toMatchObject({
+            errorResponseCode: "usage_missing",
+        });
     });
 });
 

--- a/gen.pollinations.ai/test/tracking-observability.test.ts
+++ b/gen.pollinations.ai/test/tracking-observability.test.ts
@@ -604,6 +604,102 @@ describe("tracking observability", () => {
         expect(event.modelUsed).toBe("openai");
         expect(consumePollen).toHaveBeenCalledWith(0);
     });
+
+    it("recovers OpenRouter zero usage before billing and Tinybird settlement", async () => {
+        const tinybirdRequests: Request[] = [];
+        const generationRequests: Request[] = [];
+        vi.spyOn(globalThis, "fetch").mockImplementation(
+            async (input, init) => {
+                const request = new Request(input, init);
+                if (request.url.startsWith("https://openrouter.ai/")) {
+                    generationRequests.push(request);
+                    return Response.json({
+                        data: {
+                            tokens_prompt: 12,
+                            tokens_completion: 7,
+                            native_tokens_cached: 2,
+                            native_tokens_reasoning: 3,
+                        },
+                    });
+                }
+                tinybirdRequests.push(request);
+                return new Response("ok");
+            },
+        );
+        const consumePollen = vi.fn<(amount: number) => Promise<void>>(
+            async () => {},
+        );
+        const definition = getRegistryModelDefinition("gemini-fast");
+        const ctx = createExecutionContext();
+        const response = await createTestApp(
+            consumePollen,
+            trackingUser,
+            {
+                requested: "gemini-fast",
+                resolved: "gemini-fast",
+                definition,
+            },
+            undefined,
+            {
+                "x-generation-id": "gen-e2e-zero-usage",
+                "x-model-used": "gemini-fast",
+                "x-usage-prompt-text-tokens": "0",
+                "x-usage-completion-text-tokens": "0",
+            },
+        ).fetch(
+            new Request("https://gen.pollinations.ai/v1/chat/completions", {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify({
+                    model: "gemini-fast",
+                    stream: false,
+                    messages: [{ role: "user", content: "test" }],
+                }),
+            }),
+            {
+                DB: env.DB,
+                ENVIRONMENT: "test",
+                LOG_LEVEL: "debug",
+                LOG_FORMAT: "text",
+                BETTER_AUTH_SECRET: "test_secret",
+                OPENROUTER_API_KEY: "test_openrouter_key",
+                TINYBIRD_INGEST_URL:
+                    "https://tinybird.test/v0/events?name=generation_event_v2",
+                TINYBIRD_INGEST_TOKEN: "test_tinybird_token",
+            } as CloudflareBindings,
+            ctx,
+        );
+
+        await waitOnExecutionContext(ctx);
+
+        expect(response.status).toBe(200);
+        expect(generationRequests).toHaveLength(1);
+        expect(generationRequests[0].url).toBe(
+            "https://openrouter.ai/api/v1/generation?id=gen-e2e-zero-usage",
+        );
+        expect(generationRequests[0].headers.get("authorization")).toBe(
+            "Bearer test_openrouter_key",
+        );
+        expect(tinybirdRequests).toHaveLength(1);
+        const event = (await tinybirdRequests[0].json()) as TinybirdEvent;
+        expect(event).toMatchObject({
+            responseStatus: 200,
+            modelRequested: "gemini-fast",
+            modelUsed: "gemini-fast",
+            modelProviderUsed: "openrouter",
+            isBilledUsage: true,
+            tokenCountPromptText: 10,
+            tokenCountPromptCached: 2,
+            tokenCountCompletionText: 4,
+            tokenCountCompletionReasoning: 3,
+        });
+        expect(event.totalCost).toBeGreaterThan(0);
+        expect(event.totalPrice).toBeGreaterThan(0);
+        expect(event).not.toHaveProperty("errorResponseCode");
+        expect(consumePollen).toHaveBeenCalledWith(expect.any(Number));
+        expect(consumePollen.mock.calls[0]?.[0]).toBeGreaterThan(0);
+    });
+
     it("tracks usage after a malformed SSE event", async () => {
         const tinybirdRequests: Request[] = [];
         vi.spyOn(globalThis, "fetch").mockImplementation(


### PR DESCRIPTION
## Problem

Some successful paid OpenRouter requests omit usage or return an all-zero object. Pollinations then records zero provider cost and charges zero Pollen.

## Production evidence

Tinybird production snapshot on 2026-08-21:

- Seven-day all-zero usage: `gemini-fast` 3,734/645,788 successes (142 fully missing), `gemini` 388/3,406 (166 missing), and `gemini-flash-lite-3.5` 43/4,250.
- The rolling-hour symptom was limited to those three pinned Gemini routes. Non-Gemini routes had only isolated seven-day events: Mistral 12, Llama Scout 2, Mercury 2.

## What this PR does

- Recovers exact usage from OpenRouter generation metadata before settlement.
- Retries at 0s, 5s, and 15s for metadata indexing.
- Marks unrecovered requests `usage_missing` instead of silently treating them as billed at zero.
- Excludes genuinely free community routes and does not backfill history.

## Relationship to the source fix

[Gateway #10](https://github.com/pollinations/gateway/pull/10) is the source fix: the generic adapter strips OpenRouter provider pins, while the native adapter lacked parameter parity. Once released, Pollinations can enforce Vertex pins centrally.

This PR is optional billing-boundary defense-in-depth, not the routing fix. It protects paid requests if an upstream still returns unusable usage after Gateway #10.

## Checks

- Biome, TypeScript, and all 39 tracking-observability tests pass.
