### PR TITLE
fix: prevent duplicate generation settlement (BILL-017)

### DIFF
--- a/enter.pollinations.ai/drizzle/0052_closed_jack_murdock.sql
+++ b/enter.pollinations.ai/drizzle/0052_closed_jack_murdock.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `generation_settlement` (
+	`settlement_id` text PRIMARY KEY NOT NULL,
+	`payer_user_id` text NOT NULL,
+	`api_key_id` text,
+	`base_price` real NOT NULL,
+	`billed_price` real NOT NULL,
+	`payer_bucket` text,
+	`markup_json` text,
+	`community_model_reward_json` text,
+	`post_deduction_pack_balance` real,
+	`created_at` integer DEFAULT (cast((julianday('now') - 2440587.5)*86400000 as integer)) NOT NULL
+);

--- a/enter.pollinations.ai/drizzle/meta/0052_snapshot.json
+++ b/enter.pollinations.ai/drizzle/meta/0052_snapshot.json
@@ -1,0 +1,1902 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "ee3cadea-1ee1-4014-965e-574d9bbf12b9",
+  "prevId": "411bf138-2ff3-453f-8f49-894c58d4c069",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_account_user_id": {
+          "name": "idx_account_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent": {
+      "name": "agent",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_agent_owner_user_id": {
+          "name": "idx_agent_owner_user_id",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agent_owner_user_id_user_id_fk": {
+          "name": "agent_owner_user_id_user_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1000
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 5
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pollen_balance": {
+          "name": "pollen_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "byop_client_key_id": {
+          "name": "byop_client_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_apikey_key": {
+          "name": "idx_apikey_key",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_expires_at": {
+          "name": "idx_apikey_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_user_id": {
+          "name": "idx_apikey_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_apikey_byop_client_key_id": {
+          "name": "idx_apikey_byop_client_key_id",
+          "columns": [
+            "byop_client_key_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apikey_user_id_user_id_fk": {
+          "name": "apikey_user_id_user_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "community_endpoint": {
+      "name": "community_endpoint",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "modality": {
+          "name": "modality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'text'"
+        },
+        "image_pricing": {
+          "name": "image_pricing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'request'"
+        },
+        "supports_image_edits": {
+          "name": "supports_image_edits",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "input_modalities": {
+          "name": "input_modalities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "upstream_model": {
+          "name": "upstream_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bearer_token_ciphertext": {
+          "name": "bearer_token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'private'"
+        },
+        "per_user_rpm": {
+          "name": "per_user_rpm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_text_price": {
+          "name": "prompt_text_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt_cached_price": {
+          "name": "prompt_cached_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "prompt_cache_write_price": {
+          "name": "prompt_cache_write_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "prompt_audio_price": {
+          "name": "prompt_audio_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "prompt_image_price": {
+          "name": "prompt_image_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "completion_text_price": {
+          "name": "completion_text_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completion_reasoning_price": {
+          "name": "completion_reasoning_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "completion_audio_price": {
+          "name": "completion_audio_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "completion_image_price": {
+          "name": "completion_image_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "delegates_generation": {
+          "name": "delegates_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "fallback_model_ids": {
+          "name": "fallback_model_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_reason": {
+          "name": "disabled_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "disabled_by": {
+          "name": "disabled_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_community_endpoint_owner_user_id": {
+          "name": "idx_community_endpoint_owner_user_id",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_community_endpoint_owner_name": {
+          "name": "idx_community_endpoint_owner_name",
+          "columns": [
+            "owner_user_id",
+            "name"
+          ],
+          "isUnique": true
+        },
+        "idx_community_endpoint_agent_id": {
+          "name": "idx_community_endpoint_agent_id",
+          "columns": [
+            "agent_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "community_endpoint_owner_user_id_user_id_fk": {
+          "name": "community_endpoint_owner_user_id_user_id_fk",
+          "tableFrom": "community_endpoint",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_endpoint_agent_id_agent_id_fk": {
+          "name": "community_endpoint_agent_id_agent_id_fk",
+          "tableFrom": "community_endpoint",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "device_code": {
+      "name": "device_code",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_device_code_device_code": {
+          "name": "idx_device_code_device_code",
+          "columns": [
+            "device_code"
+          ],
+          "isUnique": false
+        },
+        "idx_device_code_user_code": {
+          "name": "idx_device_code_user_code",
+          "columns": [
+            "user_code"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "device_code_user_id_user_id_fk": {
+          "name": "device_code_user_id_user_id_fk",
+          "tableFrom": "device_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "generation_settlement": {
+      "name": "generation_settlement",
+      "columns": {
+        "settlement_id": {
+          "name": "settlement_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payer_user_id": {
+          "name": "payer_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_price": {
+          "name": "base_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "billed_price": {
+          "name": "billed_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payer_bucket": {
+          "name": "payer_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "markup_json": {
+          "name": "markup_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "community_model_reward_json": {
+          "name": "community_model_reward_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "post_deduction_pack_balance": {
+          "name": "post_deduction_pack_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "polar_checkout_credits": {
+      "name": "polar_checkout_credits",
+      "columns": {
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pollen_credited": {
+          "name": "pollen_credited",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "polar_created_at": {
+          "name": "polar_created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "customer_id": {
+          "name": "customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "product_slug": {
+          "name": "product_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_polar_checkout_credits_user_id": {
+          "name": "idx_polar_checkout_credits_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "polar_checkout_credits_user_id_user_id_fk": {
+          "name": "polar_checkout_credits_user_id_user_id_fk",
+          "tableFrom": "polar_checkout_credits",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rewards": {
+      "name": "rewards",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quest_id": {
+          "name": "quest_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pollen_amount": {
+          "name": "pollen_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "balance_bucket": {
+          "name": "balance_bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rewards_idempotency_key_unique": {
+          "name": "rewards_idempotency_key_unique",
+          "columns": [
+            "idempotency_key"
+          ],
+          "isUnique": true
+        },
+        "idx_rewards_user_id": {
+          "name": "idx_rewards_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "rewards_user_id_user_id_fk": {
+          "name": "rewards_user_id_user_id_fk",
+          "tableFrom": "rewards",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_session_user_id": {
+          "name": "idx_session_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_auto_top_up_attempt": {
+      "name": "stripe_auto_top_up_attempt",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount_usd": {
+          "name": "amount_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "stripe_auto_top_up_attempt_stripe_invoice_id_unique": {
+          "name": "stripe_auto_top_up_attempt_stripe_invoice_id_unique",
+          "columns": [
+            "stripe_invoice_id"
+          ],
+          "isUnique": true
+        },
+        "idx_stripe_auto_top_up_attempt_user_id": {
+          "name": "idx_stripe_auto_top_up_attempt_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_stripe_auto_top_up_attempt_status": {
+          "name": "idx_stripe_auto_top_up_attempt_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_auto_top_up_attempt_user_id_user_id_fk": {
+          "name": "stripe_auto_top_up_attempt_user_id_user_id_fk",
+          "tableFrom": "stripe_auto_top_up_attempt",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_card_fingerprint_attempt": {
+      "name": "stripe_card_fingerprint_attempt",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "card_fingerprint": {
+          "name": "card_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_stripe_card_fingerprint_attempt_user_created": {
+          "name": "idx_stripe_card_fingerprint_attempt_user_created",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_stripe_card_fingerprint_attempt_user_fingerprint": {
+          "name": "idx_stripe_card_fingerprint_attempt_user_fingerprint",
+          "columns": [
+            "user_id",
+            "card_fingerprint"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_card_fingerprint_attempt_user_id_user_id_fk": {
+          "name": "stripe_card_fingerprint_attempt_user_id_user_id_fk",
+          "tableFrom": "stripe_card_fingerprint_attempt",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "stripe_checkout_credits": {
+      "name": "stripe_checkout_credits",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pollen_credited": {
+          "name": "pollen_credited",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_stripe_checkout_credits_user_id": {
+          "name": "idx_stripe_checkout_credits_user_id",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "stripe_checkout_credits_user_id_user_id_fk": {
+          "name": "stripe_checkout_credits_user_id_user_id_fk",
+          "tableFrom": "stripe_checkout_credits",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "community_provider_name": {
+          "name": "community_provider_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "community_provider_url": {
+          "name": "community_provider_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'spore'"
+        },
+        "tier_balance": {
+          "name": "tier_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pack_balance": {
+          "name": "pack_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_tier_grant": {
+          "name": "last_tier_grant",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "0"
+        },
+        "auto_top_up_amount_usd": {
+          "name": "auto_top_up_amount_usd",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "user_stripe_customer_id_unique": {
+          "name": "user_stripe_customer_id_unique",
+          "columns": [
+            "stripe_customer_id"
+          ],
+          "isUnique": true
+        },
+        "idx_user_email": {
+          "name": "idx_user_email",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "idx_user_auto_top_up_enabled": {
+          "name": "idx_user_auto_top_up_enabled",
+          "columns": [
+            "auto_top_up_enabled"
+          ],
+          "isUnique": false
+        },
+        "user_github_id_unique": {
+          "name": "user_github_id_unique",
+          "columns": [
+            "github_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {
+        "idx_verification_identifier": {
+          "name": "idx_verification_identifier",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_item": {
+      "name": "media_item",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "app_key_id": {
+          "name": "app_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_media_item_owner_created": {
+          "name": "idx_media_item_owner_created",
+          "columns": [
+            "owner_user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "media_item_owner_user_id_user_id_fk": {
+          "name": "media_item_owner_user_id_user_id_fk",
+          "tableFrom": "media_item",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_tag": {
+      "name": "media_tag",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_media_tag_item_tag": {
+          "name": "idx_media_tag_item_tag",
+          "columns": [
+            "item_id",
+            "tag"
+          ],
+          "isUnique": true
+        },
+        "idx_media_tag_tag_item": {
+          "name": "idx_media_tag_tag_item",
+          "columns": [
+            "tag",
+            "item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "media_tag_item_id_media_item_id_fk": {
+          "name": "media_tag_item_id_media_item_id_fk",
+          "tableFrom": "media_tag",
+          "tableTo": "media_item",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/enter.pollinations.ai/drizzle/meta/_journal.json
+++ b/enter.pollinations.ai/drizzle/meta/_journal.json
@@ -365,6 +365,13 @@
       "when": 1787093808467,
       "tag": "0051_drop_rewards_github_id",
       "breakpoints": true
+    },
+    {
+      "idx": 52,
+      "version": "6",
+      "when": 1787225963045,
+      "tag": "0052_closed_jack_murdock",
+      "breakpoints": true
     }
   ]
 }

--- a/gen.pollinations.ai/src/byop-markup.test.ts
+++ b/gen.pollinations.ai/src/byop-markup.test.ts
@@ -5,6 +5,7 @@ import { computeDevCredit, MARKUP_PCT } from "@shared/billing/markup.ts";
 import { roundPollenLedgerAmount } from "@shared/billing/precision.ts";
 import {
     handleBalanceDeduction,
+    handleBalanceDeductionOnce,
     resolveDevMarkup,
 } from "@shared/billing/track-helpers.ts";
 import {
@@ -170,6 +171,44 @@ describe("BYOP markup", () => {
         const creatorBalances = await getUserBalance(db, devId);
         expect(creatorBalances.tierBalance).toBeCloseTo(MARKUP_PCT, 10);
         expect(creatorBalances.packBalance).toBe(0);
+    });
+
+    it("settles creator and community rewards only once on retry", async () => {
+        const { payerId, devId, pkId } = await setupPayerAndDev();
+        const ownerId = await createBalanceUser("community-owner");
+        const settlementId = `generate.text:${crypto.randomUUID()}`;
+        const settle = () =>
+            handleBalanceDeductionOnce({
+                d1: env.DB,
+                settlementId,
+                isBilledUsage: true,
+                totalPrice: 1,
+                userId: payerId,
+                byopClientKeyId: pkId,
+                communityModelReward: {
+                    userId: ownerId,
+                    rewardRate: COMMUNITY_MODEL_REWARD_RATE,
+                    basePrice: 0.5,
+                },
+            });
+
+        const first = await settle();
+        const retry = await settle();
+
+        expect(first.committed).toBe(true);
+        expect(retry.committed).toBe(false);
+        expect((await getUserBalance(db, payerId)).tierBalance).toBeCloseTo(
+            2 - 1 - MARKUP_PCT,
+            10,
+        );
+        expect((await getUserBalance(db, devId)).tierBalance).toBeCloseTo(
+            MARKUP_PCT,
+            10,
+        );
+        expect((await getUserBalance(db, ownerId)).tierBalance).toBeCloseTo(
+            0.5 * COMMUNITY_MODEL_REWARD_RATE,
+            10,
+        );
     });
 
     it("credits creator pack balance when payer spends pack balance", async () => {

--- a/gen.pollinations.ai/src/middleware/track.ts
+++ b/gen.pollinations.ai/src/middleware/track.ts
@@ -4,7 +4,7 @@ import { AUTO_TOP_UP_THRESHOLD_POLLEN } from "@shared/billing/auto-top-up.ts";
 import { payerBucketToMeter } from "@shared/billing/balance.ts";
 import {
     type CommunityModelRewardResolution,
-    handleBalanceDeduction,
+    handleBalanceDeductionOnce,
     type MarkupResolution,
 } from "@shared/billing/track-helpers.ts";
 import {
@@ -352,54 +352,64 @@ export const track = (eventType: EventType) =>
 
                 // Deduct payer + credit dev before emitting the event so billing
                 // telemetry reflects the committed ledger state.
-                const balanceDb = db as unknown as Parameters<
-                    typeof handleBalanceDeduction
-                >[0]["db"];
                 let markup: MarkupResolution | null = null;
                 let payerBucket: Awaited<
-                    ReturnType<typeof handleBalanceDeduction>
+                    ReturnType<typeof handleBalanceDeductionOnce>
                 >["payerBucket"] = null;
                 let communityModelReward: CommunityModelRewardResolution | null =
                     null;
                 let billedPrice = 0;
+                let postDeductionPackBalance: number | null = null;
                 let shouldRunAutoTopUp = false;
+                let duplicateSettlement = false;
                 try {
                     const communityEndpoint = servedEntry
                         ? servedEntry.communityEndpoint
                         : c.var.model?.communityEndpoint;
-                    const deduction = await handleBalanceDeduction({
-                        db: balanceDb,
-                        isBilledUsage: responseTracking.isBilledUsage,
-                        totalPrice: responseTracking.price?.totalPrice,
-                        userId,
-                        apiKeyId: c.var.auth?.apiKey?.id,
-                        apiKeyPollenBalance: c.var.auth?.apiKey?.pollenBalance,
-                        byopClientKeyId: c.var.auth?.apiKey?.byopClientKeyId,
-                        modelPaidOnly: c.var.model?.definition.paidOnly,
-                        // Only public endpoints pay their owner a reward: a
-                        // private endpoint is owner-called (base cost billed to
-                        // the owner, no markup, no self-credit).
-                        communityModelReward:
-                            communityEndpoint?.visibility === "public"
-                                ? {
-                                      userId: communityEndpoint.ownerUserId,
-                                      rewardRate: COMMUNITY_MODEL_REWARD_RATE,
-                                      // Their own listing, not the one the
-                                      // caller bought — see basePrice.
-                                      basePrice: responseTracking.servedPrice,
-                                  }
-                                : null,
-                    });
-                    markup = deduction.markup;
-                    communityModelReward = deduction.communityModelReward;
-                    payerBucket = deduction.payerBucket;
-                    billedPrice = deduction.billedPrice;
+                    if (responseTracking.isBilledUsage) {
+                        const deduction = await handleBalanceDeductionOnce({
+                            d1: c.env.DB,
+                            settlementId: `${eventType}:${c.get("requestId")}`,
+                            isBilledUsage: true,
+                            totalPrice: responseTracking.price?.totalPrice,
+                            userId,
+                            apiKeyId: c.var.auth?.apiKey?.id,
+                            apiKeyPollenBalance:
+                                c.var.auth?.apiKey?.pollenBalance,
+                            byopClientKeyId:
+                                c.var.auth?.apiKey?.byopClientKeyId,
+                            modelPaidOnly: c.var.model?.definition.paidOnly,
+                            // Only public endpoints pay their owner a reward: a
+                            // private endpoint is owner-called (base cost billed to
+                            // the owner, no markup, no self-credit).
+                            communityModelReward:
+                                communityEndpoint?.visibility === "public"
+                                    ? {
+                                          userId: communityEndpoint.ownerUserId,
+                                          rewardRate:
+                                              COMMUNITY_MODEL_REWARD_RATE,
+                                          // Their own listing, not the one the
+                                          // caller bought — see basePrice.
+                                          basePrice:
+                                              responseTracking.servedPrice,
+                                      }
+                                    : null,
+                        });
+                        duplicateSettlement = !deduction.committed;
+                        markup = deduction.markup;
+                        communityModelReward = deduction.communityModelReward;
+                        payerBucket = deduction.payerBucket;
+                        billedPrice = deduction.billedPrice;
+                        postDeductionPackBalance =
+                            deduction.postDeductionPackBalance;
+                    }
                     const totalPrice = responseTracking.price?.totalPrice ?? 0;
                     if (
+                        !duplicateSettlement &&
                         totalPrice > 0 &&
                         payerBucket === "pack" &&
-                        deduction.postDeductionPackBalance != null &&
-                        deduction.postDeductionPackBalance <=
+                        postDeductionPackBalance != null &&
+                        postDeductionPackBalance <=
                             AUTO_TOP_UP_THRESHOLD_POLLEN &&
                         (await isAutoTopUpConfigured(db, userId))
                     ) {
@@ -415,6 +425,13 @@ export const track = (eventType: EventType) =>
                                     : String(error),
                         },
                     );
+                }
+                if (duplicateSettlement) {
+                    log.warn(
+                        "Skipped duplicate generation settlement for request {requestId}",
+                        { requestId: c.get("requestId") },
+                    );
+                    return;
                 }
                 const committedBalanceTracking = payerBucket
                     ? {

--- a/gen.pollinations.ai/test/billing-deduction.test.ts
+++ b/gen.pollinations.ai/test/billing-deduction.test.ts
@@ -1,9 +1,16 @@
 import { env } from "cloudflare:test";
 import { getUserBalance } from "@shared/billing/balance.ts";
 import { atomicDeductUserBalance } from "@shared/billing/deduction.ts";
-import { handleBalanceDeduction } from "@shared/billing/track-helpers.ts";
-import { user as userTable } from "@shared/db/better-auth.ts";
+import {
+    handleBalanceDeduction,
+    handleBalanceDeductionOnce,
+} from "@shared/billing/track-helpers.ts";
+import {
+    apikey as apiKeyTable,
+    user as userTable,
+} from "@shared/db/better-auth.ts";
 import { getRegistryModelDefinition } from "@shared/registry/registry.ts";
+import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { describe, expect, it } from "vitest";
 
@@ -109,6 +116,49 @@ describe("billing deduction", () => {
             tierBalance: 0,
             packBalance: 10,
         });
+    });
+
+    it("settles concurrent retries with the same server id only once", async () => {
+        const userId = await createUser({ tierBalance: 10, packBalance: 10 });
+        const apiKeyId = `billing-key-${crypto.randomUUID()}`;
+        await db.insert(apiKeyTable).values({
+            id: apiKeyId,
+            userId,
+            key: `hashed-${apiKeyId}`,
+            prefix: "sk",
+            pollenBalance: 1,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+        const settlementId = `generate.image:${crypto.randomUUID()}`;
+
+        const results = await Promise.all(
+            Array.from({ length: 3 }, () =>
+                handleBalanceDeductionOnce({
+                    d1: env.DB,
+                    settlementId,
+                    isBilledUsage: true,
+                    totalPrice: 0.004,
+                    userId,
+                    apiKeyId,
+                    apiKeyPollenBalance: 1,
+                }),
+            ),
+        );
+
+        expect(results.filter((result) => result.committed)).toHaveLength(1);
+        expect(results.every((result) => result.billedPrice === 0.004)).toBe(
+            true,
+        );
+        expect(await getUserBalance(db, userId)).toEqual({
+            tierBalance: 9.996,
+            packBalance: 10,
+        });
+        const [apiKey] = await db
+            .select({ pollenBalance: apiKeyTable.pollenBalance })
+            .from(apiKeyTable)
+            .where(eq(apiKeyTable.id, apiKeyId));
+        expect(apiKey?.pollenBalance).toBe(0.996);
     });
 
     it("deducts an Azure paid-only model only from pack balance", async () => {

--- a/gen.pollinations.ai/test/tracking-observability.test.ts
+++ b/gen.pollinations.ai/test/tracking-observability.test.ts
@@ -4,6 +4,7 @@ import {
     waitOnExecutionContext,
 } from "cloudflare:test";
 import type { AuthUser } from "@shared/auth/api-key.ts";
+import { getUserBalance } from "@shared/billing/balance.ts";
 import {
     COMMUNITY_MODEL_REWARD_RATE,
     type CommunityEndpointRuntime,
@@ -471,6 +472,71 @@ describe("tracking observability", () => {
         expect(event).not.toHaveProperty("cacheKey");
         expect(consumePollen).toHaveBeenCalledWith(expect.any(Number));
         expect(consumePollen.mock.calls[0]?.[0]).toBeGreaterThan(0);
+    });
+
+    it("charges and emits one billed event when a server request is retried", async () => {
+        const tinybirdRequests: Request[] = [];
+        vi.spyOn(globalThis, "fetch").mockImplementation(
+            async (input, init) => {
+                tinybirdRequests.push(new Request(input, init));
+                return new Response("ok");
+            },
+        );
+        const consumePollen = vi.fn<(amount: number) => Promise<void>>(
+            async () => {},
+        );
+        const app = createTestApp(consumePollen);
+        const requestId = crypto.randomUUID();
+        const request = () =>
+            new Request("https://gen.pollinations.ai/v1/chat/completions", {
+                method: "POST",
+                headers: {
+                    "content-type": "application/json",
+                    "x-request-id": requestId,
+                },
+                body: JSON.stringify({
+                    model: "openai",
+                    stream: false,
+                    messages: [{ role: "user", content: "test" }],
+                }),
+            });
+        const contexts = [createExecutionContext(), createExecutionContext()];
+        const before = await getUserBalance(drizzle(env.DB), trackingUser.id);
+
+        const responses = await Promise.all(
+            contexts.map((ctx) =>
+                app.fetch(
+                    request(),
+                    {
+                        DB: env.DB,
+                        ENVIRONMENT: "test",
+                        LOG_LEVEL: "debug",
+                        LOG_FORMAT: "text",
+                        BETTER_AUTH_SECRET: "test_secret",
+                        TINYBIRD_INGEST_URL:
+                            "https://tinybird.test/v0/events?name=generation_event_v2",
+                        TINYBIRD_INGEST_TOKEN: "test_tinybird_token",
+                    } as CloudflareBindings,
+                    ctx,
+                ),
+            ),
+        );
+        await Promise.all(contexts.map(waitOnExecutionContext));
+
+        expect(responses.every((response) => response.status === 200)).toBe(
+            true,
+        );
+        expect(tinybirdRequests).toHaveLength(1);
+        const event = (await tinybirdRequests[0].json()) as TinybirdEvent;
+        expect(event.requestId).toBe(requestId);
+        expect(event.totalPrice).toBeGreaterThan(0);
+        expect(consumePollen).toHaveBeenCalledTimes(1);
+        const after = await getUserBalance(drizzle(env.DB), trackingUser.id);
+        expect(after.tierBalance).toBeCloseTo(
+            before.tierBalance - event.totalPrice,
+            10,
+        );
+        expect(after.packBalance).toBe(before.packBalance);
     });
 
     it("tracks provider work but not coalesced cache hits", async () => {

--- a/shared/billing/track-helpers.ts
+++ b/shared/billing/track-helpers.ts
@@ -1,6 +1,6 @@
 import { getLogger } from "@logtape/logtape";
 import { and, eq, gt, isNull, or } from "drizzle-orm";
-import type { DrizzleD1Database } from "drizzle-orm/d1";
+import { type DrizzleD1Database, drizzle } from "drizzle-orm/d1";
 import { parseMetadata } from "../auth/api-key-metadata.ts";
 import { apikey as apikeyTable } from "../db/better-auth.ts";
 import {
@@ -38,7 +38,7 @@ export type CommunityModelRewardInput = {
     basePrice?: number;
 };
 
-interface DeductionParams {
+export interface DeductionParams {
     db: DrizzleD1Database;
     isBilledUsage: boolean;
     totalPrice?: number;
@@ -49,6 +49,18 @@ interface DeductionParams {
     modelPaidOnly?: boolean;
     communityModelReward?: CommunityModelRewardInput | null;
 }
+
+export type DeductionResult = {
+    markup: MarkupResolution | null;
+    communityModelReward: CommunityModelRewardResolution | null;
+    payerBucket: Bucket | null;
+    postDeductionPackBalance: number | null;
+    billedPrice: number;
+};
+
+export type IdempotentDeductionResult = DeductionResult & {
+    committed: boolean;
+};
 
 export async function resolveDevMarkup(
     db: DrizzleD1Database,
@@ -119,13 +131,9 @@ export function resolveCommunityModelReward(
  * (`totalPrice + devCredit`, snapped to `POLLEN_BILLING_PRECISION`). Callers
  * should use this for analytics/event totals so they match the ledger.
  */
-export async function handleBalanceDeduction(params: DeductionParams): Promise<{
-    markup: MarkupResolution | null;
-    communityModelReward: CommunityModelRewardResolution | null;
-    payerBucket: Bucket | null;
-    postDeductionPackBalance: number | null;
-    billedPrice: number;
-}> {
+export async function handleBalanceDeduction(
+    params: DeductionParams,
+): Promise<DeductionResult> {
     const {
         db,
         isBilledUsage,
@@ -297,6 +305,358 @@ export async function handleBalanceDeduction(params: DeductionParams): Promise<{
         payerBucket,
         postDeductionPackBalance,
         billedPrice,
+    };
+}
+
+type StoredSettlement = {
+    settlementId: string;
+    payerUserId: string;
+    apiKeyId: string | null;
+    basePrice: number;
+    billedPrice: number;
+    payerBucket: Bucket | null;
+    markupJson: string | null;
+    communityModelRewardJson: string | null;
+    postDeductionPackBalance: number | null;
+};
+
+type IdempotentDeductionParams = Omit<DeductionParams, "db"> & {
+    d1: D1Database;
+    settlementId: string;
+};
+
+/**
+ * Atomically settles a billable request once. Durable Object alarms are
+ * at-least-once, so every update is gated by the server-owned settlement id.
+ */
+export async function handleBalanceDeductionOnce(
+    params: IdempotentDeductionParams,
+): Promise<IdempotentDeductionResult> {
+    const {
+        d1,
+        settlementId,
+        isBilledUsage,
+        totalPrice: rawTotalPrice,
+        userId,
+        apiKeyId,
+        apiKeyPollenBalance,
+        byopClientKeyId,
+        modelPaidOnly = false,
+        communityModelReward: communityModelRewardInput,
+    } = params;
+
+    if (!isBilledUsage) {
+        return { ...emptyDeduction(), committed: true };
+    }
+    if (!userId) {
+        throw new Error("Billed generation requires a payer user");
+    }
+
+    const db = drizzle(d1);
+    const basePrice = roundPollenLedgerAmount(rawTotalPrice ?? 0);
+    const markup = await resolveDevMarkup(
+        db,
+        byopClientKeyId,
+        basePrice,
+        userId,
+    );
+    const communityModelReward = resolveCommunityModelReward(
+        communityModelRewardInput,
+        basePrice,
+        userId,
+    );
+    const billedPrice = roundPollenLedgerAmount(
+        basePrice + (markup?.devCredit ?? 0),
+    );
+    const markupJson = markup ? JSON.stringify(markup) : null;
+    const communityModelRewardJson = communityModelReward
+        ? JSON.stringify(communityModelReward)
+        : null;
+
+    if (billedPrice === 0) {
+        const result = await d1
+            .prepare(
+                `INSERT OR IGNORE INTO generation_settlement (
+                    settlement_id,
+                    payer_user_id,
+                    api_key_id,
+                    base_price,
+                    billed_price,
+                    payer_bucket,
+                    markup_json,
+                    community_model_reward_json,
+                    post_deduction_pack_balance,
+                    created_at
+                ) VALUES (?, ?, ?, 0, 0, NULL, NULL, NULL, NULL, ?)`,
+            )
+            .bind(settlementId, userId, apiKeyId ?? null, Date.now())
+            .run();
+        const stored = await requireSettlement(d1, settlementId);
+        assertSamePayer(stored, userId, apiKeyId);
+        return storedDeduction(stored, (result.meta.changes ?? 0) === 1);
+    }
+
+    const hasFiniteApiKeyBudget =
+        Boolean(apiKeyId) && typeof apiKeyPollenBalance === "number";
+    const dependencyChecks = [
+        ...(hasFiniteApiKeyBudget
+            ? [
+                  "AND EXISTS (SELECT 1 FROM apikey WHERE id = ? AND pollen_balance IS NOT NULL)",
+              ]
+            : []),
+        ...(markup ? ["AND EXISTS (SELECT 1 FROM user WHERE id = ?)"] : []),
+        ...(communityModelReward
+            ? ["AND EXISTS (SELECT 1 FROM user WHERE id = ?)"]
+            : []),
+    ].join("\n");
+    const dependencyBindings = [
+        ...(hasFiniteApiKeyBudget ? [apiKeyId] : []),
+        ...(markup ? [markup.devUserId] : []),
+        ...(communityModelReward ? [communityModelReward.userId] : []),
+    ];
+
+    const statements: D1PreparedStatement[] = [
+        d1
+            .prepare(
+                `INSERT OR IGNORE INTO generation_settlement (
+                    settlement_id,
+                    payer_user_id,
+                    api_key_id,
+                    base_price,
+                    billed_price,
+                    payer_bucket,
+                    markup_json,
+                    community_model_reward_json,
+                    post_deduction_pack_balance,
+                    created_at
+                )
+                SELECT
+                    ?,
+                    payer.id,
+                    ?,
+                    ?,
+                    ?,
+                    CASE
+                        WHEN ? = 1 THEN 'pack'
+                        WHEN COALESCE(payer.tier_balance, 0) >= ? THEN 'tier'
+                        WHEN COALESCE(payer.pack_balance, 0) > 0 THEN 'pack'
+                        ELSE 'tier'
+                    END,
+                    ?,
+                    ?,
+                    NULL,
+                    ?
+                FROM user AS payer
+                WHERE payer.id = ?
+                ${dependencyChecks}`,
+            )
+            .bind(
+                settlementId,
+                apiKeyId ?? null,
+                basePrice,
+                billedPrice,
+                modelPaidOnly ? 1 : 0,
+                billedPrice,
+                markupJson,
+                communityModelRewardJson,
+                Date.now(),
+                userId,
+                ...dependencyBindings,
+            ),
+        d1
+            .prepare(
+                `UPDATE user
+                SET
+                    tier_balance = CASE
+                        WHEN (SELECT payer_bucket FROM generation_settlement WHERE settlement_id = ?) = 'tier'
+                            THEN COALESCE(tier_balance, 0) - ?
+                        ELSE tier_balance
+                    END,
+                    pack_balance = CASE
+                        WHEN (SELECT payer_bucket FROM generation_settlement WHERE settlement_id = ?) = 'pack'
+                            THEN COALESCE(pack_balance, 0) - ?
+                        ELSE pack_balance
+                    END
+                WHERE id = ? AND changes() = 1`,
+            )
+            .bind(settlementId, billedPrice, settlementId, billedPrice, userId),
+        d1
+            .prepare(
+                `UPDATE generation_settlement
+                SET post_deduction_pack_balance = (
+                    SELECT pack_balance FROM user WHERE id = payer_user_id
+                )
+                WHERE settlement_id = ? AND changes() = 1`,
+            )
+            .bind(settlementId),
+    ];
+
+    if (hasFiniteApiKeyBudget) {
+        statements.push(
+            d1
+                .prepare(
+                    `UPDATE apikey
+                    SET pollen_balance = pollen_balance - ?
+                    WHERE id = ?
+                      AND pollen_balance IS NOT NULL
+                      AND changes() = 1`,
+                )
+                .bind(billedPrice, apiKeyId),
+        );
+    }
+
+    if (markup) {
+        statements.push(
+            creditStatement(
+                d1,
+                settlementId,
+                markup.devUserId,
+                markup.devCredit,
+            ),
+        );
+    }
+    if (communityModelReward) {
+        statements.push(
+            creditStatement(
+                d1,
+                settlementId,
+                communityModelReward.userId,
+                communityModelReward.credit,
+            ),
+        );
+    }
+
+    const results = await d1.batch(statements);
+    const committed = (results[0]?.meta.changes ?? 0) === 1;
+    if (
+        committed &&
+        results.slice(1).some((result) => result.meta.changes !== 1)
+    ) {
+        throw new Error(`Generation settlement incomplete for ${settlementId}`);
+    }
+
+    const stored = await requireSettlement(d1, settlementId);
+    assertSamePayer(stored, userId, apiKeyId);
+    if (committed) {
+        log.debug(
+            "Settled generation {settlementId}: charged {billedPrice} to {userId} from {payerBucket}",
+            {
+                settlementId,
+                billedPrice: stored.billedPrice,
+                userId,
+                payerBucket: stored.payerBucket,
+            },
+        );
+    }
+    return storedDeduction(stored, committed);
+}
+
+function creditStatement(
+    d1: D1Database,
+    settlementId: string,
+    userId: string,
+    amount: number,
+): D1PreparedStatement {
+    return d1
+        .prepare(
+            `UPDATE user
+            SET
+                tier_balance = CASE
+                    WHEN (SELECT payer_bucket FROM generation_settlement WHERE settlement_id = ?) = 'tier'
+                        THEN COALESCE(tier_balance, 0) + ?
+                    ELSE tier_balance
+                END,
+                pack_balance = CASE
+                    WHEN (SELECT payer_bucket FROM generation_settlement WHERE settlement_id = ?) = 'pack'
+                        THEN COALESCE(pack_balance, 0) + ?
+                    ELSE pack_balance
+                END
+            WHERE id = ? AND changes() = 1`,
+        )
+        .bind(settlementId, amount, settlementId, amount, userId);
+}
+
+async function loadSettlement(
+    d1: D1Database,
+    settlementId: string,
+): Promise<StoredSettlement | null> {
+    return d1
+        .prepare(
+            `SELECT
+                settlement_id AS settlementId,
+                payer_user_id AS payerUserId,
+                api_key_id AS apiKeyId,
+                base_price AS basePrice,
+                billed_price AS billedPrice,
+                payer_bucket AS payerBucket,
+                markup_json AS markupJson,
+                community_model_reward_json AS communityModelRewardJson,
+                post_deduction_pack_balance AS postDeductionPackBalance
+            FROM generation_settlement
+            WHERE settlement_id = ?`,
+        )
+        .bind(settlementId)
+        .first<StoredSettlement>();
+}
+
+async function requireSettlement(
+    d1: D1Database,
+    settlementId: string,
+): Promise<StoredSettlement> {
+    const stored = await loadSettlement(d1, settlementId);
+    if (!stored) {
+        throw new Error(
+            `Generation settlement dependencies missing for ${settlementId}`,
+        );
+    }
+    return stored;
+}
+
+function assertSamePayer(
+    stored: StoredSettlement,
+    userId: string,
+    apiKeyId: string | undefined,
+): void {
+    if (
+        stored.payerUserId !== userId ||
+        stored.apiKeyId !== (apiKeyId ?? null)
+    ) {
+        throw new Error(
+            `Settlement ${stored.settlementId} belongs to a different payer`,
+        );
+    }
+}
+
+function storedDeduction(
+    stored: StoredSettlement,
+    committed: boolean,
+): IdempotentDeductionResult {
+    return {
+        markup: stored.markupJson
+            ? (JSON.parse(stored.markupJson) as MarkupResolution)
+            : null,
+        communityModelReward: stored.communityModelRewardJson
+            ? (JSON.parse(
+                  stored.communityModelRewardJson,
+              ) as CommunityModelRewardResolution)
+            : null,
+        payerBucket: stored.payerBucket,
+        postDeductionPackBalance:
+            stored.payerBucket === "pack"
+                ? stored.postDeductionPackBalance
+                : null,
+        billedPrice: stored.billedPrice,
+        committed,
+    };
+}
+
+function emptyDeduction(): DeductionResult {
+    return {
+        markup: null,
+        communityModelReward: null,
+        payerBucket: null,
+        postDeductionPackBalance: null,
+        billedPrice: 0,
     };
 }
 

--- a/shared/db/better-auth.ts
+++ b/shared/db/better-auth.ts
@@ -197,6 +197,23 @@ export const stripeCardFingerprintAttempt = sqliteTable("stripe_card_fingerprint
   ),
 ]);
 
+// One row per billable request. The server-generated settlement id gates every
+// wallet, key-budget, and reward update so durable retries cannot charge twice.
+export const generationSettlement = sqliteTable("generation_settlement", {
+  settlementId: text("settlement_id").primaryKey(),
+  payerUserId: text("payer_user_id").notNull(),
+  apiKeyId: text("api_key_id"),
+  basePrice: real("base_price").notNull(),
+  billedPrice: real("billed_price").notNull(),
+  payerBucket: text("payer_bucket"),
+  markupJson: text("markup_json"),
+  communityModelRewardJson: text("community_model_reward_json"),
+  postDeductionPackBalance: real("post_deduction_pack_balance"),
+  createdAt: integer("created_at", { mode: "timestamp_ms" })
+    .defaultNow()
+    .notNull(),
+});
+
 export const agent = sqliteTable("agent", {
   id: text("id").primaryKey(),
   ownerUserId: text("owner_user_id")


### PR DESCRIPTION
## Summary

- Claims each billed generation once using the server-owned event type + request ID.
- Atomically gates wallet debits, finite API-key budgets, BYOP/community rewards, frontend rate-limit consumption, billed Tinybird events, and auto-top-up.
- Adds the required D1 settlement migration and concurrent-retry regression coverage.

## Production evidence

- Four Z-Image requests from August 14–18 produced two distinct billed-success events each: 0.016 Pollen confirmed excess.
- The latest 24-hour audit found 17 duplicated billed request IDs; 14 had positive prices, totaling about 0.5906778 Pollen excess across image and text.
- Durable Object alarms are at-least-once. Correlation therefore uses the stable server request ID, not the currently empty `event_processing_id`.

## Verification

- 66 focused billing, BYOP, tracking, concurrency, and observability tests pass.
- Gen typecheck and Biome pass.
- Deployment workflows already apply D1 migrations before deploying Enter or Gen.

## Scope and supersession

- Realtime settlement is unchanged.
- Historical wallet corrections are separate from this prevention fix.
- Supersedes #12542. Keep #12542 open until this PR merges; after merge, close #12542 as superseded.