### PR TITLE
chore: use staging Tinybird reader locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -314,6 +314,7 @@ text.pollinations.ai/v2/
 # Local Netlify folder
 .netlify
 .dev.vars
+.dev.vars.tmp
 .wrangler/
 
 # Crush Dev Agent

--- a/operations/economics/README.md
+++ b/operations/economics/README.md
@@ -18,9 +18,10 @@ Use fixtures mode for UI development without password or Tinybird access:
 http://127.0.0.1:4180/?fixtures=1
 ```
 
-Live mode uses a password gate. The Tinybird read token lives only in
-`secrets/web.json` and is exposed only to the local/production Worker, never to
-the browser bundle.
+Live mode uses a password gate. Local development reads the staging Tinybird
+workspace through `secrets/web.dev.json`; production reads the production
+workspace through `secrets/web.json`. The credentials are exposed only to the
+Worker, never to the browser bundle.
 
 Production deploys through `.github/workflows/deploy-applications.yml`
 on the `production` branch. The workflow deploys the Worker with both custom

--- a/operations/economics/secrets/web.dev.json
+++ b/operations/economics/secrets/web.dev.json
@@ -1,0 +1,15 @@
+{
+	"TINYBIRD_ECONOMICS_READ_TOKEN": "ENC[AES256_GCM,data:S0XLeAJVgR2kHN9l3fYHuZBnF0PVhEeOC+PO8yT15yA4qW/NukN6tMwDwMcblga21UmfCtR3xZEcGNWVCt2CkzLyAdgGf0VWlk2D9ixKny1K63jOdb7WhV7o/DWHpOC5h2yw0rW8jrV59II/K61rh0e5QhZXeVOFNzP1lhSFNeyNLlMsbTWnanxU7Id0Qdr8TsluB72eYaV5NWdtaoJ1GAVx6j1U4xvjFYfASMu3sbT2SF8kOE7c5kja1inkihYbMIBqs83Evp3lG2mzPA==,iv:bNzFaS+kTzFTYnBPgH4d88H2Ukqtar6l3enY2JdmWWw=,tag:3GsX0UjwkrWDag5/YXsNVA==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"recipient": "age1djc5mjmpvfaqzw5pgujfeqglrrqw05fmjmnnu4zcv2h7xkn2av2q67c7rt",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzdVArQ3l6alcrUmtXQndE\na1Z1ZHU4aUpBVW9tTUN4RWRrRGlrNS96M3hZCkp1aU5yWjhuYXR2MGpjTGN0aThk\nbzRWVitBSFZNb2crbkJvU2UzWnhpMmsKLS0tIHlDNFgwUHNwWnZ1YTFDQ2ZwMllX\nb2gxei9hRGlBQUh3Zjc1dlBpUy96UncKZl9gupXWjqdsOpMhgi/BfkADeEsnK4N4\n2IGh2/Eu1DKQ/0pZOQKtG95Y648YHV0HcmKPZFKfDSnGfCOEcvTpZg==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2026-08-22T18:09:47Z",
+		"mac": "ENC[AES256_GCM,data:Us5aAlhrLE4Km1skIO1FGBCzOR/mKycJ54F7V3eLuFA3xkrY5Tp659w93rb5DWzkCU0Jhl8a2e0pIFQofRmgt9rTwRhfUmfxfqKeZ026qNNnZCFClWvaQIP+U3xrUAYZ5gaI3JO1lV948+7lgWw++I4CHtMbJPIKfdCCzpJ7l/c=,iv:nEWCkUKE4KGpBcgLv3gyra9jnY/zY1sFpT9pDquU94Q=,tag:Yl9Hxv8vSJqIQjdtMewUxQ==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.11.0"
+	}
+}

--- a/operations/economics/web/README.md
+++ b/operations/economics/web/README.md
@@ -16,8 +16,10 @@ npm run dev
 The dev server is pinned to `http://127.0.0.1:4180`.
 
 Auth uses a password gate backed by the Cloudflare Worker. For local development,
-the pipe-scoped Tinybird read token is decrypted from `../secrets/web.json` into
-the ignored `.dev.vars` file and is never bundled or stored in the browser.
+the shared password and the staging-only Tinybird reader are assembled from
+`../secrets/web.json` and `../secrets/web.dev.json` into the ignored `.dev.vars`
+file. Production deployment continues to use `../secrets/web.json`. No secret is
+bundled or stored in the browser.
 
 ## Fixtures Mode
 

--- a/operations/economics/web/package.json
+++ b/operations/economics/web/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "predev": "npm run build --prefix ../../../packages/ui && npm run decrypt-vars",
-    "decrypt-vars": "sops decrypt ../secrets/web.json --output .dev.vars --output-type dotenv",
+    "decrypt-vars": "sops exec-env ../secrets/web.json 'sops exec-env ../secrets/web.dev.json \"node scripts/write-dev-vars.mjs\"'",
     "build": "vite build",
     "prebuild": "npm run build --prefix ../../../packages/ui",
     "deploy": "npm run build && wrangler deploy",

--- a/operations/economics/web/scripts/write-dev-vars.mjs
+++ b/operations/economics/web/scripts/write-dev-vars.mjs
@@ -1,0 +1,20 @@
+import { chmod, rename, writeFile } from "node:fs/promises";
+
+function required(name) {
+    const value = process.env[name];
+    if (!value) throw new Error(`Missing ${name}`);
+    return value;
+}
+
+const target = new URL("../.dev.vars", import.meta.url);
+const temporary = new URL("../.dev.vars.tmp", import.meta.url);
+const contents = [
+    `ECONOMICS_PASSWORD=${JSON.stringify(required("ECONOMICS_PASSWORD"))}`,
+    `TINYBIRD_ECONOMICS_READ_TOKEN=${JSON.stringify(required("TINYBIRD_ECONOMICS_READ_TOKEN"))}`,
+    "",
+].join("\n");
+
+await writeFile(temporary, contents, { mode: 0o600 });
+await rename(temporary, target);
+await chmod(target, 0o600);
+console.log("Wrote .dev.vars with the staging Tinybird reader.");


### PR DESCRIPTION
- Adds the encrypted staging-only Tinybird reader for Economics local development.
- Builds the ignored .dev.vars atomically from the existing password and staging reader.
- Keeps production on the existing production Tinybird configuration.
- Documents the local and production workspace split.

Verification: 172 tests pass; TypeScript clean; decrypted file permissions are 0600.