### PR TITLE
fix: make self-owned community model calls free

### DIFF
--- a/gen.pollinations.ai/src/byop-markup.test.ts
+++ b/gen.pollinations.ai/src/byop-markup.test.ts
@@ -794,7 +794,7 @@ describe("BYOP markup", () => {
         );
     });
 
-    it("credits a community model owner for their own request", async () => {
+    it("does not charge or reward a community model owner for their own request", async () => {
         const ownerId = await createBalanceUser("community-owner", {
             tier: 2,
             pack: 0,
@@ -812,15 +812,8 @@ describe("BYOP markup", () => {
                 },
             });
 
-        expect(billedPrice).toBe(1);
-        expect(communityModelReward).toEqual({
-            userId: ownerId,
-            rewardRate: COMMUNITY_MODEL_REWARD_RATE,
-            credit: COMMUNITY_MODEL_REWARD_RATE,
-        });
-        expect((await getUserBalance(db, ownerId)).tierBalance).toBeCloseTo(
-            2 - 1 + COMMUNITY_MODEL_REWARD_RATE,
-            10,
-        );
+        expect(billedPrice).toBe(0);
+        expect(communityModelReward).toBeNull();
+        expect((await getUserBalance(db, ownerId)).tierBalance).toBe(2);
     });
 });

--- a/shared/billing/track-helpers.ts
+++ b/shared/billing/track-helpers.ts
@@ -162,6 +162,20 @@ export async function handleBalanceDeduction(params: DeductionParams): Promise<{
         };
     }
 
+    // The caller already bears the upstream cost of their own community
+    // endpoint. Do not charge them through Pollinations or pay them back a
+    // partial reward. The reward input follows the endpoint that actually
+    // served the request, so a fallback owned by somebody else is still billed.
+    if (communityModelRewardInput?.userId === userId) {
+        return {
+            markup: null,
+            communityModelReward: null,
+            payerBucket: null,
+            postDeductionPackBalance: null,
+            billedPrice: 0,
+        };
+    }
+
     // 1. Resolve the two independent "who else gets money" inputs.
     const markup = await resolveDevMarkup(
         db,


### PR DESCRIPTION
- Skips wallet and API-key budget deductions when a public community endpoint serves its owner
- Skips the circular 75% owner reward for the same request
- Keeps normal billing when another owner's endpoint serves a fallback

Tests: `npm exec vitest -- run src/byop-markup.test.ts` (26 passed); `npm run typecheck --workspace pollinations-gen`

Fixes #13700