### PR TITLE
fix: classify upstream finish errors

### DIFF
--- a/gen.pollinations.ai/src/middleware/track.ts
+++ b/gen.pollinations.ai/src/middleware/track.ts
@@ -22,15 +22,7 @@ import {
     remapUpstreamStatus,
     UpstreamError,
 } from "@shared/error.ts";
-import {
-    getTinybirdDatasourceIngestUrl,
-    sendErrorEventToTinybird,
-    sendToTinybird,
-} from "@shared/events.ts";
-import {
-    collectRequestInputs,
-    stringifyRequestInputs,
-} from "@shared/observability/request-inputs.ts";
+import { sendToTinybird } from "@shared/events.ts";
 import { PUBLIC_URLS } from "@shared/public-urls.ts";
 import {
     type BillingAdjustment,
@@ -134,10 +126,6 @@ type ResponseTrackingData = {
     // A failure the response status cannot show. Replaces the status-derived
     // error data when the settlement row is emitted.
     errorTracking?: ErrorData;
-    // Complete parsed JSON response or SSE event list, retained only when an
-    // OpenRouter text response has missing/all-zero usage. The middleware
-    // writes it to error_event (24h TTL) together with the request body.
-    usageAnomalyOutput?: unknown;
 };
 
 export type TrackVariables = {
@@ -452,53 +440,6 @@ export const track = (eventType: EventType) =>
                         collectErrorData(response.status, c.get("error")),
                 });
 
-                if (responseTracking.usageAnomalyOutput !== undefined) {
-                    const errorTracking = responseTracking.errorTracking;
-                    await sendErrorEventToTinybird(
-                        {
-                            timestamp: endTime.toISOString(),
-                            kind: "usage_anomaly",
-                            severity: "error",
-                            request_id: finalEvent.requestId,
-                            environment: finalEvent.environment,
-                            route_path: finalEvent.requestPath,
-                            method: c.req.method,
-                            status: responseTracking.responseStatus,
-                            duration_ms:
-                                endTime.getTime() - startTime.getTime(),
-                            error_code: errorTracking?.errorResponseCode,
-                            error_class: "UsageAnomaly",
-                            message: errorTracking?.errorMessage,
-                            upstream_host: "openrouter.ai",
-                            upstream_status: response.status,
-                            upstream_body: stringifyUsageAnomalyOutput(
-                                responseTracking.usageAnomalyOutput,
-                            ),
-                            edge_colo: (
-                                c.req.raw as Request & {
-                                    cf?: { colo?: string };
-                                }
-                            ).cf?.colo,
-                            model_requested:
-                                finalEvent.modelRequested ?? undefined,
-                            resolved_model_requested:
-                                finalEvent.resolvedModelRequested,
-                            request_inputs: stringifyRequestInputs(
-                                await collectRequestInputs(c),
-                            ),
-                            user_id: finalEvent.userId,
-                            user_tier: finalEvent.userTier,
-                            api_key_id: finalEvent.apiKeyId,
-                        },
-                        getTinybirdDatasourceIngestUrl(
-                            c.env.TINYBIRD_INGEST_URL,
-                            "error_event",
-                        ),
-                        c.env.TINYBIRD_INGEST_TOKEN,
-                        log,
-                    );
-                }
-
                 log.trace(
                     [
                         "Tracking event:",
@@ -714,14 +655,13 @@ export async function trackResponse(
             requestTracking,
             response,
         );
-    const recordsOpenRouterUsageAnomaly =
-        eventType === "generate.text" && modelProviderUsed === "openrouter";
-    const finishReasonError = recordsOpenRouterUsageAnomaly
-        ? openRouterFinishReasonError(output)
-        : undefined;
-    if (finishReasonError) {
+    const hasFinishReasonError =
+        eventType === "generate.text"
+            ? containsFinishReasonError(output)
+            : false;
+    if (hasFinishReasonError) {
         // Keep the proxy response untouched; only billing and health reflect
-        // OpenRouter's explicit terminal failure.
+        // the upstream protocol's explicit terminal failure.
         const usage = modelUsage?.usage ?? {};
         return {
             responseStatus: 502,
@@ -743,24 +683,15 @@ export async function trackResponse(
             contentFilterResults,
             errorTracking: {
                 errorResponseCode: "upstream_finish_reason_error",
-                errorMessage: `OpenRouter ended generation with finish_reason=error (native_finish_reason=${finishReasonError})`,
+                errorMessage:
+                    "Upstream ended generation with finish_reason=error",
             },
-            usageAnomalyOutput: output ?? null,
         };
     }
     if (!modelUsage) {
         log.error("Failed to extract model usage for model {model}", {
             model: resolvedModelRequested,
         });
-        const errorTracking = recordsOpenRouterUsageAnomaly
-            ? {
-                  errorResponseCode: "usage_missing",
-                  errorMessage: `No usage and no determinable token charge for model ${resolvedModelRequested}`,
-              }
-            : undefined;
-        const usageAnomalyOutput = recordsOpenRouterUsageAnomaly
-            ? (output ?? null)
-            : undefined;
         // Missing token usage must never fabricate token charges, but some
         // provider fees are independently knowable from the request/response
         // (for example, Perplexity's flat per-request search fee).
@@ -784,8 +715,6 @@ export async function trackResponse(
                 modelUsed: modelCalled,
                 usage: {},
                 contentFilterResults,
-                errorTracking,
-                usageAnomalyOutput,
             };
         }
         // Nothing was charged and nothing could be. Mark the row so a billable
@@ -795,19 +724,14 @@ export async function trackResponse(
             contentFilterResults,
             modelUsed: modelCalled,
             errorTracking:
-                errorTracking ??
-                (eventType === "generate.text"
+                eventType === "generate.text"
                     ? {
                           errorResponseCode: "usage_missing",
                           errorMessage: `No usage and no determinable charge for model ${resolvedModelRequested}`,
                       }
-                    : undefined),
-            usageAnomalyOutput,
+                    : undefined,
         });
     }
-
-    const hasZeroOpenRouterUsage =
-        recordsOpenRouterUsageAnomaly && !hasPositiveUsage(modelUsage.usage);
     // Cost follows the model that ran; price follows the one the caller asked
     // for, so the invoice does not move because a fallback stepped in.
     const {
@@ -828,7 +752,7 @@ export async function trackResponse(
     return {
         responseStatus: response.status,
         cacheHit,
-        isBilledUsage: hasZeroOpenRouterUsage ? price.totalPrice > 0 : true,
+        isBilledUsage: true,
         fallbackUsed,
         cost,
         price,
@@ -840,20 +764,11 @@ export async function trackResponse(
         modelProviderUsed,
         usage: modelUsage.usage,
         contentFilterResults,
-        errorTracking: hasZeroOpenRouterUsage
-            ? {
-                  errorResponseCode: "usage_zero",
-                  errorMessage: `OpenRouter returned all-zero usage for model ${resolvedModelRequested}`,
-              }
-            : undefined,
-        usageAnomalyOutput: hasZeroOpenRouterUsage
-            ? (output ?? null)
-            : undefined,
     };
 }
 
-function openRouterFinishReasonError(output: unknown): string | undefined {
-    if (!output || typeof output !== "object") return undefined;
+function containsFinishReasonError(output: unknown): boolean {
+    if (!output || typeof output !== "object") return false;
     const streamEvents = (output as { streamEvents?: unknown }).streamEvents;
     const events = Array.isArray(streamEvents) ? streamEvents : [output];
     for (const event of events) {
@@ -862,34 +777,12 @@ function openRouterFinishReasonError(output: unknown): string | undefined {
         if (!Array.isArray(choices)) continue;
         for (const choice of choices) {
             if (!choice || typeof choice !== "object") continue;
-            const finish = choice as {
-                finish_reason?: unknown;
-                native_finish_reason?: unknown;
-            };
+            const finish = choice as { finish_reason?: unknown };
             if (finish.finish_reason !== "error") continue;
-            return typeof finish.native_finish_reason === "string"
-                ? finish.native_finish_reason
-                : "unknown";
+            return true;
         }
     }
-    return undefined;
-}
-
-function hasPositiveUsage(usage: Usage): boolean {
-    return Object.values(usage).some(
-        (value) => typeof value === "number" && value > 0,
-    );
-}
-
-function stringifyUsageAnomalyOutput(output: unknown): string {
-    try {
-        return JSON.stringify(output);
-    } catch (error) {
-        return JSON.stringify({
-            error: "usage_anomaly_output_json_stringify_failed",
-            message: error instanceof Error ? error.message : String(error),
-        });
-    }
+    return false;
 }
 
 // Portkey reports the served target as "config.targets[N]" via the

--- a/gen.pollinations.ai/src/middleware/track.ts
+++ b/gen.pollinations.ai/src/middleware/track.ts
@@ -470,7 +470,7 @@ export const track = (eventType: EventType) =>
                             error_class: "UsageAnomaly",
                             message: errorTracking?.errorMessage,
                             upstream_host: "openrouter.ai",
-                            upstream_status: responseTracking.responseStatus,
+                            upstream_status: response.status,
                             upstream_body: stringifyUsageAnomalyOutput(
                                 responseTracking.usageAnomalyOutput,
                             ),
@@ -716,6 +716,38 @@ export async function trackResponse(
         );
     const recordsOpenRouterUsageAnomaly =
         eventType === "generate.text" && modelProviderUsed === "openrouter";
+    const finishReasonError = recordsOpenRouterUsageAnomaly
+        ? openRouterFinishReasonError(output)
+        : undefined;
+    if (finishReasonError) {
+        // Keep the proxy response untouched; only billing and health reflect
+        // OpenRouter's explicit terminal failure.
+        const usage = modelUsage?.usage ?? {};
+        return {
+            responseStatus: 502,
+            cacheHit,
+            isBilledUsage: false,
+            fallbackUsed,
+            ...calculateUsageBilling({
+                model: resolvedModelRequested,
+                usage,
+                servedBy:
+                    servedModelDefinition ?? requestTracking.modelDefinition,
+                quotedBy: requestTracking.modelDefinition,
+                output,
+                input: pricingInput,
+            }),
+            modelUsed: modelUsage?.model ?? modelCalled,
+            modelProviderUsed,
+            usage,
+            contentFilterResults,
+            errorTracking: {
+                errorResponseCode: "upstream_finish_reason_error",
+                errorMessage: `OpenRouter ended generation with finish_reason=error (native_finish_reason=${finishReasonError})`,
+            },
+            usageAnomalyOutput: output ?? null,
+        };
+    }
     if (!modelUsage) {
         log.error("Failed to extract model usage for model {model}", {
             model: resolvedModelRequested,
@@ -818,6 +850,29 @@ export async function trackResponse(
             ? (output ?? null)
             : undefined,
     };
+}
+
+function openRouterFinishReasonError(output: unknown): string | undefined {
+    if (!output || typeof output !== "object") return undefined;
+    const streamEvents = (output as { streamEvents?: unknown }).streamEvents;
+    const events = Array.isArray(streamEvents) ? streamEvents : [output];
+    for (const event of events) {
+        if (!event || typeof event !== "object") continue;
+        const choices = (event as { choices?: unknown }).choices;
+        if (!Array.isArray(choices)) continue;
+        for (const choice of choices) {
+            if (!choice || typeof choice !== "object") continue;
+            const finish = choice as {
+                finish_reason?: unknown;
+                native_finish_reason?: unknown;
+            };
+            if (finish.finish_reason !== "error") continue;
+            return typeof finish.native_finish_reason === "string"
+                ? finish.native_finish_reason
+                : "unknown";
+        }
+    }
+    return undefined;
 }
 
 function hasPositiveUsage(usage: Usage): boolean {

--- a/gen.pollinations.ai/test/tracking-observability.test.ts
+++ b/gen.pollinations.ai/test/tracking-observability.test.ts
@@ -563,27 +563,18 @@ describe("tracking observability", () => {
 
         const ctx = createExecutionContext();
         const response = await createHeaderApp(
-            {
-                "x-model-used": "gemini-fast",
-                "x-usage-missing": "true",
-            },
+            { "x-usage-missing": "true" },
             trackingUser,
             200,
             consumePollen,
-            "gemini-fast",
         ).fetch(
             new Request("https://gen.pollinations.ai/v1/chat/completions", {
                 method: "POST",
                 headers: { "content-type": "application/json" },
                 body: JSON.stringify({
-                    model: "gemini-fast",
+                    model: "openai",
                     stream: false,
-                    messages: [
-                        {
-                            role: "user",
-                            content: "complete input for missing usage",
-                        },
-                    ],
+                    messages: [{ role: "user", content: "test" }],
                 }),
             }),
             {
@@ -602,19 +593,8 @@ describe("tracking observability", () => {
         await waitOnExecutionContext(ctx);
 
         expect(response.status).toBe(200);
-        expect(tinybirdRequests).toHaveLength(2);
-        const generationRequest = tinybirdRequests.find(
-            (request) =>
-                new URL(request.url).searchParams.get("name") ===
-                "generation_event_v2",
-        );
-        const anomalyRequest = tinybirdRequests.find(
-            (request) =>
-                new URL(request.url).searchParams.get("name") === "error_event",
-        );
-        expect(generationRequest).toBeDefined();
-        expect(anomalyRequest).toBeDefined();
-        const event = (await generationRequest?.json()) as TinybirdEvent;
+        expect(tinybirdRequests).toHaveLength(1);
+        const event = (await tinybirdRequests[0].json()) as TinybirdEvent;
         expect(event).toMatchObject({
             responseStatus: 200,
             isBilledUsage: false,
@@ -622,141 +602,11 @@ describe("tracking observability", () => {
             totalPrice: 0,
             errorResponseCode: "usage_missing",
         });
-        expect(event.modelUsed).toBe("gemini-fast");
-        const anomaly = (await anomalyRequest?.json()) as {
-            kind: string;
-            status: number;
-            error_code: string;
-            model_requested: string;
-            resolved_model_requested: string;
-            request_inputs: string;
-            upstream_body: string;
-        };
-        expect(anomaly).toMatchObject({
-            kind: "usage_anomaly",
-            status: 200,
-            error_code: "usage_missing",
-            model_requested: "gemini-fast",
-            resolved_model_requested: "gemini-fast",
-        });
-        expect(JSON.parse(anomaly.request_inputs)).toMatchObject({
-            body: {
-                model: "gemini-fast",
-                stream: false,
-                messages: [
-                    {
-                        role: "user",
-                        content: "complete input for missing usage",
-                    },
-                ],
-            },
-        });
-        expect(JSON.parse(anomaly.upstream_body)).toEqual({
-            choices: [{ message: {} }],
-        });
+        expect(event.modelUsed).toBe("openai");
         expect(consumePollen).toHaveBeenCalledWith(0);
     });
 
-    it("records and does not bill an OpenRouter response with all-zero usage", async () => {
-        const tinybirdRequests: Request[] = [];
-        vi.spyOn(globalThis, "fetch").mockImplementation(
-            async (input, init) => {
-                tinybirdRequests.push(new Request(input, init));
-                return new Response("ok");
-            },
-        );
-        const consumePollen = vi.fn<(amount: number) => Promise<void>>(
-            async () => {},
-        );
-
-        const ctx = createExecutionContext();
-        const response = await createHeaderApp(
-            {
-                "x-model-used": "gemini-fast",
-                "x-usage-prompt-text-tokens": "0",
-                "x-usage-completion-text-tokens": "0",
-            },
-            trackingUser,
-            200,
-            consumePollen,
-            "gemini-fast",
-        ).fetch(
-            new Request("https://gen.pollinations.ai/v1/chat/completions", {
-                method: "POST",
-                headers: { "content-type": "application/json" },
-                body: JSON.stringify({
-                    model: "gemini-fast",
-                    messages: [
-                        {
-                            role: "user",
-                            content: "complete input for zero usage",
-                        },
-                    ],
-                }),
-            }),
-            {
-                DB: env.DB,
-                ENVIRONMENT: "test",
-                LOG_LEVEL: "debug",
-                LOG_FORMAT: "text",
-                BETTER_AUTH_SECRET: "test_secret",
-                TINYBIRD_INGEST_URL:
-                    "https://tinybird.test/v0/events?name=generation_event_v2",
-                TINYBIRD_INGEST_TOKEN: "test_tinybird_token",
-            } as CloudflareBindings,
-            ctx,
-        );
-
-        await waitOnExecutionContext(ctx);
-
-        expect(response.status).toBe(200);
-        expect(tinybirdRequests).toHaveLength(2);
-        const generationRequest = tinybirdRequests.find(
-            (request) =>
-                new URL(request.url).searchParams.get("name") ===
-                "generation_event_v2",
-        );
-        const anomalyRequest = tinybirdRequests.find(
-            (request) =>
-                new URL(request.url).searchParams.get("name") === "error_event",
-        );
-        const event = (await generationRequest?.json()) as TinybirdEvent;
-        expect(event).toMatchObject({
-            responseStatus: 200,
-            isBilledUsage: false,
-            totalCost: 0,
-            totalPrice: 0,
-            errorResponseCode: "usage_zero",
-            modelUsed: "gemini-fast",
-        });
-        const anomaly = (await anomalyRequest?.json()) as {
-            kind: string;
-            error_code: string;
-            request_inputs: string;
-            upstream_body: string;
-        };
-        expect(anomaly).toMatchObject({
-            kind: "usage_anomaly",
-            error_code: "usage_zero",
-        });
-        expect(JSON.parse(anomaly.request_inputs)).toMatchObject({
-            body: {
-                model: "gemini-fast",
-                messages: [
-                    {
-                        role: "user",
-                        content: "complete input for zero usage",
-                    },
-                ],
-            },
-        });
-        expect(JSON.parse(anomaly.upstream_body)).toEqual({
-            choices: [{ message: {} }],
-        });
-        expect(consumePollen).toHaveBeenCalledWith(0);
-    });
-
-    it("records an OpenRouter stream ending with finish_reason error as failed", async () => {
+    it("records a stream ending with finish_reason error as failed", async () => {
         const tinybirdRequests: Request[] = [];
         vi.spyOn(globalThis, "fetch").mockImplementation(
             async (input, init) => {
@@ -768,11 +618,11 @@ describe("tracking observability", () => {
             async () => {},
         );
         const upstreamBody = [
-            'data: {"model":"google/gemini-2.5-flash-lite","choices":[{"index":0,"delta":{"content":"partial output"},"finish_reason":null}]}',
+            'data: {"model":"gpt-5-nano","choices":[{"index":0,"delta":{"content":"partial output"},"finish_reason":null}]}',
             "",
-            'data: {"model":"google/gemini-2.5-flash-lite","choices":[{"index":0,"delta":{},"finish_reason":"error","native_finish_reason":"MALFORMED_FUNCTION_CALL"}]}',
+            'data: {"model":"gpt-5-nano","choices":[{"index":0,"delta":{},"finish_reason":"error","native_finish_reason":"UPSTREAM_ERROR"}]}',
             "",
-            'data: {"model":"google/gemini-2.5-flash-lite","choices":[{"index":0,"delta":{},"finish_reason":"error","native_finish_reason":"MALFORMED_FUNCTION_CALL"}],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0,"cost":0}}',
+            'data: {"model":"gpt-5-nano","choices":[{"index":0,"delta":{},"finish_reason":"error","native_finish_reason":"UPSTREAM_ERROR"}],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}',
             "",
             "data: [DONE]",
             "",
@@ -786,13 +636,12 @@ describe("tracking observability", () => {
             consumePollen,
             "generate.text",
             upstream,
-            "gemini-fast",
         ).fetch(
             new Request("https://gen.pollinations.ai/upstream", {
                 method: "POST",
                 headers: { "content-type": "application/json" },
                 body: JSON.stringify({
-                    model: "gemini-fast",
+                    model: "openai",
                     stream: true,
                     messages: [{ role: "user", content: "test" }],
                 }),
@@ -819,21 +668,12 @@ describe("tracking observability", () => {
                 new URL(request.url).searchParams.get("name") ===
                 "generation_event_v2",
         );
-        const anomalyRequest = tinybirdRequests.find(
-            (request) =>
-                new URL(request.url).searchParams.get("name") === "error_event",
-        );
+        expect(tinybirdRequests).toHaveLength(1);
         await expect(generationRequest?.json()).resolves.toMatchObject({
             responseStatus: 502,
             isBilledUsage: false,
             errorResponseCode: "upstream_finish_reason_error",
-            errorMessage:
-                "OpenRouter ended generation with finish_reason=error (native_finish_reason=MALFORMED_FUNCTION_CALL)",
-        });
-        await expect(anomalyRequest?.json()).resolves.toMatchObject({
-            status: 502,
-            upstream_status: 200,
-            error_code: "upstream_finish_reason_error",
+            errorMessage: "Upstream ended generation with finish_reason=error",
         });
         expect(consumePollen).toHaveBeenCalledWith(0);
     });
@@ -1974,92 +1814,6 @@ describe("tracking observability", () => {
         expect(event.tokenCountCompletionText).toBe(500);
         expect(event.modelUsed).toBe("gpt-5-nano-2025-08-07");
         expect(event.isBilledUsage).toBe(true);
-    });
-
-    it("records the complete parsed stream when OpenRouter omits usage", async () => {
-        const tinybirdRequests: Request[] = [];
-        vi.spyOn(globalThis, "fetch").mockImplementation(
-            async (input, init) => {
-                tinybirdRequests.push(new Request(input, init));
-                return new Response("ok");
-            },
-        );
-
-        const ctx = createExecutionContext();
-        const response = await createSseStreamApp(
-            0,
-            {
-                requested: "gemini-fast",
-                resolved: "gemini-fast",
-                definition: getRegistryModelDefinition("gemini-fast"),
-            },
-            false,
-        ).fetch(
-            new Request("https://gen.pollinations.ai/v1/chat/completions", {
-                method: "POST",
-                headers: { "content-type": "application/json" },
-                body: JSON.stringify({
-                    model: "gemini-fast",
-                    stream: true,
-                    messages: [
-                        {
-                            role: "user",
-                            content: "complete streaming input",
-                        },
-                    ],
-                }),
-            }),
-            {
-                DB: env.DB,
-                ENVIRONMENT: "test",
-                LOG_LEVEL: "debug",
-                LOG_FORMAT: "text",
-                BETTER_AUTH_SECRET: "test_secret",
-                TINYBIRD_INGEST_URL:
-                    "https://tinybird.test/v0/events?name=generation_event_v2",
-                TINYBIRD_INGEST_TOKEN: "test_tinybird_token",
-            } as CloudflareBindings,
-            ctx,
-        );
-
-        await waitOnExecutionContext(ctx);
-
-        expect(response.status).toBe(200);
-        expect(tinybirdRequests).toHaveLength(2);
-        const anomalyRequest = tinybirdRequests.find(
-            (request) =>
-                new URL(request.url).searchParams.get("name") === "error_event",
-        );
-        const anomaly = (await anomalyRequest?.json()) as {
-            error_code: string;
-            request_inputs: string;
-            upstream_body: string;
-        };
-        expect(anomaly.error_code).toBe("usage_missing");
-        expect(JSON.parse(anomaly.request_inputs)).toMatchObject({
-            body: {
-                model: "gemini-fast",
-                stream: true,
-                messages: [
-                    {
-                        role: "user",
-                        content: "complete streaming input",
-                    },
-                ],
-            },
-        });
-        expect(JSON.parse(anomaly.upstream_body)).toEqual({
-            streamEvents: [
-                {
-                    model: "gpt-5-nano-2025-08-07",
-                    choices: [{ delta: { content: "hel" } }],
-                },
-                {
-                    model: "gpt-5-nano-2025-08-07",
-                    choices: [{ delta: { content: "lo" } }],
-                },
-            ],
-        });
     });
 
     it("marks a community endpoint stream that ended without usage", async () => {

--- a/gen.pollinations.ai/test/tracking-observability.test.ts
+++ b/gen.pollinations.ai/test/tracking-observability.test.ts
@@ -755,6 +755,89 @@ describe("tracking observability", () => {
         });
         expect(consumePollen).toHaveBeenCalledWith(0);
     });
+
+    it("records an OpenRouter stream ending with finish_reason error as failed", async () => {
+        const tinybirdRequests: Request[] = [];
+        vi.spyOn(globalThis, "fetch").mockImplementation(
+            async (input, init) => {
+                tinybirdRequests.push(new Request(input, init));
+                return new Response("ok");
+            },
+        );
+        const consumePollen = vi.fn<(amount: number) => Promise<void>>(
+            async () => {},
+        );
+        const upstreamBody = [
+            'data: {"model":"google/gemini-2.5-flash-lite","choices":[{"index":0,"delta":{"content":"partial output"},"finish_reason":null}]}',
+            "",
+            'data: {"model":"google/gemini-2.5-flash-lite","choices":[{"index":0,"delta":{},"finish_reason":"error","native_finish_reason":"MALFORMED_FUNCTION_CALL"}]}',
+            "",
+            'data: {"model":"google/gemini-2.5-flash-lite","choices":[{"index":0,"delta":{},"finish_reason":"error","native_finish_reason":"MALFORMED_FUNCTION_CALL"}],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0,"cost":0}}',
+            "",
+            "data: [DONE]",
+            "",
+        ].join("\n");
+        const upstream = new Response(upstreamBody, {
+            headers: { "content-type": "text/event-stream" },
+        });
+
+        const ctx = createExecutionContext();
+        const response = await createWrongContentTypeApp(
+            consumePollen,
+            "generate.text",
+            upstream,
+            "gemini-fast",
+        ).fetch(
+            new Request("https://gen.pollinations.ai/upstream", {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify({
+                    model: "gemini-fast",
+                    stream: true,
+                    messages: [{ role: "user", content: "test" }],
+                }),
+            }),
+            {
+                DB: env.DB,
+                ENVIRONMENT: "test",
+                LOG_LEVEL: "debug",
+                LOG_FORMAT: "text",
+                BETTER_AUTH_SECRET: "test_secret",
+                TINYBIRD_INGEST_URL:
+                    "https://tinybird.test/v0/events?name=generation_event_v2",
+                TINYBIRD_INGEST_TOKEN: "test_tinybird_token",
+            } as CloudflareBindings,
+            ctx,
+        );
+
+        expect(response.status).toBe(200);
+        await expect(response.text()).resolves.toBe(upstreamBody);
+        await waitOnExecutionContext(ctx);
+
+        const generationRequest = tinybirdRequests.find(
+            (request) =>
+                new URL(request.url).searchParams.get("name") ===
+                "generation_event_v2",
+        );
+        const anomalyRequest = tinybirdRequests.find(
+            (request) =>
+                new URL(request.url).searchParams.get("name") === "error_event",
+        );
+        await expect(generationRequest?.json()).resolves.toMatchObject({
+            responseStatus: 502,
+            isBilledUsage: false,
+            errorResponseCode: "upstream_finish_reason_error",
+            errorMessage:
+                "OpenRouter ended generation with finish_reason=error (native_finish_reason=MALFORMED_FUNCTION_CALL)",
+        });
+        await expect(anomalyRequest?.json()).resolves.toMatchObject({
+            status: 502,
+            upstream_status: 200,
+            error_code: "upstream_finish_reason_error",
+        });
+        expect(consumePollen).toHaveBeenCalledWith(0);
+    });
+
     it("tracks usage after a malformed SSE event", async () => {
         const tinybirdRequests: Request[] = [];
         vi.spyOn(globalThis, "fetch").mockImplementation(

--- a/shared/events.ts
+++ b/shared/events.ts
@@ -8,7 +8,7 @@ const MAX_DELAY = 2000;
 
 export type TinybirdErrorEvent = {
     timestamp: string;
-    kind: "server_error" | "usage_anomaly";
+    kind: "server_error";
     severity: "error";
     request_id?: string;
     environment?: string;


### PR DESCRIPTION
- Records text responses with `finish_reason: "error"` as non-billed 502 generation failures
- Preserves the upstream HTTP status and response body unchanged
- Applies the protocol check to every text provider
- Removes the temporary OpenRouter-only zero/missing-usage anomaly logger
- Keeps generic missing-usage and known flat-fee billing behavior unchanged