### PR TITLE
feat: add X showcase quest

### DIFF
--- a/.github/ISSUE_TEMPLATE/x-showcase.yml
+++ b/.github/ISSUE_TEMPLATE/x-showcase.yml
@@ -1,0 +1,49 @@
+name: X Showcase Quest
+description: Submit an original Pollinations showcase post for a 1 Pollen reward
+title: "[X-SHOWCASE]: "
+labels: [".REQUEST"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Share something original that you built or created with Pollinations on X.
+
+        Include `POLLEN-YOUR_GITHUB_USERNAME` in the post so maintainers can verify that you control it. Approved submissions earn **1 Pollen**. One reward is available per GitHub user.
+
+  - type: input
+    id: post
+    attributes:
+      label: X post
+      description: Link to your public post. It must contain your GitHub proof string.
+      placeholder: https://x.com/your-account/status/...
+    validations:
+      required: true
+
+  - type: textarea
+    id: creation
+    attributes:
+      label: What did you make?
+      description: Briefly explain how the post's image, media, project, or example uses Pollinations.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: requirements
+    attributes:
+      label: Requirements
+      options:
+        - label: I created this post, and it includes `POLLEN-` followed by my GitHub username.
+          required: true
+        - label: The post is original and meaningfully shows or explains something made with Pollinations.
+          required: true
+        - label: The post mentions `@pollinations_ai` and discloses that it is eligible for a creator-quest reward.
+          required: true
+        - label: I will not make duplicate posts or use multiple accounts to enter.
+          required: true
+        - label: I have not previously claimed this quest.
+          required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        A maintainer will review the post. If approved, a claimable reward will appear on [Enter Quests](https://enter.pollinations.ai/quests).

--- a/.github/ISSUE_TEMPLATE/x-showcase.yml
+++ b/.github/ISSUE_TEMPLATE/x-showcase.yml
@@ -1,6 +1,6 @@
 name: X Showcase Quest
 description: Submit an original Pollinations showcase post for a 1 Pollen reward
-title: "[X-SHOWCASE]: "
+title: "[CREATOR-QUEST][X-SHOWCASE]: "
 labels: [".REQUEST"]
 body:
   - type: markdown

--- a/enter.pollinations.ai/src/routes/quests.ts
+++ b/enter.pollinations.ai/src/routes/quests.ts
@@ -18,9 +18,8 @@ import type {
 } from "../services/quests/types.ts";
 import { requireAccountPermission } from "./account-permissions.ts";
 
-// Bumped to v26: established GitHub, app_paid_request, and app_users_10 are
-// available; Early Adopter and app_pollen_10 are visible as coming soon.
-const CACHE_KEY = "quests:catalog:v26";
+// Bumped to v28: the X showcase submission quest is available.
+const CACHE_KEY = "quests:catalog:v28";
 const CACHE_TTL = 60;
 const QUEST_CHECK_THROTTLE_SECONDS = 60;
 

--- a/enter.pollinations.ai/src/services/quests/groups/social-submissions.ts
+++ b/enter.pollinations.ai/src/services/quests/groups/social-submissions.ts
@@ -1,0 +1,35 @@
+import type { QuestDefinition } from "../definitions.ts";
+import type {
+    QuestCard,
+    QuestEvaluation,
+    QuestEvaluationContext,
+    QuestUser,
+} from "../types.ts";
+import { questToCard } from "../types.ts";
+
+const xShowcaseQuest: QuestDefinition = {
+    // Matches campaignId "x_showcase" in the admin grant endpoint.
+    id: "grant:x_showcase",
+    title: "Share a creation on X",
+    description:
+        "Post something original that you built or created with Pollinations, then submit it for review.",
+    category: "community",
+    scope: "perUser",
+    rewardAmount: 1,
+    balanceBucket: "tier",
+    url: "https://github.com/pollinations/pollinations/issues/new?template=x-showcase.yml",
+};
+
+export async function listQuestCards(
+    _ctx: QuestEvaluationContext,
+): Promise<QuestCard[]> {
+    return [questToCard(xShowcaseQuest)];
+}
+
+export async function evaluateUser(
+    _ctx: QuestEvaluationContext,
+    _user: QuestUser,
+): Promise<QuestEvaluation> {
+    // Completion is recorded after maintainer review through /admin/quest-grants.
+    return { proposals: [] };
+}

--- a/enter.pollinations.ai/src/services/quests/index.ts
+++ b/enter.pollinations.ai/src/services/quests/index.ts
@@ -4,12 +4,14 @@ import * as githubContributions from "./groups/github-contributions.ts";
 import * as githubProfile from "./groups/github-profile.ts";
 import * as identity from "./groups/identity.ts";
 import * as modelUsage from "./groups/model-usage.ts";
+import * as socialSubmissions from "./groups/social-submissions.ts";
 import type { QuestCard, QuestEvaluationContext, QuestGroup } from "./types.ts";
 
 export const QUEST_GROUPS: QuestGroup[] = [
     { id: "account-setup", ...accountSetup },
     { id: "app-growth", ...appGrowth },
     { id: "model-usage", ...modelUsage },
+    { id: "social-submissions", ...socialSubmissions },
     { id: "github-profile", ...githubProfile },
     { id: "github-contributions", ...githubContributions },
     { id: "identity", ...identity },

--- a/enter.pollinations.ai/test/quests.test.ts
+++ b/enter.pollinations.ai/test/quests.test.ts
@@ -273,7 +273,7 @@ test("catalog returns quest definitions without ledger stats", async ({
     sessionToken: _sessionToken,
 }) => {
     await mocks.enable("github");
-    await env.KV.delete("quests:catalog:v26");
+    await env.KV.delete("quests:catalog:v28");
 
     const response = await SELF.fetch(
         "http://localhost:3000/api/quests/catalog",
@@ -341,6 +341,11 @@ test("catalog returns quest definitions without ledger stats", async ({
         rewardAmount: 10,
         balanceBucket: "tier",
     });
+    expectStableCatalogFields("grant:x_showcase", {
+        state: "available",
+        rewardAmount: 1,
+        balanceBucket: "tier",
+    });
     expectStableCatalogFields("use_app", {
         state: "available",
         rewardAmount: 0.25,
@@ -392,7 +397,7 @@ test("catalog includes coming-soon GitHub issue placeholder", async ({
     sessionToken: _sessionToken,
 }) => {
     await mocks.enable("github");
-    await env.KV.delete("quests:catalog:v26");
+    await env.KV.delete("quests:catalog:v28");
 
     const response = await SELF.fetch(
         "http://localhost:3000/api/quests/catalog",
@@ -430,7 +435,7 @@ test("catalog excludes closed GitHub quest issues without merged PRs", async ({
     sessionToken: _sessionToken,
 }) => {
     await mocks.enable("github");
-    await env.KV.delete("quests:catalog:v26");
+    await env.KV.delete("quests:catalog:v28");
 
     seedQuestIssue(mocks.github.state, {
         issueNumber: 801,
@@ -476,7 +481,7 @@ test("account quests merge earned rewards into completed status", async ({
 }) => {
     const db = drizzle(env.DB, { schema });
     await mocks.enable("github", "tinybird");
-    await env.KV.delete("quests:catalog:v26");
+    await env.KV.delete("quests:catalog:v28");
     const user = await getOnlyUser();
 
     const createKeyResponse = await SELF.fetch(


### PR DESCRIPTION
- Adds an X showcase issue form with identity proof and anti-abuse requirements
- Adds a 1 Pollen creator quest that reuses the existing reviewed grant flow
- Reuses the creator-submissions group introduced by #13727
- Keeps review manual; no X API or account-linking dependency

Stacked on #13727; merge that PR first.