### PR TITLE
fix: bill AssemblyAI transcription add-ons

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -1800,6 +1800,11 @@ exports[`effective cost and price per model — snapshot 1`] = `
     "cost": {
       "promptAudioSeconds": 0.0000416666666666667,
     },
+    "costVariants": {
+      "diarization": {
+        "promptAudioSeconds": 0.0000472222222222222,
+      },
+    },
     "price": {
       "promptAudioSeconds": 0.0000416666666666667,
     },
@@ -1807,6 +1812,17 @@ exports[`effective cost and price per model — snapshot 1`] = `
   "universal-3.5-pro": {
     "cost": {
       "promptAudioSeconds": 0.0000583333333333333,
+    },
+    "costVariants": {
+      "diarization": {
+        "promptAudioSeconds": 0.0000638888888888889,
+      },
+      "prompting": {
+        "promptAudioSeconds": 0.0000722222222222222,
+      },
+      "prompting_diarization": {
+        "promptAudioSeconds": 0.0000777777777777778,
+      },
     },
     "price": {
       "promptAudioSeconds": 0.0000583333333333333,

--- a/enter.pollinations.ai/test/cost-variants.test.ts
+++ b/enter.pollinations.ai/test/cost-variants.test.ts
@@ -352,6 +352,33 @@ describe("long-context cost variants", () => {
     });
 });
 
+describe("AssemblyAI transcription cost variants", () => {
+    it.each([
+        ["universal-2", undefined, undefined, 0.15, undefined],
+        ["universal-2", "diarized_json", undefined, 0.17, "diarization"],
+        ["universal-3.5-pro", undefined, undefined, 0.21, undefined],
+        ["universal-3.5-pro", undefined, true, 0.26, "prompting"],
+        ["universal-3.5-pro", "diarized_json", undefined, 0.23, "diarization"],
+        [
+            "universal-3.5-pro",
+            "diarized_json",
+            true,
+            0.28,
+            "prompting_diarization",
+        ],
+    ] as const)("%s bills $%s/hour for format=%s prompt=%s", (model, transcriptionResponseFormat, hasPrompt, hourlyCost, variant) => {
+        const billing = bill(
+            model,
+            { promptAudioSeconds: 3600 },
+            { transcriptionResponseFormat, hasPrompt },
+        );
+
+        expect(billing.cost.totalCost).toBeCloseTo(hourlyCost, 12);
+        expect(billing.price.totalPrice).toBeCloseTo(hourlyCost, 12);
+        expect(billing.costVariant).toBe(variant);
+    });
+});
+
 describe("request-mode cost variants", () => {
     it("qwen-image bills text-to-image and edit at their separate rates", () => {
         const textToImage = bill("qwen-image", {

--- a/enter.pollinations.ai/test/cost-variants.test.ts
+++ b/enter.pollinations.ai/test/cost-variants.test.ts
@@ -354,11 +354,11 @@ describe("long-context cost variants", () => {
 
 describe("AssemblyAI transcription cost variants", () => {
     it.each([
-        ["universal-2", undefined, undefined, 0.15, undefined],
-        ["universal-2", "diarized_json", undefined, 0.17, "diarization"],
-        ["universal-3.5-pro", undefined, undefined, 0.21, undefined],
-        ["universal-3.5-pro", undefined, true, 0.26, "prompting"],
-        ["universal-3.5-pro", "diarized_json", undefined, 0.23, "diarization"],
+        ["universal-2", "json", false, 0.15, undefined],
+        ["universal-2", "diarized_json", false, 0.17, "diarization"],
+        ["universal-3.5-pro", "json", false, 0.21, undefined],
+        ["universal-3.5-pro", "json", true, 0.26, "prompting"],
+        ["universal-3.5-pro", "diarized_json", false, 0.23, "diarization"],
         [
             "universal-3.5-pro",
             "diarized_json",
@@ -366,11 +366,11 @@ describe("AssemblyAI transcription cost variants", () => {
             0.28,
             "prompting_diarization",
         ],
-    ] as const)("%s bills $%s/hour for format=%s prompt=%s", (model, transcriptionResponseFormat, hasPrompt, hourlyCost, variant) => {
+    ] as const)("%s format=%s prompt=%s bills $%s/hour", (model, responseFormat, hasPrompt, hourlyCost, variant) => {
         const billing = bill(
             model,
             { promptAudioSeconds: 3600 },
-            { transcriptionResponseFormat, hasPrompt },
+            { hasDiarization: responseFormat === "diarized_json", hasPrompt },
         );
 
         expect(billing.cost.totalCost).toBeCloseTo(hourlyCost, 12);

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -3011,15 +3011,10 @@ export async function handleTranscription(c: AudioContext): Promise<Response> {
         });
     }
 
-    if (
-        c.var.model.resolved === "universal-2" ||
-        c.var.model.resolved === "universal-3.5-pro"
-    ) {
-        c.var.track.setPricingInput({
-            transcriptionResponseFormat: responseFormat || "json",
-            hasPrompt: Boolean(prompt),
-        });
-    }
+    c.var.track.setPricingInput({
+        hasDiarization: responseFormat === "diarized_json",
+        hasPrompt: Boolean(prompt),
+    });
 
     const result = await withAudioFallback(c, async (candidate) => {
         if (candidate.communityEndpoint) {

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -3011,6 +3011,16 @@ export async function handleTranscription(c: AudioContext): Promise<Response> {
         });
     }
 
+    if (
+        c.var.model.resolved === "universal-2" ||
+        c.var.model.resolved === "universal-3.5-pro"
+    ) {
+        c.var.track.setPricingInput({
+            transcriptionResponseFormat: responseFormat || "json",
+            hasPrompt: Boolean(prompt),
+        });
+    }
+
     const result = await withAudioFallback(c, async (candidate) => {
         if (candidate.communityEndpoint) {
             return callCommunityTranscriptionEndpoint(

--- a/gen.pollinations.ai/test/audio/assemblyai-cost-variants-e2e.test.ts
+++ b/gen.pollinations.ai/test/audio/assemblyai-cost-variants-e2e.test.ts
@@ -1,0 +1,136 @@
+import {
+    createExecutionContext,
+    env,
+    waitOnExecutionContext,
+} from "cloudflare:test";
+import { test as baseTest } from "@shared/test/fixtures/index.ts";
+import {
+    createFetchMock,
+    teardownFetchMock,
+} from "@shared/test/mocks/fetch.ts";
+import { createMockTinybird } from "@shared/test/mocks/tinybird.ts";
+import { afterEach, expect } from "vitest";
+import worker from "../../src/index.ts";
+import { withInlineGenerationCoordinator } from "../helpers/inline-generation-coordinator.ts";
+
+function createAssemblyAiMock() {
+    const state: { submitted?: Record<string, unknown> } = {};
+    return {
+        state,
+        handlerMap: {
+            "api.assemblyai.com": async (request: Request) => {
+                const { pathname } = new URL(request.url);
+                if (pathname === "/v2/upload") {
+                    return Response.json({
+                        upload_url: "https://cdn.assemblyai.com/upload/test",
+                    });
+                }
+                if (
+                    pathname === "/v2/transcript" &&
+                    request.method === "POST"
+                ) {
+                    state.submitted = (await request.json()) as Record<
+                        string,
+                        unknown
+                    >;
+                    return Response.json({ id: "transcript-id" });
+                }
+                if (pathname === "/v2/transcript/transcript-id") {
+                    return Response.json({
+                        id: "transcript-id",
+                        status: "completed",
+                        text: "Hello from AssemblyAI.",
+                        audio_duration: 3600,
+                        language_code: "en",
+                        words: [],
+                        utterances: [
+                            {
+                                text: "Hello from AssemblyAI.",
+                                start: 0,
+                                end: 1000,
+                                speaker: "A",
+                            },
+                        ],
+                    });
+                }
+                return new Response("Unexpected AssemblyAI request", {
+                    status: 404,
+                });
+            },
+        },
+        reset: () => {
+            state.submitted = undefined;
+        },
+    };
+}
+
+function createAssemblyAiPricingMocks() {
+    return createFetchMock({
+        assemblyai: createAssemblyAiMock(),
+        tinybird: createMockTinybird(),
+    });
+}
+
+const test = baseTest.extend<{
+    mocks: ReturnType<typeof createAssemblyAiPricingMocks>;
+}>({
+    // biome-ignore lint/correctness/noEmptyPattern: vitest fixture pattern requires object destructuring
+    mocks: async ({}, use) => {
+        await use(createAssemblyAiPricingMocks());
+    },
+});
+
+afterEach(async () => {
+    await teardownFetchMock();
+});
+
+test("AssemblyAI prompt and diarization select the combined billing sheet", async ({
+    apiKey,
+    mocks,
+}) => {
+    await mocks.enable("assemblyai", "tinybird");
+
+    const form = new FormData();
+    form.set("model", "universal-3.5-pro");
+    form.set("prompt", "Pollinations pricing verification");
+    form.set("response_format", "diarized_json");
+    form.set(
+        "file",
+        new File(["assemblyai-pricing-e2e"], "pricing.wav", {
+            type: "audio/wav",
+        }),
+    );
+
+    const ctx = createExecutionContext();
+    const response = await worker.fetch(
+        new Request("https://gen.pollinations.ai/v1/audio/transcriptions", {
+            method: "POST",
+            headers: { authorization: `Bearer ${apiKey}` },
+            body: form,
+        }),
+        withInlineGenerationCoordinator({
+            ...env,
+            ASSEMBLYAI_API_KEY: "assemblyai-test-key",
+        } as CloudflareBindings),
+        ctx,
+    );
+    expect(response.status, await response.clone().text()).toBe(200);
+    await response.arrayBuffer();
+    await waitOnExecutionContext(ctx);
+
+    expect(mocks.assemblyai.state.submitted).toMatchObject({
+        speech_models: ["universal-3-5-pro"],
+        prompt: "Pollinations pricing verification",
+        speaker_labels: true,
+    });
+    expect(mocks.tinybird.state.events).toHaveLength(1);
+    expect(mocks.tinybird.state.events[0]).toMatchObject({
+        modelRequested: "universal-3.5-pro",
+        modelUsed: "universal-3.5-pro",
+        costVariant: "prompting_diarization",
+        tokenCountPromptAudioSeconds: 3600,
+        tokenPricePromptAudioSeconds: 0.28 / 3600,
+        totalCost: 0.28,
+        totalPrice: 0.28,
+    });
+});

--- a/shared/registry/audio.ts
+++ b/shared/registry/audio.ts
@@ -1,3 +1,4 @@
+import { defineCostVariants } from "./cost-variants";
 import type { ModelDefinition } from "./registry";
 
 // Voice name to ElevenLabs voice ID mapping
@@ -450,6 +451,25 @@ export const AUDIO_SERVICES = {
             // AssemblyAI Universal-2: $0.15/hour
             promptAudioSeconds: 0.15 / 3600,
         },
+        ...defineCostVariants(
+            {
+                diarization: {
+                    promptAudioSeconds: 0.17 / 3600,
+                },
+            },
+            ({ input }) =>
+                input?.transcriptionResponseFormat === "diarized_json"
+                    ? "diarization"
+                    : undefined,
+            {
+                diarization: {
+                    label: "Speaker diarization",
+                    description:
+                        "Applies when response_format is diarized_json.",
+                },
+            },
+            "Standard transcription",
+        ),
         title: "AssemblyAI Universal-2",
         description: "Fast transcription with support for 99 languages",
         inputModalities: ["audio"],
@@ -476,6 +496,44 @@ export const AUDIO_SERVICES = {
             // AssemblyAI Universal-3.5 Pro async: $0.21/hour
             promptAudioSeconds: 0.21 / 3600,
         },
+        ...defineCostVariants(
+            {
+                prompting: {
+                    promptAudioSeconds: 0.26 / 3600,
+                },
+                diarization: {
+                    promptAudioSeconds: 0.23 / 3600,
+                },
+                prompting_diarization: {
+                    promptAudioSeconds: 0.28 / 3600,
+                },
+            },
+            ({ input }) => {
+                const diarized =
+                    input?.transcriptionResponseFormat === "diarized_json";
+                if (input?.hasPrompt) {
+                    return diarized ? "prompting_diarization" : "prompting";
+                }
+                return diarized ? "diarization" : undefined;
+            },
+            {
+                prompting: {
+                    label: "Prompting",
+                    description: "Applies when a prompt is provided.",
+                },
+                diarization: {
+                    label: "Speaker diarization",
+                    description:
+                        "Applies when response_format is diarized_json.",
+                },
+                prompting_diarization: {
+                    label: "Prompting and speaker diarization",
+                    description:
+                        "Applies when a prompt is provided and response_format is diarized_json.",
+                },
+            },
+            "Standard transcription",
+        ),
         title: "AssemblyAI Universal-3.5 Pro",
         description:
             "High-accuracy transcription with multilingual code switching and prompts",

--- a/shared/registry/audio.ts
+++ b/shared/registry/audio.ts
@@ -457,10 +457,7 @@ export const AUDIO_SERVICES = {
                     promptAudioSeconds: 0.17 / 3600,
                 },
             },
-            ({ input }) =>
-                input?.transcriptionResponseFormat === "diarized_json"
-                    ? "diarization"
-                    : undefined,
+            ({ input }) => (input?.hasDiarization ? "diarization" : undefined),
             {
                 diarization: {
                     label: "Speaker diarization",
@@ -509,12 +506,12 @@ export const AUDIO_SERVICES = {
                 },
             },
             ({ input }) => {
-                const diarized =
-                    input?.transcriptionResponseFormat === "diarized_json";
                 if (input?.hasPrompt) {
-                    return diarized ? "prompting_diarization" : "prompting";
+                    return input.hasDiarization
+                        ? "prompting_diarization"
+                        : "prompting";
                 }
-                return diarized ? "diarization" : undefined;
+                return input?.hasDiarization ? "diarization" : undefined;
             },
             {
                 prompting: {

--- a/shared/registry/cost-variants.ts
+++ b/shared/registry/cost-variants.ts
@@ -21,7 +21,7 @@ export type PricingInput = {
     hasImage?: boolean;
     megapixels?: number;
     searchContextSize?: "low" | "high";
-    transcriptionResponseFormat?: string;
+    hasDiarization?: boolean;
     hasPrompt?: boolean;
 };
 

--- a/shared/registry/cost-variants.ts
+++ b/shared/registry/cost-variants.ts
@@ -21,6 +21,8 @@ export type PricingInput = {
     hasImage?: boolean;
     megapixels?: number;
     searchContextSize?: "low" | "high";
+    transcriptionResponseFormat?: string;
+    hasPrompt?: boolean;
 };
 
 export type CostVariantContext = {


### PR DESCRIPTION
- Adds request-priced AssemblyAI transcription sheets using the official [pricing](https://www.assemblyai.com/pricing): Universal-2 diarization is $0.17/hour.
- Bills Universal-3.5 Pro at $0.21/hour base, $0.26 with prompting, $0.23 with diarization, and $0.28 with both.
- Leaves canonical names, aliases, provider routes, access, capabilities, and fallback behavior unchanged.
- Verified all six combinations directly with AssemblyAI and through local Gen, including catalog prices, exact wallet debits, billing events, and a no-charge cache hit.
- Tests: cost variants, effective-price snapshot, AssemblyAI transcription, model permissions, Gen/Enter typechecks, Biome.