### PR TITLE
chore: promote Pollen spent KPI

### DIFF
--- a/operations/kpi/src/lib/kpis.js
+++ b/operations/kpi/src/lib/kpis.js
@@ -94,6 +94,12 @@ export const KPIS = [
                     "Gross USD from Pollen pack purchases. Source: Stripe checkout events in Tinybird.",
             },
             {
+                key: "pollenRevenue",
+                name: "Pollen spent",
+                tooltip:
+                    "USD value of Pollen consumed by generation requests this week, across Paid and Quest balances. Source: Tinybird (weekly_usage_stats).",
+            },
+            {
                 name: "ARPA",
                 calc: (w) => w.revenue / w.wau,
                 tooltip:

--- a/operations/kpi/test/kpis.test.js
+++ b/operations/kpi/test/kpis.test.js
@@ -107,6 +107,7 @@ describe("explorer view list", () => {
 
 const margin = KPIS.find((row) => row.key === "grossMargin");
 const coverage = KPIS.find((row) => row.key === "cashCoverage");
+const revenue = KPIS.find((row) => row.key === "revenue");
 
 // A real week from prod (2026-08-10), trimmed to the fields these rows read.
 const marginWeek = {
@@ -115,6 +116,25 @@ const marginWeek = {
     costUsd: 3740,
     revenue: 2278,
 };
+
+describe("revenue row", () => {
+    it("cycles between Pollen bought, Pollen spent, and ARPA", () => {
+        expect([0, 1, 2].map((i) => kpiView(revenue, i).name)).toEqual([
+            "Revenue",
+            "Pollen spent",
+            "ARPA",
+        ]);
+        expect(
+            [0, 1, 2].map((i) =>
+                kpiValue(kpiView(revenue, i), {
+                    revenue: 2278,
+                    pollenRevenue: 3469,
+                    wau: 3352,
+                }),
+            ),
+        ).toEqual([2278, 3469, 2278 / 3352]);
+    });
+});
 
 describe("gross margin row", () => {
     it("measures Pollen revenue against cost, not Stripe cash", () => {


### PR DESCRIPTION
- Promotes the switchable Pollen spent KPI view from #13696
- Reuses the existing weekly usage data
- Includes no schema or Tinybird changes