### PR TITLE
fix: prevent caching of authenticated account responses

### DIFF
--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -796,6 +796,11 @@ const usageResponseSchema = z.object({
  */
 export const accountRoutes = new Hono<Env>()
     .use(auth({ allowApiKey: true, allowSessionCookie: true }))
+    .use(async (c, next) => {
+        await next();
+        c.header("Cache-Control", "private, no-store, max-age=0");
+        c.header("Pragma", "no-cache");
+    })
     .route("/my-models", communityEndpointsRoutes)
     .get(
         "/profile",
@@ -1394,7 +1399,6 @@ export const accountRoutes = new Hono<Env>()
                 ? await getVisibleModelIdsForUser(c.env.DB, user.id)
                 : null;
 
-            c.header("Cache-Control", "private, no-store, max-age=0");
             return c.json({
                 data: keys.map((key, index) => ({
                     id: key.id,

--- a/enter.pollinations.ai/test/integration/account-cache-headers.test.ts
+++ b/enter.pollinations.ai/test/integration/account-cache-headers.test.ts
@@ -1,0 +1,42 @@
+import { SELF } from "cloudflare:test";
+import { describe, expect } from "vitest";
+import { test } from "../fixtures.ts";
+
+const CACHE_CONTROL = "private, no-store, max-age=0";
+const PRAGMA = "no-cache";
+
+describe("account route cache headers", () => {
+    test("top-level /account/profile sets no-cache headers", async ({
+        sessionToken,
+    }) => {
+        const response = await SELF.fetch(
+            "http://localhost:3000/api/account/profile",
+            {
+                headers: {
+                    Cookie: `better-auth.session_token=${sessionToken}`,
+                },
+            },
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("cache-control")).toBe(CACHE_CONTROL);
+        expect(response.headers.get("pragma")).toBe(PRAGMA);
+    });
+
+    test("nested /account/my-models sets no-cache headers", async ({
+        sessionToken,
+    }) => {
+        const response = await SELF.fetch(
+            "http://localhost:3000/api/account/my-models",
+            {
+                headers: {
+                    Cookie: `better-auth.session_token=${sessionToken}`,
+                },
+            },
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("cache-control")).toBe(CACHE_CONTROL);
+        expect(response.headers.get("pragma")).toBe(PRAGMA);
+    });
+});


### PR DESCRIPTION
Fixes #13771

## Changes

- Adds a single `.use()` after-handler middleware on `accountRoutes` that sets `Cache-Control: private, no-store, max-age=0` and `Pragma: no-cache` for every route under `/account`, including nested `/my-models` routes — applied once, not per-handler.
- Removes the existing per-handler `c.header("Cache-Control", ...)` from the `/keys` list endpoint, which was the only route that set it before.
- Adds `test/integration/account-cache-headers.test.ts` with two focused tests: one for a top-level account route (`/account/profile`) and one for a nested route (`/account/my-models`), both asserting the correct `Cache-Control` and `Pragma` values.