### PR TITLE
refactor: centralize fallback target formatting

### DIFF
--- a/gen.pollinations.ai/src/fallback.ts
+++ b/gen.pollinations.ai/src/fallback.ts
@@ -10,15 +10,11 @@ import { FALLBACK_TARGET_HEADER } from "@shared/registry/usage-headers.ts";
 import { firstContentPolicyMessage } from "./image/utils/contentModeration.ts";
 import type { GenerationModelEntry } from "./model-registry.ts";
 
-/**
- * Upstream statuses that make a request move on to the model's next fallback
- * target.
- *
- * 400 and 422 are left out on purpose: those are caller errors and retrying
- * them elsewhere cannot succeed. 401/402/403/404 are included because they mean
- * the primary's credentials or upstream model are broken, which the fallback may
- * survive.
- */
+/** Formats the served target marker in Portkey's header shape. */
+export function formatFallbackTarget(index: number): string {
+    return `config.targets[${index}]`;
+}
+
 /**
  * Internal-only marker: which declared target served. Must stay
  * non-enumerable so JSON bodies and R2 cache snapshots never leak it.
@@ -29,7 +25,7 @@ export function attachFallbackTarget<T extends object>(
 ): T {
     if (index <= 0) return value;
     Object.defineProperty(value, "fallbackTarget", {
-        value: `config.targets[${index}]`,
+        value: formatFallbackTarget(index),
         enumerable: false,
         configurable: true,
         writable: true,
@@ -37,6 +33,15 @@ export function attachFallbackTarget<T extends object>(
     return value;
 }
 
+/**
+ * Upstream statuses that make a request move on to the model's next fallback
+ * target.
+ *
+ * 400 and 422 are left out on purpose: those are caller errors and retrying
+ * them elsewhere cannot succeed. 401/402/403/404 are included because they mean
+ * the primary's credentials or upstream model are broken, which the fallback may
+ * survive.
+ */
 export const FALLBACK_ON_STATUS_CODES = [
     401, 402, 403, 404, 408, 429, 500, 502, 503, 504,
 ];
@@ -378,7 +383,7 @@ export async function withModelFallbackResponse(
         beforeAttempt,
     );
     if (index > 0) {
-        result.headers.set(FALLBACK_TARGET_HEADER, `config.targets[${index}]`);
+        result.headers.set(FALLBACK_TARGET_HEADER, formatFallbackTarget(index));
     }
     return { response: result, servedEntry: candidate.entry };
 }

--- a/gen.pollinations.ai/src/image/handler.ts
+++ b/gen.pollinations.ai/src/image/handler.ts
@@ -6,7 +6,11 @@ import { FALLBACK_TARGET_HEADER } from "@shared/registry/usage-headers.ts";
 import type { Context } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { Env } from "@/env.ts";
-import { fallbackCandidates, withModelFallback } from "../fallback.ts";
+import {
+    fallbackCandidates,
+    formatFallbackTarget,
+    withModelFallback,
+} from "../fallback.ts";
 import type { GenerationModelEntry } from "../model-registry.ts";
 import { enforceModelRateLimit } from "../utils/model-rate-limit.ts";
 import {
@@ -540,7 +544,7 @@ export async function generateImageOrVideoResponse(
             // Same shape text emits, so tracking has one fallback marker.
             headers.set(
                 FALLBACK_TARGET_HEADER,
-                `config.targets[${servedIndex}]`,
+                formatFallbackTarget(servedIndex),
             );
         }
         return new Response(bufferToUint8Array(result.buffer), { headers });

--- a/gen.pollinations.ai/test/fallback.test.ts
+++ b/gen.pollinations.ai/test/fallback.test.ts
@@ -8,6 +8,7 @@ import {
     type FailedCall,
     type FallbackCandidate,
     fallbackCandidates,
+    formatFallbackTarget,
     isRetryableFallbackError,
     linkFallbackEntries,
     withModelFallback,
@@ -244,6 +245,14 @@ describe("registry fallback linking", () => {
         );
 
         expect(primary.fallbackEntries).toBeUndefined();
+    });
+});
+
+describe("formatFallbackTarget", () => {
+    it("formats the marker for index > 0", () => {
+        expect(formatFallbackTarget(1)).toBe("config.targets[1]");
+        expect(formatFallbackTarget(2)).toBe("config.targets[2]");
+        expect(formatFallbackTarget(10)).toBe("config.targets[10]");
     });
 });
 


### PR DESCRIPTION
- Adds one canonical `formatFallbackTarget(index)` for locally produced `config.targets[N]` markers.
- Reuses it for non-enumerable text completion metadata, fallback response headers, and image response headers.
- Preserves all index guards, non-enumerability, external Portkey passthrough, and the existing permissive tracking parser.
- Adds a focused formatter test; no parser, type, or codec framework is introduced.

Checks:
- Biome
- Gen TypeScript typecheck
- Focused fallback/image tests (24 passed)