### PR TITLE
deploy: gen registry hardening

### DIFF
--- a/gen.pollinations.ai/src/model-registry.test.ts
+++ b/gen.pollinations.ai/src/model-registry.test.ts
@@ -1,0 +1,68 @@
+import { env } from "cloudflare:test";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { CommunityModelEnv } from "./community-models.ts";
+import {
+    getGenerationModelRegistry,
+    resetGenerationModelRegistryCache,
+} from "./model-registry.ts";
+
+afterEach(() => {
+    resetGenerationModelRegistryCache();
+    vi.restoreAllMocks();
+});
+
+// A D1 binding that fails the way schema skew fails: the statement prepares,
+// then errors on execution. This is what gen sees in the window between a
+// migration landing and the Worker that understands it going live.
+function skewedDbBinding(): CloudflareBindings["DB"] {
+    // Throws synchronously rather than returning a rejected promise: drizzle
+    // probes several statement methods, and the ones it discards would leave
+    // unhandled rejections behind.
+    const fail = () => {
+        throw new Error("D1_ERROR: no such column: agent.config");
+    };
+    const statement = {
+        bind: () => statement,
+        all: fail,
+        run: fail,
+        first: fail,
+        raw: fail,
+    };
+    return {
+        prepare: () => statement,
+        batch: fail,
+        dump: fail,
+        exec: fail,
+        withSession: () => {
+            throw new Error("unused");
+        },
+    } as unknown as CloudflareBindings["DB"];
+}
+
+describe("getGenerationModelRegistry", () => {
+    it("serves static models when the community catalog query fails", async () => {
+        const consoleError = vi
+            .spyOn(console, "error")
+            .mockImplementation(() => {});
+
+        resetGenerationModelRegistryCache();
+        const healthy = await getGenerationModelRegistry(env);
+        const healthyCount = healthy.visibleEntries().length;
+        expect(healthyCount).toBeGreaterThan(0);
+
+        resetGenerationModelRegistryCache();
+        const degradedEnv: CommunityModelEnv = {
+            ...env,
+            DB: skewedDbBinding(),
+        };
+        const degraded = await getGenerationModelRegistry(degradedEnv);
+
+        const entries = degraded.visibleEntries();
+        expect(entries.length).toBeGreaterThan(0);
+        expect(entries.every((e) => !e.communityEndpoint)).toBe(true);
+        expect(consoleError).toHaveBeenCalledWith(
+            "Community model registry unavailable",
+            expect.any(Error),
+        );
+    });
+});

--- a/gen.pollinations.ai/src/model-registry.ts
+++ b/gen.pollinations.ai/src/model-registry.ts
@@ -31,6 +31,9 @@ import {
 import { linkFallbackEntries } from "./fallback.ts";
 
 const REGISTRY_TTL_MS = 60_000;
+// A static-only registry is cached briefly so the community models come back
+// seconds after D1 recovers, instead of being missing for a full TTL.
+const DEGRADED_REGISTRY_TTL_MS = 5_000;
 const TEXT_MODEL_ENDPOINTS = [
     "/v1/chat/completions",
     "/text",
@@ -227,11 +230,27 @@ function buildRegistry(
 
 async function loadGenerationModelRegistry(
     env: CommunityModelEnv,
-): Promise<GenerationModelRegistry> {
-    const communityEntries = (await getCommunityModelRegistryEntries(env)).map(
-        communityEntryToGenerationEntry,
-    );
-    return buildRegistry([...STATIC_ENTRIES, ...communityEntries]);
+): Promise<{ registry: GenerationModelRegistry; degraded: boolean }> {
+    let communityEntries: GenerationModelEntry[] = [];
+    let degraded = false;
+    try {
+        communityEntries = (await getCommunityModelRegistryEntries(env)).map(
+            communityEntryToGenerationEntry,
+        );
+    } catch (error) {
+        // Community models are additive: every request that resolves a model
+        // goes through this registry, so letting a D1 failure escape turns a
+        // community-catalog problem into a total gen outage. The realistic
+        // trigger is schema skew — a migration lands before the Worker that
+        // understands it — which is exactly when the static models are still
+        // perfectly servable.
+        degraded = true;
+        console.error("Community model registry unavailable", error);
+    }
+    return {
+        registry: buildRegistry([...STATIC_ENTRIES, ...communityEntries]),
+        degraded,
+    };
 }
 
 export async function getGenerationModelRegistry(
@@ -250,10 +269,12 @@ export async function getGenerationModelRegistry(
     // cancelled the promise can never settle, wedging the isolate for good.
     // Racing a few cheap SELECTs on cache expiry is the better trade.
     const dbBinding = env.DB;
-    const registry = await loadGenerationModelRegistry(env);
+    const { registry, degraded } = await loadGenerationModelRegistry(env);
     cachedRegistry = {
         dbBinding,
-        expiresAt: Date.now() + REGISTRY_TTL_MS,
+        expiresAt:
+            Date.now() +
+            (degraded ? DEGRADED_REGISTRY_TTL_MS : REGISTRY_TTL_MS),
         registry,
     };
     return registry;


### PR DESCRIPTION
- Promotes #13643 so gen degrades to static models instead of 500ing when the community-model D1 query fails.
- Must be live before the listing-envelope migration (#13623), which does `DROP TABLE agent`.