### PR TITLE
feat: add private media upload entrypoint

### DIFF
--- a/media.pollinations.ai/package.json
+++ b/media.pollinations.ai/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
+    "deploy:staging": "wrangler deploy --env staging",
     "deploy:production": "wrangler deploy --env production",
     "migrate:production": "wrangler d1 migrations apply DB --remote --env production",
     "apply-lifecycle:production": "wrangler r2 bucket lifecycle set pollinations-media --file r2-lifecycle.json --force",

--- a/media.pollinations.ai/src/index.ts
+++ b/media.pollinations.ai/src/index.ts
@@ -23,6 +23,8 @@ import {
     tagsForItems,
 } from "./catalog.ts";
 
+export { MediaUpload } from "./media-upload.ts";
+
 const DOMAIN = "media.pollinations.ai";
 // gen.pollinations.ai proxies /account/* to enter — using the public path
 // keeps internal services consistent with the documented SDK/external usage.

--- a/media.pollinations.ai/src/media-upload.ts
+++ b/media.pollinations.ai/src/media-upload.ts
@@ -1,0 +1,75 @@
+import { WorkerEntrypoint } from "cloudflare:workers";
+
+const DEFAULT_MAX_SIZE = 100 * 1024 * 1024;
+const IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable";
+
+type MediaUploadEnv = {
+    MEDIA_BUCKET: R2Bucket;
+    MAX_FILE_SIZE: string;
+};
+
+export type UnlistedMediaUpload = {
+    contentType: string;
+    fileName?: string;
+    size: number;
+};
+
+export type UnlistedMediaUploadResult = {
+    id: string;
+    url: string;
+    contentType: string;
+    size: number;
+};
+
+export async function uploadUnlistedMedia(
+    env: MediaUploadEnv,
+    body: ReadableStream<Uint8Array>,
+    input: UnlistedMediaUpload,
+): Promise<UnlistedMediaUploadResult> {
+    const maxSize = parseInt(env.MAX_FILE_SIZE, 10) || DEFAULT_MAX_SIZE;
+    if (!Number.isSafeInteger(input.size) || input.size <= 0) {
+        throw new Error("Media size must be a positive integer");
+    }
+    if (input.size > maxSize) {
+        throw new Error(`Media exceeds ${maxSize} bytes`);
+    }
+
+    const id = crypto.randomUUID();
+    const contentType = input.contentType || "application/octet-stream";
+    const upload = new FixedLengthStream(input.size);
+    body.pipeTo(upload.writable).catch(() => undefined);
+    try {
+        await env.MEDIA_BUCKET.put(id, upload.readable, {
+            httpMetadata: {
+                contentType,
+                cacheControl: IMMUTABLE_CACHE_CONTROL,
+            },
+            customMetadata: {
+                uploadedAt: new Date().toISOString(),
+                originalName: input.fileName?.slice(0, 253) || "",
+                uploadedBy: "pollinations-service",
+                keyType: "service",
+            },
+        });
+    } catch (error) {
+        throw new Error(
+            `R2 upload failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        );
+    }
+
+    return {
+        id,
+        url: `https://media.pollinations.ai/${id}`,
+        contentType,
+        size: input.size,
+    };
+}
+
+export class MediaUpload extends WorkerEntrypoint<MediaUploadEnv> {
+    upload(
+        body: ReadableStream<Uint8Array>,
+        input: UnlistedMediaUpload,
+    ): Promise<UnlistedMediaUploadResult> {
+        return uploadUnlistedMedia(this.env, body, input);
+    }
+}

--- a/media.pollinations.ai/test/integration.test.ts
+++ b/media.pollinations.ai/test/integration.test.ts
@@ -12,6 +12,7 @@ import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import app from "../src/index";
+import { uploadUnlistedMedia } from "../src/media-upload.ts";
 
 // 1x1 red PNG (67 bytes)
 const TINY_PNG = new Uint8Array([
@@ -220,6 +221,47 @@ describe("media.pollinations.ai", () => {
         const body = (await res.json()) as Record<string, unknown>;
         expect(res.status).toBe(200);
         expect(body.service).toBe("media.pollinations.ai");
+    });
+
+    it("stores streamed unlisted media for internal services", async () => {
+        const bucket = createTestR2Bucket();
+        const upload = await uploadUnlistedMedia(
+            createMediaEnv(bucket),
+            new Blob([TINY_PNG]).stream(),
+            {
+                contentType: "image/png",
+                fileName: "ffmpeg.png",
+                size: TINY_PNG.length,
+            },
+        );
+
+        expect(upload.url).toBe(`https://media.pollinations.ai/${upload.id}`);
+        const object = bucket.getObject(upload.id);
+        expect(object?.body).toEqual(TINY_PNG);
+        expect(object?.httpMetadata?.contentType).toBe("image/png");
+        expect(object?.customMetadata?.uploadedBy).toBe("pollinations-service");
+    });
+
+    it("rejects invalid internal upload sizes before writing to R2", async () => {
+        const bucket = createTestR2Bucket();
+        const mediaEnv = {
+            ...createMediaEnv(bucket),
+            MAX_FILE_SIZE: "10",
+        };
+
+        await expect(
+            uploadUnlistedMedia(mediaEnv, new Blob([TINY_PNG]).stream(), {
+                contentType: "image/png",
+                size: 0,
+            }),
+        ).rejects.toThrow("Media size must be a positive integer");
+        await expect(
+            uploadUnlistedMedia(mediaEnv, new Blob([TINY_PNG]).stream(), {
+                contentType: "image/png",
+                size: 11,
+            }),
+        ).rejects.toThrow("Media exceeds 10 bytes");
+        expect(bucket.putCount).toBe(0);
     });
 
     it("POST /upload without key returns 401", async () => {

--- a/media.pollinations.ai/wrangler.toml
+++ b/media.pollinations.ai/wrangler.toml
@@ -21,6 +21,24 @@ database_name = "development-pollinations-enter-db"
 database_id = "2b844596-9890-4a2e-9da9-6c65681fa24d"
 migrations_dir = "../enter.pollinations.ai/drizzle"
 
+# Private staging Worker used through service bindings.
+[env.staging]
+name = "pollinations-media-staging"
+workers_dev = false
+
+[env.staging.vars]
+MAX_FILE_SIZE = "104857600"
+
+[[env.staging.r2_buckets]]
+binding = "MEDIA_BUCKET"
+bucket_name = "pollinations-media"
+
+[[env.staging.d1_databases]]
+binding = "DB"
+database_name = "staging-pollinations-enter-db"
+database_id = "2cb1cf1a-a18a-4cad-a4bb-be64e3c0e39f"
+migrations_dir = "../enter.pollinations.ai/drizzle"
+
 # Production environment
 [env.production]
 name = "pollinations-media-prod"


### PR DESCRIPTION
- Adds a private Worker entrypoint for streamed service-owned media uploads
- Stores unlisted outputs in the existing Media R2 bucket with immutable metadata
- Validates declared sizes before writing and caps uploads at the configured limit
- Adds a staging Media Worker environment for service-binding integration
- Covers streamed storage and invalid-size rejection