### PR TITLE
fix: invalidate stale KPI cache entries

### DIFF
--- a/operations/kpi/worker/index.ts
+++ b/operations/kpi/worker/index.ts
@@ -23,7 +23,7 @@ const TINYBIRD_CACHE_TTL = 1800; // 30 minutes
 // Part of the cache key, not the request. A pipe that gains a column keeps
 // serving the old shape for TINYBIRD_CACHE_TTL because a Worker redeploy does
 // not touch caches.default — bump this in the same commit as the pipe change.
-const TINYBIRD_CACHE_VERSION = "4";
+const TINYBIRD_CACHE_VERSION = "5";
 
 async function fetchTinybird(
     env: Env,


### PR DESCRIPTION
- Bumps the KPI Tinybird cache key version
- Invalidates existing six-hour edge entries
- Makes the new 30-minute TTL effective immediately