### PR TITLE
chore: promote main to production

### DIFF
--- a/enter.pollinations.ai/src/services/prompt-agent-runtime.ts
+++ b/enter.pollinations.ai/src/services/prompt-agent-runtime.ts
@@ -13,11 +13,11 @@ import type { PromptAgentConfig } from "./prompt-agent.ts";
 
 const log = getLogger(["enter", "prompt-agent-runtime"]);
 
-// Use z.any() for messages instead of z.custom() to allow JSON Schema generation.
-// Actual runtime validation is handled by the ai package internally.
 export const PromptAgentRequestSchema = z
     .object({
-        messages: z.array(z.any()).optional().default([]),
+        // z.custom() accepts the same inputs, but cannot be represented in the
+        // OpenAPI JSON Schema generated for the account service.
+        messages: z.array(z.unknown()).optional().default([]),
         stream: z.boolean().optional().default(false),
     })
     .passthrough();
@@ -574,7 +574,9 @@ export async function handlePromptAgentRequest(
     signal: AbortSignal,
     runtime: PromptAgentRuntime,
 ): Promise<Response> {
-    const messages = Array.isArray(body.messages) ? body.messages : [];
+    const messages = (
+        Array.isArray(body.messages) ? body.messages : []
+    ) as ModelMessage[];
     const id = `chatcmpl-${crypto.randomUUID()}`;
     const created = Math.floor(Date.now() / 1000);
     try {

--- a/enter.pollinations.ai/test/docs-redirect.test.ts
+++ b/enter.pollinations.ai/test/docs-redirect.test.ts
@@ -27,6 +27,7 @@ test("enter docs schema remains available for gen service binding", async () => 
     expect(schema.paths?.["/account/profile"]).toBeDefined();
     expect(schema.paths?.["/account/quests"]).toBeDefined();
     expect(schema.paths?.["/account/my-models"]).toBeDefined();
+    expect(schema.paths?.["/account/agents"]).toBeDefined();
 });
 
 test("legacy enter docs redirect keeps the docs path boundary", async () => {

--- a/gen.pollinations.ai/scripts/generate-apidocs.ts
+++ b/gen.pollinations.ai/scripts/generate-apidocs.ts
@@ -25,6 +25,7 @@ type Spec = {
     info: { title: string; description: string; version: string };
     openapi: string;
     servers: { url: string }[];
+    tags?: { name: string; description?: string }[];
     paths: Record<string, Record<string, Operation>>;
     components: { schemas: Record<string, Schema> };
 };
@@ -756,10 +757,10 @@ function loadIntroductionTagline(): string {
 function renderGettingStarted(): string {
     return `## ${sectionHeading(SECTIONS.start)}
 
-**1. Get an API key** at [enter.pollinations.ai](https://enter.pollinations.ai/keys). Two key types are available:
+**1. Get an API key** at [enter.pollinations.ai](https://enter.pollinations.ai/keys). Use the key type for your environment:
 
-- \`sk_*\` — secret key for backend use (full account access)
-- \`pk_*\` — publishable key, safe to ship in browsers and mobile apps
+- \`sk_*\` — secret key for backend use. Never ship it in a browser, mobile app, or repository.
+- \`pk_*\` App Key — public OAuth client id for BYOP. Use it to obtain a scoped user \`sk_*\`; do not use raw publishable keys for new browser generation integrations.
 
 **2. Send the key** in the \`Authorization\` header (or as \`?key=\` query param for GET endpoints):
 
@@ -837,6 +838,13 @@ function renderEndpoints(
     for (const [tag, ops] of byTag) {
         out.push(`### ${tag}`);
         out.push("");
+        const description = spec.tags?.find(
+            (item) => item.name === tag,
+        )?.description;
+        if (description) {
+            out.push(description.trim());
+            out.push("");
+        }
         for (const { method, path, op } of ops) {
             out.push(renderEndpoint(spec, method, path, op));
             out.push("---");
@@ -1066,6 +1074,21 @@ const TAG_ORDER = [
     "Account",
 ];
 
+const REQUIRED_PATHS = [
+    "/account/profile",
+    "/account/my-models",
+    "/account/agents",
+];
+
+function requireMergedPaths(spec: Spec): void {
+    const missing = REQUIRED_PATHS.filter((path) => !spec.paths[path]);
+    if (missing.length > 0) {
+        throw new Error(
+            `OpenAPI schema is incomplete; missing required paths: ${missing.join(", ")}`,
+        );
+    }
+}
+
 /** Group operations by tag, then re-key the map to follow TAG_ORDER. */
 function groupByTag(
     spec: Spec,
@@ -1116,6 +1139,7 @@ function groupByTag(
 async function main() {
     console.log(`Fetching OpenAPI spec from ${OPENAPI_URL}...`);
     const spec = (await fetch(OPENAPI_URL).then((r) => r.json())) as Spec;
+    requireMergedPaths(spec);
     simplifyModelEnums(spec);
 
     const byTag = groupByTag(spec);

--- a/gen.pollinations.ai/src/community-models.ts
+++ b/gen.pollinations.ai/src/community-models.ts
@@ -192,7 +192,6 @@ export async function getCommunityModelRegistryEntries(
                 info: modelInfoFromDefinition(modelId, definition, {
                     community: true,
                     agent: usesAgentRunToken(communityEndpoint),
-                    perUserRpm: communityEndpoint.perUserRpm,
                 }),
                 definition,
                 communityEndpoint,

--- a/gen.pollinations.ai/src/durable-objects/CommunityModelRateLimiter.ts
+++ b/gen.pollinations.ai/src/durable-objects/CommunityModelRateLimiter.ts
@@ -8,7 +8,7 @@ type RateLimitState = {
     updatedAt: number;
 };
 
-/** One token bucket per community endpoint and Pollinations user. */
+/** One token bucket per model and Pollinations user. */
 export class CommunityModelRateLimiter extends DurableObject {
     private state: RateLimitState | null = null;
 
@@ -27,22 +27,31 @@ export class CommunityModelRateLimiter extends DurableObject {
     > {
         const now = Date.now();
         const capacity = Math.max(1, limit);
-        const state =
-            this.state?.rpm === limit
-                ? {
-                      ...this.state,
-                      tokens: Math.min(
-                          capacity,
-                          this.state.tokens +
-                              ((now - this.state.updatedAt) * limit) /
-                                  MINUTE_MS,
-                      ),
-                      updatedAt: now,
-                  }
-                : { rpm: limit, tokens: capacity, updatedAt: now };
+        const previous = this.state;
+        const limitChanged = previous !== null && previous.rpm !== limit;
+        const state = previous
+            ? {
+                  rpm: limit,
+                  tokens: Math.min(
+                      capacity,
+                      previous.tokens +
+                          ((now - previous.updatedAt) * previous.rpm) /
+                              MINUTE_MS,
+                  ),
+                  updatedAt: now,
+              }
+            : { rpm: limit, tokens: capacity, updatedAt: now };
 
         if (state.tokens < 1) {
             this.state = state;
+            // Persist a changed rate even when this request is denied; otherwise
+            // eviction could restore the old refill rate and grant tokens early.
+            if (limitChanged) {
+                await this.ctx.storage.put("state", state);
+                await this.ctx.storage.setAlarm(
+                    now + ((capacity - state.tokens) * MINUTE_MS) / limit,
+                );
+            }
             return {
                 allowed: false,
                 retryAfterSeconds: Math.max(

--- a/gen.pollinations.ai/src/fallback.ts
+++ b/gen.pollinations.ai/src/fallback.ts
@@ -369,11 +369,13 @@ export async function withModelFallbackResponse(
     model: PrimaryModel,
     attempt: (candidate: FallbackCandidate) => Promise<Response>,
     failures?: FailedCall[],
+    beforeAttempt?: (candidate: FallbackCandidate) => Promise<void>,
 ): Promise<{ response: Response; servedEntry?: GenerationModelEntry }> {
     const { result, candidate, index } = await withModelFallback(
         fallbackCandidates(model),
         attempt,
         failures,
+        beforeAttempt,
     );
     if (index > 0) {
         result.headers.set(FALLBACK_TARGET_HEADER, `config.targets[${index}]`);

--- a/gen.pollinations.ai/src/image/handler.ts
+++ b/gen.pollinations.ai/src/image/handler.ts
@@ -8,7 +8,7 @@ import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { Env } from "@/env.ts";
 import { fallbackCandidates, withModelFallback } from "../fallback.ts";
 import type { GenerationModelEntry } from "../model-registry.ts";
-import { enforceCommunityModelRateLimit } from "../utils/community-model-rate-limit.ts";
+import { enforceModelRateLimit } from "../utils/model-rate-limit.ts";
 import {
     getRegisteredServers,
     isValidType,
@@ -445,8 +445,7 @@ async function generateMediaWithFallback(
             return { result: generated, params };
         },
         c.var.track?.failedCalls,
-        (attempt) =>
-            enforceCommunityModelRateLimit(c, attempt.communityEndpoint),
+        (attempt) => enforceModelRateLimit(c, attempt),
     );
     return {
         ...result,

--- a/gen.pollinations.ai/src/model3d/handler.ts
+++ b/gen.pollinations.ai/src/model3d/handler.ts
@@ -6,6 +6,7 @@ import type { Context } from "hono";
 import type { Env } from "@/env.ts";
 import { withModelFallbackResponse } from "../fallback.ts";
 import { bufferToUint8Array } from "../image/utils/imageDownload.ts";
+import { enforceModelRateLimit } from "../utils/model-rate-limit.ts";
 import {
     createAndReturnModel3d,
     type Model3dGenerationResult,
@@ -40,6 +41,7 @@ export async function generate3dResponse(
                 });
             },
             c.var.track?.failedCalls,
+            (candidate) => enforceModelRateLimit(c, candidate),
         );
         if (servedEntry) c.set("servedModelEntry", servedEntry);
         return response;

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -45,6 +45,7 @@ import {
     type FallbackCandidate,
     withModelFallbackResponse,
 } from "../fallback.ts";
+import { enforceModelRateLimit } from "../utils/model-rate-limit.ts";
 import { validateUserMediaUrl } from "../utils/user-media-url.ts";
 import { transcribeWithAssemblyAi } from "./assemblyai-transcription.ts";
 import type { SimpleAudioQuery } from "./generation-handlers.ts";
@@ -158,6 +159,7 @@ async function withAudioFallback(
         c.var.model,
         attempt,
         c.var.track?.failedCalls,
+        (candidate) => enforceModelRateLimit(c, candidate),
     );
     if (servedEntry) c.set("servedModelEntry", servedEntry);
     return response;

--- a/gen.pollinations.ai/src/routes/docs.ts
+++ b/gen.pollinations.ai/src/routes/docs.ts
@@ -615,7 +615,9 @@ async function fetchEnterSchema(c: Context<Env>) {
             headers: c.req.raw.headers,
         }),
     );
-    if (!response.ok) return undefined;
+    if (!response.ok) {
+        throw new Error(`Enter OpenAPI schema returned ${response.status}`);
+    }
 
     const schema = (await response.json()) as OpenApiSchema;
     return transformEnterSchema(stripGenerationPaths(schema));
@@ -895,7 +897,7 @@ export async function buildMergedOpenApiSpec(
 ): Promise<OpenApiSchema> {
     const [generationSchema, enterSchema, mediaSchema] = await Promise.all([
         getGenerationSchema(genApp),
-        fetchEnterSchema(c).catch(() => undefined),
+        fetchEnterSchema(c),
         fetchMediaSchema(c).catch(() => undefined),
     ]);
     return injectSamples(

--- a/gen.pollinations.ai/src/routes/generation-handlers.ts
+++ b/gen.pollinations.ai/src/routes/generation-handlers.ts
@@ -28,6 +28,7 @@ import {
     handleTextContentLocal,
 } from "@/text/handler.ts";
 import { withModelFallbackResponse } from "../fallback.ts";
+import { enforceModelRateLimit } from "../utils/model-rate-limit.ts";
 
 export const textBodyLimit = bodyLimit({
     maxSize: 20 * 1024 * 1024,
@@ -159,6 +160,7 @@ export async function generateEmbeddingsResponse(
                 candidate.id,
             ),
         c.var.track?.failedCalls,
+        (candidate) => enforceModelRateLimit(c, candidate),
     );
     if (servedEntry) c.set("servedModelEntry", servedEntry);
     return response;

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -338,8 +338,8 @@ export const proxyRoutes = new Hono<Env>()
                 ...(entry.info.context_length && {
                     context_length: entry.info.context_length,
                 }),
-                ...(entry.info.community && {
-                    per_user_rpm: entry.info.per_user_rpm ?? null,
+                ...(entry.info.per_user_rpm !== undefined && {
+                    per_user_rpm: entry.info.per_user_rpm,
                 }),
             });
 

--- a/gen.pollinations.ai/src/routes/realtime.ts
+++ b/gen.pollinations.ai/src/routes/realtime.ts
@@ -42,6 +42,7 @@ import {
 import { RealtimeUsageSchema } from "@/schemas/realtime.ts";
 import { generateRandomId } from "@/util.ts";
 import { checkBalance } from "@/utils/generation-access.ts";
+import { enforceModelRateLimit } from "../utils/model-rate-limit.ts";
 
 type AzureRealtimeApiKey =
     | "AZURE_MYCELI_PROD_EASTUS2_API_KEY"
@@ -1411,6 +1412,11 @@ export async function handleRealtimeWebSocket(
         return new Response("Expected Upgrade: websocket", { status: 426 });
     }
     const userId = await authorizeRealtimeSession(c);
+    await enforceModelRateLimit(c, {
+        id: c.var.model.resolved,
+        definition: c.var.model.definition,
+        communityEndpoint: c.var.model.communityEndpoint,
+    });
     const tracking = await createRealtimeBillingContext(c);
     if (c.var.model.resolved === "scribe-realtime") {
         if (!c.env.ELEVENLABS_API_KEY) {

--- a/gen.pollinations.ai/src/text/configs/providerConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/providerConfigs.ts
@@ -101,11 +101,12 @@ export function createDeepInfraModelConfig(
 export function createOpenRouterModelConfig(
     overrides: ModelOverride = {},
 ): ProviderConfig {
-    return createOpenAICompatibleConfig(
-        "https://openrouter.ai/api/v1",
-        process.env.OPENROUTER_API_KEY,
-        overrides,
-    );
+    return {
+        provider: "openrouter",
+        directEndpoint: "https://openrouter.ai/api/v1/chat/completions",
+        authKey: process.env.OPENROUTER_API_KEY,
+        ...overrides,
+    };
 }
 
 export function createVercelAIGatewayModelConfig(

--- a/gen.pollinations.ai/src/text/generateTextPortkey.ts
+++ b/gen.pollinations.ai/src/text/generateTextPortkey.ts
@@ -40,7 +40,7 @@ function buildEndpoint(gatewayUrl: unknown): string {
 export async function generateTextPortkey(
     messages: ChatMessage[],
     options: TransformOptions = {},
-    fetcher?: OpenAIClientConfig["fetcher"],
+    portkeyFetcher?: OpenAIClientConfig["fetcher"],
 ): Promise<ChatCompletion> {
     let state: TransformResult = { messages, options: { ...options } };
     const modelDef = state.options.model
@@ -64,19 +64,31 @@ export async function generateTextPortkey(
         state = await processParameters(state.messages, state.options);
     }
 
+    const directEndpoint = state.options.modelConfig?.directEndpoint;
+    // Read before the delete below: the endpoint thunk runs after it.
     const portkeyGatewayUrl = state.options.portkeyGatewayUrl;
-    const requestConfig = {
-        ...clientConfig,
-        endpoint: () => buildEndpoint(portkeyGatewayUrl),
-        additionalHeaders: {
-            "x-portkey-request-timeout": String(PORTKEY_REQUEST_TIMEOUT_MS),
-            ...((state.options.additionalHeaders || {}) as Record<
-                string,
-                string
-            >),
-        },
-        fetcher,
-    };
+    const additionalHeaders = (state.options.additionalHeaders || {}) as Record<
+        string,
+        string
+    >;
+    const requestConfig =
+        typeof directEndpoint === "string"
+            ? {
+                  ...clientConfig,
+                  endpoint: directEndpoint,
+                  additionalHeaders,
+              }
+            : {
+                  ...clientConfig,
+                  endpoint: () => buildEndpoint(portkeyGatewayUrl),
+                  additionalHeaders: {
+                      "x-portkey-request-timeout": String(
+                          PORTKEY_REQUEST_TIMEOUT_MS,
+                      ),
+                      ...additionalHeaders,
+                  },
+                  fetcher: portkeyFetcher,
+              };
 
     delete state.options.additionalHeaders;
     delete state.options.portkeyGatewayUrl;

--- a/gen.pollinations.ai/src/text/handler.ts
+++ b/gen.pollinations.ai/src/text/handler.ts
@@ -17,7 +17,7 @@ import {
     withModelFallback,
 } from "../fallback.ts";
 import { fixWavHeader } from "../routes/audio.js";
-import { enforceCommunityModelRateLimit } from "../utils/community-model-rate-limit.ts";
+import { enforceModelRateLimit } from "../utils/model-rate-limit.ts";
 import { communityEndpointGatewayContext } from "./communityEndpoint.ts";
 import { generateTextPortkey } from "./generateTextPortkey.js";
 import { type ExpressLikeRequest, getRequestData } from "./requestUtils.js";
@@ -406,8 +406,7 @@ async function generateTextResponse(
                         : undefined,
                 ),
             c.var.track?.failedCalls,
-            (attempt) =>
-                enforceCommunityModelRateLimit(c, attempt.communityEndpoint),
+            (attempt) => enforceModelRateLimit(c, attempt),
         );
         c.set("upstreamRequestUrl", completion.upstreamRequestUrl);
         completion.id = completion.id || generatePollinationsId();

--- a/gen.pollinations.ai/src/text/transforms/headerGenerator.ts
+++ b/gen.pollinations.ai/src/text/transforms/headerGenerator.ts
@@ -19,10 +19,12 @@ export async function generateHeaders(
         return { messages, options };
     }
 
-    const additionalHeaders = await generatePortkeyHeaders(
-        options.modelConfig,
-        options,
-    );
+    // Direct providers need only bearer auth; Portkey needs its whole
+    // x-portkey-* config translated from the same modelConfig.
+    const additionalHeaders =
+        typeof options.modelConfig.directEndpoint === "string"
+            ? { Authorization: `Bearer ${options.modelConfig.authKey}` }
+            : await generatePortkeyHeaders(options.modelConfig, options);
 
     log("Generated header keys:", Object.keys(additionalHeaders));
 

--- a/gen.pollinations.ai/src/utils/model-rate-limit.ts
+++ b/gen.pollinations.ai/src/utils/model-rate-limit.ts
@@ -1,27 +1,28 @@
-import type { CommunityEndpointRuntime } from "@shared/community-endpoints.ts";
 import { UpstreamError } from "@shared/error.ts";
 import type { Context } from "hono";
 import type { CommunityModelRateLimiter } from "../durable-objects/CommunityModelRateLimiter.ts";
 import type { Env } from "../env.ts";
+import type { FallbackCandidate } from "../fallback.ts";
 
-export async function enforceCommunityModelRateLimit(
+export async function enforceModelRateLimit(
     c: Context<Env>,
-    endpoint: CommunityEndpointRuntime | undefined,
+    candidate: FallbackCandidate,
 ): Promise<void> {
-    if (!endpoint || endpoint.perUserRpm == null) return;
-    const limit = endpoint.perUserRpm;
+    const limit = candidate.definition?.perUserRpm;
+    if (limit == null) return;
 
     const userId = c.var.auth.requireUser().id;
     const namespace = c.env.COMMUNITY_MODEL_RATE_LIMITER;
     const stub = namespace.get(
-        namespace.idFromName(`${endpoint.id}:${userId}`),
+        namespace.idFromName(`${candidate.id}:${userId}`),
     ) as DurableObjectStub<CommunityModelRateLimiter>;
     const result = await stub.check(limit);
     if (result.allowed) return;
 
     c.header("Retry-After", String(result.retryAfterSeconds));
     throw new UpstreamError(429, {
-        message: `Per-user limit of ${limit} RPM exceeded for this community model`,
+        message: `Per-user limit of ${limit} RPM exceeded for model ${candidate.id}`,
+        // Kept for API compatibility and the existing model-health exclusion.
         errorCode: "community_model_rate_limit",
     });
 }

--- a/gen.pollinations.ai/test/community-model-rate-limit.test.ts
+++ b/gen.pollinations.ai/test/community-model-rate-limit.test.ts
@@ -1,8 +1,28 @@
 import { env } from "cloudflare:test";
+import { modelInfoFromDefinition } from "@shared/registry/model-info.ts";
+import type { ModelDefinition } from "@shared/registry/registry.ts";
 import { describe, expect, it } from "vitest";
 import type { CommunityModelRateLimiter } from "../src/durable-objects/CommunityModelRateLimiter.ts";
 
-describe("CommunityModelRateLimiter", () => {
+describe("model rate limiting", () => {
+    it("publishes a catalog model's configured per-user RPM", () => {
+        const definition: ModelDefinition = {
+            aliases: [],
+            provider: "test",
+            perUserRpm: 0.5,
+            brand: "Test",
+            category: "text",
+            cost: {},
+            priceMultiplier: 1,
+            addedDate: 0,
+            title: "Test",
+        };
+
+        expect(modelInfoFromDefinition("test", definition).per_user_rpm).toBe(
+            0.5,
+        );
+    });
+
     it("enforces whole and fractional limits independently per object", async () => {
         const namespace = env.COMMUNITY_MODEL_RATE_LIMITER;
         const first = namespace.get(
@@ -21,5 +41,15 @@ describe("CommunityModelRateLimiter", () => {
         if (!blocked.allowed) {
             expect(blocked.retryAfterSeconds).toBeGreaterThan(60);
         }
+    });
+
+    it("does not refill an exhausted bucket when its limit changes", async () => {
+        const stub = env.COMMUNITY_MODEL_RATE_LIMITER.get(
+            env.COMMUNITY_MODEL_RATE_LIMITER.newUniqueId(),
+        ) as DurableObjectStub<CommunityModelRateLimiter>;
+
+        await expect(stub.check(2)).resolves.toEqual({ allowed: true });
+        await expect(stub.check(2)).resolves.toEqual({ allowed: true });
+        await expect(stub.check(1)).resolves.toMatchObject({ allowed: false });
     });
 });

--- a/gen.pollinations.ai/test/docs.test.ts
+++ b/gen.pollinations.ai/test/docs.test.ts
@@ -20,6 +20,20 @@ function envWithEnterSchema(schema: unknown): CloudflareBindings {
     } as CloudflareBindings;
 }
 
+function envWithFailedEnterSchema(): CloudflareBindings {
+    return {
+        ENTER: {
+            fetch: async () => new Response("unavailable", { status: 503 }),
+        } as unknown as Fetcher,
+        ENVIRONMENT: "test",
+        LOG_LEVEL: "debug",
+        LOG_FORMAT: "text",
+        TINYBIRD_INGEST_URL:
+            "https://tinybird.test/v0/events?name=request_event",
+        TINYBIRD_INGEST_TOKEN: "test-token",
+    } as CloudflareBindings;
+}
+
 describe("docs routes", () => {
     afterEach(() => {
         vi.restoreAllMocks();
@@ -94,6 +108,16 @@ describe("docs routes", () => {
                 },
                 "/api/account/my-models/{id}/update": {
                     post: { tags: ["👤 Account"] },
+                },
+                "/api/account/agents": {
+                    get: {
+                        tags: ["👤 Account"],
+                        description:
+                            "List managed agents. API keys require `account:keys`.",
+                    },
+                },
+                "/api/account/agents/{id}": {
+                    patch: { tags: ["👤 Account"] },
                 },
                 "/api/quests/catalog": {
                     get: { tags: ["✨ Quests"], security: [] },
@@ -172,11 +196,14 @@ describe("docs routes", () => {
         expect(schema.paths["/account/quests"]).toBeDefined();
         expect(schema.paths["/account/my-models"]).toBeDefined();
         expect(schema.paths["/account/my-models/{id}/update"]).toBeDefined();
+        expect(schema.paths["/account/agents"]).toBeDefined();
+        expect(schema.paths["/account/agents/{id}"]).toBeDefined();
         expect(schema.paths["/quests/catalog"]).toBeDefined();
         expect(schema.paths["/api/account/key"]).toBeUndefined();
         expect(schema.paths["/api/account/profile"]).toBeUndefined();
         expect(schema.paths["/api/account/quests"]).toBeUndefined();
         expect(schema.paths["/api/account/my-models"]).toBeUndefined();
+        expect(schema.paths["/api/account/agents"]).toBeUndefined();
         expect(schema.paths["/api/quests/catalog"]).toBeUndefined();
         expect(schema.paths["/quests/check"]).toBeUndefined();
         expect(schema.paths["/quests/rewards"]).toBeUndefined();
@@ -259,11 +286,36 @@ describe("docs routes", () => {
         )?.get as Record<string, unknown> | undefined;
         expect(myModelsGet?.description).toContain("account:keys");
 
+        const agentsGet = (
+            schema.paths["/account/agents"] as Record<string, unknown>
+        )?.get as Record<string, unknown> | undefined;
+        expect(agentsGet?.description).toContain("account:keys");
+
         // The catalog is unauthenticated → marked public (security: []).
         const questsCatalogGet = (
             schema.paths["/quests/catalog"] as Record<string, unknown>
         )?.get as Record<string, unknown> | undefined;
         expect(questsCatalogGet?.security).toEqual([]);
+    });
+
+    it("does not publish a partial schema when the account schema fails", async () => {
+        const ctx = createExecutionContext();
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+            new Response(JSON.stringify({ paths: {}, components: {} }), {
+                headers: { "Content-Type": "application/json" },
+            }),
+        );
+
+        const response = await worker.fetch(
+            new Request(
+                "https://gen.pollinations.ai/docs/open-api/generate-schema",
+            ),
+            envWithFailedEnterSchema(),
+            ctx,
+        );
+        await waitOnExecutionContext(ctx);
+
+        expect(response.status).toBe(500);
     });
 
     it("does not add noindex to docs responses at the worker boundary", async () => {

--- a/gen.pollinations.ai/test/error-observability.test.ts
+++ b/gen.pollinations.ai/test/error-observability.test.ts
@@ -802,7 +802,7 @@ describe("error observability", () => {
         });
     });
 
-    it("returns 400 for a status-less invalid image URL error from Portkey", async () => {
+    it("returns 400 for a status-less invalid image URL error from the provider", async () => {
         const fetchRequests: Request[] = [];
         vi.spyOn(globalThis, "fetch").mockImplementation(
             async (input, init) => {
@@ -860,13 +860,13 @@ describe("error observability", () => {
                 message:
                     "The image URL must be a valid and downloadable URL or look like data:<MIMEType>;base64,<YOUR-BASE64-CONTENT>",
                 details: {
-                    upstreamHost: "portkey.test",
+                    upstreamHost: "openrouter.ai",
                 },
             },
         });
         expect(fetchRequests).toHaveLength(1);
         expect(fetchRequests[0].url).toBe(
-            "https://portkey.test/v1/chat/completions",
+            "https://openrouter.ai/api/v1/chat/completions",
         );
     });
 });

--- a/gen.pollinations.ai/test/fallback.test.ts
+++ b/gen.pollinations.ai/test/fallback.test.ts
@@ -557,6 +557,9 @@ describe("withModelFallbackResponse", () => {
         const primary = registryEntry("primary", ["target"]);
         const target = registryEntry("target");
         primary.fallbackEntries = [target];
+        const beforeAttempt = vi.fn(
+            async (_candidate: FallbackCandidate) => {},
+        );
 
         const { response, servedEntry } = await withModelFallbackResponse(
             {
@@ -572,9 +575,14 @@ describe("withModelFallbackResponse", () => {
                 }
                 return Response.json({ model: candidate.id });
             },
+            undefined,
+            beforeAttempt,
         );
 
         expect(servedEntry?.id).toBe("target");
+        expect(
+            beforeAttempt.mock.calls.map(([candidate]) => candidate.id),
+        ).toEqual(["primary", "target"]);
         expect(response.headers.get(FALLBACK_TARGET_HEADER)).toBe(
             "config.targets[1]",
         );

--- a/gen.pollinations.ai/test/text/generateTextPortkey.test.ts
+++ b/gen.pollinations.ai/test/text/generateTextPortkey.test.ts
@@ -13,6 +13,150 @@ afterEach(() => {
 });
 
 describe("generateTextPortkey", () => {
+    it("calls OpenRouter directly and preserves its request and response fields", async () => {
+        const fetchSpy = vi
+            .spyOn(globalThis, "fetch")
+            .mockImplementationOnce(
+                async (input: RequestInfo | URL, init?: RequestInit) => {
+                    expect(String(input)).toBe(
+                        "https://openrouter.ai/api/v1/chat/completions",
+                    );
+                    const headers = new Headers(init?.headers);
+                    expect(headers.has("x-portkey-provider")).toBe(false);
+                    expect(headers.has("x-portkey-request-timeout")).toBe(
+                        false,
+                    );
+                    expect(JSON.parse(String(init?.body))).toMatchObject({
+                        model: "google/gemini-2.5-flash-lite",
+                        provider: {
+                            only: ["google-vertex/eu"],
+                            allow_fallbacks: false,
+                        },
+                    });
+
+                    return Response.json({
+                        id: "generation-1",
+                        model: "google/gemini-2.5-flash-lite",
+                        provider: "Google",
+                        service_tier: null,
+                        system_fingerprint: "fp_test",
+                        choices: [
+                            {
+                                index: 0,
+                                message: { role: "assistant", content: "ok" },
+                                finish_reason: "stop",
+                                native_finish_reason: "STOP",
+                            },
+                        ],
+                        usage: {
+                            prompt_tokens: 5,
+                            completion_tokens: 1,
+                            total_tokens: 6,
+                            cost: 0.0000009,
+                            is_byok: false,
+                            prompt_tokens_details: {
+                                cached_tokens: 0,
+                                cache_write_tokens: 0,
+                                audio_tokens: 0,
+                                video_tokens: 0,
+                            },
+                            cost_details: {
+                                upstream_inference_cost: 0.0000009,
+                                upstream_inference_prompt_cost: 0.0000005,
+                                upstream_inference_completions_cost: 0.0000004,
+                            },
+                            completion_tokens_details: {
+                                reasoning_tokens: 0,
+                                image_tokens: 0,
+                                audio_tokens: 0,
+                            },
+                        },
+                    });
+                },
+            );
+        const portkeyFetcher = vi.fn();
+
+        const completion = await generateTextPortkey(
+            [{ role: "user", content: "hello" }],
+            {
+                model: "gemini-fast",
+                portkeyGatewayUrl: "https://portkey.test",
+            },
+            portkeyFetcher,
+        );
+
+        expect(fetchSpy).toHaveBeenCalledOnce();
+        expect(portkeyFetcher).not.toHaveBeenCalled();
+        expect(completion).toMatchObject({
+            id: "generation-1",
+            provider: "Google",
+            service_tier: null,
+            system_fingerprint: "fp_test",
+            choices: [{ native_finish_reason: "STOP" }],
+            usage: {
+                prompt_tokens: 5,
+                completion_tokens: 1,
+                total_tokens: 6,
+                cost: 0.0000009,
+                is_byok: false,
+                prompt_tokens_details: {
+                    cached_tokens: 0,
+                    cache_write_tokens: 0,
+                    audio_tokens: 0,
+                    video_tokens: 0,
+                },
+                cost_details: {
+                    upstream_inference_cost: 0.0000009,
+                    upstream_inference_prompt_cost: 0.0000005,
+                    upstream_inference_completions_cost: 0.0000004,
+                },
+                completion_tokens_details: {
+                    reasoning_tokens: 0,
+                    image_tokens: 0,
+                    audio_tokens: 0,
+                },
+            },
+        });
+    });
+
+    it("passes OpenRouter streaming responses through unchanged", async () => {
+        const upstream =
+            'data: {"id":"generation-2","provider":"Google","choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null}]}\n\n' +
+            'data: {"id":"generation-2","provider":"Google","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":1,"total_tokens":6,"cost":9e-7}}\n\n' +
+            "data: [DONE]\n\n";
+        const fetchSpy = vi
+            .spyOn(globalThis, "fetch")
+            .mockImplementationOnce(
+                async (input: RequestInfo | URL, init?: RequestInit) => {
+                    expect(String(input)).toBe(
+                        "https://openrouter.ai/api/v1/chat/completions",
+                    );
+                    expect(JSON.parse(String(init?.body))).toMatchObject({
+                        model: "google/gemini-2.5-flash-lite",
+                        stream: true,
+                        stream_options: { include_usage: true },
+                    });
+                    return new Response(upstream, {
+                        headers: { "Content-Type": "text/event-stream" },
+                    });
+                },
+            );
+        const portkeyFetcher = vi.fn();
+
+        const completion = await generateTextPortkey(
+            [{ role: "user", content: "hello" }],
+            { model: "gemini-fast", stream: true },
+            portkeyFetcher,
+        );
+
+        expect(fetchSpy).toHaveBeenCalledOnce();
+        expect(portkeyFetcher).not.toHaveBeenCalled();
+        expect(completion.stream).toBe(true);
+        expect(await new Response(completion.responseStream).text()).toBe(
+            upstream,
+        );
+    });
+
     it("sets an owned request deadline below the public gateway limit", async () => {
         const fetcher = vi.fn(
             async (_input: RequestInfo | URL, init?: RequestInit) => {

--- a/gen.pollinations.ai/test/text/transforms/createGeminiToolsTransform.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/createGeminiToolsTransform.test.ts
@@ -34,8 +34,8 @@ describe("OpenRouter Gemini routing", () => {
             allow_fallbacks: false,
         });
         expect(options.modelConfig).toMatchObject({
-            provider: "openai",
-            "custom-host": "https://openrouter.ai/api/v1",
+            provider: "openrouter",
+            directEndpoint: "https://openrouter.ai/api/v1/chat/completions",
         });
     });
 

--- a/gen.pollinations.ai/test/text/transforms/headerGenerator.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/headerGenerator.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { generateHeaders } from "../../../src/text/transforms/headerGenerator.js";
+
+describe("generateHeaders", () => {
+    it("sends bearer auth and no Portkey headers for a direct endpoint", async () => {
+        const { options } = await generateHeaders([], {
+            modelConfig: {
+                provider: "openrouter",
+                directEndpoint: "https://openrouter.ai/api/v1/chat/completions",
+                authKey: "test-openrouter-key",
+            },
+        });
+
+        expect(options.additionalHeaders).toEqual({
+            Authorization: "Bearer test-openrouter-key",
+        });
+    });
+
+    it("translates a Portkey config into x-portkey-* headers", async () => {
+        const { options } = await generateHeaders([], {
+            modelConfig: { provider: "perplexity-ai", authKey: "test-key" },
+        });
+
+        expect(options.additionalHeaders).toEqual({
+            "x-portkey-strict-open-ai-compliance": "false",
+            "x-portkey-provider": "perplexity-ai",
+            Authorization: "Bearer test-key",
+        });
+    });
+});

--- a/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
+++ b/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
@@ -129,8 +129,8 @@ describe("resolveModelConfig", () => {
 
         expect(result.options.model).toBe("qwen/qwen3.7-flash");
         expect(result.options.modelConfig).toMatchObject({
-            provider: "openai",
-            "custom-host": "https://openrouter.ai/api/v1",
+            provider: "openrouter",
+            directEndpoint: "https://openrouter.ai/api/v1/chat/completions",
         });
         expect(result.options.provider).toEqual({
             only: ["Alibaba"],
@@ -143,8 +143,8 @@ describe("resolveModelConfig", () => {
 
         expect(result.options.model).toBe("qwen/qwen3.8-max");
         expect(result.options.modelConfig).toMatchObject({
-            provider: "openai",
-            "custom-host": "https://openrouter.ai/api/v1",
+            provider: "openrouter",
+            directEndpoint: "https://openrouter.ai/api/v1/chat/completions",
         });
         expect(result.options.provider).toEqual({
             only: ["Alibaba"],
@@ -174,8 +174,8 @@ describe("resolveModelConfig", () => {
 
         expect(result.options.model).toBe("qwen/qwen3.8-27b");
         expect(result.options.modelConfig).toMatchObject({
-            provider: "openai",
-            "custom-host": "https://openrouter.ai/api/v1",
+            provider: "openrouter",
+            directEndpoint: "https://openrouter.ai/api/v1/chat/completions",
         });
         expect(result.options.provider).toEqual({
             only: ["Chutes"],
@@ -225,8 +225,8 @@ describe("resolveModelConfig", () => {
 
         expect(result.options.model).toBe("x-ai/grok-4.6");
         expect(result.options.modelConfig).toMatchObject({
-            provider: "openai",
-            "custom-host": "https://openrouter.ai/api/v1",
+            provider: "openrouter",
+            directEndpoint: "https://openrouter.ai/api/v1/chat/completions",
         });
         expect(result.options.provider).toEqual({
             only: ["xai/zdr"],
@@ -239,8 +239,8 @@ describe("resolveModelConfig", () => {
 
         expect(result.options.model).toBe("z-ai/glm-5.3");
         expect(result.options.modelConfig).toMatchObject({
-            provider: "openai",
-            "custom-host": "https://openrouter.ai/api/v1",
+            provider: "openrouter",
+            directEndpoint: "https://openrouter.ai/api/v1/chat/completions",
         });
         expect(result.options.provider).toEqual({
             only: ["z-ai/fp8"],

--- a/shared/community-endpoints.ts
+++ b/shared/community-endpoints.ts
@@ -611,6 +611,7 @@ export function usesAgentRunToken(endpoint: CommunityEndpointRuntime): boolean {
 export type CommunityModelDefinitionInput = {
     modelId: string;
     addedDate?: number;
+    perUserRpm?: number | null;
     title?: string | null;
     description: string | null;
     providerName?: string | null;
@@ -969,6 +970,7 @@ export function communityModelDefinition(
     return {
         aliases,
         provider: "community",
+        perUserRpm: endpoint.perUserRpm,
         brand: providerName || "Community",
         brandUrl: providerName && providerUrl ? providerUrl : undefined,
         category: isImage ? "image" : isTranscription ? "audio" : "text",

--- a/shared/registry/model-info.ts
+++ b/shared/registry/model-info.ts
@@ -133,7 +133,6 @@ function getCapabilities(service: ModelDefinition): ModelCapability[] {
 type ModelInfoOptions = {
     community?: boolean;
     agent?: boolean;
-    perUserRpm?: number | null;
 };
 
 function pricingInfoFromDefinition(
@@ -181,7 +180,7 @@ export function modelInfoFromDefinition(
         brand_url: service.brandUrl,
         community: options.community || undefined,
         agent: options.agent || undefined,
-        per_user_rpm: options.perUserRpm,
+        per_user_rpm: service.perUserRpm,
         pricing: pricingInfoFromDefinition(getPriceDefinitionForModel(service)),
         pricing_variants:
             service.costVariants && service.costVariantMetadata

--- a/shared/registry/registry.ts
+++ b/shared/registry/registry.ts
@@ -146,6 +146,8 @@ export type BillingAdjustment = {
 export type ModelDefinition = {
     aliases: string[];
     provider: string;
+    /** Exact gateway-side request cap per Pollinations user. Null/unset means uncapped. */
+    perUserRpm?: number | null;
     /** Ordered model ids to try when this model's upstream fails. */
     fallbacks?: string[];
     /** Override the shared fallback status list for this model. Network failures always retry. */


### PR DESCRIPTION
- Promotes per-user RPM support for catalog models (#13617).
- Keeps generated API documentation complete (#13609).
- Bypasses Portkey for OpenRouter-backed text models (#13664).

Production CI will deploy Enter and Gen; Gen CI will synchronize the existing production secret bindings from SOPS.