### PR TITLE
fix: align MiniMax H3 768p pricing

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -1056,7 +1056,7 @@ exports[`effective cost and price per model — snapshot 1`] = `
         "completionVideoSeconds": 0.13,
       },
       "768p": {
-        "completionVideoSeconds": 0.08,
+        "completionVideoSeconds": 0.06,
       },
     },
     "price": {

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -1041,7 +1041,7 @@ const IMAGE_BASE_SERVICES = {
         },
         ...defineCostVariants(
             {
-                "768p": { completionVideoSeconds: 0.08 },
+                "768p": { completionVideoSeconds: 0.06 },
                 "2k": { completionVideoSeconds: 0.13 },
             },
             matchResolution("768p", "2k"),


### PR DESCRIPTION
- Changes only the `minimax-h3` 768p rate from $0.08/second to fal's exact $0.06/second sheet; 480p and 2K remain unchanged and 4K remains excluded.
- Updates the required effective-prices snapshot without changing routing, aliases, access, multiplier, capabilities, GPU status, or fallback.
- Verifies a direct 5-second 768p fal request: 6 weighted billable base units × $0.05 = $0.30.
- Verifies full local Gen billing: one cache miss returned MP4 and debited exactly $0.30; the identical cache hit returned in 0.1s with no second debit.
- Passes 364 focused tests, both service typechecks, and Biome.