### PR TITLE
fix: execute detached generations at most once

### DIFF
--- a/gen.pollinations.ai/src/durable-objects/GenerationCoordinator.ts
+++ b/gen.pollinations.ai/src/durable-objects/GenerationCoordinator.ts
@@ -14,6 +14,7 @@ const BODY_CHUNK_BYTES = 1_000_000;
 type PersistedJob = Omit<GenerationJob, "request"> & {
     request: Omit<GenerationRequestSnapshot, "body">;
     bodyChunks: number;
+    started: boolean;
 };
 
 function bodyChunkKeys(count: number): string[] {
@@ -77,7 +78,31 @@ export class GenerationCoordinator extends DurableObject<CloudflareBindings> {
     }
 
     async alarm(): Promise<void> {
-        const stored = await this.ctx.storage.get<PersistedJob>(JOB_KEY);
+        let stored: PersistedJob | undefined;
+        let interrupted: PersistedJob | undefined;
+
+        await this.ctx.blockConcurrencyWhile(async () => {
+            const job = await this.ctx.storage.get<PersistedJob>(JOB_KEY);
+            if (!job) return;
+
+            // The alarm provides an independent timeout, not retry semantics.
+            // Claim before the provider call so a restarted alarm fails closed.
+            if (job.started) {
+                interrupted = job;
+                return;
+            }
+
+            stored = { ...job, started: true };
+            await this.ctx.storage.put(JOB_KEY, stored);
+        });
+
+        if (interrupted) {
+            await this.finish(
+                unavailable("Detached generation was interrupted"),
+                interrupted.bodyChunks,
+            );
+            return;
+        }
         if (!stored) return;
 
         let settlement: Promise<void> | undefined;
@@ -135,6 +160,7 @@ export class GenerationCoordinator extends DurableObject<CloudflareBindings> {
             balanceCheckResult: job.balanceCheckResult,
             request,
             bodyChunks: chunks.length,
+            started: false,
         };
         const entries: Record<string, unknown> = { [JOB_KEY]: stored };
         for (const [index, chunk] of chunks.entries()) {

--- a/gen.pollinations.ai/test/generation-coordinator.test.ts
+++ b/gen.pollinations.ai/test/generation-coordinator.test.ts
@@ -77,6 +77,36 @@ describe("GenerationCoordinator", () => {
         );
     });
 
+    it("does not execute a generation again after an alarm interruption", async () => {
+        vi.spyOn(Date, "now").mockReturnValue(Date.now() + 60_000);
+        const stub = env.GENERATION_COORDINATOR.getByName(
+            `test-${crypto.randomUUID()}`,
+        );
+        const key = `interrupted-${crypto.randomUUID()}`;
+
+        const result = await runInDurableObject(
+            stub,
+            async (coordinator, state) => {
+                const pending = coordinator.startAndWait(testJob(key));
+                await waitForAlarm(state);
+                const job =
+                    await state.storage.get<Record<string, unknown>>("job");
+                await state.storage.put("job", { ...job, started: true });
+
+                await coordinator.alarm();
+                await state.storage.deleteAlarm();
+                return pending;
+            },
+        );
+
+        expect(result.status).toBe("failed");
+        if (result.status !== "failed") return;
+        expect(new TextDecoder().decode(result.error.body)).toBe(
+            "Detached generation was interrupted",
+        );
+        expect(await env.TEXT_BUCKET.head(key)).toBeNull();
+    });
+
     it("persists request bodies larger than one storage value", async () => {
         vi.spyOn(Date, "now").mockReturnValue(Date.now() + 60_000);
         const stub = env.GENERATION_COORDINATOR.getByName(


### PR DESCRIPTION
- Claims a detached job before calling the provider
- Fails and clears an interrupted alarm instead of executing the generation again
- Adds coordinator regression coverage for alarm redelivery

Alternative root-cause fix to #13622: this prevents duplicate provider execution while keeping alarms for their independent timeout.

Tests:
- 11 focused coordinator and generation-deduplication tests
- Gen TypeScript check
- Biome and diff checks