### PR TITLE
refactor: clarify balance deduction pipeline

### DIFF
--- a/shared/billing/bucket-selection.ts
+++ b/shared/billing/bucket-selection.ts
@@ -5,6 +5,19 @@ export type UserBalance = {
 
 export type BalanceBucket = "tier" | "pack";
 
+/**
+ * Preflight "can the caller afford this estimate" check. This is intentionally
+ * a different question from the authoritative bucket ladder in
+ * `atomicDeductUserBalance`: that function chooses *which* bucket to write to
+ * when money actually moves; this one only asks whether *enough exists* to let
+ * the request proceed before any mutation.
+ *
+ * The two therefore need not use identical thresholds. This preflight clamps
+ * negative estimates to zero and accepts zero-cost coverage. The write path
+ * skips non-positive charges entirely; for a positive actual charge, it uses
+ * Quest Pollen when that bucket covers the charge, otherwise any positive paid
+ * balance, and finally Quest Pollen debt when the paid balance is non-positive.
+ */
 export function canCoverEstimatedCharge(
     balances: UserBalance,
     estimatedCost: number,

--- a/shared/billing/deduction.ts
+++ b/shared/billing/deduction.ts
@@ -14,10 +14,21 @@ const BUCKET_COLUMNS = {
 /**
  * Atomically deducts pollen from user balance.
  *
- * Regular requests are binary: Quest Pollen pays when it can cover the actual
- * charge, pack pays when Quest Pollen cannot cover and pack is positive, and
- * regular overage falls back to Quest Pollen when pack is empty.
- * Paid-only requests always deduct from pack and never touch Quest Pollen.
+ * This is the authoritative deduction ladder — the one place a positive charge
+ * picks a bucket and money actually moves, read top-to-bottom as the `decision`
+ * CASE below. `canCoverEstimatedCharge` answers the separate preflight question
+ * of whether an estimate is affordable, while `createBalanceCheckResult` only
+ * labels a meter for reporting. Neither is an authoritative write-path rule.
+ *
+ *   1. paid-only  → `pack` only (never Quest Pollen)
+ *   2. tier       → Quest Pollen when it covers the full amount (`>=`)
+ *   3. pack       → any positive paid balance when Quest Pollen can't cover
+ *   4. tier       → fall back to Quest Pollen when pack is non-positive
+ *
+ * The final `tier` fall-through is load-bearing: when Quest Pollen cannot cover
+ * the charge and paid balance is non-positive, the charge accrues Quest-Pollen
+ * debt instead of reducing paid balance further. Non-positive amounts return
+ * without selecting a bucket or writing.
  */
 export async function atomicDeductUserBalance(
     db: DrizzleD1Database,

--- a/shared/billing/track-helpers.ts
+++ b/shared/billing/track-helpers.ts
@@ -122,6 +122,13 @@ export function resolveCommunityModelReward(
 /**
  * Handles balance deduction and developer credits for billable requests.
  *
+ * The pipeline, in order:
+ *
+ *   1. resolve markup eligibility (DB lookup) and the community reward (pure),
+ *   2. compute `billedPrice` (baseline + markup, snapped to ledger precision),
+ *   3. deduct the payer (user balance, then API-key budget),
+ *   4. credit the dev (BYOP markup) and community owner (reward).
+ *
  * Returns `billedPrice` — the rounded amount actually debited from the payer
  * (`totalPrice + devCredit`, snapped to `POLLEN_BILLING_PRECISION`). Callers
  * should use this for analytics/event totals so they match the ledger.
@@ -155,21 +162,25 @@ export async function handleBalanceDeduction(params: DeductionParams): Promise<{
         };
     }
 
-    const resolved = await resolveDevMarkup(
+    // 1. Resolve the two independent "who else gets money" inputs.
+    const markup = await resolveDevMarkup(
         db,
         byopClientKeyId,
         totalPrice,
         userId,
     );
-    const markup: MarkupResolution | null = resolved;
     const communityModelReward = resolveCommunityModelReward(
         communityModelRewardInput,
         totalPrice,
         userId,
     );
-    const billedPrice = roundPollenLedgerAmount(
-        totalPrice + (markup?.devCredit ?? 0),
-    );
+
+    // 2. The payer is charged baseline + markup (the community reward is paid
+    //    out of the baseline, not added on top of what the payer owes).
+    const billedPrice = computeBilledPrice(totalPrice, markup);
+
+    // 3. Deduct the payer. Markup and reward credits go to the same bucket the
+    //    payer drew from, so they are only possible once that bucket is known.
     let payerBucket: Bucket | null = null;
     let postDeductionPackBalance: number | null = null;
 
@@ -191,110 +202,16 @@ export async function handleBalanceDeduction(params: DeductionParams): Promise<{
             await deductApiKeyBalance(db, apiKeyId, billedPrice);
         }
 
+        // 4. Credits. Both require a payer bucket (nothing to net against
+        //    otherwise) and write to it so the flows stay in balance.
         if (markup) {
-            if (!payerBucket) {
-                throw new Error("BYOP markup requires a payer balance bucket");
-            }
-            const creditBucket = payerBucket;
-            const creditAmount = roundPollenLedgerAmount(markup.devCredit);
-            const { ok } = await atomicCreditUserBalance(
-                db,
-                markup.devUserId,
-                creditBucket,
-                creditAmount,
-            );
-            if (!ok) {
-                throw new Error(
-                    `Dev credit UPDATE affected 0 rows for ${markup.devUserId}`,
-                );
-            }
-            log.debug(
-                "Credited {credit} pollen to dev {devUserId} {bucket} balance (markup={pct}%)",
-                {
-                    credit: creditAmount,
-                    devUserId: markup.devUserId,
-                    bucket: creditBucket,
-                    pct: (markup.markupRate * 100).toFixed(0),
-                },
-            );
+            await creditDev(db, markup, payerBucket);
         }
-
         if (communityModelReward) {
-            if (!payerBucket) {
-                throw new Error(
-                    "Community model reward requires a payer balance bucket",
-                );
-            }
-            const creditAmount = communityModelReward.credit;
-            const { ok } = await atomicCreditUserBalance(
-                db,
-                communityModelReward.userId,
-                payerBucket,
-                creditAmount,
-            );
-            if (!ok) {
-                throw new Error(
-                    `Community model reward UPDATE affected 0 rows for ${communityModelReward.userId}`,
-                );
-            }
-            log.debug(
-                "Credited {credit} pollen to community model owner {userId} {bucket} balance (reward={pct}%)",
-                {
-                    credit: creditAmount,
-                    userId: communityModelReward.userId,
-                    bucket: payerBucket,
-                    pct: (communityModelReward.rewardRate * 100).toFixed(0),
-                },
-            );
+            await creditCommunityOwner(db, communityModelReward, payerBucket);
         }
     } catch (error) {
-        if (communityModelReward) {
-            if (
-                error instanceof Error &&
-                error.message.startsWith("Community model reward")
-            ) {
-                log.error(
-                    "Community model reward failed for {userId}: {error}",
-                    {
-                        userId: communityModelReward.userId,
-                        error: error.message,
-                    },
-                );
-            } else {
-                log.error(
-                    "Failed to bill community model request for owner {userId}: {error}",
-                    {
-                        userId: communityModelReward.userId,
-                        error:
-                            error instanceof Error
-                                ? error.message
-                                : String(error),
-                    },
-                );
-            }
-        }
-        if (markup) {
-            if (
-                error instanceof Error &&
-                error.message.startsWith("Dev credit")
-            ) {
-                log.error("Dev credit failed for {devUserId}: {error}", {
-                    devUserId: markup.devUserId,
-                    error: error.message,
-                });
-            } else {
-                log.error(
-                    "Failed to bill BYOP request for dev {devUserId}: {error}",
-                    {
-                        devUserId: markup.devUserId,
-                        error:
-                            error instanceof Error
-                                ? error.message
-                                : String(error),
-                    },
-                );
-            }
-        }
+        logBillingFailure(error, markup, communityModelReward);
         throw error;
     }
 
@@ -305,6 +222,120 @@ export async function handleBalanceDeduction(params: DeductionParams): Promise<{
         postDeductionPackBalance,
         billedPrice,
     };
+}
+
+/** Baseline charge + dev markup, snapped to the shared ledger precision. */
+function computeBilledPrice(
+    totalPrice: number,
+    markup: MarkupResolution | null,
+): number {
+    return roundPollenLedgerAmount(totalPrice + (markup?.devCredit ?? 0));
+}
+
+/** Credit the dev the BYOP markup, into the bucket the payer drew from. */
+async function creditDev(
+    db: DrizzleD1Database,
+    markup: MarkupResolution,
+    payerBucket: Bucket | null,
+): Promise<void> {
+    if (!payerBucket) {
+        throw new Error("BYOP markup requires a payer balance bucket");
+    }
+    const creditAmount = roundPollenLedgerAmount(markup.devCredit);
+    const { ok } = await atomicCreditUserBalance(
+        db,
+        markup.devUserId,
+        payerBucket,
+        creditAmount,
+    );
+    if (!ok) {
+        throw new Error(
+            `Dev credit UPDATE affected 0 rows for ${markup.devUserId}`,
+        );
+    }
+    log.debug(
+        "Credited {credit} pollen to dev {devUserId} {bucket} balance (markup={pct}%)",
+        {
+            credit: creditAmount,
+            devUserId: markup.devUserId,
+            bucket: payerBucket,
+            pct: (markup.markupRate * 100).toFixed(0),
+        },
+    );
+}
+
+/** Credit the community model owner their reward, into the payer's bucket. */
+async function creditCommunityOwner(
+    db: DrizzleD1Database,
+    reward: CommunityModelRewardResolution,
+    payerBucket: Bucket | null,
+): Promise<void> {
+    if (!payerBucket) {
+        throw new Error(
+            "Community model reward requires a payer balance bucket",
+        );
+    }
+    const { ok } = await atomicCreditUserBalance(
+        db,
+        reward.userId,
+        payerBucket,
+        reward.credit,
+    );
+    if (!ok) {
+        throw new Error(
+            `Community model reward UPDATE affected 0 rows for ${reward.userId}`,
+        );
+    }
+    log.debug(
+        "Credited {credit} pollen to community model owner {userId} {bucket} balance (reward={pct}%)",
+        {
+            credit: reward.credit,
+            userId: reward.userId,
+            bucket: payerBucket,
+            pct: (reward.rewardRate * 100).toFixed(0),
+        },
+    );
+}
+
+/** Log a pipeline failure with the same severity and labels as before. */
+function logBillingFailure(
+    error: unknown,
+    markup: MarkupResolution | null,
+    communityModelReward: CommunityModelRewardResolution | null,
+): void {
+    const message = error instanceof Error ? error.message : String(error);
+    const isCommunityCreditFailure =
+        error instanceof Error &&
+        error.message.startsWith("Community model reward");
+    const isDevCreditFailure =
+        error instanceof Error && error.message.startsWith("Dev credit");
+
+    if (communityModelReward) {
+        if (isCommunityCreditFailure) {
+            log.error("Community model reward failed for {userId}: {error}", {
+                userId: communityModelReward.userId,
+                error: message,
+            });
+        } else {
+            log.error(
+                "Failed to bill community model request for owner {userId}: {error}",
+                { userId: communityModelReward.userId, error: message },
+            );
+        }
+    }
+    if (markup) {
+        if (isDevCreditFailure) {
+            log.error("Dev credit failed for {devUserId}: {error}", {
+                devUserId: markup.devUserId,
+                error: message,
+            });
+        } else {
+            log.error(
+                "Failed to bill BYOP request for dev {devUserId}: {error}",
+                { devUserId: markup.devUserId, error: message },
+            );
+        }
+    }
 }
 
 function hasApiKeyBudget(


### PR DESCRIPTION
- Extracts the billing flow into named resolve, compute, deduct, and credit steps.
- Deduplicates developer and community-owner credit handling without changing execution order.
- Preserves SQL, balance thresholds, rounding, errors, logging, and return shapes.
- Documents the authoritative deduction ladder and separates it from preflight/reporting behavior.

Checks:
- `npm run typecheck` (gen.pollinations.ai)
- `npm run test` — 104 files passed; 1,248 tests passed, 6 skipped
- `npx biome check --write shared/billing/bucket-selection.ts shared/billing/deduction.ts shared/billing/track-helpers.ts`