### PR TITLE
chore: promote main to production

### DIFF
--- a/operations/kpi/worker/index.ts
+++ b/operations/kpi/worker/index.ts
@@ -19,7 +19,7 @@ type Env = {
 
 // Helper to fetch from Tinybird with caching, retry, and error logging
 // Uses Cloudflare Cache API to avoid hammering Tinybird on concurrent page loads
-const TINYBIRD_CACHE_TTL = 21600; // 6 hours — weekly data barely changes
+const TINYBIRD_CACHE_TTL = 1800; // 30 minutes
 // Part of the cache key, not the request. A pipe that gains a column keeps
 // serving the old shape for TINYBIRD_CACHE_TTL because a Worker redeploy does
 // not touch caches.default — bump this in the same commit as the pipe change.


### PR DESCRIPTION
- Promotes the latest main branch to production
- Includes the KPI cache refresh reduction from 6 hours to 30 minutes (#13689)