### PR TITLE
feat: add OpenAI web search model

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -1344,6 +1344,18 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.000005,
     },
   },
+  "openai-search": {
+    "cost": {
+      "completionTextTokens": 0.00000125,
+      "promptCachedTokens": 0.00000002,
+      "promptTextTokens": 0.0000002,
+    },
+    "price": {
+      "completionTextTokens": 0.0000009375,
+      "promptCachedTokens": 0.000000015,
+      "promptTextTokens": 0.00000015,
+    },
+  },
   "p-image": {
     "cost": {
       "completionImageTokens": 0.005,

--- a/enter.pollinations.ai/test/aliases.test.ts
+++ b/enter.pollinations.ai/test/aliases.test.ts
@@ -2,6 +2,7 @@ import { AUDIO_SERVICES } from "@shared/registry/audio";
 import { IMAGE_SERVICES } from "@shared/registry/image";
 import type { ModelDefinition } from "@shared/registry/registry.js";
 import {
+    calculateBillingAdjustments,
     calculateCost,
     calculatePrice,
     getCostDefinition,
@@ -74,6 +75,49 @@ test("gemini-search applies grounding cost on top of shared token rates", () => 
     expect(geminiSearchCost.totalCost).toBeGreaterThan(
         geminiFastCost.totalCost,
     );
+});
+
+test("openai-search bills reported Azure web-search requests", () => {
+    const model = getRegistryModelDefinition("openai-search");
+    const adjustments = calculateBillingAdjustments(
+        model,
+        {
+            usage: {
+                server_tool_use_details: { web_search_requests: 2 },
+            },
+        },
+        "openai-search",
+    );
+
+    expect(adjustments).toEqual([
+        {
+            ruleId: "azure.bing.web_search.v1",
+            kind: "search_request",
+            unit: "request",
+            units: 2,
+            unitCost: 0.014,
+            cost: 0.028,
+            price: 0.021,
+        },
+    ]);
+    expect(
+        calculateBillingAdjustments(
+            model,
+            {
+                streamEvents: [
+                    {},
+                    {
+                        usage: {
+                            server_tool_use_details: {
+                                web_search_requests: 1,
+                            },
+                        },
+                    },
+                ],
+            },
+            "openai-search",
+        ),
+    ).toMatchObject([{ units: 1, cost: 0.014, price: 0.0105 }]);
 });
 
 test("public price equals provider cost times priceMultiplier for every model", () => {

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -37,6 +37,8 @@ interface ModelDefinition {
     transform?: TransformFn;
     /** Route through the Azure Responses API instead of Chat Completions. */
     useResponsesApi?: boolean;
+    /** Always run Azure Responses web search before answering. */
+    useWebSearch?: boolean;
 }
 
 function usesGrokReasoning(options: TransformOptions): boolean {
@@ -55,6 +57,12 @@ const models: ModelDefinition[] = [
     {
         name: "openai",
         config: portkeyConfig["gpt-5.4-nano"],
+    },
+    {
+        name: "openai-search",
+        config: portkeyConfig["gpt-5.4-nano"],
+        useResponsesApi: true,
+        useWebSearch: true,
     },
     {
         name: "openai-fast",

--- a/gen.pollinations.ai/src/text/azureResponsesClient.ts
+++ b/gen.pollinations.ai/src/text/azureResponsesClient.ts
@@ -31,8 +31,21 @@ interface ResponseItem {
     call_id?: string;
     name?: string;
     arguments?: string;
-    content?: Array<{ type?: string; text?: string; refusal?: string }>;
+    content?: Array<{
+        type?: string;
+        text?: string;
+        refusal?: string;
+        annotations?: ResponseCitation[];
+    }>;
     summary?: Array<{ text?: string }>;
+}
+
+interface ResponseCitation {
+    type?: string;
+    start_index?: number;
+    end_index?: number;
+    title?: string;
+    url?: string;
 }
 
 interface ResponsesUsage {
@@ -54,7 +67,33 @@ interface ResponsesData {
     incomplete_details?: { reason?: string };
     output?: ResponseItem[];
     usage?: ResponsesUsage;
+    tool_usage?: {
+        web_search?: { num_requests?: number };
+    };
     error?: { message?: string; status?: number };
+}
+
+function chatAnnotation(value: unknown): Json | null {
+    if (!value || typeof value !== "object") return null;
+    const citation = value as ResponseCitation;
+    if (
+        citation.type !== "url_citation" ||
+        typeof citation.start_index !== "number" ||
+        typeof citation.end_index !== "number" ||
+        typeof citation.title !== "string" ||
+        typeof citation.url !== "string"
+    ) {
+        return null;
+    }
+    return {
+        type: "url_citation",
+        url_citation: {
+            start_index: citation.start_index,
+            end_index: citation.end_index,
+            title: citation.title,
+            url: citation.url,
+        },
+    };
 }
 
 function contentParts(
@@ -188,7 +227,20 @@ function buildBody(messages: ChatMessage[], options: TransformOptions): Json {
     ) {
         body.reasoning = { effort: options.reasoning_effort, summary: "auto" };
     }
-    if (Array.isArray(options.tools) && options.tools.length) {
+    if (options.azureWebSearch === true) {
+        body.tools = [
+            {
+                type: "web_search",
+                ...(options.web_search_options?.search_context_size
+                    ? {
+                          search_context_size:
+                              options.web_search_options.search_context_size,
+                      }
+                    : {}),
+            },
+        ];
+        body.tool_choice = "required";
+    } else if (Array.isArray(options.tools) && options.tools.length) {
         body.tools = options.tools.flatMap((raw) => {
             if (!raw || typeof raw !== "object") return [];
             const tool = raw as Json;
@@ -205,7 +257,7 @@ function buildBody(messages: ChatMessage[], options: TransformOptions): Json {
             ];
         });
     }
-    if (options.tool_choice !== undefined) {
+    if (options.azureWebSearch !== true && options.tool_choice !== undefined) {
         const choice = options.tool_choice as Json;
         body.tool_choice =
             choice?.type === "function"
@@ -215,7 +267,10 @@ function buildBody(messages: ChatMessage[], options: TransformOptions): Json {
                   }
                 : options.tool_choice;
     }
-    if (typeof options.parallel_tool_calls === "boolean") {
+    if (
+        options.azureWebSearch !== true &&
+        typeof options.parallel_tool_calls === "boolean"
+    ) {
         body.parallel_tool_calls = options.parallel_tool_calls;
     }
     const maxTokens = options.max_completion_tokens ?? options.max_tokens;
@@ -233,7 +288,10 @@ function buildBody(messages: ChatMessage[], options: TransformOptions): Json {
     return body;
 }
 
-function chatUsage(usage: ResponsesUsage): Json {
+function chatUsage(
+    usage: ResponsesUsage,
+    toolUsage?: ResponsesData["tool_usage"],
+): Json {
     const result: Json = {
         prompt_tokens: usage.input_tokens ?? 0,
         completion_tokens: usage.output_tokens ?? 0,
@@ -249,6 +307,16 @@ function chatUsage(usage: ResponsesUsage): Json {
     if (usage.output_tokens_details) {
         result.completion_tokens_details = {
             reasoning_tokens: usage.output_tokens_details.reasoning_tokens ?? 0,
+        };
+    }
+    const webSearchRequests = toolUsage?.web_search?.num_requests;
+    if (
+        typeof webSearchRequests === "number" &&
+        Number.isFinite(webSearchRequests) &&
+        webSearchRequests > 0
+    ) {
+        result.server_tool_use_details = {
+            web_search_requests: webSearchRequests,
         };
     }
     return result;
@@ -275,6 +343,7 @@ function parseResponse(data: ResponsesData, requestedModel: string) {
     const refusals: string[] = [];
     const reasoning: string[] = [];
     const toolCalls: Json[] = [];
+    const annotations: Json[] = [];
 
     for (const item of data.output ?? []) {
         if (item.type === "reasoning") {
@@ -288,6 +357,10 @@ function parseResponse(data: ResponsesData, requestedModel: string) {
             for (const part of item.content ?? []) {
                 if (part.type === "output_text" && part.text) {
                     texts.push(part.text);
+                    for (const raw of part.annotations ?? []) {
+                        const annotation = chatAnnotation(raw);
+                        if (annotation) annotations.push(annotation);
+                    }
                 } else if (part.type === "refusal" && part.refusal) {
                     refusals.push(part.refusal);
                 }
@@ -311,6 +384,7 @@ function parseResponse(data: ResponsesData, requestedModel: string) {
     };
     if (toolCalls.length) message.tool_calls = toolCalls;
     if (reasoning.length) message.reasoning_content = reasoning.join("\n");
+    if (annotations.length) message.annotations = annotations;
 
     const completion: ChatCompletion = {
         id: data.id,
@@ -325,7 +399,7 @@ function parseResponse(data: ResponsesData, requestedModel: string) {
             },
         ],
     };
-    if (data.usage) completion.usage = chatUsage(data.usage);
+    if (data.usage) completion.usage = chatUsage(data.usage, data.tool_usage);
     return completion;
 }
 
@@ -371,14 +445,14 @@ function convertStream(
             choices: [{ index: 0, delta, finish_reason }],
             ...(includeUsage ? { usage: null } : {}),
         });
-    const usageChunk = (usage: ResponsesUsage) =>
+    const usageChunk = (response: ResponsesData) =>
         dataEvent({
             id,
             object: "chat.completion.chunk",
             created,
             model,
             choices: [],
-            usage: chatUsage(usage),
+            usage: chatUsage(response.usage ?? {}, response.tool_usage),
         });
 
     return source
@@ -447,6 +521,13 @@ function convertStream(
                         }
                         return;
                     }
+                    if (type === "response.output_text.annotation.added") {
+                        const annotation = chatAnnotation(payload.annotation);
+                        if (annotation) {
+                            emit(chatChunk({ annotations: [annotation] }));
+                        }
+                        return;
+                    }
                     if (type === "response.refusal.delta") {
                         if (typeof payload.delta === "string") {
                             emit(chatChunk({ refusal: payload.delta }));
@@ -492,7 +573,7 @@ function convertStream(
                             {}) as ResponsesData;
                         emit(chatChunk({}, finishReason(response)));
                         if (includeUsage && response.usage) {
-                            emit(usageChunk(response.usage));
+                            emit(usageChunk(response));
                         }
                         emit(dataEvent("[DONE]"));
                         terminal = true;

--- a/gen.pollinations.ai/src/text/generateTextPortkey.ts
+++ b/gen.pollinations.ai/src/text/generateTextPortkey.ts
@@ -101,7 +101,8 @@ export async function generateTextPortkey(
     // forwarded to Azure — the Responses client sets its own headers/timeout.
     const needsResponsesApi =
         modelDef?.useResponsesApi &&
-        (state.options.seed === undefined ||
+        (modelDef.useWebSearch ||
+            state.options.seed === undefined ||
             state.options.reasoning_effort !== undefined ||
             (Array.isArray(state.options.tools) &&
                 state.options.tools.length > 0));
@@ -112,10 +113,13 @@ export async function generateTextPortkey(
     if (needsResponsesApi) {
         if (state.options.seed !== undefined) {
             log(
-                "Ignoring seed because Azure Responses is required for tools/reasoning",
+                "Ignoring seed because Azure Responses is required for tools/reasoning/search",
             );
         }
-        return callAzureResponses(state.messages, state.options);
+        return callAzureResponses(state.messages, {
+            ...state.options,
+            azureWebSearch: modelDef?.useWebSearch === true,
+        });
     }
 
     // Only the Responses adapter owns this parameter. Keep generic provider

--- a/gen.pollinations.ai/src/text/handler.ts
+++ b/gen.pollinations.ai/src/text/handler.ts
@@ -462,7 +462,7 @@ function normalizeSearchContext(
     if (
         supported.length > 1 &&
         requested !== undefined &&
-        !supported.includes(requested as "low" | "high")
+        !supported.includes(requested)
     ) {
         return {
             errorResponse: c.json(
@@ -481,9 +481,7 @@ function normalizeSearchContext(
     }
 
     const searchContextSize =
-        supported.length > 1 && requested
-            ? (requested as "low" | "high")
-            : supported[0];
+        supported.length > 1 && requested ? requested : supported[0];
     c.var.track.setPricingInput({ searchContextSize });
     return {
         requestData: {

--- a/gen.pollinations.ai/test/text/azureResponsesClient.test.ts
+++ b/gen.pollinations.ai/test/text/azureResponsesClient.test.ts
@@ -213,6 +213,42 @@ describe("callAzureResponses", () => {
         });
     });
 
+    it("always sends the configured Azure web-search tool", async () => {
+        let body: Record<string, unknown> | undefined;
+        vi.spyOn(globalThis, "fetch").mockImplementation(
+            async (_input, init) => {
+                body = JSON.parse(String(init?.body));
+                return Response.json({
+                    id: "resp_search",
+                    model: "gpt-5.4-nano",
+                    status: "completed",
+                    output: [],
+                });
+            },
+        );
+
+        await callAzureResponses([{ role: "user", content: "Latest news" }], {
+            model: "gpt-5.4-nano",
+            modelConfig,
+            azureWebSearch: true,
+            web_search_options: { search_context_size: "high" },
+            tools: [
+                {
+                    type: "function",
+                    function: { name: "ignored", parameters: {} },
+                },
+            ],
+            tool_choice: "none",
+            parallel_tool_calls: true,
+        });
+
+        expect(body).toMatchObject({
+            tools: [{ type: "web_search", search_context_size: "high" }],
+            tool_choice: "required",
+        });
+        expect(body).not.toHaveProperty("parallel_tool_calls");
+    });
+
     it("maps output, tool calls, finish reason, and every billable usage field", async () => {
         mockJson({
             id: "resp_tool",
@@ -226,7 +262,21 @@ describe("callAzureResponses", () => {
                 },
                 {
                     type: "message",
-                    content: [{ type: "output_text", text: "Calling." }],
+                    content: [
+                        {
+                            type: "output_text",
+                            text: "Calling.",
+                            annotations: [
+                                {
+                                    type: "url_citation",
+                                    start_index: 0,
+                                    end_index: 8,
+                                    title: "Weather",
+                                    url: "https://example.com/weather",
+                                },
+                            ],
+                        },
+                    ],
                 },
                 {
                     type: "function_call",
@@ -245,6 +295,7 @@ describe("callAzureResponses", () => {
                 output_tokens_details: { reasoning_tokens: 3 },
                 total_tokens: 15,
             },
+            tool_usage: { web_search: { num_requests: 2 } },
         });
 
         const completion = await callAzureResponses(
@@ -264,6 +315,17 @@ describe("callAzureResponses", () => {
                         content: "Calling.",
                         refusal: null,
                         reasoning_content: "Checked.",
+                        annotations: [
+                            {
+                                type: "url_citation",
+                                url_citation: {
+                                    start_index: 0,
+                                    end_index: 8,
+                                    title: "Weather",
+                                    url: "https://example.com/weather",
+                                },
+                            },
+                        ],
                         tool_calls: [
                             {
                                 id: "call_9",
@@ -285,6 +347,7 @@ describe("callAzureResponses", () => {
                 },
                 completion_tokens: 5,
                 completion_tokens_details: { reasoning_tokens: 3 },
+                server_tool_use_details: { web_search_requests: 2 },
                 total_tokens: 15,
             },
         });
@@ -307,7 +370,8 @@ describe("callAzureResponses", () => {
         mockStream([
             'data: {"type":"response.created","response":{"id":"resp_stream","created_at":1234}}\n\n',
             'data: {"type":"response.output_text.delta","delta":"Hello"}\n\n',
-            'data: {"type":"response.completed","response":{"status":"completed","output":[{"type":"message"}],"usage":{"input_tokens":3,"input_tokens_details":{"cached_tokens":1,"cache_write_tokens":0},"output_tokens":2,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":5}}}\n\n',
+            'data: {"type":"response.output_text.annotation.added","annotation":{"type":"url_citation","start_index":0,"end_index":5,"title":"Hello","url":"https://example.com/hello"}}\n\n',
+            'data: {"type":"response.completed","response":{"status":"completed","output":[{"type":"message"}],"usage":{"input_tokens":3,"input_tokens_details":{"cached_tokens":1,"cache_write_tokens":0},"output_tokens":2,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":5},"tool_usage":{"web_search":{"num_requests":1}}}}\n\n',
         ]);
         const completion = await callAzureResponses(
             [{ role: "user", content: "Hi" }],
@@ -333,8 +397,21 @@ describe("callAzureResponses", () => {
             ],
         });
         expect(output[1].choices[0].delta).toEqual({ content: "Hello" });
-        expect(output[2].choices[0].finish_reason).toBe("stop");
-        expect(output[3]).toMatchObject({
+        expect(output[2].choices[0].delta).toEqual({
+            annotations: [
+                {
+                    type: "url_citation",
+                    url_citation: {
+                        start_index: 0,
+                        end_index: 5,
+                        title: "Hello",
+                        url: "https://example.com/hello",
+                    },
+                },
+            ],
+        });
+        expect(output[3].choices[0].finish_reason).toBe("stop");
+        expect(output[4]).toMatchObject({
             choices: [],
             usage: {
                 prompt_tokens: 3,
@@ -344,10 +421,11 @@ describe("callAzureResponses", () => {
                 },
                 completion_tokens: 2,
                 completion_tokens_details: { reasoning_tokens: 0 },
+                server_tool_use_details: { web_search_requests: 1 },
                 total_tokens: 5,
             },
         });
-        expect(output[4]).toBe("[DONE]");
+        expect(output[5]).toBe("[DONE]");
     });
 
     it("streams reasoning and indexed function-call deltas", async () => {

--- a/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
+++ b/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
@@ -47,6 +47,20 @@ describe("resolveModelConfig", () => {
         expect(result.options.max_tokens).toBeUndefined();
     });
 
+    it("routes openai-search through Azure Responses web search", () => {
+        const model = findModelByName("openai-search");
+
+        expect(model).toMatchObject({
+            useResponsesApi: true,
+            useWebSearch: true,
+        });
+        expect(model?.config()).toMatchObject({
+            provider: "azure-openai",
+            "azure-resource-name": "myceli-prod-eastus",
+            "azure-deployment-id": "gpt-5.4-nano",
+        });
+    });
+
     it("resolves nova-fast to us.amazon.nova-micro-v1:0", () => {
         const result = resolveModelConfig(messages, { model: "nova-fast" });
 

--- a/shared/registry/azure-billing.ts
+++ b/shared/registry/azure-billing.ts
@@ -1,0 +1,41 @@
+import type { BillingRules } from "./registry";
+
+type AzureSearchOutput = {
+    usage?: {
+        server_tool_use_details?: {
+            web_search_requests?: unknown;
+        };
+    };
+    streamEvents?: AzureSearchOutput[];
+};
+
+function countWebSearchRequests(output: unknown): number {
+    const value = output as AzureSearchOutput | undefined;
+    const events = value?.streamEvents ?? (value ? [value] : []);
+    for (const event of [...events].reverse()) {
+        const count = event.usage?.server_tool_use_details?.web_search_requests;
+        if (typeof count === "number" && Number.isFinite(count) && count > 0) {
+            return count;
+        }
+    }
+    return 0;
+}
+
+export const AZURE_WEB_SEARCH_BILLING: BillingRules = {
+    adjustments: [
+        {
+            id: "azure.bing.web_search.v1",
+            description:
+                "Azure Grounding with Bing adds $14 / 1K search requests reported by provider usage.",
+            kind: "search_request",
+            unit: "request",
+            unitCost: 14 / 1_000,
+            publicPricing: {
+                label: "Search",
+                quantity: 1_000,
+                unit: "search requests",
+            },
+            countUnits: countWebSearchRequests,
+        },
+    ],
+};

--- a/shared/registry/cost-variants.ts
+++ b/shared/registry/cost-variants.ts
@@ -20,7 +20,7 @@ export type PricingInput = {
     quality?: string;
     hasImage?: boolean;
     megapixels?: number;
-    searchContextSize?: "low" | "high";
+    searchContextSize?: "low" | "medium" | "high";
     hasDiarization?: boolean;
     hasPrompt?: boolean;
 };

--- a/shared/registry/registry.ts
+++ b/shared/registry/registry.ts
@@ -189,9 +189,9 @@ export type ModelDefinition = {
     tools?: boolean;
     reasoning?: boolean;
     search?: boolean;
-    // Supported Perplexity search-context sizes; first entry is the default.
+    // Supported web-search context sizes; first entry is the default.
     // A single entry is fixed and ignores request overrides.
-    searchContextSizes?: ("low" | "high")[];
+    searchContextSizes?: ("low" | "medium" | "high")[];
     codeExecution?: boolean;
     contextLength?: number;
     voices?: string[];

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -1,3 +1,4 @@
+import { AZURE_WEB_SEARCH_BILLING } from "./azure-billing";
 import {
     defineCostVariants,
     longContextAbove,
@@ -57,6 +58,32 @@ export const TEXT_SERVICES = {
         outputModalities: ["text"],
         maxReferenceImages: 10, // Azure OpenAI vision limit: 10 images/chat request (provider cap).
         tools: true,
+        contextLength: 400000,
+        isSpecialized: false,
+    },
+    "openai-search": {
+        aliases: [],
+        provider: "azure",
+        brand: "OpenAI",
+        category: "text",
+        addedDate: new Date("2026-08-22").getTime(),
+        paidOnly: true,
+        priceMultiplier: 0.75,
+        cost: {
+            promptTextTokens: perMillion(0.2),
+            promptCachedTokens: perMillion(0.02),
+            completionTextTokens: perMillion(1.25),
+        },
+        billing: AZURE_WEB_SEARCH_BILLING,
+        title: "OpenAI Search",
+        description:
+            "Fast answers grounded in current web sources with inline citations",
+        inputModalities: ["text", "image"],
+        outputModalities: ["text"],
+        maxReferenceImages: 10,
+        tools: false,
+        search: true,
+        searchContextSizes: ["medium", "low", "high"],
         contextLength: 400000,
         isSpecialized: false,
     },

--- a/shared/schemas/openai.ts
+++ b/shared/schemas/openai.ts
@@ -323,7 +323,7 @@ export const CreateChatCompletionRequestSchema = z
                 search_context_size: z.enum(["low", "medium", "high"]),
             })
             .describe(
-                "Controls Perplexity Sonar search context. Pollinations currently supports low and high.",
+                "Controls how much web-search context is provided to supported search models.",
             )
             .optional(),
         temperature: z.number().min(0).max(2).nullable().optional(),
@@ -361,6 +361,16 @@ const ChatCompletionMessageContentBlockSchema = z.union([
         .passthrough(),
 ]);
 
+const ChatCompletionMessageAnnotationSchema = z.object({
+    type: z.literal("url_citation"),
+    url_citation: z.object({
+        start_index: z.number().int().nonnegative(),
+        end_index: z.number().int().nonnegative(),
+        title: z.string(),
+        url: z.url(),
+    }),
+});
+
 const ChatCompletionResponseMessageSchema = z.object({
     content: z.string().nullish(),
     tool_calls: ChatCompletionMessageToolCallsSchema.nullish(),
@@ -382,6 +392,7 @@ const ChatCompletionResponseMessageSchema = z.object({
         .nullish(),
     // DeepSeek reasoning format
     reasoning_content: z.string().nullish(),
+    annotations: z.array(ChatCompletionMessageAnnotationSchema).nullish(),
 });
 
 const ChatCompletionTokenTopLogprobSchema = z.object({


### PR DESCRIPTION
- Adds paid `openai-search` backed by Azure OpenAI Responses `gpt-5.4-nano` with mandatory web search.
- Supports low, medium, and high search context through the existing Chat Completions API.
- Maps URL citations for streaming and non-streaming responses and bills provider-reported search requests.
- Adds focused adapter, routing, registry, and billing coverage; live Azure probe returned one search and one citation.