### PR TITLE
fix: align Laguna OpenRouter pricing

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -908,14 +908,14 @@ exports[`effective cost and price per model — snapshot 1`] = `
   },
   "laguna": {
     "cost": {
-      "completionTextTokens": 0.0000002,
-      "promptCachedTokens": 0.00000001,
-      "promptTextTokens": 0.0000001,
+      "completionTextTokens": 0.00000018,
+      "promptCachedTokens": 0.000000009,
+      "promptTextTokens": 0.00000009,
     },
     "price": {
-      "completionTextTokens": 0.0000002,
-      "promptCachedTokens": 0.00000001,
-      "promptTextTokens": 0.0000001,
+      "completionTextTokens": 0.00000018,
+      "promptCachedTokens": 0.000000009,
+      "promptTextTokens": 0.00000009,
     },
   },
   "llama": {

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -1288,10 +1288,10 @@ export const TEXT_SERVICES = {
         paidOnly: true,
         priceMultiplier: 1,
         cost: {
-            // OpenRouter Poolside route rates (2026-07-22).
-            promptTextTokens: perMillion(0.1),
-            promptCachedTokens: perMillion(0.01),
-            completionTextTokens: perMillion(0.2),
+            // OpenRouter Poolside route rates (2026-08-22).
+            promptTextTokens: perMillion(0.09),
+            promptCachedTokens: perMillion(0.009),
+            completionTextTokens: perMillion(0.18),
         },
         title: "Laguna S 2.1",
         description:


### PR DESCRIPTION
- Updates `laguna` provider cost from $0.10/$0.01/$0.20 to $0.09/$0.009/$0.18 per million uncached input/cached input/output tokens.
- Matches the exact pinned OpenRouter route `poolside/laguna-s-2.1` on Poolside (`poolside/fp4`), with provider fallback disabled.
- Verifies a direct pinned request and a full local Gen billing request; 38 uncached + 32 cached + 16 output tokens produced $0.000006588 and a $0.00000659 wallet debit after precision rounding.
- Leaves the canonical name, aliases, access, multiplier, routing, capabilities, and fallback unchanged.
- Passes 349 focused registry/pricing tests, both service typechecks, and Biome.