### PR TITLE
fix: keep approved app PRs open through merge delays

### DIFF
--- a/.github/workflows/apps-publish-submissions.yml
+++ b/.github/workflows/apps-publish-submissions.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Generate app token
         id: token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.POLLY_BOT_APP_ID }}
           private-key: ${{ secrets.POLLY_BOT_PRIVATE_KEY }}
@@ -40,15 +40,16 @@ jobs:
           echo "login=$BOT_LOGIN" >> "$GITHUB_OUTPUT"
           echo "id=$BOT_ID" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 0
           token: ${{ steps.token.outputs.token }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "22"
+          package-manager-cache: false
 
       - name: Revalidate approved submission
         id: app
@@ -138,7 +139,14 @@ jobs:
             fi
             sleep 10
           done
-          echo "Catalog PR did not merge within 10 minutes"
+          echo "Catalog PR did not merge within 10 minutes; retrying once"
+          gh pr merge "$PR_URL" --repo "$GITHUB_REPOSITORY" --squash --delete-branch || true
+          sleep 10
+          STATE=$(gh pr view "$PR_URL" --repo "$GITHUB_REPOSITORY" --json state --jq .state)
+          if [ "$STATE" = "MERGED" ]; then
+            exit 0
+          fi
+          echo "Catalog PR is still open with auto-merge enabled"
           exit 1
 
       - name: Remove review label
@@ -157,7 +165,8 @@ jobs:
           BRANCH="auto/app-${ISSUE_NUMBER}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           OPEN_PR=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$BRANCH" --state open --json url --jq '.[0].url // empty' || true)
           if [ -n "$OPEN_PR" ]; then
-            gh pr close "$OPEN_PR" --repo "$GITHUB_REPOSITORY" --comment "Automated publication failed; closing this attempt so it can be retried cleanly." || true
+            gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body "The catalog PR is still open and waiting for GitHub auto-merge. No app changes are needed: $OPEN_PR"
+            exit 0
           fi
           if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
             git push origin --delete "$BRANCH" || true


### PR DESCRIPTION
- Updates the GitHub actions to Node 24-based releases while keeping app scripts on Node 22
- Retries a catalog merge once after the normal auto-merge window
- Leaves a healthy catalog PR open when GitHub auto-merge is delayed
- Prevents transient GitHub failures from sending approved apps back to review