### PR TITLE
refactor: make UpstreamError canonical

### DIFF
--- a/gen.pollinations.ai/src/image/handler.ts
+++ b/gen.pollinations.ai/src/image/handler.ts
@@ -201,7 +201,9 @@ function safeUpstreamUrl(value: string | undefined): URL | undefined {
 }
 
 function throwImageError(error: unknown): never {
-    if (error instanceof UpstreamError) throw error;
+    if (error instanceof UpstreamError && !(error instanceof HttpError)) {
+        throw error;
+    }
 
     // Content-policy rejections from any provider (DashScope green-net, Replicate
     // moderation, Vertex safety, Azure content safety) are client errors, not

--- a/gen.pollinations.ai/src/model3d/handler.ts
+++ b/gen.pollinations.ai/src/model3d/handler.ts
@@ -130,8 +130,6 @@ export function mediaHeaders(
 }
 
 export function throw3dError(error: unknown): never {
-    if (error instanceof UpstreamError) throw error;
-
     if (error instanceof HttpError) {
         throw new UpstreamError(remapUpstreamStatus(error.status), {
             message: error.message,
@@ -142,6 +140,8 @@ export function throw3dError(error: unknown): never {
             cause: error,
         });
     }
+    if (error instanceof UpstreamError) throw error;
+
     const message = error instanceof Error ? error.message : String(error);
     throw new UpstreamError(500, {
         message: message || "3D model generation failed",

--- a/gen.pollinations.ai/test/image/fetchUpstream.test.ts
+++ b/gen.pollinations.ai/test/image/fetchUpstream.test.ts
@@ -1,3 +1,4 @@
+import { UpstreamError } from "@shared/error.ts";
 import { HttpError } from "@shared/http-error.ts";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { fetchUpstream } from "../../src/image/utils/fetchUpstream.ts";
@@ -45,6 +46,7 @@ describe("fetchUpstream", () => {
             errorLabel: "Foo failed",
         }).catch((e) => e);
         expect(error).toBeInstanceOf(HttpError);
+        expect(error).toBeInstanceOf(UpstreamError);
         expect(error).toMatchObject({
             name: "HttpError",
             status: 502,

--- a/gen.pollinations.ai/test/image/gptImageRouting.test.ts
+++ b/gen.pollinations.ai/test/image/gptImageRouting.test.ts
@@ -1,4 +1,3 @@
-import type { HttpError } from "@shared/http-error.ts";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
     type AuthResult,
@@ -90,7 +89,7 @@ describe("gpt-image-2 Azure routing", () => {
 
             await expect(
                 callGPTImage("test", params, userInfo, "gpt-image-2"),
-            ).rejects.toMatchObject({ status } satisfies Partial<HttpError>);
+            ).rejects.toMatchObject({ status });
             expect(fetchMock).toHaveBeenCalledOnce();
         });
     }

--- a/gen.pollinations.ai/test/model3d/createAndReturnModel3d.test.ts
+++ b/gen.pollinations.ai/test/model3d/createAndReturnModel3d.test.ts
@@ -1,4 +1,6 @@
 import { createExecutionContext, env } from "cloudflare:test";
+import { UpstreamError } from "@shared/error.ts";
+import { HttpError } from "@shared/http-error.ts";
 import { getRegistryModelDefinition } from "@shared/registry/registry.ts";
 import { FALLBACK_TARGET_HEADER } from "@shared/registry/usage-headers.ts";
 import { test as workerTest } from "@shared/test/fixtures/index.ts";
@@ -7,6 +9,7 @@ import worker from "../../src/index.ts";
 import { resetGenerationModelRegistryCache } from "../../src/model-registry.ts";
 import { createAndReturnModel3d } from "../../src/model3d/createAndReturnModel3d.ts";
 import { syncModel3dEnvironment } from "../../src/model3d/env.ts";
+import { throw3dError } from "../../src/model3d/handler.ts";
 import type { Model3dParams } from "../../src/model3d/params.ts";
 import { withInlineGenerationCoordinator } from "../helpers/inline-generation-coordinator.ts";
 
@@ -67,6 +70,25 @@ describe("createAndReturnModel3d dispatch", () => {
                 baseParams("not-a-real-model") as Model3dParams,
             ),
         ).rejects.toThrow(/not supported/);
+    });
+});
+
+describe("3D error compatibility", () => {
+    it("remaps a legacy HttpError before passing through UpstreamError", () => {
+        const error = (() => {
+            try {
+                throw3dError(new HttpError("provider rate limited", 429));
+            } catch (caught) {
+                return caught;
+            }
+        })();
+
+        expect(error).toBeInstanceOf(UpstreamError);
+        expect(error).toMatchObject({
+            name: "UpstreamError",
+            status: 502,
+            upstreamStatus: 429,
+        });
     });
 });
 

--- a/shared/error.ts
+++ b/shared/error.ts
@@ -50,8 +50,15 @@ type UpstreamErrorOptions = {
     errorCode?: string;
 };
 
+/**
+ * Use for failures from a remote service or any error that must retain
+ * upstream diagnostics at the HTTP boundary. Use the more specific validation
+ * and auth errors for local client failures; plain Error remains appropriate
+ * for internal invariants. New code must not introduce HttpError, which is kept
+ * only as a compatibility adapter for existing image and 3D providers.
+ */
 export class UpstreamError extends HTTPException {
-    public readonly name = "UpstreamError" as const;
+    public override name: string = "UpstreamError";
     public readonly requestUrl?: URL;
     public readonly requestBody?: unknown;
     public readonly upstreamStatus?: number;

--- a/shared/http-error.ts
+++ b/shared/http-error.ts
@@ -1,37 +1,46 @@
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import { UpstreamError } from "./error.ts";
+
+function safeUrl(value?: string): URL | undefined {
+    if (!value) return undefined;
+    try {
+        return new URL(value);
+    } catch {
+        return undefined;
+    }
+}
+
 /**
- * Custom HTTP error class with status code.
+ * @deprecated Use UpstreamError for new code.
  *
- * Adds a status code and optional details/upstream URL to Error for passing
- * HTTP status codes through the error chain. `upstreamUrl` is the URL of the
- * upstream backend that produced the error (e.g. a provider enqueue endpoint),
- * threaded through to UpstreamError.requestUrl in the error envelope so
- * `upstreamHost` reflects the actual backend rather than the gen.pollinations.ai
- * request URL. Callers must not pass URLs that include credentials in query
- * strings; this codebase auths via headers, not query strings.
- *
- * `errorCode` is an optional stable, machine-readable code (mirrors
- * `UpstreamError.errorCode`) that the error funnels propagate into the response
- * envelope so callers can branch on a code instead of matching message prose.
+ * Preserves the legacy image/3D constructor and fields while making existing
+ * errors visible to the shared UpstreamError handler.
  */
-export class HttpError extends Error {
-    status: number;
+export class HttpError extends UpstreamError {
+    public override name = "HttpError";
+    // biome-ignore lint/suspicious/noExplicitAny: legacy callers attach provider-specific response shapes
     details?: any;
     upstreamUrl?: string;
-    errorCode?: string;
 
     constructor(
         message: string,
         status: number = 500,
+        // biome-ignore lint/suspicious/noExplicitAny: preserve the legacy constructor while callers migrate
         details?: any,
         upstreamUrl?: string,
         errorCode?: string,
     ) {
-        super(message);
-        this.name = "HttpError";
-        this.status = status;
+        const responseBody =
+            typeof details?.body === "string" ? details.body : undefined;
+        super(status as ContentfulStatusCode, {
+            message,
+            requestUrl: safeUrl(upstreamUrl),
+            upstreamStatus: status,
+            responseBody,
+            errorCode,
+        });
         this.details = details;
         this.upstreamUrl = upstreamUrl;
-        this.errorCode = errorCode;
 
         // Maintains proper stack trace for where our error was thrown (only available on V8)
         Error.captureStackTrace(this, HttpError);


### PR DESCRIPTION
## Summary

- makes legacy `HttpError` a compatibility subclass of `UpstreamError` without changing its constructor or name
- documents the error rule for new code
- preserves the existing image and 3D error remapping order
- adds focused compatibility regressions

## Verification

- `biome check` on all changed files
- `npm run typecheck --workspace pollinations-gen`
- `npm test --workspace pollinations-gen` — 101 files, 1,157 passed, 6 skipped

Fixes #13551
Supersedes #13627