### PR TITLE
fix: add agent request bodies to generated API docs

### DIFF
--- a/gen.pollinations.ai/scripts/generate-apidocs.ts
+++ b/gen.pollinations.ai/scripts/generate-apidocs.ts
@@ -992,6 +992,18 @@ const CURATED_BODIES: Record<string, Json> = {
     postAccountMyModelsByIdUpdate: {
         description: "Updated model description",
     },
+    postAccountAgents: {
+        name: "my-agent",
+        title: "My Agent",
+        systemPrompt: "You are a helpful assistant.",
+        baseModel: "openai",
+        mcpServers: ["pollinations"],
+    },
+    patchAccountAgentsById: {
+        systemPrompt: "You are a concise assistant.",
+        baseModel: "openai",
+        mcpServers: ["pollinations"],
+    },
     post3dByPrompt: {
         model: "hyper3d-rodin",
     },


### PR DESCRIPTION
- Adds runnable request bodies for agent creation and updates
- Fixes `docs:validate` failures for `/account/agents`
- Keeps `APIDOCS.md` generated and untouched

Follow-up to #13609.