### PR TITLE
fix: align OVHcloud model pricing

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -1405,12 +1405,12 @@ exports[`effective cost and price per model — snapshot 1`] = `
   },
   "qwen-coder": {
     "cost": {
-      "completionTextTokens": 0.00000022,
-      "promptTextTokens": 0.00000006,
+      "completionTextTokens": 0.00000026,
+      "promptTextTokens": 0.00000007,
     },
     "price": {
-      "completionTextTokens": 0.00000022,
-      "promptTextTokens": 0.00000006,
+      "completionTextTokens": 0.00000026,
+      "promptTextTokens": 0.00000007,
     },
   },
   "qwen-coder-large": {
@@ -1893,10 +1893,10 @@ exports[`effective cost and price per model — snapshot 1`] = `
   },
   "whisper": {
     "cost": {
-      "promptAudioSeconds": 0.0000445,
+      "promptAudioSeconds": 0.0000452777777777778,
     },
     "price": {
-      "promptAudioSeconds": 0.0000445,
+      "promptAudioSeconds": 0.0000452777777777778,
     },
   },
   "zimage": {

--- a/shared/registry/audio.ts
+++ b/shared/registry/audio.ts
@@ -354,8 +354,8 @@ export const AUDIO_SERVICES = {
         addedDate: new Date("2026-02-08").getTime(),
         priceMultiplier: 1,
         cost: {
-            // OVH Whisper: €0.00004083/sec ≈ $0.0000445/sec
-            promptAudioSeconds: 0.0000445,
+            // OVHcloud USD list price: $0.163/hour.
+            promptAudioSeconds: 0.163 / 3600,
         },
         title: "Whisper Large V3",
         description: "Accurate, affordable speech-to-text transcription",

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -394,8 +394,9 @@ export const TEXT_SERVICES = {
         addedDate: new Date("2025-10-07").getTime(),
         priceMultiplier: 1,
         cost: {
-            promptTextTokens: perMillion(0.06),
-            completionTextTokens: perMillion(0.22),
+            // OVHcloud USD list price for Qwen3-Coder-30B-A3B-Instruct.
+            promptTextTokens: perMillion(0.07),
+            completionTextTokens: perMillion(0.26),
         },
         title: "Qwen3 Coder 30B",
         description:


### PR DESCRIPTION
- Updates `qwen-coder` from $0.06/$0.22 to the OVHcloud USD list price of $0.07/$0.26 per million input/output tokens.
- Updates `whisper` from $0.1602/hour to the OVHcloud USD list price of $0.163/hour.
- Leaves routes, capabilities, aliases, permissions, multipliers, GPU status, and fallbacks unchanged.
- Verified both exact OVHcloud routes directly and through authenticated local E2E, including aliases, Quest billing, cache no-double-debit, error handling, catalogs, and Tinybird settlement.

Sources: [OVHcloud USD prices](https://www.ovhcloud.com/en/public-cloud/prices/) and [OVHcloud EUR prices](https://www.ovhcloud.com/fr/public-cloud/prices/).