### PR TITLE
fix: reward private fallbacks at served price

### DIFF
--- a/gen.pollinations.ai/src/middleware/track.ts
+++ b/gen.pollinations.ai/src/middleware/track.ts
@@ -399,6 +399,7 @@ export const track = (eventType: EventType) =>
                                   ? {
                                         userId: requestedCommunityEndpoint.ownerUserId,
                                         rewardRate: COMMUNITY_MODEL_REWARD_RATE,
+                                        basePrice: responseTracking.servedPrice,
                                     }
                                   : null,
                     });

--- a/gen.pollinations.ai/test/tracking-observability.test.ts
+++ b/gen.pollinations.ai/test/tracking-observability.test.ts
@@ -1549,6 +1549,10 @@ describe("tracking observability", () => {
             modelId: "test-owner/private-fallback",
             name: "private-fallback",
             visibility: "private",
+            ...communityEndpointPrices({
+                promptTextPrice: 0.00005,
+                completionTextPrice: 0.0001,
+            }),
         });
         const fallbackEntry = createCommunityEntry(fallbackEndpoint);
         const model: ModelVariables["model"] = {
@@ -1609,7 +1613,7 @@ describe("tracking observability", () => {
             totalPrice: 0.2,
             communityModelRewardUserId: ownerId,
             communityModelRewardRate: COMMUNITY_MODEL_REWARD_RATE,
-            communityModelRewardAmount: 0.15,
+            communityModelRewardAmount: 0.075,
         });
 
         const [owner] = await db
@@ -1617,7 +1621,7 @@ describe("tracking observability", () => {
             .from(userTable)
             .where(eq(userTable.id, ownerId))
             .limit(1);
-        expect(owner?.tierBalance).toBeCloseTo(0.15, 10);
+        expect(owner?.tierBalance).toBeCloseTo(0.075, 10);
     });
 
     it("does not bill image generation that returns a JSON (non-image) content-type", async () => {


### PR DESCRIPTION
- Keeps the caller charge fixed to the requested public listing price
- Calculates the owner reward from the private fallback's own served price
- Preserves the existing 75% reward rate and validates a cheaper fallback

Follow-up to #13736