### PR TITLE
fix: filter text leaderboard queries by event_type = 'generate.text' Fixes #13639

### DIFF
--- a/operations/community-monitor/leaderboard/build-leaderboard.mjs
+++ b/operations/community-monitor/leaderboard/build-leaderboard.mjs
@@ -49,7 +49,7 @@ async function fetchLeaderboardData() {
       round(medianIf((token_count_completion_text + token_count_completion_reasoning) / (response_time / 1000), response_status < 300 AND response_time > 0 AND token_count_completion_text + token_count_completion_reasoning >= 20), 1) AS median_tps,
       round(100 * countIf(response_status >= 200 AND response_status < 300) / greatest(countIf(response_status < 400 OR response_status >= 500), 1), 2) AS success
     FROM generation_event_v2
-    WHERE start_time > now() - INTERVAL 24 HOUR AND model_requested LIKE '%/%' AND is_final
+    WHERE start_time > now() - INTERVAL 24 HOUR AND event_type = 'generate.text' AND model_requested LIKE '%/%' AND is_final
     GROUP BY model
     HAVING requests >= ${MIN_REQUESTS}
     ORDER BY total_tokens DESC
@@ -62,7 +62,7 @@ async function fetchLeaderboardData() {
            sum(token_count_prompt_text + token_count_prompt_cached + token_count_completion_text + token_count_completion_reasoning) AS total_tokens,
            uniq(model_requested) AS models
     FROM generation_event_v2
-    WHERE start_time > now() - INTERVAL 24 HOUR AND model_requested LIKE '%/%' AND is_final
+    WHERE start_time > now() - INTERVAL 24 HOUR AND event_type = 'generate.text' AND model_requested LIKE '%/%' AND is_final
     FORMAT JSON
   `)
     )[0];


### PR DESCRIPTION
Fixes #13639

Video models registered under chat/completions return URL/base64 payloads that get tokenized as huge completion text, inflating median_tps to implausible values (e.g. 29,520 t/s). Add the missing event_type filter to both queries in build-leaderboard.mjs, mirroring build-image-leaderboard.mjs which already filters by event_type = 'generate.image'.