### PR TITLE
refactor: share Stripe checkout serialization

### DIFF
--- a/enter.pollinations.ai/src/routes/stripe-webhooks.ts
+++ b/enter.pollinations.ai/src/routes/stripe-webhooks.ts
@@ -319,6 +319,34 @@ async function sendStripeEventToTinybird(
     }
 }
 
+function checkoutSessionEventData(
+    event: Stripe.Event,
+    session: Stripe.Checkout.Session,
+    paymentStatus: string,
+    paymentMethodsOffered?: string,
+    presentment?: {
+        currency: string;
+        amount: number;
+    },
+): StripeEventData {
+    return {
+        eventType: event.type,
+        eventId: event.id,
+        sessionId: session.id,
+        userId: session.metadata?.userId || "",
+        amountCents: session.amount_total || 0,
+        currency: session.currency || "usd",
+        paymentStatus,
+        paymentMethod: "unknown",
+        paymentMethodsOffered,
+        presentmentCurrency: presentment?.currency ?? "",
+        presentmentAmount: presentment?.amount ?? 0,
+        customerEmail: session.customer_email || "",
+        livemode: event.livemode,
+        payload: event,
+    };
+}
+
 /**
  * Emit a checkout-session success to Tinybird (shared by
  * checkout.session.completed and async_payment_succeeded). On a failed
@@ -336,25 +364,20 @@ function emitCheckoutSessionAnalytics(
     failureLabel: string,
 ): void {
     if (result.success && session.metadata) {
-        const methodsOffered = (session.payment_method_types ?? []).join(",");
-
         c.executionCtx.waitUntil(
-            sendStripeEventToTinybird(c.env, {
-                eventType: event.type,
-                eventId: event.id,
-                sessionId: session.id,
-                userId: session.metadata.userId || "",
-                amountCents: session.amount_total || 0,
-                currency: session.currency || "usd",
-                paymentStatus: session.payment_status || "unknown",
-                paymentMethod: "unknown",
-                paymentMethodsOffered: methodsOffered,
-                presentmentCurrency: result.presentmentCurrency ?? "",
-                presentmentAmount: result.presentmentAmount ?? 0,
-                customerEmail: session.customer_email || "",
-                livemode: event.livemode,
-                payload: event,
-            }).catch((err) =>
+            sendStripeEventToTinybird(
+                c.env,
+                checkoutSessionEventData(
+                    event,
+                    session,
+                    session.payment_status || "unknown",
+                    (session.payment_method_types ?? []).join(","),
+                    {
+                        currency: result.presentmentCurrency ?? "",
+                        amount: result.presentmentAmount ?? 0,
+                    },
+                ),
+            ).catch((err) =>
                 console.error("TinyBird Stripe send failed:", err),
             ),
         );
@@ -670,24 +693,16 @@ export const stripeWebhooksRoutes = new Hono<Env>()
             case "checkout.session.async_payment_failed": {
                 const session = event.data.object as Stripe.Checkout.Session;
                 console.log(`Async payment failed for session ${session.id}`);
-                const methodsOffered = (
-                    session.payment_method_types ?? []
-                ).join(",");
                 c.executionCtx.waitUntil(
-                    sendStripeEventToTinybird(c.env, {
-                        eventType: event.type,
-                        eventId: event.id,
-                        sessionId: session.id,
-                        userId: session.metadata?.userId || "",
-                        amountCents: session.amount_total || 0,
-                        currency: session.currency || "usd",
-                        paymentStatus: session.payment_status || "unpaid",
-                        paymentMethod: "unknown",
-                        paymentMethodsOffered: methodsOffered,
-                        customerEmail: session.customer_email || "",
-                        livemode: event.livemode,
-                        payload: event,
-                    }).catch((err) =>
+                    sendStripeEventToTinybird(
+                        c.env,
+                        checkoutSessionEventData(
+                            event,
+                            session,
+                            session.payment_status || "unpaid",
+                            (session.payment_method_types ?? []).join(","),
+                        ),
+                    ).catch((err) =>
                         console.error("TinyBird Stripe send failed:", err),
                     ),
                 );
@@ -698,19 +713,10 @@ export const stripeWebhooksRoutes = new Hono<Env>()
                 const session = event.data.object as Stripe.Checkout.Session;
                 console.log(`Checkout session expired: ${session.id}`);
                 c.executionCtx.waitUntil(
-                    sendStripeEventToTinybird(c.env, {
-                        eventType: event.type,
-                        eventId: event.id,
-                        sessionId: session.id,
-                        userId: session.metadata?.userId || "",
-                        amountCents: session.amount_total || 0,
-                        currency: session.currency || "usd",
-                        paymentStatus: "expired",
-                        paymentMethod: "unknown",
-                        customerEmail: session.customer_email || "",
-                        livemode: event.livemode,
-                        payload: event,
-                    }).catch((err) =>
+                    sendStripeEventToTinybird(
+                        c.env,
+                        checkoutSessionEventData(event, session, "expired"),
+                    ).catch((err) =>
                         console.error("TinyBird Stripe send failed:", err),
                     ),
                 );

--- a/enter.pollinations.ai/test/integration/stripe.test.ts
+++ b/enter.pollinations.ai/test/integration/stripe.test.ts
@@ -3249,8 +3249,61 @@ test("POST /api/webhooks/stripe emits checkout.session.async_payment_failed to T
     expect(mocks.tinybird.state.stripeEvents[0]).toMatchObject({
         event_id: "evt_test_async_failed",
         event_type: "checkout.session.async_payment_failed",
+        session_id: "cs_test_async_failed",
+        user_id: "u_test",
+        amount_cents: 429,
         currency: "eur",
         payment_status: "unpaid",
+        payment_method: "unknown",
         payment_methods_offered: "sepa_debit",
+        customer_email: "buyer@example.com",
+        livemode: 0,
     });
+});
+
+test("POST /api/webhooks/stripe emits checkout.session.expired to Tinybird without payment_methods_offered", async ({
+    mocks,
+}) => {
+    await mocks.enable("tinybird");
+
+    // Expired sessions serialize a hardcoded "expired" status and omit
+    // payment_methods_offered (unlike the completed/async handlers).
+    const expiredEvent = {
+        id: "evt_test_expired",
+        type: "checkout.session.expired",
+        livemode: false,
+        data: {
+            object: {
+                id: "cs_test_expired",
+                object: "checkout.session",
+                amount_total: 429,
+                currency: "eur",
+                payment_status: "unpaid",
+                payment_method_types: ["card"],
+                metadata: { userId: "u_test" },
+                customer_email: "buyer@example.com",
+            },
+        },
+    };
+
+    const response = await postSignedStripeWebhook(expiredEvent);
+    expect(response.status).toBe(200);
+
+    expect(mocks.tinybird.state.stripeEvents).toHaveLength(1);
+    const emitted = mocks.tinybird.state.stripeEvents[0];
+    expect(emitted).toMatchObject({
+        event_id: "evt_test_expired",
+        event_type: "checkout.session.expired",
+        session_id: "cs_test_expired",
+        user_id: "u_test",
+        amount_cents: 429,
+        currency: "eur",
+        payment_status: "expired",
+        payment_method: "unknown",
+        customer_email: "buyer@example.com",
+        livemode: 0,
+    });
+    // Exact serialization: the expired handler does not emit the offered
+    // payment methods, so the shared mapper must not synthesize them here.
+    expect(emitted.payment_methods_offered).toBe("");
 });


### PR DESCRIPTION
- Extracts the duplicated checkout-session-to-Tinybird mapping into one private builder.
- Reuses it for successful checkout analytics, async payment failure, and expiration.
- Preserves each branch's exact payment-status fallback, presentment fields, offered-method behavior, logs, `waitUntil` placement, and webhook acknowledgement.
- Leaves fulfillment, duplicate handling, charge/refund serialization, and the explicit event switch unchanged.

Checks:
- Biome
- Enter TypeScript typecheck
- Focused Stripe webhook tests (3 passed)
- `git diff --check`