### PR TITLE
chore: promote main to production

### DIFF
--- a/shared/auth/github-id-list.ts
+++ b/shared/auth/github-id-list.ts
@@ -39,6 +39,8 @@ export const COMMUNITY_MODEL_ALLOWED_GITHUB_IDS = [
     228795921, //novastardev
     30191185, // rekty
     145819645, // rodrigookk
+    85689068, // pegalink
+    147928812, // iotserver24
 ] as const;
 
 const COMMUNITY_MODEL_ALLOWED_GITHUB_ID_SET = new Set<number>(


### PR DESCRIPTION
- Promotes the current main branch to production
- Adds pegalink and iotserver24 to the community-model publisher allowlist
- Includes only shared/auth/github-id-list.ts