### PR TITLE
feat: import public agents from GitHub

### DIFF
--- a/BUILD_YOUR_OWN_AGENT.md
+++ b/BUILD_YOUR_OWN_AGENT.md
@@ -7,9 +7,9 @@ This is different from hosting your own OpenAI-compatible model endpoint. It is 
 ## Create an agent in the dashboard
 
 1. Open [My Models](https://enter.pollinations.ai/my-models).
-2. Add an agent and choose its name, title, visibility, system prompt, and base model.
-3. Optionally enable Pollinations tools so the agent can generate media, call other models, and inspect the model catalog.
-4. Save it. The dashboard creates the agent configuration and registers its callable model name.
+2. Add an agent and choose its name, title, and visibility.
+3. For a private agent, enter the system prompt, base model, and optional Pollinations tools. For a public agent, enter a public GitHub repository and manifest path.
+4. Save it. Pollinations validates the configuration and registers its callable model name.
 
 A linked GitHub username is required to create an agent. Private agents are visible and callable only by their owner. Publishing an agent for everyone requires [community publisher access](https://github.com/pollinations/pollinations/issues/new?template=community-model-allowlist.yml).
 
@@ -23,11 +23,13 @@ An agent combines catalog fields with its runtime configuration:
 | `title` | Yes | Display title shown in the model catalog. |
 | `description` | No | Catalog description. |
 | `visibility` | No | `private` by default, or `public` with publisher access. |
-| `systemPrompt` | Yes | Instructions for the agent, from 1 to 8,000 characters. |
-| `baseModel` | Yes | A text model ID from [`GET /v1/models`](https://gen.pollinations.ai/v1/models). |
+| `systemPrompt` | Private/manifest | Instructions for the agent, from 1 to 8,000 characters. |
+| `baseModel` | Private/manifest | A text model ID from [`GET /v1/models`](https://gen.pollinations.ai/v1/models). |
 | `mcpServers` | No | `[]` or `["pollinations"]` to enable the built-in Pollinations tools. |
+| `source.repositoryUrl` | Public | Public repository owned by the account's linked GitHub identity. |
+| `source.manifestPath` | Public | Relative JSON manifest path. Defaults to `pollinations-agent.json`. |
 
-Example `agent.json`:
+Private CLI configuration and public GitHub manifests use the same strict JSON schema:
 
 ```json
 {
@@ -37,7 +39,7 @@ Example `agent.json`:
 }
 ```
 
-Updates replace the runtime configuration, so include `systemPrompt` and `baseModel`; include `mcpServers` if tools should remain enabled. You can also change the name, title, description, or visibility.
+Public agents run the last valid snapshot stored by Pollinations, not a live GitHub response. Each successful import records the exact commit SHA. Invalid repository updates leave the previous snapshot active.
 
 ## Create with the CLI
 
@@ -50,7 +52,18 @@ npx @pollinations/cli agents create \
   --title "Research Assistant"
 ```
 
-The callable model ID is `<your-github-username>/research-assistant`. Add `--visibility public` to publish it after your account has community publisher access. Managed agents are always text-only and free: they cannot set prices, fallbacks, or a per-user request limit.
+To publish the same manifest from GitHub:
+
+```bash
+npx @pollinations/cli agents create \
+  --repo https://github.com/your-name/research-agent \
+  --manifest pollinations-agent.json \
+  --name research-assistant \
+  --title "Research Assistant" \
+  --visibility public
+```
+
+The callable model ID is `<your-github-username>/research-assistant`. Public publishing requires community publisher access. Managed agents are always text-only and free: they cannot set prices, fallbacks, or a per-user request limit.
 
 ## Call an agent
 
@@ -74,9 +87,10 @@ The agent listing itself has no owner-set price. The caller still pays for the s
 npx @pollinations/cli agents list
 npx @pollinations/cli agents get <agent-id>
 npx @pollinations/cli agents update <agent-id> --config agent.json
+npx @pollinations/cli agents sync <agent-id>
 npx @pollinations/cli agents delete <agent-id>
 ```
 
-Deleting an agent also deletes its model listing. Updating an agent can change its prompt, base model, tools, name, title, description, or visibility.
+Deleting an agent also deletes its model listing. Private inline agents can replace their prompt, base model, and tools. Public agents import those fields from GitHub; use `sync` after changing the repository. Listing fields can be updated through the dashboard or API.
 
 The Account API exposes the same operations under `/account/agents`. API keys need the `account:keys` permission. See the [Community Agents API reference](https://gen.pollinations.ai/docs#tag/community-agents) for request and response schemas.

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/agent-dialog.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/agent-dialog.tsx
@@ -3,6 +3,8 @@ import {
     Button,
     Dialog,
     DialogTitle,
+    FieldStack,
+    Input,
     ScrollArea,
 } from "@pollinations/ui";
 import type { FormEvent, ReactNode } from "react";
@@ -34,6 +36,7 @@ type AgentDialogProps = {
         agent: AgentPayload,
         listing: AgentListingDetailsPayload,
     ) => Promise<void>;
+    onSync?: () => Promise<void>;
     trigger?: ReactNode;
 };
 
@@ -44,6 +47,7 @@ export function AgentDialog({
     open,
     onOpenChange,
     onSubmit,
+    onSync,
     trigger,
 }: AgentDialogProps) {
     const [form, setForm] = useState<AgentDialogFormState>(() => ({
@@ -61,6 +65,10 @@ export function AgentDialog({
                       systemPrompt: agent.systemPrompt,
                       baseModel: agent.baseModel,
                       mcpServers: agent.mcpServers,
+                      repositoryUrl: agent.source?.repositoryUrl ?? "",
+                      manifestPath:
+                          agent.source?.manifestPath ??
+                          emptyAgentForm.manifestPath,
                   }
                 : emptyAgentForm),
         });
@@ -80,7 +88,10 @@ export function AgentDialog({
         setIsSubmitting(true);
         setError(null);
         try {
-            await onSubmit(toAgentPayload(form), toAgentListingPayload(form));
+            await onSubmit(
+                toAgentPayload(form, form.visibility === "public"),
+                toAgentListingPayload(form),
+            );
             onOpenChange(false);
         } catch (thrown) {
             setError(
@@ -91,12 +102,32 @@ export function AgentDialog({
         }
     }
 
+    async function handleSync(): Promise<void> {
+        if (!onSync) return;
+        setIsSubmitting(true);
+        setError(null);
+        try {
+            await onSync();
+            onOpenChange(false);
+        } catch (thrown) {
+            setError(
+                thrown instanceof Error ? thrown.message : "Agent sync failed",
+            );
+        } finally {
+            setIsSubmitting(false);
+        }
+    }
+
+    const hasConfiguration =
+        form.visibility === "public"
+            ? form.repositoryUrl.trim() !== "" &&
+              form.manifestPath.trim() !== ""
+            : form.systemPrompt.trim() !== "" && form.baseModel.trim() !== "";
     const canSubmit =
         !isSubmitting &&
         form.name.trim() !== "" &&
         form.title.trim() !== "" &&
-        form.systemPrompt.trim() !== "" &&
-        form.baseModel.trim() !== "";
+        hasConfiguration;
     const submitLabel = endpoint
         ? "Save Agent"
         : form.visibility === "public"
@@ -148,14 +179,80 @@ export function AgentDialog({
                     />
 
                     <div className="border-t border-divider pt-4">
-                        <PromptAgentFields
-                            form={form}
-                            disabled={isSubmitting}
-                            onChange={updateAgentForm}
-                        />
+                        {form.visibility === "public" ? (
+                            <div className="space-y-4">
+                                <Alert
+                                    intent="info"
+                                    title="Public agents are imported from GitHub"
+                                >
+                                    Pollinations validates the manifest and runs
+                                    the last valid, commit-pinned snapshot. The
+                                    repository must be public and owned by your
+                                    linked GitHub account.
+                                </Alert>
+                                <FieldStack
+                                    label="GitHub repository"
+                                    helper="A public repository owned by your linked GitHub account."
+                                    alignLabelRow
+                                >
+                                    <Input
+                                        type="url"
+                                        name="prompt-agent-repository-url"
+                                        value={form.repositoryUrl}
+                                        placeholder="https://github.com/username/agent"
+                                        disabled={isSubmitting}
+                                        onChange={(event) =>
+                                            updateAgentForm(
+                                                "repositoryUrl",
+                                                event.target.value,
+                                            )
+                                        }
+                                    />
+                                </FieldStack>
+                                <FieldStack
+                                    label="Manifest path"
+                                    helper="Relative path to the JSON agent configuration."
+                                    alignLabelRow
+                                >
+                                    <Input
+                                        name="prompt-agent-manifest-path"
+                                        value={form.manifestPath}
+                                        placeholder="pollinations-agent.json"
+                                        disabled={isSubmitting}
+                                        onChange={(event) =>
+                                            updateAgentForm(
+                                                "manifestPath",
+                                                event.target.value,
+                                            )
+                                        }
+                                    />
+                                </FieldStack>
+                                {agent?.source && (
+                                    <p className="break-all font-mono text-xs text-theme-text-muted">
+                                        Synced commit {agent.source.commitSha}
+                                    </p>
+                                )}
+                            </div>
+                        ) : (
+                            <PromptAgentFields
+                                form={form}
+                                disabled={isSubmitting}
+                                onChange={updateAgentForm}
+                            />
+                        )}
                     </div>
                 </ScrollArea>
-                <div className="flex shrink-0 justify-end gap-2 border-t border-divider p-6 pt-4">
+                <div className="flex shrink-0 flex-wrap justify-end gap-2 border-t border-divider p-6 pt-4">
+                    {agent?.source && onSync && (
+                        <Button
+                            type="button"
+                            intent="info"
+                            disabled={isSubmitting}
+                            onClick={() => void handleSync()}
+                        >
+                            {isSubmitting ? "Syncing…" : "Sync from GitHub"}
+                        </Button>
+                    )}
                     <Button
                         type="button"
                         intent="danger"

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoints.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoints.tsx
@@ -157,6 +157,17 @@ export function CommunityEndpoints({
         }
     }
 
+    async function handleSyncAgent(): Promise<void> {
+        if (!editingAgent) return;
+        const response = await apiClient.account.agents[":id"].sync.$post({
+            param: { id: editingAgent.id },
+        });
+        if (!response.ok) throw new Error(await readError(response));
+        setEditingAgent(null);
+        await loadEndpoints();
+        await onChange?.();
+    }
+
     async function handleCreate(
         payload: EndpointPayload,
         bearerToken: string,
@@ -554,6 +565,7 @@ export function CommunityEndpoints({
                 open={!!editingAgent}
                 onOpenChange={(open) => !open && setEditingAgent(null)}
                 onSubmit={handleUpdateAgent}
+                onSync={handleSyncAgent}
             />
 
             <AgentDeleteConfirmation

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/types.ts
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/types.ts
@@ -9,6 +9,7 @@ import {
     type CommunityEndpointPrices,
     type CommunityEndpointVisibility,
     communityEndpointPriceFieldsForModality,
+    DEFAULT_PROMPT_AGENT_MANIFEST_PATH,
     MAX_COMMUNITY_PRICE_PER_IMAGE,
     MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS,
     MAX_COMMUNITY_PRICE_PER_SECOND,
@@ -31,8 +32,16 @@ export type ManagedAgent = {
     systemPrompt: string;
     baseModel: string;
     mcpServers: "pollinations"[];
+    source: AgentGitHubSource | null;
     createdAt: string;
     updatedAt: string;
+};
+
+export type AgentGitHubSource = {
+    repositoryUrl: string;
+    manifestPath: string;
+    commitSha: string;
+    syncedAt: string;
 };
 
 type AgentFields = Pick<
@@ -40,9 +49,16 @@ type AgentFields = Pick<
     "systemPrompt" | "baseModel" | "mcpServers"
 >;
 
-export type AgentFormState = AgentFields;
+export type AgentFormState = AgentFields & {
+    repositoryUrl: string;
+    manifestPath: string;
+};
 
-export type AgentPayload = AgentFields;
+export type AgentPayload =
+    | AgentFields
+    | {
+          source: Pick<AgentGitHubSource, "repositoryUrl" | "manifestPath">;
+      };
 
 export type CommunityProviderProfile = {
     name: string | null;
@@ -236,6 +252,8 @@ export const emptyAgentForm: AgentFormState = {
     systemPrompt: "",
     baseModel: "",
     mcpServers: [],
+    repositoryUrl: "",
+    manifestPath: DEFAULT_PROMPT_AGENT_MANIFEST_PATH,
 };
 
 export const idleAction: ActionState = { status: "idle" };
@@ -444,7 +462,21 @@ export function observedUsageValue(
         : null;
 }
 
-export function toAgentPayload(form: AgentFormState): AgentPayload {
+export function toAgentPayload(
+    form: AgentFormState,
+    githubBacked: boolean,
+): AgentPayload {
+    if (githubBacked) {
+        const repositoryUrl = form.repositoryUrl.trim();
+        if (!repositoryUrl) {
+            throw new Error("GitHub repository URL is required");
+        }
+        const manifestPath = form.manifestPath.trim();
+        if (!manifestPath) {
+            throw new Error("Manifest path is required");
+        }
+        return { source: { repositoryUrl, manifestPath } };
+    }
     const systemPrompt = form.systemPrompt.trim();
     if (!systemPrompt) {
         throw new Error("System prompt is required for a prompt agent");

--- a/enter.pollinations.ai/src/routes/agents.ts
+++ b/enter.pollinations.ai/src/routes/agents.ts
@@ -352,18 +352,17 @@ export const agentsRoutes = new Hono<Env>()
                     message: "GitHub-backed agents must be public",
                 });
             }
-            const imported =
+            const config =
                 "source" in input
                     ? await importPromptAgentFromGitHub(
                           input.source,
                           requireOwnerGithubId(owner),
                           await requireGitHubAccessToken(db, user.id),
                       )
-                    : null;
-            const config = imported ?? {
-                config: promptConfigFromInput(input),
-                source: undefined,
-            };
+                    : {
+                          config: promptConfigFromInput(input),
+                          source: undefined,
+                      };
             const id = crypto.randomUUID();
             const [row] = await db
                 .insert(schema.communityEndpoint)

--- a/enter.pollinations.ai/src/routes/agents.ts
+++ b/enter.pollinations.ai/src/routes/agents.ts
@@ -4,6 +4,8 @@ import {
     COMMUNITY_ENDPOINT_VISIBILITIES,
     isCommunityEndpointOwnerAllowed,
     PROMPT_AGENT_BASE_URL_PLACEHOLDER,
+    PromptAgentGitHubSourceInputSchema,
+    PromptAgentGitHubSourceSchema,
 } from "@shared/community-endpoints.ts";
 import * as schema from "@shared/db/better-auth.ts";
 import { validator } from "@shared/middleware/validator.ts";
@@ -19,9 +21,10 @@ import {
     agentRuntimeBaseUrl,
     BuiltinMcpServerIdSchema,
     PromptAgentInputSchema,
-    parsePromptAgentConfig,
-    serializePromptAgentConfig,
+    parsePromptAgentListing,
+    serializePromptAgentListing,
 } from "../services/prompt-agent.ts";
+import { importPromptAgentFromGitHub } from "../services/prompt-agent-github.ts";
 import { requireAccountPermission } from "./account-permissions.ts";
 
 const ListingFieldsSchema = z.object({
@@ -42,23 +45,60 @@ const ListingFieldsSchema = z.object({
     visibility: z.enum(COMMUNITY_ENDPOINT_VISIBILITIES),
 });
 
-// Agent writes are one operation: prompt configuration and catalog identity
-// live in the same community_endpoint row and cannot get out of sync.
-const AgentWriteSchema = PromptAgentInputSchema.extend(
-    ListingFieldsSchema.shape,
-).strict();
-const CreateAgentSchema = AgentWriteSchema.extend({
+const CreateListingFieldsSchema = ListingFieldsSchema.extend({
     description: ListingFieldsSchema.shape.description.optional().default(""),
     visibility: ListingFieldsSchema.shape.visibility
         .optional()
         .default("private"),
+});
+const CreateInlineAgentSchema = PromptAgentInputSchema.extend(
+    CreateListingFieldsSchema.shape,
+).strict();
+const CreateGitHubAgentSchema = CreateListingFieldsSchema.extend({
+    source: PromptAgentGitHubSourceInputSchema,
 }).strict();
-const UpdateAgentSchema = PromptAgentInputSchema.extend({
-    name: ListingFieldsSchema.shape.name.optional(),
-    title: ListingFieldsSchema.shape.title.optional(),
-    description: ListingFieldsSchema.shape.description.optional(),
-    visibility: ListingFieldsSchema.shape.visibility.optional(),
-}).strict();
+const CreateAgentSchema = z.union([
+    CreateInlineAgentSchema,
+    CreateGitHubAgentSchema,
+]);
+const UpdateAgentSchema = z
+    .object({
+        systemPrompt: PromptAgentInputSchema.shape.systemPrompt.optional(),
+        baseModel: PromptAgentInputSchema.shape.baseModel.optional(),
+        mcpServers: z.array(BuiltinMcpServerIdSchema).max(1).optional(),
+        source: PromptAgentGitHubSourceInputSchema.optional(),
+        name: ListingFieldsSchema.shape.name.optional(),
+        title: ListingFieldsSchema.shape.title.optional(),
+        description: ListingFieldsSchema.shape.description.optional(),
+        visibility: ListingFieldsSchema.shape.visibility.optional(),
+    })
+    .strict()
+    .superRefine((input, ctx) => {
+        const hasInlineConfig =
+            input.systemPrompt !== undefined ||
+            input.baseModel !== undefined ||
+            input.mcpServers !== undefined;
+        if (
+            hasInlineConfig &&
+            (input.systemPrompt === undefined || input.baseModel === undefined)
+        ) {
+            ctx.addIssue({
+                code: "custom",
+                message:
+                    "systemPrompt and baseModel are both required when replacing inline configuration",
+            });
+        }
+        if (hasInlineConfig && input.source) {
+            ctx.addIssue({
+                code: "custom",
+                message:
+                    "Provide either inline configuration or a GitHub source, not both",
+            });
+        }
+        if (Object.keys(input).length === 0) {
+            ctx.addIssue({ code: "custom", message: "No updates provided" });
+        }
+    });
 const AgentResponseSchema = z.object({
     id: z.string(),
     name: z.string(),
@@ -70,6 +110,7 @@ const AgentResponseSchema = z.object({
     systemPrompt: z.string(),
     baseModel: z.string(),
     mcpServers: z.array(BuiltinMcpServerIdSchema),
+    source: PromptAgentGitHubSourceSchema.nullable(),
     createdAt: z.string(),
     updatedAt: z.string(),
 });
@@ -81,9 +122,31 @@ const AgentDeleteResponseSchema = z.object({ id: z.string() });
 type Db = ReturnType<typeof drizzle<typeof schema>>;
 type AgentRow = typeof schema.communityEndpoint.$inferSelect;
 
+function promptConfigFromInput(input: {
+    systemPrompt?: string;
+    baseModel?: string;
+    mcpServers?: "pollinations"[];
+}) {
+    return PromptAgentInputSchema.parse({
+        systemPrompt: input.systemPrompt,
+        baseModel: input.baseModel,
+        mcpServers: input.mcpServers,
+    });
+}
+
+function requireOwnerGithubId(owner: { githubId: number | null } | undefined) {
+    if (!owner?.githubId) {
+        throw new HTTPException(400, {
+            message: "A linked GitHub account is required",
+        });
+    }
+    return owner.githubId;
+}
+
 function toResponse(row: AgentRow, baseUrl: string) {
-    const config = parsePromptAgentConfig(row.payload);
-    if (!config) throw new Error(`Agent ${row.id} has invalid configuration`);
+    const listing = parsePromptAgentListing(row.payload);
+    if (!listing) throw new Error(`Agent ${row.id} has invalid configuration`);
+    const { source = null, ...config } = listing;
     return {
         id: row.id,
         name: row.name,
@@ -93,6 +156,7 @@ function toResponse(row: AgentRow, baseUrl: string) {
         baseUrl,
         upstreamModel: row.upstreamModel,
         ...config,
+        source,
         createdAt: row.createdAt,
         updatedAt: row.updatedAt,
     };
@@ -148,6 +212,28 @@ async function requireAgentWriteAccess(
             message: "Community model name is already registered",
         });
     }
+    return owner;
+}
+
+async function requireGitHubAccessToken(db: Db, ownerUserId: string) {
+    const githubAccount = await db.query.account.findFirst({
+        columns: { accessToken: true, accessTokenExpiresAt: true },
+        where: and(
+            eq(schema.account.userId, ownerUserId),
+            eq(schema.account.providerId, "github"),
+        ),
+    });
+    if (
+        !githubAccount?.accessToken ||
+        (githubAccount.accessTokenExpiresAt &&
+            githubAccount.accessTokenExpiresAt <= new Date())
+    ) {
+        throw new HTTPException(400, {
+            message:
+                "GitHub authorization is unavailable. Sign out and reconnect GitHub, then try again.",
+        });
+    }
+    return githubAccount.accessToken;
 }
 
 export const agentsRoutes = new Hono<Env>()
@@ -250,12 +336,34 @@ export const agentsRoutes = new Hono<Env>()
             const input = c.req.valid("json");
             requireAccountPermission(c.var.auth.apiKey, "keys");
             const db = drizzle(c.env.DB, { schema });
-            await requireAgentWriteAccess(
+            const owner = await requireAgentWriteAccess(
                 db,
                 user.id,
                 input.name,
                 input.visibility,
             );
+            if (input.visibility === "public" && !("source" in input)) {
+                throw new HTTPException(400, {
+                    message: "Public agents require a GitHub source repository",
+                });
+            }
+            if (input.visibility !== "public" && "source" in input) {
+                throw new HTTPException(400, {
+                    message: "GitHub-backed agents must be public",
+                });
+            }
+            const imported =
+                "source" in input
+                    ? await importPromptAgentFromGitHub(
+                          input.source,
+                          requireOwnerGithubId(owner),
+                          await requireGitHubAccessToken(db, user.id),
+                      )
+                    : null;
+            const config = imported ?? {
+                config: promptConfigFromInput(input),
+                source: undefined,
+            };
             const id = crypto.randomUUID();
             const [row] = await db
                 .insert(schema.communityEndpoint)
@@ -268,7 +376,10 @@ export const agentsRoutes = new Hono<Env>()
                     type: "prompt_agent",
                     baseUrl: PROMPT_AGENT_BASE_URL_PLACEHOLDER,
                     upstreamModel: id,
-                    payload: serializePromptAgentConfig(input),
+                    payload: serializePromptAgentListing(
+                        config.config,
+                        config.source,
+                    ),
                     visibility: input.visibility,
                     createdAt: new Date(),
                     updatedAt: new Date(),
@@ -307,9 +418,52 @@ export const agentsRoutes = new Hono<Env>()
             const db = drizzle(c.env.DB, { schema });
             const id = c.req.param("id");
             const stored = await requireOwnedAgent(db, id, user.id);
+            const storedListing = parsePromptAgentListing(stored.payload);
+            if (!storedListing) {
+                throw new HTTPException(500, {
+                    message: "Stored agent configuration is invalid",
+                });
+            }
             const name = input.name ?? stored.name;
             const visibility = input.visibility ?? stored.visibility;
-            await requireAgentWriteAccess(db, user.id, name, visibility, id);
+            const owner = await requireAgentWriteAccess(
+                db,
+                user.id,
+                name,
+                visibility,
+                id,
+            );
+            const hasInlineConfig =
+                input.systemPrompt !== undefined ||
+                input.baseModel !== undefined ||
+                input.mcpServers !== undefined;
+            if (input.source && visibility !== "public") {
+                throw new HTTPException(400, {
+                    message: "GitHub-backed agents must be public",
+                });
+            }
+            const imported = input.source
+                ? await importPromptAgentFromGitHub(
+                      input.source,
+                      requireOwnerGithubId(owner),
+                      await requireGitHubAccessToken(db, user.id),
+                  )
+                : null;
+            const nextConfig = imported
+                ? imported.config
+                : hasInlineConfig
+                  ? promptConfigFromInput(input)
+                  : storedListing;
+            const nextSource = imported
+                ? imported.source
+                : hasInlineConfig || visibility === "private"
+                  ? undefined
+                  : storedListing.source;
+            if (visibility === "public" && !nextSource) {
+                throw new HTTPException(400, {
+                    message: "Public agents require a GitHub source repository",
+                });
+            }
             const [row] = await db
                 .update(schema.communityEndpoint)
                 .set({
@@ -320,7 +474,78 @@ export const agentsRoutes = new Hono<Env>()
                             ? stored.description
                             : input.description || null,
                     visibility,
-                    payload: serializePromptAgentConfig(input),
+                    payload: serializePromptAgentListing(
+                        nextConfig,
+                        nextSource,
+                    ),
+                    updatedAt: new Date(),
+                })
+                .where(
+                    and(
+                        eq(schema.communityEndpoint.id, id),
+                        eq(schema.communityEndpoint.ownerUserId, user.id),
+                        eq(schema.communityEndpoint.type, "prompt_agent"),
+                    ),
+                )
+                .returning();
+            return c.json(toResponse(row, agentRuntimeBaseUrl(c.env)));
+        },
+    )
+    .post(
+        "/:id/sync",
+        describeRoute({
+            tags: ["🤖 Community Agents"],
+            summary: "Sync Agent from GitHub",
+            description:
+                "Import the current default-branch manifest from an agent's public GitHub source. The previous valid snapshot remains active if synchronization fails. API keys require `account:keys`.",
+            responses: {
+                200: {
+                    description: "Synchronized agent",
+                    content: {
+                        "application/json": {
+                            schema: resolver(AgentResponseSchema),
+                        },
+                    },
+                },
+                400: { description: "Invalid GitHub source or manifest" },
+                401: { description: "Unauthorized" },
+                403: { description: "Permission denied" },
+                404: { description: "Agent not found" },
+                502: { description: "GitHub request failed" },
+                503: { description: "GitHub rate limit reached" },
+            },
+        }),
+        async (c) => {
+            const user = c.var.auth.requireUser();
+            requireAccountPermission(c.var.auth.apiKey, "keys");
+            const db = drizzle(c.env.DB, { schema });
+            const id = c.req.param("id");
+            const stored = await requireOwnedAgent(db, id, user.id);
+            const listing = parsePromptAgentListing(stored.payload);
+            if (!listing?.source) {
+                throw new HTTPException(400, {
+                    message: "Agent does not have a GitHub source",
+                });
+            }
+            const owner = await db.query.user.findFirst({
+                columns: { githubId: true },
+                where: eq(schema.user.id, user.id),
+            });
+            const imported = await importPromptAgentFromGitHub(
+                {
+                    repositoryUrl: listing.source.repositoryUrl,
+                    manifestPath: listing.source.manifestPath,
+                },
+                requireOwnerGithubId(owner),
+                await requireGitHubAccessToken(db, user.id),
+            );
+            const [row] = await db
+                .update(schema.communityEndpoint)
+                .set({
+                    payload: serializePromptAgentListing(
+                        imported.config,
+                        imported.source,
+                    ),
                     updatedAt: new Date(),
                 })
                 .where(

--- a/enter.pollinations.ai/src/services/prompt-agent-github.ts
+++ b/enter.pollinations.ai/src/services/prompt-agent-github.ts
@@ -1,0 +1,214 @@
+import {
+    type PromptAgentGitHubSource,
+    type PromptAgentGitHubSourceInput,
+    PromptAgentGitHubSourceInputSchema,
+} from "@shared/community-endpoints.ts";
+import { HTTPException } from "hono/http-exception";
+import {
+    type PromptAgentConfig,
+    PromptAgentInputSchema,
+} from "./prompt-agent.ts";
+
+const GITHUB_API_BASE_URL = "https://api.github.com";
+const MAX_MANIFEST_BYTES = 64 * 1024;
+const GITHUB_REPOSITORY_OWNER =
+    /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
+const GITHUB_REPOSITORY_NAME = /^[A-Za-z0-9._-]{1,100}$/;
+
+type GitHubRepository = {
+    private: boolean;
+    default_branch: string;
+    html_url: string;
+    owner: { id: number };
+};
+
+function githubHeaders(accessToken: string, accept: string): HeadersInit {
+    return {
+        Accept: accept,
+        Authorization: `Bearer ${accessToken}`,
+        "User-Agent": "pollinations-enter",
+        "X-GitHub-Api-Version": "2022-11-28",
+    };
+}
+
+function githubFailure(response: Response, resource: string): never {
+    if (response.status === 401) {
+        throw new HTTPException(400, {
+            message:
+                "GitHub authorization expired. Sign out and reconnect GitHub, then try again.",
+        });
+    }
+    if (response.status === 404) {
+        throw new HTTPException(400, {
+            message: `${resource} was not found or is not public`,
+        });
+    }
+    if (
+        response.status === 403 &&
+        response.headers.get("x-ratelimit-remaining") === "0"
+    ) {
+        throw new HTTPException(503, {
+            message: "GitHub rate limit reached. Try again later.",
+        });
+    }
+    throw new HTTPException(502, {
+        message: `GitHub could not load ${resource}`,
+    });
+}
+
+export function parseGitHubRepositoryUrl(repositoryUrl: string): {
+    owner: string;
+    repository: string;
+} {
+    const parsed =
+        PromptAgentGitHubSourceInputSchema.shape.repositoryUrl.parse(
+            repositoryUrl,
+        );
+    const url = new URL(parsed);
+    const segments = url.pathname.split("/").filter(Boolean);
+    if (
+        url.protocol !== "https:" ||
+        url.hostname.toLowerCase() !== "github.com" ||
+        url.port ||
+        url.username ||
+        url.password ||
+        url.search ||
+        url.hash ||
+        segments.length !== 2
+    ) {
+        throw new HTTPException(400, {
+            message: "Repository URL must be https://github.com/owner/repo",
+        });
+    }
+    const owner = segments[0] ?? "";
+    const repository = (segments[1] ?? "").replace(/\.git$/i, "");
+    if (
+        !GITHUB_REPOSITORY_OWNER.test(owner) ||
+        !GITHUB_REPOSITORY_NAME.test(repository)
+    ) {
+        throw new HTTPException(400, {
+            message: "Repository URL has an invalid GitHub owner or name",
+        });
+    }
+    return { owner, repository };
+}
+
+function manifestApiPath(manifestPath: string): string {
+    const normalized = manifestPath.trim();
+    const segments = normalized.split("/");
+    if (
+        normalized.startsWith("/") ||
+        normalized.includes("\\") ||
+        segments.some(
+            (segment) =>
+                !segment ||
+                segment === "." ||
+                segment === ".." ||
+                segment === ".git",
+        )
+    ) {
+        throw new HTTPException(400, {
+            message: "Manifest path must be a relative file path",
+        });
+    }
+    return segments.map(encodeURIComponent).join("/");
+}
+
+export async function importPromptAgentFromGitHub(
+    rawSource: PromptAgentGitHubSourceInput,
+    ownerGithubId: number,
+    accessToken: string,
+): Promise<{
+    config: PromptAgentConfig;
+    source: PromptAgentGitHubSource;
+}> {
+    const source = PromptAgentGitHubSourceInputSchema.parse(rawSource);
+    const { owner, repository } = parseGitHubRepositoryUrl(
+        source.repositoryUrl,
+    );
+    const repositoryApiUrl = `${GITHUB_API_BASE_URL}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repository)}`;
+    const repositoryResponse = await fetch(repositoryApiUrl, {
+        headers: githubHeaders(accessToken, "application/vnd.github+json"),
+    });
+    if (!repositoryResponse.ok) {
+        githubFailure(repositoryResponse, "repository");
+    }
+    const repositoryData =
+        (await repositoryResponse.json()) as GitHubRepository;
+    if (repositoryData.private) {
+        throw new HTTPException(400, {
+            message: "Agent source repository must be public",
+        });
+    }
+    if (repositoryData.owner.id !== ownerGithubId) {
+        throw new HTTPException(403, {
+            message:
+                "Agent source repository must be owned by your linked GitHub account",
+        });
+    }
+
+    const commitResponse = await fetch(
+        `${repositoryApiUrl}/commits/${encodeURIComponent(repositoryData.default_branch)}`,
+        {
+            headers: githubHeaders(accessToken, "application/vnd.github.sha"),
+        },
+    );
+    if (!commitResponse.ok) githubFailure(commitResponse, "default branch");
+    const commitSha = (await commitResponse.text()).trim().toLowerCase();
+    if (!/^[0-9a-f]{40}$/.test(commitSha)) {
+        throw new HTTPException(502, {
+            message: "GitHub returned an invalid commit SHA",
+        });
+    }
+
+    const manifestResponse = await fetch(
+        `${repositoryApiUrl}/contents/${manifestApiPath(source.manifestPath)}?ref=${commitSha}`,
+        {
+            headers: githubHeaders(
+                accessToken,
+                "application/vnd.github.raw+json",
+            ),
+        },
+    );
+    if (!manifestResponse.ok) githubFailure(manifestResponse, "agent manifest");
+    const declaredLength = Number(
+        manifestResponse.headers.get("content-length") ?? "0",
+    );
+    if (declaredLength > MAX_MANIFEST_BYTES) {
+        throw new HTTPException(400, {
+            message: "Agent manifest must be 64 KB or smaller",
+        });
+    }
+    const manifestText = await manifestResponse.text();
+    if (
+        new TextEncoder().encode(manifestText).byteLength > MAX_MANIFEST_BYTES
+    ) {
+        throw new HTTPException(400, {
+            message: "Agent manifest must be 64 KB or smaller",
+        });
+    }
+
+    let manifest: unknown;
+    try {
+        manifest = JSON.parse(manifestText);
+    } catch {
+        throw new HTTPException(400, {
+            message: "Agent manifest must contain valid JSON",
+        });
+    }
+    const config = PromptAgentInputSchema.safeParse(manifest);
+    if (!config.success) {
+        throw new HTTPException(400, {
+            message: `Invalid agent manifest: ${config.error.issues[0]?.message ?? "invalid configuration"}`,
+        });
+    }
+    return {
+        config: config.data,
+        source: {
+            repositoryUrl: repositoryData.html_url,
+            manifestPath: source.manifestPath,
+            commitSha,
+            syncedAt: new Date().toISOString(),
+        },
+    };
+}

--- a/enter.pollinations.ai/src/services/prompt-agent.ts
+++ b/enter.pollinations.ai/src/services/prompt-agent.ts
@@ -3,13 +3,16 @@
 import {
     BuiltinMcpServerIdSchema,
     PromptAgentConfigSchema,
+    type PromptAgentGitHubSource,
     PromptAgentInputSchema,
     type PromptAgentListingPayload,
+    PromptAgentListingPayloadSchema,
 } from "@shared/community-endpoints.ts";
+import type { z } from "zod";
 
 export { BuiltinMcpServerIdSchema, PromptAgentInputSchema };
-export type PromptAgentConfig = PromptAgentListingPayload;
-export type PromptAgentInput = PromptAgentListingPayload;
+export type PromptAgentConfig = z.infer<typeof PromptAgentConfigSchema>;
+export type PromptAgentInput = z.infer<typeof PromptAgentInputSchema>;
 
 export function agentRuntimeBaseUrl(env: {
     AGENT_RUNTIME_BASE_URL: string;
@@ -26,6 +29,27 @@ export function parsePromptAgentConfig(raw: string): PromptAgentConfig | null {
     }
 }
 
-export function serializePromptAgentConfig(config: PromptAgentConfig): string {
-    return JSON.stringify(PromptAgentConfigSchema.parse(config));
+export function parsePromptAgentListing(
+    raw: string,
+): PromptAgentListingPayload | null {
+    try {
+        const parsed = PromptAgentListingPayloadSchema.safeParse(
+            JSON.parse(raw),
+        );
+        return parsed.success ? parsed.data : null;
+    } catch {
+        return null;
+    }
+}
+
+export function serializePromptAgentListing(
+    config: PromptAgentConfig,
+    source?: PromptAgentGitHubSource,
+): string {
+    return JSON.stringify(
+        PromptAgentListingPayloadSchema.parse({
+            ...config,
+            ...(source ? { source } : {}),
+        }),
+    );
 }

--- a/enter.pollinations.ai/test/community-endpoint-rpm-input.test.ts
+++ b/enter.pollinations.ai/test/community-endpoint-rpm-input.test.ts
@@ -26,16 +26,37 @@ describe("community endpoint per-user RPM input", () => {
 
     it("serializes the prompt-agent fields", () => {
         expect(
-            toAgentPayload({
-                ...emptyAgentForm,
-                systemPrompt: " Help ",
-                baseModel: " openai ",
-                mcpServers: ["pollinations"],
-            }),
+            toAgentPayload(
+                {
+                    ...emptyAgentForm,
+                    systemPrompt: " Help ",
+                    baseModel: " openai ",
+                    mcpServers: ["pollinations"],
+                },
+                false,
+            ),
         ).toEqual({
             systemPrompt: "Help",
             baseModel: "openai",
             mcpServers: ["pollinations"],
+        });
+    });
+
+    it("serializes a GitHub-backed prompt-agent source", () => {
+        expect(
+            toAgentPayload(
+                {
+                    ...emptyAgentForm,
+                    repositoryUrl: " https://github.com/owner/agent ",
+                    manifestPath: " agents/research.json ",
+                },
+                true,
+            ),
+        ).toEqual({
+            source: {
+                repositoryUrl: "https://github.com/owner/agent",
+                manifestPath: "agents/research.json",
+            },
         });
     });
 

--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -46,6 +46,7 @@ import {
     parseCommunityModelId,
 } from "@shared/community-endpoints.ts";
 import {
+    account as accountTable,
     communityEndpoint as communityEndpointTable,
     session as sessionTable,
 } from "@shared/db/better-auth.ts";
@@ -4663,10 +4664,20 @@ fixtureTest(
 
 fixtureTest("creates, edits, routes, and deletes managed agents", async () => {
     const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;
+    const ownerGithubId = nextAllowedGithubId();
     const modelName = `model-${crypto.randomUUID().slice(0, 8)}`;
     const ownerUserId = await createTestUser({
-        githubId: nextAllowedGithubId(),
+        githubId: ownerGithubId,
         githubUsername: ownerGithubUsername,
+    });
+    await db.insert(accountTable).values({
+        id: `account-${crypto.randomUUID()}`,
+        accountId: String(ownerGithubId),
+        providerId: "github",
+        userId: ownerUserId,
+        accessToken: "mock_github_auth_token",
+        createdAt: new Date(),
+        updatedAt: new Date(),
     });
     const sessionToken = `session-${crypto.randomUUID()}`;
     await db.insert(sessionTable).values({
@@ -4693,6 +4704,45 @@ fixtureTest("creates, edits, routes, and deletes managed agents", async () => {
         baseModel: "openai-fast",
         mcpServers: ["pollinations"],
     };
+    const githubRepositoryUrl = `https://github.com/${ownerGithubUsername}/sql-agent`;
+    let githubCommitSha = "a".repeat(40);
+    let githubRepositoryOwnerId = ownerGithubId;
+    let githubManifest = {
+        ...promptAgent,
+        systemPrompt: "You are an editable SQL tutor.",
+    };
+    const originalFetch = globalThis.fetch;
+    vi.stubGlobal(
+        "fetch",
+        async (input: RequestInfo | URL, init?: RequestInit) => {
+            const request = new Request(input, init);
+            const url = new URL(request.url);
+            if (url.hostname !== "api.github.com") {
+                return originalFetch(input, init);
+            }
+            expect(request.headers.get("authorization")).toMatch(/^Bearer /);
+            const repositoryPath = `/repos/${ownerGithubUsername}/sql-agent`;
+            if (url.pathname === repositoryPath) {
+                return Response.json({
+                    private: false,
+                    default_branch: "main",
+                    html_url: githubRepositoryUrl,
+                    owner: { id: githubRepositoryOwnerId },
+                });
+            }
+            if (url.pathname === `${repositoryPath}/commits/main`) {
+                return new Response(githubCommitSha);
+            }
+            if (
+                url.pathname ===
+                `${repositoryPath}/contents/pollinations-agent.json`
+            ) {
+                expect(url.searchParams.get("ref")).toBe(githubCommitSha);
+                return new Response(JSON.stringify(githubManifest));
+            }
+            return Response.json({ message: "Not Found" }, { status: 404 });
+        },
+    );
     const createAgentResponse = await fetchEnterApi(
         enterApi,
         new Request("https://enter.test/api/account/agents", {
@@ -4754,6 +4804,27 @@ fixtureTest("creates, edits, routes, and deletes managed agents", async () => {
         enterEnv,
     );
     expect(partialUpdateResponse.status).toBe(400);
+    githubRepositoryOwnerId = ownerGithubId + 1;
+    const wrongOwnerResponse = await fetchEnterApi(
+        enterApi,
+        new Request(`https://enter.test/api/account/agents/${agent.id}`, {
+            method: "PATCH",
+            headers: {
+                "Content-Type": "application/json",
+                Cookie: cookie,
+            },
+            body: JSON.stringify({
+                source: {
+                    repositoryUrl: githubRepositoryUrl,
+                    manifestPath: "pollinations-agent.json",
+                },
+                visibility: "public",
+            }),
+        }),
+        enterEnv,
+    );
+    expect(wrongOwnerResponse.status).toBe(403);
+    githubRepositoryOwnerId = ownerGithubId;
     const updateAgentResponse = await fetchEnterApi(
         enterApi,
         new Request(`https://enter.test/api/account/agents/${agent.id}`, {
@@ -4763,8 +4834,10 @@ fixtureTest("creates, edits, routes, and deletes managed agents", async () => {
                 Cookie: cookie,
             },
             body: JSON.stringify({
-                ...promptAgent,
-                systemPrompt: "You are an editable SQL tutor.",
+                source: {
+                    repositoryUrl: githubRepositoryUrl,
+                    manifestPath: "pollinations-agent.json",
+                },
                 name: modelName,
                 title: "Managed SQL Tutor",
                 description: "",
@@ -4778,14 +4851,64 @@ fixtureTest("creates, edits, routes, and deletes managed agents", async () => {
         id: agent.id,
         systemPrompt: "You are an editable SQL tutor.",
         mcpServers: ["pollinations"],
+        source: {
+            repositoryUrl: githubRepositoryUrl,
+            manifestPath: "pollinations-agent.json",
+            commitSha: githubCommitSha,
+        },
     });
     const [agentAfterPromptUpdate] = await db
         .select()
         .from(communityEndpointTable)
         .where(eq(communityEndpointTable.id, agent.id));
-    expect(JSON.parse(agentAfterPromptUpdate.payload)).toEqual({
-        ...promptAgent,
-        systemPrompt: "You are an editable SQL tutor.",
+    expect(JSON.parse(agentAfterPromptUpdate.payload)).toMatchObject({
+        ...githubManifest,
+        source: {
+            repositoryUrl: githubRepositoryUrl,
+            manifestPath: "pollinations-agent.json",
+            commitSha: githubCommitSha,
+        },
+    });
+    githubManifest = {
+        ...githubManifest,
+        systemPrompt: "You are a synced SQL tutor.",
+    };
+    githubCommitSha = "b".repeat(40);
+    const syncAgentResponse = await fetchEnterApi(
+        enterApi,
+        new Request(`https://enter.test/api/account/agents/${agent.id}/sync`, {
+            method: "POST",
+            headers: { Cookie: cookie },
+        }),
+        enterEnv,
+    );
+    expect(syncAgentResponse.status).toBe(200);
+    await expect(syncAgentResponse.json()).resolves.toMatchObject({
+        id: agent.id,
+        systemPrompt: "You are a synced SQL tutor.",
+        source: { commitSha: githubCommitSha },
+    });
+    githubManifest = {
+        ...githubManifest,
+        systemPrompt: "",
+    };
+    githubCommitSha = "c".repeat(40);
+    const invalidSyncResponse = await fetchEnterApi(
+        enterApi,
+        new Request(`https://enter.test/api/account/agents/${agent.id}/sync`, {
+            method: "POST",
+            headers: { Cookie: cookie },
+        }),
+        enterEnv,
+    );
+    expect(invalidSyncResponse.status).toBe(400);
+    const [agentAfterInvalidSync] = await db
+        .select()
+        .from(communityEndpointTable)
+        .where(eq(communityEndpointTable.id, agent.id));
+    expect(JSON.parse(agentAfterInvalidSync.payload)).toMatchObject({
+        systemPrompt: "You are a synced SQL tutor.",
+        source: { commitSha: "b".repeat(40) },
     });
     const listResponse = await fetchEnterApi(
         enterApi,

--- a/packages/polli-cli/README.md
+++ b/packages/polli-cli/README.md
@@ -104,6 +104,8 @@ and catalog title:
 polli agents get <id>
 polli agents create --config agent.json --name my-agent --title "My Agent"
 polli agents update <id> --config agent.json
+polli agents create --repo https://github.com/me/my-agent --name my-agent --title "My Agent" --visibility public
+polli agents sync <id>
 polli agents delete <id>
 ```
 
@@ -117,7 +119,7 @@ polli agents delete <id>
 }
 ```
 
-Creating an agent also creates its callable model listing. See [Publish an Agent](https://github.com/pollinations/pollinations/blob/main/BUILD_YOUR_OWN_AGENT.md) for visibility, billing, and lifecycle details.
+Creating an agent also creates its callable model listing. Private agents can use an inline config file. Public agents import the same JSON schema from a public GitHub repository owned by the linked GitHub account. See [Publish an Agent](https://github.com/pollinations/pollinations/blob/main/BUILD_YOUR_OWN_AGENT.md) for visibility, synchronization, billing, and lifecycle details.
 
 `polli auth login` creates a key with all account permissions Polli needs: `profile`, `usage`, and `keys`. Use `account:usage` for narrow read-only account state like usage and quests. Use `account:keys` to manage keys and, where invite-only My Models access is enabled, my-models. Quest claiming remains in the dashboard.
 

--- a/packages/polli-cli/SKILL.md
+++ b/packages/polli-cli/SKILL.md
@@ -184,9 +184,11 @@ polli agents list
 polli agents get <id>
 polli agents create --config agent.json --name my-agent --title "My Agent"
 polli agents update <id> --config agent.json
+polli agents create --repo https://github.com/me/my-agent --name my-agent --title "My Agent" --visibility public
+polli agents sync <id>
 polli agents delete <id>
 ```
-The config file contains `systemPrompt`, `baseModel`, and optional `mcpServers`; create also requires `--name` and `--title` for the callable model listing. The only supported server ID is currently `"pollinations"`. Updates replace the complete agent configuration.
+Private agents use `--config`; the file contains `systemPrompt`, `baseModel`, and optional `mcpServers`. Public agents use `--repo` plus optional `--manifest` and import the same strict JSON schema from a public repository owned by the linked GitHub account. Create also requires `--name` and `--title`. The only supported server ID is currently `"pollinations"`.
 
 Creating an agent also creates its callable model listing. Managed agents are text-only and free, with no fallbacks or per-user RPM. Deleting the agent also deletes its model listing. See [Publish an Agent](https://github.com/pollinations/pollinations/blob/main/BUILD_YOUR_OWN_AGENT.md).
 

--- a/packages/polli-cli/src/commands/agents.test.ts
+++ b/packages/polli-cli/src/commands/agents.test.ts
@@ -34,4 +34,24 @@ describe("agentBody", () => {
             visibility: "private",
         });
     });
+
+    it("builds a public GitHub source request without reading a config file", () => {
+        expect(
+            agentBody(undefined, {
+                repo: "https://github.com/example/research-agent",
+                manifest: "agents/research.json",
+                name: "research-agent",
+                title: "Research Agent",
+                visibility: "public",
+            }),
+        ).toEqual({
+            source: {
+                repositoryUrl: "https://github.com/example/research-agent",
+                manifestPath: "agents/research.json",
+            },
+            name: "research-agent",
+            title: "Research Agent",
+            visibility: "public",
+        });
+    });
 });

--- a/packages/polli-cli/src/commands/agents.ts
+++ b/packages/polli-cli/src/commands/agents.ts
@@ -21,6 +21,12 @@ type Agent = {
     systemPrompt: string;
     baseModel: string;
     mcpServers: string[];
+    source: {
+        repositoryUrl: string;
+        manifestPath: string;
+        commitSha: string;
+        syncedAt: string;
+    } | null;
     createdAt: string;
     updatedAt: string;
 };
@@ -41,7 +47,7 @@ function readConfig(path: string): Record<string, unknown> {
 }
 
 export function agentBody(
-    configPath: string,
+    configPath: string | undefined,
     opts: Record<string, unknown>,
 ): Record<string, unknown> {
     if (
@@ -52,8 +58,31 @@ export function agentBody(
         printError("--visibility must be 'private' or 'public'");
         process.exit(1);
     }
+    const repositoryUrl = typeof opts.repo === "string" ? opts.repo.trim() : "";
+    if (!!configPath === !!repositoryUrl) {
+        printError("Provide exactly one of --config or --repo");
+        process.exit(1);
+    }
+    if (opts.visibility === "public" && !repositoryUrl) {
+        printError("Public agents require --repo");
+        process.exit(1);
+    }
+    if (repositoryUrl && opts.visibility === "private") {
+        printError("--repo requires --visibility public");
+        process.exit(1);
+    }
     return {
-        ...readConfig(configPath),
+        ...(repositoryUrl
+            ? {
+                  source: {
+                      repositoryUrl,
+                      manifestPath:
+                          typeof opts.manifest === "string"
+                              ? opts.manifest
+                              : "pollinations-agent.json",
+                  },
+              }
+            : readConfig(configPath ?? "")),
         ...(opts.name !== undefined && { name: opts.name }),
         ...(opts.title !== undefined && { title: opts.title }),
         ...(opts.description !== undefined && {
@@ -76,11 +105,19 @@ function printAgents(agents: Agent[]): void {
             name: agent.name,
             base_model: agent.baseModel,
             visibility: agent.visibility,
+            source: agent.source ? "github" : "inline",
             pollinations_tools: agent.mcpServers.includes("pollinations")
                 ? "yes"
                 : "no",
         })),
-        ["id", "name", "base_model", "visibility", "pollinations_tools"],
+        [
+            "id",
+            "name",
+            "base_model",
+            "visibility",
+            "source",
+            "pollinations_tools",
+        ],
     );
 }
 
@@ -123,9 +160,12 @@ const get = new Command("get")
 
 const create = new Command("create")
     .description("Create a prompt agent")
-    .requiredOption(
-        "--config <file>",
-        "JSON agent config file sent directly to the API",
+    .option("--config <file>", "JSON agent config file for a private agent")
+    .option("--repo <url>", "Public GitHub repository containing the manifest")
+    .option(
+        "--manifest <path>",
+        "Manifest path inside the repository",
+        "pollinations-agent.json",
     )
     .requiredOption("--name <name>", "Callable model name")
     .requiredOption("--title <title>", "Display title shown in the catalog")
@@ -159,9 +199,12 @@ const create = new Command("create")
 const update = new Command("update")
     .description("Update an agent")
     .argument("<id>", "Agent id")
-    .requiredOption(
-        "--config <file>",
-        "JSON agent config file sent directly to the API",
+    .option("--config <file>", "JSON agent config file for a private agent")
+    .option("--repo <url>", "Public GitHub repository containing the manifest")
+    .option(
+        "--manifest <path>",
+        "Manifest path inside the repository",
+        "pollinations-agent.json",
     )
     .option("--name <name>", "Callable model name")
     .option("--title <title>", "Display title shown in the catalog")
@@ -186,6 +229,29 @@ const update = new Command("update")
         } catch (error) {
             printError(
                 `Failed to update agent: ${error instanceof Error ? error.message : "unknown"}`,
+            );
+            process.exit(1);
+        }
+    });
+
+const sync = new Command("sync")
+    .description("Sync an agent from its GitHub repository")
+    .argument("<id>", "Agent id")
+    .action(async (id) => {
+        const key = requireKey();
+        try {
+            const agent = await gen<Agent>(
+                `/account/agents/${encodeURIComponent(id)}/sync`,
+                { apiKey: key, method: "POST" },
+            );
+            if (getOutputMode() === "json") printResult(agent);
+            else {
+                printSuccess(`Agent synced: ${agent.id}`);
+                printAgents([agent]);
+            }
+        } catch (error) {
+            printError(
+                `Failed to sync agent: ${error instanceof Error ? error.message : "unknown"}`,
             );
             process.exit(1);
         }
@@ -217,4 +283,5 @@ export const agentsCommand = new Command("agents")
     .addCommand(get)
     .addCommand(create)
     .addCommand(update)
+    .addCommand(sync)
     .addCommand(remove);

--- a/shared/community-endpoints.ts
+++ b/shared/community-endpoints.ts
@@ -447,7 +447,44 @@ export const PromptAgentConfigSchema = z.object({
 });
 export const PromptAgentInputSchema = PromptAgentConfigSchema.strict();
 
-export type PromptAgentListingPayload = z.infer<typeof PromptAgentConfigSchema>;
+export const DEFAULT_PROMPT_AGENT_MANIFEST_PATH = "pollinations-agent.json";
+
+export const PromptAgentGitHubSourceInputSchema = z
+    .object({
+        repositoryUrl: z
+            .string()
+            .trim()
+            .url()
+            .max(COMMUNITY_PROVIDER_URL_MAX_LENGTH)
+            .startsWith("https://github.com/"),
+        manifestPath: z
+            .string()
+            .trim()
+            .min(1)
+            .max(240)
+            .default(DEFAULT_PROMPT_AGENT_MANIFEST_PATH),
+    })
+    .strict();
+
+export const PromptAgentGitHubSourceSchema =
+    PromptAgentGitHubSourceInputSchema.extend({
+        commitSha: z.string().regex(/^[0-9a-f]{40}$/),
+        syncedAt: z.string().datetime(),
+    }).strict();
+
+export const PromptAgentListingPayloadSchema = PromptAgentConfigSchema.extend({
+    source: PromptAgentGitHubSourceSchema.optional(),
+});
+
+export type PromptAgentGitHubSourceInput = z.infer<
+    typeof PromptAgentGitHubSourceInputSchema
+>;
+export type PromptAgentGitHubSource = z.infer<
+    typeof PromptAgentGitHubSourceSchema
+>;
+export type PromptAgentListingPayload = z.infer<
+    typeof PromptAgentListingPayloadSchema
+>;
 
 /**
  * An agent on the owner's own server. It is sent a run token rather than a
@@ -495,7 +532,7 @@ export function parseListingPayload<K extends ListingType>(
         return result.success ? (result.data as ListingPayloadByType[K]) : null;
     }
     if (type === "prompt_agent") {
-        const result = PromptAgentConfigSchema.safeParse(source);
+        const result = PromptAgentListingPayloadSchema.safeParse(source);
         return result.success ? (result.data as ListingPayloadByType[K]) : null;
     }
 


### PR DESCRIPTION
- Adds public prompt-agent imports from owner-controlled GitHub repositories with strict Zod manifest validation.
- Stores the canonical repository URL, manifest path, exact commit SHA, sync timestamp, and last valid runtime snapshot in the existing typed listing payload.
- Adds explicit GitHub sync to the Account API, dashboard, and Polli CLI; failed imports leave the active snapshot untouched.
- Keeps private agents inline and requires publisher approval plus repository ownership for public agents.
- Adds lifecycle, ownership, commit-pinning, failed-sync, dashboard payload, and CLI coverage.

Addresses #13477