### PR TITLE
fix: bypass Portkey for OpenRouter models

### DIFF
--- a/gen.pollinations.ai/src/text/configs/providerConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/providerConfigs.ts
@@ -101,11 +101,12 @@ export function createDeepInfraModelConfig(
 export function createOpenRouterModelConfig(
     overrides: ModelOverride = {},
 ): ProviderConfig {
-    return createOpenAICompatibleConfig(
-        "https://openrouter.ai/api/v1",
-        process.env.OPENROUTER_API_KEY,
-        overrides,
-    );
+    return {
+        provider: "openrouter",
+        directEndpoint: "https://openrouter.ai/api/v1/chat/completions",
+        authKey: process.env.OPENROUTER_API_KEY,
+        ...overrides,
+    };
 }
 
 export function createVercelAIGatewayModelConfig(

--- a/gen.pollinations.ai/src/text/generateTextPortkey.ts
+++ b/gen.pollinations.ai/src/text/generateTextPortkey.ts
@@ -65,6 +65,8 @@ export async function generateTextPortkey(
     }
 
     const directEndpoint = state.options.modelConfig?.directEndpoint;
+    // Read before the delete below: the endpoint thunk runs after it.
+    const portkeyGatewayUrl = state.options.portkeyGatewayUrl;
     const additionalHeaders = (state.options.additionalHeaders || {}) as Record<
         string,
         string
@@ -78,8 +80,7 @@ export async function generateTextPortkey(
               }
             : {
                   ...clientConfig,
-                  endpoint: () =>
-                      buildEndpoint(state.options.portkeyGatewayUrl),
+                  endpoint: () => buildEndpoint(portkeyGatewayUrl),
                   additionalHeaders: {
                       "x-portkey-request-timeout": String(
                           PORTKEY_REQUEST_TIMEOUT_MS,

--- a/gen.pollinations.ai/src/text/generateTextPortkey.ts
+++ b/gen.pollinations.ai/src/text/generateTextPortkey.ts
@@ -40,7 +40,7 @@ function buildEndpoint(gatewayUrl: unknown): string {
 export async function generateTextPortkey(
     messages: ChatMessage[],
     options: TransformOptions = {},
-    fetcher?: OpenAIClientConfig["fetcher"],
+    portkeyFetcher?: OpenAIClientConfig["fetcher"],
 ): Promise<ChatCompletion> {
     let state: TransformResult = { messages, options: { ...options } };
     const modelDef = state.options.model
@@ -64,19 +64,30 @@ export async function generateTextPortkey(
         state = await processParameters(state.messages, state.options);
     }
 
-    const portkeyGatewayUrl = state.options.portkeyGatewayUrl;
-    const requestConfig = {
-        ...clientConfig,
-        endpoint: () => buildEndpoint(portkeyGatewayUrl),
-        additionalHeaders: {
-            "x-portkey-request-timeout": String(PORTKEY_REQUEST_TIMEOUT_MS),
-            ...((state.options.additionalHeaders || {}) as Record<
-                string,
-                string
-            >),
-        },
-        fetcher,
-    };
+    const directEndpoint = state.options.modelConfig?.directEndpoint;
+    const additionalHeaders = (state.options.additionalHeaders || {}) as Record<
+        string,
+        string
+    >;
+    const requestConfig =
+        typeof directEndpoint === "string"
+            ? {
+                  ...clientConfig,
+                  endpoint: directEndpoint,
+                  additionalHeaders,
+              }
+            : {
+                  ...clientConfig,
+                  endpoint: () =>
+                      buildEndpoint(state.options.portkeyGatewayUrl),
+                  additionalHeaders: {
+                      "x-portkey-request-timeout": String(
+                          PORTKEY_REQUEST_TIMEOUT_MS,
+                      ),
+                      ...additionalHeaders,
+                  },
+                  fetcher: portkeyFetcher,
+              };
 
     delete state.options.additionalHeaders;
     delete state.options.portkeyGatewayUrl;

--- a/gen.pollinations.ai/src/text/transforms/headerGenerator.ts
+++ b/gen.pollinations.ai/src/text/transforms/headerGenerator.ts
@@ -8,19 +8,6 @@ import type {
 
 const log = debug("pollinations:transforms:headers");
 
-async function generateDirectHeaders(
-    config: Record<string, unknown>,
-): Promise<Record<string, string>> {
-    const authKey = config.authKey;
-    if (!authKey) return {};
-
-    const token =
-        typeof authKey === "function"
-            ? await (authKey as () => string | Promise<string>)()
-            : String(authKey);
-    return { Authorization: `Bearer ${token}` };
-}
-
 /**
  * Transform that generates provider-specific headers for the request.
  */
@@ -32,9 +19,11 @@ export async function generateHeaders(
         return { messages, options };
     }
 
+    // Direct providers need only bearer auth; Portkey needs its whole
+    // x-portkey-* config translated from the same modelConfig.
     const additionalHeaders =
         typeof options.modelConfig.directEndpoint === "string"
-            ? await generateDirectHeaders(options.modelConfig)
+            ? { Authorization: `Bearer ${options.modelConfig.authKey}` }
             : await generatePortkeyHeaders(options.modelConfig, options);
 
     log("Generated header keys:", Object.keys(additionalHeaders));

--- a/gen.pollinations.ai/src/text/transforms/headerGenerator.ts
+++ b/gen.pollinations.ai/src/text/transforms/headerGenerator.ts
@@ -8,6 +8,19 @@ import type {
 
 const log = debug("pollinations:transforms:headers");
 
+async function generateDirectHeaders(
+    config: Record<string, unknown>,
+): Promise<Record<string, string>> {
+    const authKey = config.authKey;
+    if (!authKey) return {};
+
+    const token =
+        typeof authKey === "function"
+            ? await (authKey as () => string | Promise<string>)()
+            : String(authKey);
+    return { Authorization: `Bearer ${token}` };
+}
+
 /**
  * Transform that generates provider-specific headers for the request.
  */
@@ -19,10 +32,10 @@ export async function generateHeaders(
         return { messages, options };
     }
 
-    const additionalHeaders = await generatePortkeyHeaders(
-        options.modelConfig,
-        options,
-    );
+    const additionalHeaders =
+        typeof options.modelConfig.directEndpoint === "string"
+            ? await generateDirectHeaders(options.modelConfig)
+            : await generatePortkeyHeaders(options.modelConfig, options);
 
     log("Generated header keys:", Object.keys(additionalHeaders));
 

--- a/gen.pollinations.ai/test/error-observability.test.ts
+++ b/gen.pollinations.ai/test/error-observability.test.ts
@@ -802,7 +802,7 @@ describe("error observability", () => {
         });
     });
 
-    it("returns 400 for a status-less invalid image URL error from Portkey", async () => {
+    it("returns 400 for a status-less invalid image URL error from the provider", async () => {
         const fetchRequests: Request[] = [];
         vi.spyOn(globalThis, "fetch").mockImplementation(
             async (input, init) => {
@@ -860,13 +860,13 @@ describe("error observability", () => {
                 message:
                     "The image URL must be a valid and downloadable URL or look like data:<MIMEType>;base64,<YOUR-BASE64-CONTENT>",
                 details: {
-                    upstreamHost: "portkey.test",
+                    upstreamHost: "openrouter.ai",
                 },
             },
         });
         expect(fetchRequests).toHaveLength(1);
         expect(fetchRequests[0].url).toBe(
-            "https://portkey.test/v1/chat/completions",
+            "https://openrouter.ai/api/v1/chat/completions",
         );
     });
 });

--- a/gen.pollinations.ai/test/text/generateTextPortkey.test.ts
+++ b/gen.pollinations.ai/test/text/generateTextPortkey.test.ts
@@ -10,12 +10,10 @@ const azureModelConfig = {
 
 afterEach(() => {
     vi.restoreAllMocks();
-    vi.unstubAllEnvs();
 });
 
 describe("generateTextPortkey", () => {
     it("calls OpenRouter directly and preserves its request and response fields", async () => {
-        vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
         const fetchSpy = vi
             .spyOn(globalThis, "fetch")
             .mockImplementationOnce(
@@ -24,9 +22,6 @@ describe("generateTextPortkey", () => {
                         "https://openrouter.ai/api/v1/chat/completions",
                     );
                     const headers = new Headers(init?.headers);
-                    expect(headers.get("Authorization")).toBe(
-                        "Bearer test-openrouter-key",
-                    );
                     expect(headers.has("x-portkey-provider")).toBe(false);
                     expect(headers.has("x-portkey-request-timeout")).toBe(
                         false,
@@ -125,7 +120,6 @@ describe("generateTextPortkey", () => {
     });
 
     it("passes OpenRouter streaming responses through unchanged", async () => {
-        vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
         const upstream =
             'data: {"id":"generation-2","provider":"Google","choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null}]}\n\n' +
             'data: {"id":"generation-2","provider":"Google","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":1,"total_tokens":6,"cost":9e-7}}\n\n' +

--- a/gen.pollinations.ai/test/text/generateTextPortkey.test.ts
+++ b/gen.pollinations.ai/test/text/generateTextPortkey.test.ts
@@ -10,9 +10,159 @@ const azureModelConfig = {
 
 afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
 });
 
 describe("generateTextPortkey", () => {
+    it("calls OpenRouter directly and preserves its request and response fields", async () => {
+        vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+        const fetchSpy = vi
+            .spyOn(globalThis, "fetch")
+            .mockImplementationOnce(
+                async (input: RequestInfo | URL, init?: RequestInit) => {
+                    expect(String(input)).toBe(
+                        "https://openrouter.ai/api/v1/chat/completions",
+                    );
+                    const headers = new Headers(init?.headers);
+                    expect(headers.get("Authorization")).toBe(
+                        "Bearer test-openrouter-key",
+                    );
+                    expect(headers.has("x-portkey-provider")).toBe(false);
+                    expect(headers.has("x-portkey-request-timeout")).toBe(
+                        false,
+                    );
+                    expect(JSON.parse(String(init?.body))).toMatchObject({
+                        model: "google/gemini-2.5-flash-lite",
+                        provider: {
+                            only: ["google-vertex/eu"],
+                            allow_fallbacks: false,
+                        },
+                    });
+
+                    return Response.json({
+                        id: "generation-1",
+                        model: "google/gemini-2.5-flash-lite",
+                        provider: "Google",
+                        service_tier: null,
+                        system_fingerprint: "fp_test",
+                        choices: [
+                            {
+                                index: 0,
+                                message: { role: "assistant", content: "ok" },
+                                finish_reason: "stop",
+                                native_finish_reason: "STOP",
+                            },
+                        ],
+                        usage: {
+                            prompt_tokens: 5,
+                            completion_tokens: 1,
+                            total_tokens: 6,
+                            cost: 0.0000009,
+                            is_byok: false,
+                            prompt_tokens_details: {
+                                cached_tokens: 0,
+                                cache_write_tokens: 0,
+                                audio_tokens: 0,
+                                video_tokens: 0,
+                            },
+                            cost_details: {
+                                upstream_inference_cost: 0.0000009,
+                                upstream_inference_prompt_cost: 0.0000005,
+                                upstream_inference_completions_cost: 0.0000004,
+                            },
+                            completion_tokens_details: {
+                                reasoning_tokens: 0,
+                                image_tokens: 0,
+                                audio_tokens: 0,
+                            },
+                        },
+                    });
+                },
+            );
+        const portkeyFetcher = vi.fn();
+
+        const completion = await generateTextPortkey(
+            [{ role: "user", content: "hello" }],
+            {
+                model: "gemini-fast",
+                portkeyGatewayUrl: "https://portkey.test",
+            },
+            portkeyFetcher,
+        );
+
+        expect(fetchSpy).toHaveBeenCalledOnce();
+        expect(portkeyFetcher).not.toHaveBeenCalled();
+        expect(completion).toMatchObject({
+            id: "generation-1",
+            provider: "Google",
+            service_tier: null,
+            system_fingerprint: "fp_test",
+            choices: [{ native_finish_reason: "STOP" }],
+            usage: {
+                prompt_tokens: 5,
+                completion_tokens: 1,
+                total_tokens: 6,
+                cost: 0.0000009,
+                is_byok: false,
+                prompt_tokens_details: {
+                    cached_tokens: 0,
+                    cache_write_tokens: 0,
+                    audio_tokens: 0,
+                    video_tokens: 0,
+                },
+                cost_details: {
+                    upstream_inference_cost: 0.0000009,
+                    upstream_inference_prompt_cost: 0.0000005,
+                    upstream_inference_completions_cost: 0.0000004,
+                },
+                completion_tokens_details: {
+                    reasoning_tokens: 0,
+                    image_tokens: 0,
+                    audio_tokens: 0,
+                },
+            },
+        });
+    });
+
+    it("passes OpenRouter streaming responses through unchanged", async () => {
+        vi.stubEnv("OPENROUTER_API_KEY", "test-openrouter-key");
+        const upstream =
+            'data: {"id":"generation-2","provider":"Google","choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null}]}\n\n' +
+            'data: {"id":"generation-2","provider":"Google","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":1,"total_tokens":6,"cost":9e-7}}\n\n' +
+            "data: [DONE]\n\n";
+        const fetchSpy = vi
+            .spyOn(globalThis, "fetch")
+            .mockImplementationOnce(
+                async (input: RequestInfo | URL, init?: RequestInit) => {
+                    expect(String(input)).toBe(
+                        "https://openrouter.ai/api/v1/chat/completions",
+                    );
+                    expect(JSON.parse(String(init?.body))).toMatchObject({
+                        model: "google/gemini-2.5-flash-lite",
+                        stream: true,
+                        stream_options: { include_usage: true },
+                    });
+                    return new Response(upstream, {
+                        headers: { "Content-Type": "text/event-stream" },
+                    });
+                },
+            );
+        const portkeyFetcher = vi.fn();
+
+        const completion = await generateTextPortkey(
+            [{ role: "user", content: "hello" }],
+            { model: "gemini-fast", stream: true },
+            portkeyFetcher,
+        );
+
+        expect(fetchSpy).toHaveBeenCalledOnce();
+        expect(portkeyFetcher).not.toHaveBeenCalled();
+        expect(completion.stream).toBe(true);
+        expect(await new Response(completion.responseStream).text()).toBe(
+            upstream,
+        );
+    });
+
     it("sets an owned request deadline below the public gateway limit", async () => {
         const fetcher = vi.fn(
             async (_input: RequestInfo | URL, init?: RequestInit) => {

--- a/gen.pollinations.ai/test/text/transforms/createGeminiToolsTransform.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/createGeminiToolsTransform.test.ts
@@ -34,8 +34,8 @@ describe("OpenRouter Gemini routing", () => {
             allow_fallbacks: false,
         });
         expect(options.modelConfig).toMatchObject({
-            provider: "openai",
-            "custom-host": "https://openrouter.ai/api/v1",
+            provider: "openrouter",
+            directEndpoint: "https://openrouter.ai/api/v1/chat/completions",
         });
     });
 

--- a/gen.pollinations.ai/test/text/transforms/headerGenerator.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/headerGenerator.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { generateHeaders } from "../../../src/text/transforms/headerGenerator.js";
+
+describe("generateHeaders", () => {
+    it("sends bearer auth and no Portkey headers for a direct endpoint", async () => {
+        const { options } = await generateHeaders([], {
+            modelConfig: {
+                provider: "openrouter",
+                directEndpoint: "https://openrouter.ai/api/v1/chat/completions",
+                authKey: "test-openrouter-key",
+            },
+        });
+
+        expect(options.additionalHeaders).toEqual({
+            Authorization: "Bearer test-openrouter-key",
+        });
+    });
+
+    it("translates a Portkey config into x-portkey-* headers", async () => {
+        const { options } = await generateHeaders([], {
+            modelConfig: { provider: "perplexity-ai", authKey: "test-key" },
+        });
+
+        expect(options.additionalHeaders).toEqual({
+            "x-portkey-strict-open-ai-compliance": "false",
+            "x-portkey-provider": "perplexity-ai",
+            Authorization: "Bearer test-key",
+        });
+    });
+});

--- a/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
+++ b/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
@@ -129,8 +129,8 @@ describe("resolveModelConfig", () => {
 
         expect(result.options.model).toBe("qwen/qwen3.7-flash");
         expect(result.options.modelConfig).toMatchObject({
-            provider: "openai",
-            "custom-host": "https://openrouter.ai/api/v1",
+            provider: "openrouter",
+            directEndpoint: "https://openrouter.ai/api/v1/chat/completions",
         });
         expect(result.options.provider).toEqual({
             only: ["Alibaba"],
@@ -143,8 +143,8 @@ describe("resolveModelConfig", () => {
 
         expect(result.options.model).toBe("qwen/qwen3.8-max");
         expect(result.options.modelConfig).toMatchObject({
-            provider: "openai",
-            "custom-host": "https://openrouter.ai/api/v1",
+            provider: "openrouter",
+            directEndpoint: "https://openrouter.ai/api/v1/chat/completions",
         });
         expect(result.options.provider).toEqual({
             only: ["Alibaba"],
@@ -174,8 +174,8 @@ describe("resolveModelConfig", () => {
 
         expect(result.options.model).toBe("qwen/qwen3.8-27b");
         expect(result.options.modelConfig).toMatchObject({
-            provider: "openai",
-            "custom-host": "https://openrouter.ai/api/v1",
+            provider: "openrouter",
+            directEndpoint: "https://openrouter.ai/api/v1/chat/completions",
         });
         expect(result.options.provider).toEqual({
             only: ["Chutes"],
@@ -225,8 +225,8 @@ describe("resolveModelConfig", () => {
 
         expect(result.options.model).toBe("x-ai/grok-4.6");
         expect(result.options.modelConfig).toMatchObject({
-            provider: "openai",
-            "custom-host": "https://openrouter.ai/api/v1",
+            provider: "openrouter",
+            directEndpoint: "https://openrouter.ai/api/v1/chat/completions",
         });
         expect(result.options.provider).toEqual({
             only: ["xai/zdr"],
@@ -239,8 +239,8 @@ describe("resolveModelConfig", () => {
 
         expect(result.options.model).toBe("z-ai/glm-5.3");
         expect(result.options.modelConfig).toMatchObject({
-            provider: "openai",
-            "custom-host": "https://openrouter.ai/api/v1",
+            provider: "openrouter",
+            directEndpoint: "https://openrouter.ai/api/v1/chat/completions",
         });
         expect(result.options.provider).toEqual({
             only: ["z-ai/fp8"],


### PR DESCRIPTION
- Sends OpenRouter-backed chat requests directly to the OpenRouter OpenAI-compatible endpoint.
- Preserves OpenRouter provider constraints and raw usage/cost fields.
- Keeps the existing Portkey path and timeout header unchanged for other providers.
- Adds direct non-streaming and streaming transport coverage; 87 focused tests pass.

Alternative fix for #13620.