### PR TITLE
fix: #13660 - Activity timezone display

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/activity/activity-helpers.tsx
+++ b/enter.pollinations.ai/frontend/src/components/activity/activity-helpers.tsx
@@ -88,21 +88,21 @@ export function formatActivityChartDate(
     date: Date,
     isHourly: boolean,
 ): { label: string; fullDate: string } {
+    // No `timeZone` override on any of these — each bucket boundary is a
+    // fixed instant in time, and formatting it without a timezone renders
+    // it in the browser's local timezone.
     return {
         label: isHourly
             ? date.toLocaleTimeString("en-US", {
-                  timeZone: "UTC",
                   hour: "2-digit",
                   minute: "2-digit",
                   hour12: false,
               })
             : date.toLocaleDateString("en-US", {
-                  timeZone: "UTC",
                   month: "short",
                   day: "numeric",
               }),
         fullDate: date.toLocaleDateString("en-US", {
-            timeZone: "UTC",
             weekday: "short",
             year: "numeric",
             month: "short",

--- a/enter.pollinations.ai/frontend/src/components/pollen/last-events-panel.tsx
+++ b/enter.pollinations.ai/frontend/src/components/pollen/last-events-panel.tsx
@@ -66,8 +66,8 @@ function timestampMs(value: string): number {
 }
 
 function formatTimestamp(value: string): string {
+    // No `timeZone` override — renders in the browser's local timezone.
     return parseTimestamp(value).toLocaleString(undefined, {
-        timeZone: "UTC",
         year: "numeric",
         month: "short",
         day: "numeric",
@@ -262,7 +262,7 @@ export const LastEventsPanel: FC = () => {
                             </div>
                             <div className="flex items-center justify-between gap-2 text-xs">
                                 <span className="text-ink-600 tabular-nums">
-                                    {formatTimestamp(event.timestamp)} UTC
+                                    {formatTimestamp(event.timestamp)}
                                 </span>
                                 <EventKindChip kind={event.kind} />
                             </div>
@@ -283,7 +283,7 @@ export const LastEventsPanel: FC = () => {
                                 <TableHeaderCell
                                     className={TABLE_HEADER_CELL_CLASS}
                                 >
-                                    Time (UTC)
+                                    Time
                                 </TableHeaderCell>
                                 <TableHeaderCell
                                     align="center"

--- a/enter.pollinations.ai/frontend/src/components/pollen/last-events-panel.tsx
+++ b/enter.pollinations.ai/frontend/src/components/pollen/last-events-panel.tsx
@@ -262,7 +262,7 @@ export const LastEventsPanel: FC = () => {
                             </div>
                             <div className="flex items-center justify-between gap-2 text-xs">
                                 <span className="text-ink-600 tabular-nums">
-                                    {formatTimestamp(event.timestamp)}
+                                    {formatTimestamp(event.timestamp)} UTC
                                 </span>
                                 <EventKindChip kind={event.kind} />
                             </div>
@@ -283,7 +283,7 @@ export const LastEventsPanel: FC = () => {
                                 <TableHeaderCell
                                     className={TABLE_HEADER_CELL_CLASS}
                                 >
-                                    Time
+                                    Time (UTC)
                                 </TableHeaderCell>
                                 <TableHeaderCell
                                     align="center"

--- a/enter.pollinations.ai/frontend/src/routes/_dashboard.activity.tsx
+++ b/enter.pollinations.ai/frontend/src/routes/_dashboard.activity.tsx
@@ -95,7 +95,8 @@ function ActivityPage() {
                         minDate={ACTIVITY_MIN_DATE}
                     />
                     <p className="text-micro text-theme-text-muted">
-                        Usage refreshes hourly. Times are shown in UTC.
+                        Usage refreshes hourly. Times are shown in your local
+                        timezone.
                     </p>
                 </div>
                 <UsageSection

--- a/operations/model-monitor/src/App.jsx
+++ b/operations/model-monitor/src/App.jsx
@@ -665,12 +665,10 @@ function App() {
                         <p className="m-0 text-xs leading-normal text-theme-text-soft">
                             Data as of:{" "}
                             {lastUpdated?.toLocaleTimeString("en-GB", {
-                                timeZone: "UTC",
                                 hour: "2-digit",
                                 minute: "2-digit",
                                 second: "2-digit",
-                            }) || "-"}{" "}
-                            UTC
+                            }) || "-"}
                         </p>
                     </div>
                 </section>


### PR DESCRIPTION
Fixes #13660

- Activity dashboard timestamps (Last events, Events over time) and Model Monitor "data as of" time were
  hardcoded to render in UTC via `timeZone: "UTC"`, so users outside
  UTC (e.g. IST) saw times that didn't match their local clock.
- `formatTimestamp` (last-events-panel.tsx) and `formatActivityChartDate`
  (activity-helpers.tsx) now format without a `timeZone` override, so
  `toLocaleString`/`toLocaleDateString` render in the viewer's browser
  timezone instead.
- Both Last events and Events over time now behave consistently.
- Updated the graph caption from "Times are shown in UTC" to "Times
  are shown in your local timezone."
Note: the usage/earnings graph buckets are still aggregated
server-side on fixed UTC day/hour windows — only the displayed label
is now localized, not the bucket boundary itself. For timezones
behind UTC this can occasionally shift which local date a bar's label
shows relative to the UTC window it sums. Fully localized bucketing
would need backend aggregation changes, out of scope here.