### PR TITLE
refactor: extract auto top-up eligibility

### DIFF
--- a/enter.pollinations.ai/src/utils/stripe-billing/auto-top-up.ts
+++ b/enter.pollinations.ai/src/utils/stripe-billing/auto-top-up.ts
@@ -8,6 +8,7 @@ import {
     calculateServiceFeeCents,
     getPollenPackByAmount,
     POLLEN_PACK_LINE_TYPE,
+    type PollenPack,
     SERVICE_FEE_LINE_TYPE,
     SERVICE_FEE_NAME,
     SERVICE_FEE_TAX_CODE,
@@ -37,7 +38,36 @@ import type {
     AutoTopUpProcessResult,
     BillingOverview,
     PendingAutoTopUpAttempt,
+    UserStripeBillingRow,
 } from "./types.ts";
+
+type AutoTopUpEligibilityInput = Pick<
+    UserStripeBillingRow,
+    "autoTopUpEnabled" | "packBalance" | "autoTopUpAmountUsd"
+>;
+
+type AutoTopUpEligibility =
+    | { eligible: false; reason: "auto top-up disabled" }
+    | { eligible: false; reason: "paid balance above threshold" }
+    | { eligible: false; reason: "auto top-up pack invalid" }
+    | { eligible: true; pack: PollenPack };
+
+function getAutoTopUpEligibility(
+    user: AutoTopUpEligibilityInput,
+): AutoTopUpEligibility {
+    if (!user.autoTopUpEnabled) {
+        return { eligible: false, reason: "auto top-up disabled" };
+    }
+
+    if ((user.packBalance ?? 0) > AUTO_TOP_UP_THRESHOLD_POLLEN) {
+        return { eligible: false, reason: "paid balance above threshold" };
+    }
+
+    const pack = getPollenPackByAmount(user.autoTopUpAmountUsd);
+    return pack
+        ? { eligible: true, pack }
+        : { eligible: false, reason: "auto top-up pack invalid" };
+}
 
 export async function updateAutoTopUpSettings(
     env: CloudflareBindings,
@@ -123,22 +153,12 @@ export async function processAutoTopUpForUser(
 ): Promise<AutoTopUpProcessResult> {
     const user = await getUserStripeBillingRow(env.DB, userId);
 
-    if (!user.autoTopUpEnabled) {
-        return { status: "skipped", reason: "auto top-up disabled" };
+    const eligibility = getAutoTopUpEligibility(user);
+    if (!eligibility.eligible) {
+        return { status: "skipped", reason: eligibility.reason };
     }
 
-    const threshold = AUTO_TOP_UP_THRESHOLD_POLLEN;
-    if ((user.packBalance ?? 0) > threshold) {
-        return { status: "skipped", reason: "paid balance above threshold" };
-    }
-
-    const pack =
-        user.autoTopUpAmountUsd == null
-            ? undefined
-            : getPollenPackByAmount(user.autoTopUpAmountUsd);
-    if (!pack) {
-        return { status: "skipped", reason: "auto top-up pack invalid" };
-    }
+    const { pack } = eligibility;
 
     await expireStaleClaimedAttempts(env.DB, userId);
 

--- a/enter.pollinations.ai/test/integration/stripe.test.ts
+++ b/enter.pollinations.ai/test/integration/stripe.test.ts
@@ -1208,6 +1208,81 @@ test("PATCH /api/stripe/auto-top-up does not charge immediately when balance is 
     expect(updatedUser?.autoTopUpEnabled).toBe(true);
 });
 
+test.for([
+    {
+        name: "disabled even with high balance and invalid pack",
+        setup: {
+            autoTopUpEnabled: false,
+            packBalance: 6,
+            autoTopUpAmountUsd: 7,
+        },
+        reason: "auto top-up disabled",
+    },
+    {
+        name: "paid balance is above threshold even with invalid pack",
+        setup: {
+            autoTopUpEnabled: true,
+            packBalance: 6,
+            autoTopUpAmountUsd: 7,
+        },
+        reason: "paid balance above threshold",
+    },
+    {
+        name: "balance is at threshold and configured pack is invalid",
+        setup: {
+            autoTopUpEnabled: true,
+            packBalance: 5,
+            autoTopUpAmountUsd: 7,
+        },
+        reason: "auto top-up pack invalid",
+    },
+])("POST /api/stripe/auto-top-up/trigger skips before Stripe when $name", async ({
+    setup,
+    reason,
+}, { sessionToken, mocks }) => {
+    void sessionToken;
+    await mocks.enable("stripe", "tinybird");
+
+    const db = drizzle(env.DB);
+    const [user] = await db
+        .select({ id: userTable.id })
+        .from(userTable)
+        .limit(1);
+
+    expect(user).toBeTruthy();
+    if (!user) throw new Error("Expected seeded test user");
+
+    await db.update(userTable).set(setup).where(eq(userTable.id, user.id));
+
+    const response = await SELF.fetch(`${base}/auto-top-up/trigger`, {
+        method: "POST",
+        headers: {
+            "Authorization": `Bearer ${env.PLN_ENTER_TOKEN}`,
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ userId: user.id, environment: env.ENVIRONMENT }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+        status: "skipped",
+        reason,
+    });
+
+    expect(mocks.stripe.state.invoices).toHaveLength(0);
+    expect(
+        mocks.stripe.state.requests.some(
+            (request) => request.path === "/v1/invoices",
+        ),
+    ).toBe(false);
+    const attempts = await env.DB.prepare(
+        `SELECT COUNT(*) AS count FROM stripe_auto_top_up_attempt WHERE user_id = ?`,
+    )
+        .bind(user.id)
+        .first<{ count: number }>();
+    expect(attempts?.count).toBe(0);
+});
+
 test("POST /api/stripe/auto-top-up/trigger creates and pays auto top-up invoice", async ({
     sessionToken,
     mocks,


### PR DESCRIPTION
- Extracts the initial auto top-up decision into a private pure eligibility helper.
- Preserves disabled, paid-balance threshold, invalid-pack precedence, exact reason strings, and the strict `> 5` boundary.
- Leaves claim SQL, Stripe operations, persisted transitions, cleanup, and the public result shape unchanged.
- Adds focused trigger-route coverage proving each skip path performs no invoice request and creates no attempt row.

Checks:
- Biome
- Enter TypeScript typecheck
- Focused Stripe integration tests (17 passed)
- `git diff --check`