### PR TITLE
fix: update DeepSeek V4 Flash pricing

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -130,14 +130,14 @@ exports[`effective cost and price per model — snapshot 1`] = `
   },
   "deepseek": {
     "cost": {
-      "completionTextTokens": 0.00000028,
-      "promptCachedTokens": 0.000000028,
-      "promptTextTokens": 0.00000014,
+      "completionTextTokens": 0.00000066,
+      "promptCachedTokens": 0.000000007,
+      "promptTextTokens": 0.00000022,
     },
     "price": {
-      "completionTextTokens": 0.00000028,
-      "promptCachedTokens": 0.000000028,
-      "promptTextTokens": 0.00000014,
+      "completionTextTokens": 0.00000066,
+      "promptCachedTokens": 0.000000007,
+      "promptTextTokens": 0.00000022,
     },
   },
   "deepseek-pro": {

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -666,9 +666,9 @@ export const TEXT_SERVICES = {
         addedDate: new Date("2025-10-10").getTime(),
         priceMultiplier: 1,
         cost: {
-            promptTextTokens: perMillion(0.14),
-            promptCachedTokens: perMillion(0.028),
-            completionTextTokens: perMillion(0.28),
+            promptTextTokens: perMillion(0.22),
+            promptCachedTokens: perMillion(0.007),
+            completionTextTokens: perMillion(0.66),
         },
         title: "DeepSeek V4 Flash 0731",
         description: "Fast reasoning and coding at bargain prices",


### PR DESCRIPTION
## Summary

- Updates `deepseek` on Fireworks from `$0.14/$0.028/$0.28` to `$0.22/$0.007/$0.66` per million input/cached-input/output tokens.
- Keeps the canonical name, five compatibility aliases, Quest-Pollen access, multiplier `1`, exact route `accounts/fireworks/models/deepseek-v4-flash-0731`, capabilities, and no-fallback contract unchanged.
- Regenerates the required effective cost/price snapshot.

## Verification

- [Fireworks’ live model page](https://fireworks.ai/models/deepseek-ai/deepseek-v4-flash-0731) publishes the exact new sheet.
- Direct Fireworks probes passed: 10,009 uncached prompt tokens and 16 reasoning tokens; the identical repeat reported 10,008 cached tokens.
- Local Gen passed the canonical model, all aliases, streaming, native `/text`, `/v1/models`, and provider caching.
- Staging Tinybird recorded `fireworks`, the three exact rates, and reconciled `total_cost == total_price`; the local wallet matched every deduction and logs had no missing conversion warning.
- 412 focused registry/pricing/resolver tests and both Gen and Enter typechecks pass.