### PR TITLE
refactor: clarify community endpoint policy

### DIFF
--- a/enter.pollinations.ai/src/routes/community-endpoints.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints.ts
@@ -482,6 +482,102 @@ const UpdateEndpointSchema = z
     })
     .strict();
 
+type ProxyUpdateInput = z.infer<typeof ProxyUpdateSchema>;
+type ProxyPolicy = Pick<
+    ProxyListingPayload,
+    | "modality"
+    | "imagePricing"
+    | "inputModalities"
+    | "paidOnly"
+    | "perUserRpm"
+    | "advertised"
+    | "prices"
+>;
+
+function pricesForVisibility(
+    visibility: CommunityEndpointVisibility,
+    source: Partial<Record<CommunityEndpointPriceKey, number>>,
+    modality: CommunityEndpointModality,
+    imagePricing: CommunityEndpointImagePricing,
+): CommunityEndpointPrices {
+    return visibility === "private"
+        ? communityEndpointPrices({})
+        : communityEndpointPricesForModality(source, modality, imagePricing);
+}
+
+function changesProxyPayload(input: ProxyUpdateInput): boolean {
+    return [
+        input.bearerToken,
+        input.visibility,
+        input.perUserRpm,
+        input.paidOnly,
+        input.imagePricing,
+        input.inputModalities,
+        input.advertised,
+        input.fallbacks,
+        ...COMMUNITY_ENDPOINT_PRICE_FIELDS.map(({ key }) => input[key]),
+    ].some((value) => value !== undefined);
+}
+
+function deriveProxyPolicy(
+    input: ProxyUpdateInput,
+    visibility: CommunityEndpointVisibility,
+    modality: CommunityEndpointModality,
+    stored?: ProxyListingPayload,
+): ProxyPolicy {
+    // Omitted values preserve an existing declaration or follow the modality
+    // when this is a new endpoint.
+    const inputModalities =
+        input.inputModalities ??
+        stored?.inputModalities ??
+        normalizeCommunityEndpointInputModalities(undefined, modality);
+    enforceCommunityEndpointInputModalities(modality, inputModalities);
+    enforceCommunityEndpointAdvertised(modality, input.advertised);
+
+    const imagePricing =
+        modality === "image"
+            ? (input.imagePricing ?? stored?.imagePricing ?? "request")
+            : (stored?.imagePricing ?? "request");
+    const priceSource = { ...stored?.prices, ...input };
+    if (stored && imagePricing !== stored.imagePricing) {
+        for (const field of communityEndpointPriceFieldsForModality(
+            modality,
+            imagePricing,
+        )) {
+            if (input[field.key] === undefined) priceSource[field.key] = 0;
+        }
+    }
+    const prices = pricesForVisibility(
+        visibility,
+        priceSource,
+        modality,
+        imagePricing,
+    );
+    const paidOnly =
+        visibility === "public"
+            ? (input.paidOnly ?? stored?.paidOnly ?? false)
+            : false;
+    enforceCommunityEndpointPriceLimits(prices, modality, imagePricing);
+
+    return {
+        modality,
+        imagePricing,
+        inputModalities,
+        paidOnly,
+        perUserRpm:
+            input.perUserRpm === undefined
+                ? (stored?.perUserRpm ?? null)
+                : input.perUserRpm,
+        advertised:
+            input.advertised === undefined
+                ? stored?.advertised
+                : hasAdvertisedClaim(input.advertised)
+                  ? input.advertised
+                  : undefined,
+        prices,
+    };
+}
+
 function assertValidUpdate(
     type: "proxy" | "prompt_agent" | "endpoint_agent",
     input: unknown,
@@ -1053,56 +1149,25 @@ export const communityEndpointsRoutes = new Hono<Env>()
                 user.id,
             );
             await ensureModelNameAvailable(db, user.id, input.name);
-            const modality = input.modality;
-            const imagePricing =
-                modality === "image" ? input.imagePricing : "request";
-            // An omitted set follows the modality — audio for transcription,
-            // text otherwise. An explicit set is validated rather than
-            // silently rewritten, so a wrong declaration still gets a 400.
-            const inputModalities =
-                input.inputModalities ??
-                normalizeCommunityEndpointInputModalities(undefined, modality);
-            enforceCommunityEndpointInputModalities(modality, inputModalities);
-            enforceCommunityEndpointAdvertised(modality, input.advertised);
-            const prices =
-                input.visibility === "public"
-                    ? communityEndpointPricesForModality(
-                          input,
-                          modality,
-                          imagePricing,
-                      )
-                    : communityEndpointPrices({});
-            const paidOnly =
-                input.visibility === "public" ? input.paidOnly : false;
-            enforceCommunityEndpointPriceLimits(prices, modality, imagePricing);
+            const policy = deriveProxyPolicy(
+                input,
+                input.visibility,
+                input.modality,
+            );
+            const modelId = communityModelId(ownerGithubUsername, input.name);
             const payload: ProxyListingPayload = {
-                modality,
-                imagePricing,
-                inputModalities,
-                paidOnly,
                 bearerTokenCiphertext: await encryptSecret(
                     normalizeInputBearerToken(input.bearerToken),
                     c.env.BETTER_AUTH_SECRET,
                 ),
-                perUserRpm: input.perUserRpm ?? null,
+                ...policy,
                 fallbacks: input.fallbacks
                     ? await resolveFallbacks(db, input.fallbacks, {
-                          modelId: communityModelId(
-                              ownerGithubUsername,
-                              input.name,
-                          ),
+                          modelId,
                           ownerUserId: user.id,
-                          modality,
-                          imagePricing,
-                          paidOnly,
-                          prices,
-                          inputModalities,
+                          ...policy,
                       })
                     : [],
-                ...(hasAdvertisedClaim(input.advertised)
-                    ? { advertised: input.advertised }
-                    : {}),
-                prices,
             };
             await enforcePublishingAccess(db, user.id, input.visibility);
             const [row] = await db
@@ -1321,45 +1386,11 @@ export const communityEndpointsRoutes = new Hono<Env>()
                 if (!stored) {
                     throw new Error(`Invalid proxy payload for ${endpoint.id}`);
                 }
-                const modality = stored.modality;
-                const inputModalities =
-                    input.inputModalities ?? stored.inputModalities;
-                enforceCommunityEndpointInputModalities(
-                    modality,
-                    inputModalities,
-                );
-                enforceCommunityEndpointAdvertised(modality, input.advertised);
-                const imagePricing =
-                    modality === "image" && input.imagePricing !== undefined
-                        ? input.imagePricing
-                        : stored.imagePricing;
-                const priceSource = { ...stored.prices, ...input };
-                if (imagePricing !== stored.imagePricing) {
-                    for (const field of communityEndpointPriceFieldsForModality(
-                        modality,
-                        imagePricing,
-                    )) {
-                        if (input[field.key] === undefined) {
-                            priceSource[field.key] = 0;
-                        }
-                    }
-                }
-                const prices =
-                    effectiveVisibility === "private"
-                        ? communityEndpointPrices({})
-                        : communityEndpointPricesForModality(
-                              priceSource,
-                              modality,
-                              imagePricing,
-                          );
-                const paidOnly =
-                    effectiveVisibility === "public"
-                        ? (input.paidOnly ?? stored.paidOnly)
-                        : false;
-                enforceCommunityEndpointPriceLimits(
-                    prices,
-                    modality,
-                    imagePricing,
+                const policy = deriveProxyPolicy(
+                    input,
+                    effectiveVisibility,
+                    stored.modality,
+                    stored,
                 );
                 const fallbacks =
                     input.fallbacks === undefined
@@ -1370,11 +1401,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
                                   input.name ?? endpoint.name,
                               ),
                               ownerUserId: user.id,
-                              modality,
-                              imagePricing,
-                              paidOnly,
-                              prices,
-                              inputModalities,
+                              ...policy,
                           });
                 if (input.baseUrl !== undefined) {
                     update.baseUrl = normalizeInputBaseUrl(input.baseUrl);
@@ -1382,20 +1409,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
                 if (input.upstreamModel !== undefined) {
                     update.upstreamModel = input.upstreamModel;
                 }
-                const changesPayload = [
-                    input.bearerToken,
-                    input.visibility,
-                    input.perUserRpm,
-                    input.paidOnly,
-                    input.imagePricing,
-                    input.inputModalities,
-                    input.advertised,
-                    input.fallbacks,
-                    ...COMMUNITY_ENDPOINT_PRICE_FIELDS.map(
-                        ({ key }) => input[key],
-                    ),
-                ].some((value) => value !== undefined);
-                if (changesPayload) {
+                if (changesProxyPayload(input)) {
                     const payload: ProxyListingPayload = {
                         bearerTokenCiphertext:
                             input.bearerToken === undefined
@@ -1406,22 +1420,8 @@ export const communityEndpointsRoutes = new Hono<Env>()
                                       ),
                                       c.env.BETTER_AUTH_SECRET,
                                   ),
-                        modality,
-                        imagePricing,
-                        inputModalities,
-                        paidOnly,
-                        perUserRpm:
-                            input.perUserRpm === undefined
-                                ? stored.perUserRpm
-                                : input.perUserRpm,
+                        ...policy,
                         fallbacks,
-                        advertised:
-                            input.advertised === undefined
-                                ? stored.advertised
-                                : hasAdvertisedClaim(input.advertised)
-                                  ? input.advertised
-                                  : undefined,
-                        prices,
                     };
                     update.payload = JSON.stringify(payload);
                 }

--- a/enter.pollinations.ai/test/integration/community-endpoint-policy.test.ts
+++ b/enter.pollinations.ai/test/integration/community-endpoint-policy.test.ts
@@ -1,0 +1,133 @@
+import { env, SELF } from "cloudflare:test";
+import { COMMUNITY_ENDPOINT_PRICE_FIELDS } from "@shared/community-endpoints.ts";
+import * as schema from "@shared/db/better-auth.ts";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import { describe, expect } from "vitest";
+import { test } from "../fixtures.ts";
+
+const endpointUrl = "http://localhost:3000/api/account/my-models";
+
+async function approveCommunityModels(): Promise<void> {
+    await drizzle(env.DB)
+        .update(schema.user)
+        .set({ githubId: 36901823 })
+        .where(eq(schema.user.githubUsername, "testuser"));
+}
+
+async function postModel(
+    sessionToken: string,
+    path: string,
+    body: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+    const response = await SELF.fetch(`${endpointUrl}${path}`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            Cookie: `better-auth.session_token=${sessionToken}`,
+        },
+        body: JSON.stringify(body),
+    });
+    expect(response.status, await response.clone().text()).toBe(200);
+    return response.json<Record<string, unknown>>();
+}
+
+describe("community endpoint configuration policy", () => {
+    test("derives image pricing transitions and private visibility", async ({
+        sessionToken,
+    }) => {
+        await approveCommunityModels();
+        const created = await postModel(sessionToken, "", {
+            name: "image-policy",
+            title: "Image policy",
+            visibility: "public",
+            baseUrl: "https://images.example.com/v1",
+            bearerToken: "test-provider-token",
+            modality: "image",
+            imagePricing: "request",
+            inputModalities: ["text", "image"],
+            paidOnly: true,
+            perUserRpm: 2.5,
+            completionImagePrice: 0.2,
+        });
+
+        expect(created).toMatchObject({
+            modality: "image",
+            imagePricing: "request",
+            inputModalities: ["text", "image"],
+            paidOnly: true,
+            perUserRpm: 2.5,
+            completionImagePrice: 0.2,
+        });
+
+        const tokenPriced = await postModel(
+            sessionToken,
+            `/${created.id as string}/update`,
+            {
+                imagePricing: "tokens",
+                promptImagePrice: 0.000001,
+            },
+        );
+        expect(tokenPriced).toMatchObject({
+            imagePricing: "tokens",
+            promptTextPrice: 0,
+            promptImagePrice: 0.000001,
+            completionImagePrice: 0,
+            paidOnly: true,
+        });
+
+        const privateModel = await postModel(
+            sessionToken,
+            `/${created.id as string}/update`,
+            { visibility: "private" },
+        );
+        expect(privateModel).toMatchObject({
+            visibility: "private",
+            inputModalities: ["text", "image"],
+            perUserRpm: 2.5,
+            paidOnly: false,
+        });
+        for (const { key } of COMMUNITY_ENDPOINT_PRICE_FIELDS) {
+            expect(privateModel[key]).toBe(0);
+        }
+    });
+
+    test("clears advertised metadata without rewriting payload for listing-only changes", async ({
+        sessionToken,
+    }) => {
+        await approveCommunityModels();
+        const created = await postModel(sessionToken, "", {
+            name: "text-policy",
+            title: "Text policy",
+            visibility: "public",
+            baseUrl: "https://text.example.com/v1",
+            bearerToken: "test-provider-token",
+            modality: "text",
+            perUserRpm: 3,
+            advertised: {
+                capabilities: ["tool_calling"],
+                contextLength: 32000,
+            },
+            promptTextPrice: 0.000001,
+        });
+
+        const cleared = await postModel(
+            sessionToken,
+            `/${created.id as string}/update`,
+            { advertised: {}, perUserRpm: null },
+        );
+        expect(cleared).toMatchObject({ advertised: {}, perUserRpm: null });
+
+        const db = drizzle(env.DB, { schema });
+        const before = await db.query.communityEndpoint.findFirst({
+            where: eq(schema.communityEndpoint.id, created.id as string),
+        });
+        await postModel(sessionToken, `/${created.id as string}/update`, {
+            title: "Renamed listing",
+        });
+        const after = await db.query.communityEndpoint.findFirst({
+            where: eq(schema.communityEndpoint.id, created.id as string),
+        });
+        expect(after?.payload).toBe(before?.payload);
+    });
+});


### PR DESCRIPTION
- Derives create/update modality, pricing, visibility, RPM, and advertised policy in one pure decision path
- Leaves fallback lookup, credential encryption, publish authorization, and SQL visibly ordered in the handlers
- Preserves private zero-pricing, paid-only resets, image-pricing transitions, and payload rewrite boundaries
- Adds integration coverage for create/update policy transitions

Checks:
- `npm run typecheck` (`enter.pollinations.ai`)
- focused community endpoint suite: 29 passed
- `npx biome check --write` on changed files
- `git diff --check`