### PR TITLE
feat(polli-cli): add polli earnings command

### DIFF
--- a/packages/polli-cli/src/commands/earnings.test.ts
+++ b/packages/polli-cli/src/commands/earnings.test.ts
@@ -5,9 +5,7 @@ import {
     earningsTableRows,
 } from "./earnings.js";
 
-function makeRow(
-    overrides: Partial<EarningsRow> = {},
-): EarningsRow {
+function makeRow(overrides: Partial<EarningsRow> = {}): EarningsRow {
     return {
         date: "2026-08-01",
         entity_id: "app-1",
@@ -73,7 +71,9 @@ describe("earningsTableRows", () => {
     });
 
     it("formats pollen to 4 decimal places", () => {
-        const rows = earningsTableRows([makeRow({ pollen_earned: 1.23456789 })]);
+        const rows = earningsTableRows([
+            makeRow({ pollen_earned: 1.23456789 }),
+        ]);
         expect(rows[0]).toMatchObject({ pollen: "1.2346" });
     });
 });

--- a/packages/polli-cli/src/commands/earnings.test.ts
+++ b/packages/polli-cli/src/commands/earnings.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+    type EarningsRow,
+    earningsSummary,
+    earningsTableRows,
+} from "./earnings.js";
+
+function makeRow(
+    overrides: Partial<EarningsRow> = {},
+): EarningsRow {
+    return {
+        date: "2026-08-01",
+        entity_id: "app-1",
+        entity_name: "My App",
+        source: "byop_markup",
+        requests: 100,
+        paid_requests: 50,
+        tier_requests: 50,
+        baseline_price: 0,
+        pollen_earned: 5,
+        paid_earned: 3,
+        tier_earned: 2,
+        cost_usd: 0.01,
+        reward_rate: 0.5,
+        ...overrides,
+    };
+}
+
+describe("earningsSummary", () => {
+    it("returns zeros for empty input", () => {
+        expect(earningsSummary([])).toEqual({
+            totalPollen: 0,
+            totalRequests: 0,
+        });
+    });
+
+    it("sums pollen and requests across rows", () => {
+        const rows = [
+            makeRow({ pollen_earned: 10, requests: 200 }),
+            makeRow({ pollen_earned: 5.5, requests: 100 }),
+        ];
+        expect(earningsSummary(rows)).toEqual({
+            totalPollen: 15.5,
+            totalRequests: 300,
+        });
+    });
+});
+
+describe("earningsTableRows", () => {
+    it("maps byop_markup source to app type", () => {
+        const rows = earningsTableRows([
+            makeRow({ source: "byop_markup", entity_name: "My App" }),
+        ]);
+        expect(rows[0]).toMatchObject({ type: "app", entity: "My App" });
+    });
+
+    it("maps community_model source to model type", () => {
+        const rows = earningsTableRows([
+            makeRow({
+                source: "community_model",
+                entity_name: "my-model",
+                entity_id: "model-1",
+            }),
+        ]);
+        expect(rows[0]).toMatchObject({ type: "model", entity: "my-model" });
+    });
+
+    it("falls back to entity_id when entity_name is empty", () => {
+        const rows = earningsTableRows([
+            makeRow({ entity_name: "", entity_id: "fallback-id" }),
+        ]);
+        expect(rows[0]).toMatchObject({ entity: "fallback-id" });
+    });
+
+    it("formats pollen to 4 decimal places", () => {
+        const rows = earningsTableRows([makeRow({ pollen_earned: 1.23456789 })]);
+        expect(rows[0]).toMatchObject({ pollen: "1.2346" });
+    });
+});

--- a/packages/polli-cli/src/commands/earnings.ts
+++ b/packages/polli-cli/src/commands/earnings.ts
@@ -53,9 +53,7 @@ export function earningsTableRows(
 }
 
 export const earningsCommand = new Command("earnings")
-    .description(
-        "Show developer earnings from BYOP apps and community models",
-    )
+    .description("Show developer earnings from BYOP apps and community models")
     .option("--days <n>", "Days to look back (1–90)", "90")
     .action(async (opts) => {
         const key = requireKey();

--- a/packages/polli-cli/src/commands/earnings.ts
+++ b/packages/polli-cli/src/commands/earnings.ts
@@ -1,0 +1,104 @@
+import chalk from "chalk";
+import { Command } from "commander";
+import { gen, requireKey } from "../lib/api.js";
+import {
+    getOutputMode,
+    printError,
+    printResult,
+    printTable,
+} from "../lib/output.js";
+
+type EarningsSource = "byop_markup" | "community_model";
+
+export interface EarningsRow {
+    date: string;
+    entity_id: string;
+    entity_name: string;
+    source: EarningsSource;
+    requests: number;
+    paid_requests: number;
+    tier_requests: number;
+    baseline_price: number;
+    pollen_earned: number;
+    paid_earned: number;
+    tier_earned: number;
+    cost_usd: number;
+    reward_rate: number;
+}
+
+export interface EarningsResponse {
+    daily: EarningsRow[];
+    perEntity: EarningsRow[];
+}
+
+export function earningsSummary(perEntity: EarningsRow[]): {
+    totalPollen: number;
+    totalRequests: number;
+} {
+    return {
+        totalPollen: perEntity.reduce((sum, r) => sum + r.pollen_earned, 0),
+        totalRequests: perEntity.reduce((sum, r) => sum + r.requests, 0),
+    };
+}
+
+export function earningsTableRows(
+    perEntity: EarningsRow[],
+): Record<string, unknown>[] {
+    return perEntity.map((r) => ({
+        entity: r.entity_name || r.entity_id,
+        type: r.source === "byop_markup" ? "app" : "model",
+        requests: r.requests,
+        pollen: r.pollen_earned.toFixed(4),
+    }));
+}
+
+export const earningsCommand = new Command("earnings")
+    .description(
+        "Show developer earnings from BYOP apps and community models",
+    )
+    .option("--days <n>", "Days to look back (1–90)", "90")
+    .action(async (opts) => {
+        const key = requireKey();
+
+        const days = Number(opts.days);
+        if (!Number.isInteger(days) || days < 1 || days > 90) {
+            printError("--days must be an integer between 1 and 90");
+            process.exit(1);
+        }
+
+        try {
+            const data = await gen<EarningsResponse>(
+                `/account/earnings?days=${days}`,
+                { apiKey: key },
+            );
+
+            if (getOutputMode() !== "human") {
+                printResult(data as unknown as Record<string, unknown>);
+                return;
+            }
+
+            const perEntity = data.perEntity ?? [];
+            const { totalPollen, totalRequests } = earningsSummary(perEntity);
+
+            process.stdout.write(
+                `${chalk.bold("pollen")}: ${chalk.green(totalPollen.toFixed(4))}\n`,
+            );
+            process.stdout.write(
+                `${chalk.bold("requests")}: ${totalRequests}\n\n`,
+            );
+
+            if (perEntity.length === 0) {
+                process.stdout.write(
+                    chalk.dim("No earnings in the selected period.\n"),
+                );
+                return;
+            }
+
+            printTable(earningsTableRows(perEntity));
+        } catch (err) {
+            printError(
+                `Failed to fetch earnings: ${err instanceof Error ? err.message : "unknown"}`,
+            );
+            process.exit(1);
+        }
+    });

--- a/packages/polli-cli/src/index.ts
+++ b/packages/polli-cli/src/index.ts
@@ -4,6 +4,7 @@ import { Command } from "commander";
 
 import { authCommand } from "./commands/auth.js";
 import { docsCommand } from "./commands/docs.js";
+import { earningsCommand } from "./commands/earnings.js";
 import { createGenCommand } from "./commands/gen/index.js";
 import { keysCommand } from "./commands/keys.js";
 import { modelsCommand } from "./commands/models.js";
@@ -62,6 +63,7 @@ program
 program.addCommand(authCommand);
 program.addCommand(keysCommand);
 program.addCommand(usageCommand);
+program.addCommand(earningsCommand);
 program.addCommand(questsCommand);
 program.addCommand(myModelsCommand);
 


### PR DESCRIPTION
Fixes #13768

## What this adds

- `polli earnings` — shows total pollen earned and a per-entity breakdown (BYOP apps + community models) for the last 90 days
- `polli earnings --days N` — look back 1–90 days (matches the API's supported range); invalid values produce a clear error
- `--json` (global flag) — returns the raw `{ daily, perEntity }` API response as machine-readable JSON

## Implementation

- `packages/polli-cli/src/commands/earnings.ts` — new command; calls `GET /account/earnings?days=N`, prints totals then a table; pure helper functions (`earningsSummary`, `earningsTableRows`) extracted for testability
- `packages/polli-cli/src/commands/earnings.test.ts` — 6 focused unit tests covering the summary aggregation and table row mapping (empty input, sums, source labels, entity_id fallback, pollen formatting)
- `packages/polli-cli/src/index.ts` — registers `earningsCommand` alongside the other account commands

Follows the patterns in `usage.ts`; no new server functionality.