### PR TITLE
docs(polli-cli): fix stale 'quests mine' examples in README

### DIFF
--- a/packages/polli-cli/README.md
+++ b/packages/polli-cli/README.md
@@ -67,7 +67,7 @@ polli docs                   # full API reference in the terminal
 polli docs /image            # one endpoint
 polli docs --open            # open in browser
 polli quests                 # public quest catalog
-polli quests mine            # your completed and earned quest status
+polli quests --claimed       # already-completed and earned quest status
 ```
 
 ## Account
@@ -92,7 +92,7 @@ Keys can't be edited — to change a name, budget, or model list, revoke and rec
 polli usage                  # pollen balance
 polli usage --history        # recent requests
 polli usage --daily          # daily spend
-polli quests mine --completed # completed and earned quests
+polli quests --claimable     # only rewards ready to claim
 polli agents list            # managed prompt agents
 polli my-models list         # invite-only community text, image, and transcription models
 ```


### PR DESCRIPTION
## Summary
The `polli-cli` README documents a `polli quests mine` command in two places, but the `quests` command takes no positional arguments — commander rejects it with:

```
error: too many arguments for 'quests'. Expected 0 arguments but got 1.
```

## Changes
- `polli quests mine` → `polli quests --claimed`
- `polli quests mine --completed` → `polli quests --claimable`

These match the real interface in `packages/polli-cli/src/commands/quests.ts` (filter flags: `--open`, `--claimable`, `--claimed`, `--coming-soon`) and the examples already used correctly in `SKILL.md`.

## Verification
- Reproduced the failure on polli 0.1.10: `polli quests mine` → argument-count error
- Confirmed via code search this was the only file still referencing `quests mine`

## Quest link
Contributes to the Contribute-a-pull-request quest 🌱
