### PR TITLE
fix: log OpenRouter usage anomalies

### DIFF
--- a/gen.pollinations.ai/src/middleware/track.ts
+++ b/gen.pollinations.ai/src/middleware/track.ts
@@ -22,7 +22,15 @@ import {
     remapUpstreamStatus,
     UpstreamError,
 } from "@shared/error.ts";
-import { sendToTinybird } from "@shared/events.ts";
+import {
+    getTinybirdDatasourceIngestUrl,
+    sendErrorEventToTinybird,
+    sendToTinybird,
+} from "@shared/events.ts";
+import {
+    collectRequestInputs,
+    stringifyRequestInputs,
+} from "@shared/observability/request-inputs.ts";
 import { PUBLIC_URLS } from "@shared/public-urls.ts";
 import {
     type BillingAdjustment,
@@ -126,6 +134,10 @@ type ResponseTrackingData = {
     // A failure the response status cannot show. Replaces the status-derived
     // error data when the settlement row is emitted.
     errorTracking?: ErrorData;
+    // Complete parsed JSON response or SSE event list, retained only when an
+    // OpenRouter text response has missing/all-zero usage. The middleware
+    // writes it to error_event (24h TTL) together with the request body.
+    usageAnomalyOutput?: unknown;
 };
 
 export type TrackVariables = {
@@ -440,6 +452,53 @@ export const track = (eventType: EventType) =>
                         collectErrorData(response.status, c.get("error")),
                 });
 
+                if (responseTracking.usageAnomalyOutput !== undefined) {
+                    const errorTracking = responseTracking.errorTracking;
+                    await sendErrorEventToTinybird(
+                        {
+                            timestamp: endTime.toISOString(),
+                            kind: "usage_anomaly",
+                            severity: "error",
+                            request_id: finalEvent.requestId,
+                            environment: finalEvent.environment,
+                            route_path: finalEvent.requestPath,
+                            method: c.req.method,
+                            status: responseTracking.responseStatus,
+                            duration_ms:
+                                endTime.getTime() - startTime.getTime(),
+                            error_code: errorTracking?.errorResponseCode,
+                            error_class: "UsageAnomaly",
+                            message: errorTracking?.errorMessage,
+                            upstream_host: "openrouter.ai",
+                            upstream_status: responseTracking.responseStatus,
+                            upstream_body: stringifyUsageAnomalyOutput(
+                                responseTracking.usageAnomalyOutput,
+                            ),
+                            edge_colo: (
+                                c.req.raw as Request & {
+                                    cf?: { colo?: string };
+                                }
+                            ).cf?.colo,
+                            model_requested:
+                                finalEvent.modelRequested ?? undefined,
+                            resolved_model_requested:
+                                finalEvent.resolvedModelRequested,
+                            request_inputs: stringifyRequestInputs(
+                                await collectRequestInputs(c),
+                            ),
+                            user_id: finalEvent.userId,
+                            user_tier: finalEvent.userTier,
+                            api_key_id: finalEvent.apiKeyId,
+                        },
+                        getTinybirdDatasourceIngestUrl(
+                            c.env.TINYBIRD_INGEST_URL,
+                            "error_event",
+                        ),
+                        c.env.TINYBIRD_INGEST_TOKEN,
+                        log,
+                    );
+                }
+
                 log.trace(
                     [
                         "Tracking event:",
@@ -655,10 +714,21 @@ export async function trackResponse(
             requestTracking,
             response,
         );
+    const recordsOpenRouterUsageAnomaly =
+        eventType === "generate.text" && modelProviderUsed === "openrouter";
     if (!modelUsage) {
         log.error("Failed to extract model usage for model {model}", {
             model: resolvedModelRequested,
         });
+        const errorTracking = recordsOpenRouterUsageAnomaly
+            ? {
+                  errorResponseCode: "usage_missing",
+                  errorMessage: `No usage and no determinable token charge for model ${resolvedModelRequested}`,
+              }
+            : undefined;
+        const usageAnomalyOutput = recordsOpenRouterUsageAnomaly
+            ? (output ?? null)
+            : undefined;
         // Missing token usage must never fabricate token charges, but some
         // provider fees are independently knowable from the request/response
         // (for example, Perplexity's flat per-request search fee).
@@ -682,6 +752,8 @@ export async function trackResponse(
                 modelUsed: modelCalled,
                 usage: {},
                 contentFilterResults,
+                errorTracking,
+                usageAnomalyOutput,
             };
         }
         // Nothing was charged and nothing could be. Mark the row so a billable
@@ -691,14 +763,19 @@ export async function trackResponse(
             contentFilterResults,
             modelUsed: modelCalled,
             errorTracking:
-                eventType === "generate.text"
+                errorTracking ??
+                (eventType === "generate.text"
                     ? {
                           errorResponseCode: "usage_missing",
                           errorMessage: `No usage and no determinable charge for model ${resolvedModelRequested}`,
                       }
-                    : undefined,
+                    : undefined),
+            usageAnomalyOutput,
         });
     }
+
+    const hasZeroOpenRouterUsage =
+        recordsOpenRouterUsageAnomaly && !hasPositiveUsage(modelUsage.usage);
     // Cost follows the model that ran; price follows the one the caller asked
     // for, so the invoice does not move because a fallback stepped in.
     const {
@@ -719,7 +796,7 @@ export async function trackResponse(
     return {
         responseStatus: response.status,
         cacheHit,
-        isBilledUsage: true,
+        isBilledUsage: hasZeroOpenRouterUsage ? price.totalPrice > 0 : true,
         fallbackUsed,
         cost,
         price,
@@ -731,7 +808,33 @@ export async function trackResponse(
         modelProviderUsed,
         usage: modelUsage.usage,
         contentFilterResults,
+        errorTracking: hasZeroOpenRouterUsage
+            ? {
+                  errorResponseCode: "usage_zero",
+                  errorMessage: `OpenRouter returned all-zero usage for model ${resolvedModelRequested}`,
+              }
+            : undefined,
+        usageAnomalyOutput: hasZeroOpenRouterUsage
+            ? (output ?? null)
+            : undefined,
     };
+}
+
+function hasPositiveUsage(usage: Usage): boolean {
+    return Object.values(usage).some(
+        (value) => typeof value === "number" && value > 0,
+    );
+}
+
+function stringifyUsageAnomalyOutput(output: unknown): string {
+    try {
+        return JSON.stringify(output);
+    } catch (error) {
+        return JSON.stringify({
+            error: "usage_anomaly_output_json_stringify_failed",
+            message: error instanceof Error ? error.message : String(error),
+        });
+    }
 }
 
 // Portkey reports the served target as "config.targets[N]" via the

--- a/gen.pollinations.ai/test/tracking-observability.test.ts
+++ b/gen.pollinations.ai/test/tracking-observability.test.ts
@@ -563,18 +563,27 @@ describe("tracking observability", () => {
 
         const ctx = createExecutionContext();
         const response = await createHeaderApp(
-            { "x-usage-missing": "true" },
+            {
+                "x-model-used": "gemini-fast",
+                "x-usage-missing": "true",
+            },
             trackingUser,
             200,
             consumePollen,
+            "gemini-fast",
         ).fetch(
             new Request("https://gen.pollinations.ai/v1/chat/completions", {
                 method: "POST",
                 headers: { "content-type": "application/json" },
                 body: JSON.stringify({
-                    model: "openai",
+                    model: "gemini-fast",
                     stream: false,
-                    messages: [{ role: "user", content: "test" }],
+                    messages: [
+                        {
+                            role: "user",
+                            content: "complete input for missing usage",
+                        },
+                    ],
                 }),
             }),
             {
@@ -593,8 +602,19 @@ describe("tracking observability", () => {
         await waitOnExecutionContext(ctx);
 
         expect(response.status).toBe(200);
-        expect(tinybirdRequests).toHaveLength(1);
-        const event = (await tinybirdRequests[0].json()) as TinybirdEvent;
+        expect(tinybirdRequests).toHaveLength(2);
+        const generationRequest = tinybirdRequests.find(
+            (request) =>
+                new URL(request.url).searchParams.get("name") ===
+                "generation_event_v2",
+        );
+        const anomalyRequest = tinybirdRequests.find(
+            (request) =>
+                new URL(request.url).searchParams.get("name") === "error_event",
+        );
+        expect(generationRequest).toBeDefined();
+        expect(anomalyRequest).toBeDefined();
+        const event = (await generationRequest?.json()) as TinybirdEvent;
         expect(event).toMatchObject({
             responseStatus: 200,
             isBilledUsage: false,
@@ -602,7 +622,137 @@ describe("tracking observability", () => {
             totalPrice: 0,
             errorResponseCode: "usage_missing",
         });
-        expect(event.modelUsed).toBe("openai");
+        expect(event.modelUsed).toBe("gemini-fast");
+        const anomaly = (await anomalyRequest?.json()) as {
+            kind: string;
+            status: number;
+            error_code: string;
+            model_requested: string;
+            resolved_model_requested: string;
+            request_inputs: string;
+            upstream_body: string;
+        };
+        expect(anomaly).toMatchObject({
+            kind: "usage_anomaly",
+            status: 200,
+            error_code: "usage_missing",
+            model_requested: "gemini-fast",
+            resolved_model_requested: "gemini-fast",
+        });
+        expect(JSON.parse(anomaly.request_inputs)).toMatchObject({
+            body: {
+                model: "gemini-fast",
+                stream: false,
+                messages: [
+                    {
+                        role: "user",
+                        content: "complete input for missing usage",
+                    },
+                ],
+            },
+        });
+        expect(JSON.parse(anomaly.upstream_body)).toEqual({
+            choices: [{ message: {} }],
+        });
+        expect(consumePollen).toHaveBeenCalledWith(0);
+    });
+
+    it("records and does not bill an OpenRouter response with all-zero usage", async () => {
+        const tinybirdRequests: Request[] = [];
+        vi.spyOn(globalThis, "fetch").mockImplementation(
+            async (input, init) => {
+                tinybirdRequests.push(new Request(input, init));
+                return new Response("ok");
+            },
+        );
+        const consumePollen = vi.fn<(amount: number) => Promise<void>>(
+            async () => {},
+        );
+
+        const ctx = createExecutionContext();
+        const response = await createHeaderApp(
+            {
+                "x-model-used": "gemini-fast",
+                "x-usage-prompt-text-tokens": "0",
+                "x-usage-completion-text-tokens": "0",
+            },
+            trackingUser,
+            200,
+            consumePollen,
+            "gemini-fast",
+        ).fetch(
+            new Request("https://gen.pollinations.ai/v1/chat/completions", {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify({
+                    model: "gemini-fast",
+                    messages: [
+                        {
+                            role: "user",
+                            content: "complete input for zero usage",
+                        },
+                    ],
+                }),
+            }),
+            {
+                DB: env.DB,
+                ENVIRONMENT: "test",
+                LOG_LEVEL: "debug",
+                LOG_FORMAT: "text",
+                BETTER_AUTH_SECRET: "test_secret",
+                TINYBIRD_INGEST_URL:
+                    "https://tinybird.test/v0/events?name=generation_event_v2",
+                TINYBIRD_INGEST_TOKEN: "test_tinybird_token",
+            } as CloudflareBindings,
+            ctx,
+        );
+
+        await waitOnExecutionContext(ctx);
+
+        expect(response.status).toBe(200);
+        expect(tinybirdRequests).toHaveLength(2);
+        const generationRequest = tinybirdRequests.find(
+            (request) =>
+                new URL(request.url).searchParams.get("name") ===
+                "generation_event_v2",
+        );
+        const anomalyRequest = tinybirdRequests.find(
+            (request) =>
+                new URL(request.url).searchParams.get("name") === "error_event",
+        );
+        const event = (await generationRequest?.json()) as TinybirdEvent;
+        expect(event).toMatchObject({
+            responseStatus: 200,
+            isBilledUsage: false,
+            totalCost: 0,
+            totalPrice: 0,
+            errorResponseCode: "usage_zero",
+            modelUsed: "gemini-fast",
+        });
+        const anomaly = (await anomalyRequest?.json()) as {
+            kind: string;
+            error_code: string;
+            request_inputs: string;
+            upstream_body: string;
+        };
+        expect(anomaly).toMatchObject({
+            kind: "usage_anomaly",
+            error_code: "usage_zero",
+        });
+        expect(JSON.parse(anomaly.request_inputs)).toMatchObject({
+            body: {
+                model: "gemini-fast",
+                messages: [
+                    {
+                        role: "user",
+                        content: "complete input for zero usage",
+                    },
+                ],
+            },
+        });
+        expect(JSON.parse(anomaly.upstream_body)).toEqual({
+            choices: [{ message: {} }],
+        });
         expect(consumePollen).toHaveBeenCalledWith(0);
     });
     it("tracks usage after a malformed SSE event", async () => {
@@ -1741,6 +1891,92 @@ describe("tracking observability", () => {
         expect(event.tokenCountCompletionText).toBe(500);
         expect(event.modelUsed).toBe("gpt-5-nano-2025-08-07");
         expect(event.isBilledUsage).toBe(true);
+    });
+
+    it("records the complete parsed stream when OpenRouter omits usage", async () => {
+        const tinybirdRequests: Request[] = [];
+        vi.spyOn(globalThis, "fetch").mockImplementation(
+            async (input, init) => {
+                tinybirdRequests.push(new Request(input, init));
+                return new Response("ok");
+            },
+        );
+
+        const ctx = createExecutionContext();
+        const response = await createSseStreamApp(
+            0,
+            {
+                requested: "gemini-fast",
+                resolved: "gemini-fast",
+                definition: getRegistryModelDefinition("gemini-fast"),
+            },
+            false,
+        ).fetch(
+            new Request("https://gen.pollinations.ai/v1/chat/completions", {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify({
+                    model: "gemini-fast",
+                    stream: true,
+                    messages: [
+                        {
+                            role: "user",
+                            content: "complete streaming input",
+                        },
+                    ],
+                }),
+            }),
+            {
+                DB: env.DB,
+                ENVIRONMENT: "test",
+                LOG_LEVEL: "debug",
+                LOG_FORMAT: "text",
+                BETTER_AUTH_SECRET: "test_secret",
+                TINYBIRD_INGEST_URL:
+                    "https://tinybird.test/v0/events?name=generation_event_v2",
+                TINYBIRD_INGEST_TOKEN: "test_tinybird_token",
+            } as CloudflareBindings,
+            ctx,
+        );
+
+        await waitOnExecutionContext(ctx);
+
+        expect(response.status).toBe(200);
+        expect(tinybirdRequests).toHaveLength(2);
+        const anomalyRequest = tinybirdRequests.find(
+            (request) =>
+                new URL(request.url).searchParams.get("name") === "error_event",
+        );
+        const anomaly = (await anomalyRequest?.json()) as {
+            error_code: string;
+            request_inputs: string;
+            upstream_body: string;
+        };
+        expect(anomaly.error_code).toBe("usage_missing");
+        expect(JSON.parse(anomaly.request_inputs)).toMatchObject({
+            body: {
+                model: "gemini-fast",
+                stream: true,
+                messages: [
+                    {
+                        role: "user",
+                        content: "complete streaming input",
+                    },
+                ],
+            },
+        });
+        expect(JSON.parse(anomaly.upstream_body)).toEqual({
+            streamEvents: [
+                {
+                    model: "gpt-5-nano-2025-08-07",
+                    choices: [{ delta: { content: "hel" } }],
+                },
+                {
+                    model: "gpt-5-nano-2025-08-07",
+                    choices: [{ delta: { content: "lo" } }],
+                },
+            ],
+        });
     });
 
     it("marks a community endpoint stream that ended without usage", async () => {

--- a/shared/events.ts
+++ b/shared/events.ts
@@ -8,7 +8,7 @@ const MAX_DELAY = 2000;
 
 export type TinybirdErrorEvent = {
     timestamp: string;
-    kind: "server_error";
+    kind: "server_error" | "usage_anomaly";
     severity: "error";
     request_id?: string;
     environment?: string;


### PR DESCRIPTION
- Records `usage_missing` and `usage_zero` OpenRouter responses in the private 24-hour `error_event` datasource.
- Stores credential-redacted full request inputs and complete parsed JSON/SSE output for diagnosis.
- Marks pure zero usage unbilled while preserving separately knowable provider fees.
- Leaves the successful client response unchanged.

Related: #13620

Tests: `npx vitest run test/tracking-observability.test.ts test/error-observability.test.ts`; `npm run typecheck`