### PR TITLE
fix: pin OpenRouter routes to exact pricing

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -388,22 +388,22 @@ exports[`effective cost and price per model — snapshot 1`] = `
   },
   "gemma": {
     "cost": {
-      "completionTextTokens": 0.00000033,
-      "promptTextTokens": 0.00000006,
+      "completionTextTokens": 0.0000004,
+      "promptTextTokens": 0.00000013,
     },
     "price": {
-      "completionTextTokens": 0.00000033,
-      "promptTextTokens": 0.00000006,
+      "completionTextTokens": 0.0000004,
+      "promptTextTokens": 0.00000013,
     },
   },
   "gemma-4-31b": {
     "cost": {
-      "completionTextTokens": 0.00000037,
-      "promptTextTokens": 0.00000012,
+      "completionTextTokens": 0.0000004,
+      "promptTextTokens": 0.00000014,
     },
     "price": {
-      "completionTextTokens": 0.00000037,
-      "promptTextTokens": 0.00000012,
+      "completionTextTokens": 0.0000004,
+      "promptTextTokens": 0.00000014,
     },
   },
   "glm": {
@@ -1025,14 +1025,14 @@ exports[`effective cost and price per model — snapshot 1`] = `
   },
   "mimo-v2.5-pro": {
     "cost": {
-      "completionTextTokens": 0.00000087,
-      "promptCachedTokens": 0.0000000036,
-      "promptTextTokens": 0.000000435,
+      "completionTextTokens": 0.00000096048,
+      "promptCachedTokens": 0.000000003956,
+      "promptTextTokens": 0.00000048024,
     },
     "price": {
-      "completionTextTokens": 0.00000087,
-      "promptCachedTokens": 0.0000000036,
-      "promptTextTokens": 0.000000435,
+      "completionTextTokens": 0.00000096048,
+      "promptCachedTokens": 0.000000003956,
+      "promptTextTokens": 0.00000048024,
     },
   },
   "minimax": {
@@ -1417,12 +1417,12 @@ exports[`effective cost and price per model — snapshot 1`] = `
     "cost": {
       "completionTextTokens": 0.0000008,
       "promptCachedTokens": 0.00000007,
-      "promptTextTokens": 0.00000011,
+      "promptTextTokens": 0.00000012,
     },
     "price": {
       "completionTextTokens": 0.0000008,
       "promptCachedTokens": 0.00000007,
-      "promptTextTokens": 0.00000011,
+      "promptTextTokens": 0.00000012,
     },
   },
   "qwen-image": {
@@ -1514,12 +1514,12 @@ exports[`effective cost and price per model — snapshot 1`] = `
   },
   "qwen-vision-pro": {
     "cost": {
-      "completionTextTokens": 0.0000026,
-      "promptTextTokens": 0.00000026,
+      "completionTextTokens": 0.000004,
+      "promptTextTokens": 0.0000004,
     },
     "price": {
-      "completionTextTokens": 0.0000026,
-      "promptTextTokens": 0.00000026,
+      "completionTextTokens": 0.000004,
+      "promptTextTokens": 0.0000004,
     },
   },
   "qwen3-embedding-8b": {

--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -1025,14 +1025,14 @@ exports[`effective cost and price per model — snapshot 1`] = `
   },
   "mimo-v2.5-pro": {
     "cost": {
-      "completionTextTokens": 0.00000096048,
-      "promptCachedTokens": 0.000000003956,
-      "promptTextTokens": 0.00000048024,
+      "completionTextTokens": 0.00000087,
+      "promptCachedTokens": 0.0000000036,
+      "promptTextTokens": 0.000000435,
     },
     "price": {
-      "completionTextTokens": 0.00000096048,
-      "promptCachedTokens": 0.000000003956,
-      "promptTextTokens": 0.00000048024,
+      "completionTextTokens": 0.00000087,
+      "promptCachedTokens": 0.0000000036,
+      "promptTextTokens": 0.000000435,
     },
   },
   "minimax": {

--- a/enter.pollinations.ai/test/pricing-data.test.ts
+++ b/enter.pollinations.ai/test/pricing-data.test.ts
@@ -650,7 +650,7 @@ test("Gemini search cost follows each route's provider metadata", () => {
     // OpenRouter search-capable routes bill per reported web search request.
     expect(gemini3FlashCost.totalCost).toBeCloseTo(3.528, 8);
     expect(geminiSearchFastCost.totalCost).toBeCloseTo(2.828, 8);
-    expect(geminiSearchLargeCost.totalCost).toBeCloseTo(2.264, 8);
+    expect(geminiSearchLargeCost.totalCost).toBeCloseTo(2.278, 8);
     expect(ungroundedGeminiSearchFastCost.totalCost).toBeCloseTo(2.8, 8);
 });
 
@@ -1130,9 +1130,9 @@ test("OpenRouter Gemini adjustments use provider-reported cache and search usage
         kind: "search_request",
         unit: "request",
         units: 1,
-        unitCost: 0.007,
-        cost: 0.007,
-        price: 0.007,
+        unitCost: 0.014,
+        cost: 0.014,
+        price: 0.014,
     });
 
     const streamedSearch = calculateBillingAdjustments(

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -21,13 +21,11 @@ type PortkeyConfigMap = Record<string, PortkeyConfigFactory>;
 function createPinnedOpenRouterConfig(
     model: string,
     providerTag: string,
-    maxTokens?: number,
 ): PortkeyConfigFactory {
     return () =>
         createOpenRouterModelConfig({
             model,
             defaultOptions: {
-                ...(maxTokens === undefined ? {} : { max_tokens: maxTokens }),
                 provider: {
                     only: [providerTag],
                     allow_fallbacks: false,
@@ -178,7 +176,7 @@ export const portkeyConfig: PortkeyConfigMap = {
     ),
     "xiaomi/mimo-v2.5-pro": createPinnedOpenRouterConfig(
         "xiaomi/mimo-v2.5-pro",
-        "novita",
+        "xiaomi/fp8",
     ),
     // Reasoning models: explicit max_tokens default below. Without one, the
     // upstream provider's own default applies (Chutes AI defaults to 1024),
@@ -273,6 +271,7 @@ export const portkeyConfig: PortkeyConfigMap = {
         }),
 
     // -- OpenRouter (Gemma) ---------------------------------------------------
+    // Novita preserves remote image URLs; NextBit rejects that public input form.
     "google/gemma-4-26b-a4b-it": createPinnedOpenRouterConfig(
         "google/gemma-4-26b-a4b-it",
         "novita/bf16",

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -18,6 +18,24 @@ import {
 type PortkeyConfigFactory = () => Record<string, unknown>;
 type PortkeyConfigMap = Record<string, PortkeyConfigFactory>;
 
+function createPinnedOpenRouterConfig(
+    model: string,
+    providerTag: string,
+    maxTokens?: number,
+): PortkeyConfigFactory {
+    return () =>
+        createOpenRouterModelConfig({
+            model,
+            defaultOptions: {
+                ...(maxTokens === undefined ? {} : { max_tokens: maxTokens }),
+                provider: {
+                    only: [providerTag],
+                    allow_fallbacks: false,
+                },
+            },
+        });
+}
+
 /** Creates a direct Vertex AI config for Gemini models. */
 function createVertexGeminiConfig(
     modelId: string,
@@ -38,16 +56,7 @@ function createPinnedOpenRouterGeminiConfig(
     modelId: string,
     providerTag: string,
 ): PortkeyConfigFactory {
-    return () =>
-        createOpenRouterModelConfig({
-            model: `google/${modelId}`,
-            defaultOptions: {
-                provider: {
-                    only: [providerTag],
-                    allow_fallbacks: false,
-                },
-            },
-        });
+    return createPinnedOpenRouterConfig(`google/${modelId}`, providerTag);
 }
 
 // =============================================================================
@@ -163,16 +172,14 @@ export const portkeyConfig: PortkeyConfigMap = {
                 },
             },
         }),
-    "xiaomi/mimo-v2.5": () =>
-        createOpenRouterModelConfig({
-            model: "xiaomi/mimo-v2.5",
-            defaultOptions: { provider: { sort: "price" } },
-        }),
-    "xiaomi/mimo-v2.5-pro": () =>
-        createOpenRouterModelConfig({
-            model: "xiaomi/mimo-v2.5-pro",
-            defaultOptions: { provider: { sort: "price" } },
-        }),
+    "xiaomi/mimo-v2.5": createPinnedOpenRouterConfig(
+        "xiaomi/mimo-v2.5",
+        "xiaomi/fp8",
+    ),
+    "xiaomi/mimo-v2.5-pro": createPinnedOpenRouterConfig(
+        "xiaomi/mimo-v2.5-pro",
+        "novita",
+    ),
     // Reasoning models: explicit max_tokens default below. Without one, the
     // upstream provider's own default applies (Chutes AI defaults to 1024),
     // which reasoning models can burn entirely on their internal thinking
@@ -266,17 +273,14 @@ export const portkeyConfig: PortkeyConfigMap = {
         }),
 
     // -- OpenRouter (Gemma) ---------------------------------------------------
-    // Moved off DeepInfra: OpenRouter serves the same SKU ~cheaper ($0.06/$0.33
-    // posted vs $0.07/$0.34) and is credit-eligible.
-    "google/gemma-4-26b-a4b-it": () =>
-        createOpenRouterModelConfig({
-            model: "google/gemma-4-26b-a4b-it",
-        }),
-    "google/gemma-4-31b-it": () =>
-        createOpenRouterModelConfig({
-            model: "google/gemma-4-31b-it",
-            defaultOptions: { provider: { sort: "price" } },
-        }),
+    "google/gemma-4-26b-a4b-it": createPinnedOpenRouterConfig(
+        "google/gemma-4-26b-a4b-it",
+        "novita/bf16",
+    ),
+    "google/gemma-4-31b-it": createPinnedOpenRouterConfig(
+        "google/gemma-4-31b-it",
+        "novita/bf16",
+    ),
 
     // -- OpenRouter (Inception Labs) -----------------------------------------
     "mercury-2": () =>
@@ -322,10 +326,10 @@ export const portkeyConfig: PortkeyConfigMap = {
     // Moved off Azure: Mistral Small was Marketplace SaaS pass-through on
     // Azure (not credit-eligible). Bumped the 2503 alias from 3.1 → 3.2 since
     // OpenRouter 3.2 is ~37% cheaper than the Azure 3.1 we were paying.
-    "mistral-small-2503": () =>
-        createOpenRouterModelConfig({
-            model: "mistralai/mistral-small-3.2-24b-instruct",
-        }),
+    "mistral-small-2503": createPinnedOpenRouterConfig(
+        "mistralai/mistral-small-3.2-24b-instruct",
+        "deepinfra/fp8",
+    ),
     // No provider pin (no `only`/`sort`) — the widest-risk case for the
     // blank-answer/billed-tokens bug, since OpenRouter can route this to any
     // provider at any time, including ones with a low max_tokens default.
@@ -476,18 +480,19 @@ export const portkeyConfig: PortkeyConfigMap = {
         }),
 
     // -- OpenRouter (Qwen Coder, Qwen VL) -------------------------------------
-    // Moved off Alibaba DashScope: OpenRouter serves the same SKU far cheaper
-    // ($0.11/$0.80 vs DashScope's $0.30/$1.50 per 1M tokens).
-    "qwen/qwen3-coder-next": () =>
-        createOpenRouterModelConfig({ model: "qwen/qwen3-coder-next" }),
-    "qwen/qwen3-vl-30b-a3b-instruct": () =>
-        createOpenRouterModelConfig({
-            model: "qwen/qwen3-vl-30b-a3b-instruct",
-        }),
-    "qwen/qwen3-vl-235b-a22b-thinking": () =>
-        createOpenRouterModelConfig({
-            model: "qwen/qwen3-vl-235b-a22b-thinking",
-        }),
+    // Exact provider pins keep OpenRouter routing and billing deterministic.
+    "qwen/qwen3-coder-next": createPinnedOpenRouterConfig(
+        "qwen/qwen3-coder-next",
+        "parasail/bf16",
+    ),
+    "qwen/qwen3-vl-30b-a3b-instruct": createPinnedOpenRouterConfig(
+        "qwen/qwen3-vl-30b-a3b-instruct",
+        "alibaba",
+    ),
+    "qwen/qwen3-vl-235b-a22b-thinking": createPinnedOpenRouterConfig(
+        "qwen/qwen3-vl-235b-a22b-thinking",
+        "alibaba",
+    ),
 
     // -- OpenRouter (StepFun) -------------------------------------------------
     "stepfun/step-3.5-flash": () =>

--- a/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
+++ b/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
@@ -260,7 +260,7 @@ describe("resolveModelConfig", () => {
         ["gemma", "google/gemma-4-26b-a4b-it", "novita/bf16"],
         ["gemma-4-31b", "google/gemma-4-31b-it", "novita/bf16"],
         ["mimo-v2.5", "xiaomi/mimo-v2.5", "xiaomi/fp8"],
-        ["mimo-v2.5-pro", "xiaomi/mimo-v2.5-pro", "novita"],
+        ["mimo-v2.5-pro", "xiaomi/mimo-v2.5-pro", "xiaomi/fp8"],
     ])("pins %s to %s through %s without fallback", (model, route, provider) => {
         const result = resolveModelConfig(messages, { model });
 

--- a/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
+++ b/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
@@ -248,6 +248,29 @@ describe("resolveModelConfig", () => {
         });
     });
 
+    it.each([
+        ["qwen-coder-large", "qwen/qwen3-coder-next", "parasail/bf16"],
+        ["qwen-vision", "qwen/qwen3-vl-30b-a3b-instruct", "alibaba"],
+        ["qwen-vision-pro", "qwen/qwen3-vl-235b-a22b-thinking", "alibaba"],
+        [
+            "mistral-small-3.2",
+            "mistralai/mistral-small-3.2-24b-instruct",
+            "deepinfra/fp8",
+        ],
+        ["gemma", "google/gemma-4-26b-a4b-it", "novita/bf16"],
+        ["gemma-4-31b", "google/gemma-4-31b-it", "novita/bf16"],
+        ["mimo-v2.5", "xiaomi/mimo-v2.5", "xiaomi/fp8"],
+        ["mimo-v2.5-pro", "xiaomi/mimo-v2.5-pro", "novita"],
+    ])("pins %s to %s through %s without fallback", (model, route, provider) => {
+        const result = resolveModelConfig(messages, { model });
+
+        expect(result.options.model).toBe(route);
+        expect(result.options.provider).toEqual({
+            only: [provider],
+            allow_fallbacks: false,
+        });
+    });
+
     it("routes DeepSeek to the exact Fireworks 0731 checkpoint", () => {
         const result = resolveModelConfig(messages, { model: "deepseek" });
 

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -565,7 +565,7 @@ export const TEXT_SERVICES = {
             completionTextTokens: perMillion(1.875),
         },
         billing: openRouterGeminiBilling({
-            searchCostPerThousandRequests: 7,
+            searchCostPerThousandRequests: 14,
             storageCostPerMillionTokenHours: 0.25,
         }),
         title: "Gemini 3.7 Flash",
@@ -693,10 +693,9 @@ export const TEXT_SERVICES = {
         paidOnly: true,
         priceMultiplier: 1,
         cost: {
-            // OpenRouter google/gemma-4-26b-a4b-it posted rates (2026-06-02):
-            // prompt $0.06/M, completion $0.33/M. No prompt caching upstream.
-            promptTextTokens: perMillion(0.06),
-            completionTextTokens: perMillion(0.33),
+            // OpenRouter Novita BF16 endpoint, verified 2026-08-22.
+            promptTextTokens: perMillion(0.13),
+            completionTextTokens: perMillion(0.4),
         },
         title: "Gemma 4 26B A4B",
         description:
@@ -718,8 +717,9 @@ export const TEXT_SERVICES = {
         paidOnly: true,
         priceMultiplier: 1,
         cost: {
-            promptTextTokens: perMillion(0.12),
-            completionTextTokens: perMillion(0.37),
+            // OpenRouter Novita BF16 endpoint, verified 2026-08-22.
+            promptTextTokens: perMillion(0.14),
+            completionTextTokens: perMillion(0.4),
         },
         title: "Gemma 4 31B",
         description: "Dense multimodal reasoning with configurable thinking",
@@ -1437,9 +1437,10 @@ export const TEXT_SERVICES = {
         paidOnly: true,
         priceMultiplier: 1,
         cost: {
-            promptTextTokens: perMillion(0.435),
-            promptCachedTokens: perMillion(0.0036),
-            completionTextTokens: perMillion(0.87),
+            // OpenRouter Novita endpoint, verified 2026-08-22.
+            promptTextTokens: perMillion(0.48024),
+            promptCachedTokens: perMillion(0.003956),
+            completionTextTokens: perMillion(0.96048),
         },
         title: "MiMo V2.5 Pro",
         description: "Long-context reasoning and coding with higher capability",
@@ -1803,10 +1804,9 @@ export const TEXT_SERVICES = {
         addedDate: new Date("2026-03-22").getTime(),
         paidOnly: true,
         priceMultiplier: 1,
-        // Moved off Alibaba DashScope ($0.30/$1.50) to OpenRouter — same SKU,
-        // ~2.5x cheaper. OpenRouter routes to the cheapest live endpoint.
+        // OpenRouter Parasail BF16 endpoint, verified 2026-08-22.
         cost: {
-            promptTextTokens: perMillion(0.11), // per 1M tokens
+            promptTextTokens: perMillion(0.12), // per 1M tokens
             promptCachedTokens: perMillion(0.07), // per 1M cached input tokens
             completionTextTokens: perMillion(0.8), // per 1M tokens
         },
@@ -2087,8 +2087,9 @@ export const TEXT_SERVICES = {
         priceMultiplier: 1,
         category: "text",
         cost: {
-            promptTextTokens: perMillion(0.26),
-            completionTextTokens: perMillion(2.6),
+            // OpenRouter Alibaba endpoint, verified 2026-08-22.
+            promptTextTokens: perMillion(0.4),
+            completionTextTokens: perMillion(4),
         },
         title: "Qwen3 VL 235B A22B Thinking",
         description:

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -693,7 +693,7 @@ export const TEXT_SERVICES = {
         paidOnly: true,
         priceMultiplier: 1,
         cost: {
-            // OpenRouter Novita BF16 endpoint, verified 2026-08-22.
+            // OpenRouter Novita BF16 preserves remote image URLs; verified 2026-08-22.
             promptTextTokens: perMillion(0.13),
             completionTextTokens: perMillion(0.4),
         },
@@ -1437,10 +1437,10 @@ export const TEXT_SERVICES = {
         paidOnly: true,
         priceMultiplier: 1,
         cost: {
-            // OpenRouter Novita endpoint, verified 2026-08-22.
-            promptTextTokens: perMillion(0.48024),
-            promptCachedTokens: perMillion(0.003956),
-            completionTextTokens: perMillion(0.96048),
+            // OpenRouter Xiaomi FP8 endpoint, verified 2026-08-22.
+            promptTextTokens: perMillion(0.435),
+            promptCachedTokens: perMillion(0.0036),
+            completionTextTokens: perMillion(0.87),
         },
         title: "MiMo V2.5 Pro",
         description: "Long-context reasoning and coding with higher capability",


### PR DESCRIPTION
- Pins eight existing OpenRouter routes to exact providers with `allow_fallbacks: false`: Qwen Coder (Parasail BF16), Qwen VL 30B/235B (Alibaba), Mistral Small 3.2 (DeepInfra FP8), Gemma 26B/31B (Novita BF16), and both MiMo V2.5 routes (Xiaomi FP8).
- Aligns each registry sheet to its selected endpoint. MiMo Pro now uses Xiaomi's first-party FP8 route at `$0.435/$0.0036 cached/$0.87` per million tokens; Gemini search is corrected from `$0.007` to `$0.014` per request.
- Keeps Gemma 26B on Novita despite NextBit's lower headline price: direct and local probes showed NextBit rejects normal remote `image_url` inputs, while Novita preserves the public vision contract and useful 400 errors.
- Preserves canonical names, aliases, permissions, multipliers, capabilities, and the no-Pollinations-fallback policy. Mistral and Llama Scout remain in separate PR #13684.

Verification: exact OpenRouter endpoint catalogs; MiMo Xiaomi 9/9 comparative burst plus text, stream, tools, reasoning, JSON, aliases, cache, permissions, billing, and errors; Gemma remote URL, ten embedded images, tools, cache, billing, and errors; 420 focused assertions; Gen and Enter typechecks. Local billing selected paid balance and recorded `totalCost = totalPrice`.
