### PR TITLE
fix: pin Mistral and Llama Scout routes

### DIFF
--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -21,11 +21,13 @@ type PortkeyConfigMap = Record<string, PortkeyConfigFactory>;
 function createPinnedOpenRouterConfig(
     model: string,
     providerTag: string,
+    maxTokens?: number,
 ): PortkeyConfigFactory {
     return () =>
         createOpenRouterModelConfig({
             model,
             defaultOptions: {
+                ...(maxTokens === undefined ? {} : { max_tokens: maxTokens }),
                 provider: {
                     only: [providerTag],
                     allow_fallbacks: false,
@@ -329,14 +331,11 @@ export const portkeyConfig: PortkeyConfigMap = {
         "mistralai/mistral-small-3.2-24b-instruct",
         "deepinfra/fp8",
     ),
-    // No provider pin (no `only`/`sort`) — the widest-risk case for the
-    // blank-answer/billed-tokens bug, since OpenRouter can route this to any
-    // provider at any time, including ones with a low max_tokens default.
-    "mistral-small-2603": () =>
-        createOpenRouterModelConfig({
-            model: "mistralai/mistral-small-2603",
-            defaultOptions: { max_tokens: 64000 },
-        }),
+    "mistral-small-2603": createPinnedOpenRouterConfig(
+        "mistralai/mistral-small-2603",
+        "mistral",
+        64000,
+    ),
 
     // -- Azure (Myceli Prod — eastus, Mistral Large) -------------------------
     "Mistral-Large-3": () =>
@@ -473,10 +472,10 @@ export const portkeyConfig: PortkeyConfigMap = {
         ),
     // Llama 4 Scout is Marketplace SaaS pass-through on Azure (not
     // credit-eligible). OpenRouter is the cheapest provider with the same SKU.
-    "Llama-4-Scout-17B-16E-Instruct": () =>
-        createOpenRouterModelConfig({
-            model: "meta-llama/llama-4-scout",
-        }),
+    "Llama-4-Scout-17B-16E-Instruct": createPinnedOpenRouterConfig(
+        "meta-llama/llama-4-scout",
+        "deepinfra/fp8",
+    ),
 
     // -- OpenRouter (Qwen Coder, Qwen VL) -------------------------------------
     // Exact provider pins keep OpenRouter routing and billing deterministic.

--- a/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
+++ b/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
@@ -261,6 +261,8 @@ describe("resolveModelConfig", () => {
         ["gemma-4-31b", "google/gemma-4-31b-it", "novita/bf16"],
         ["mimo-v2.5", "xiaomi/mimo-v2.5", "xiaomi/fp8"],
         ["mimo-v2.5-pro", "xiaomi/mimo-v2.5-pro", "xiaomi/fp8"],
+        ["mistral", "mistralai/mistral-small-2603", "mistral"],
+        ["llama-scout", "meta-llama/llama-4-scout", "deepinfra/fp8"],
     ])("pins %s to %s through %s without fallback", (model, route, provider) => {
         const result = resolveModelConfig(messages, { model });
 

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -446,6 +446,7 @@ export const TEXT_SERVICES = {
         paidOnly: true,
         priceMultiplier: 1,
         cost: {
+            // OpenRouter Mistral endpoint, verified 2026-08-22.
             promptTextTokens: perMillion(0.15),
             promptCachedTokens: perMillion(0.015),
             completionTextTokens: perMillion(0.6),
@@ -455,7 +456,7 @@ export const TEXT_SERVICES = {
             "Compact all-rounder that combines reasoning with image understanding",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
-        maxReferenceImages: 10, // Mistral image count varies by model/token budget; Pollinations cap.
+        maxReferenceImages: 8, // Exact OpenRouter Mistral route limit.
         tools: true,
         reasoning: true,
         contextLength: 262144,
@@ -1667,6 +1668,7 @@ export const TEXT_SERVICES = {
         paidOnly: true,
         priceMultiplier: 1,
         cost: {
+            // OpenRouter DeepInfra FP8 endpoint, verified 2026-08-22.
             promptTextTokens: perMillion(0.1),
             completionTextTokens: perMillion(0.3),
         },
@@ -1675,7 +1677,7 @@ export const TEXT_SERVICES = {
             "Open-source long-context specialist for digging through big documents",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
-        maxReferenceImages: 10, // OpenRouter image count varies by provider/model; Pollinations cap.
+        maxReferenceImages: 10, // Verified on the pinned DeepInfra FP8 route; Pollinations cap.
         tools: true,
         contextLength: 327680,
         isSpecialized: false,


### PR DESCRIPTION
- Pins `mistral` to OpenRouter Mistral with provider fallback disabled.
- Pins `llama-scout` to OpenRouter DeepInfra FP8 with provider fallback disabled.
- Reduces Mistral’s declared reference-image limit from 10 to the exact route’s limit of 8.
- Preserves canonical names, aliases, capabilities, paid-only access, and verified price sheets.

Tests: gen typecheck; model resolver 41/41; Enter pricing/registry invariants 381/381; local E2E 35/35.