### PR TITLE
fix: clarify community model privacy

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/models.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/models.tsx
@@ -499,18 +499,29 @@ export const Models: FC = () => {
                         title="Community model privacy"
                         className="mb-4"
                     >
-                        Requests to community models are sent to independent
-                        providers, including configured fallback providers. They
-                        may retain, share, or train on your data under their own
-                        policies. Check the provider information before sending
-                        confidential or sensitive data. See our{" "}
-                        <InlineLink
-                            href="https://pollinations.ai/privacy"
-                            showIcon={false}
-                        >
-                            Privacy Policy
-                        </InlineLink>
-                        .
+                        <p>
+                            Requests go to independent providers and configured
+                            fallbacks, which handle your data under their own
+                            policies.
+                        </p>
+                        <p className="mt-2">
+                            <strong>Avoid sensitive data.</strong> For text
+                            input, you can use our optional{" "}
+                            <InlineLink
+                                href="https://gen.pollinations.ai/docs#tag/Safety"
+                                showIcon={false}
+                            >
+                                privacy filter
+                            </InlineLink>
+                            . See our{" "}
+                            <InlineLink
+                                href="https://pollinations.ai/privacy"
+                                showIcon={false}
+                            >
+                                Privacy Policy
+                            </InlineLink>
+                            .
+                        </p>
                     </Alert>
                 )}
                 {catalogError && (

--- a/gen.pollinations.ai/src/docs/safety.md
+++ b/gen.pollinations.ai/src/docs/safety.md
@@ -2,6 +2,8 @@
 
 Optional safety checking runs on text input before generation. Omitted, `false`, or `0` means off.
 
+For community models, enabled checks run before text is sent to the provider or a configured fallback.
+
 Use `safe` as a query parameter or JSON body field, or send the same value in the `Pollinations-Safe` header.
 
 Values: `privacy` redacts personal information like names, email, phone, address, IP, URLs, and usernames. `secrets` redacts keys and passwords. `sexual`, `violence`, and `shield` block matching requests. Aliases: `true` = `privacy,secrets`, `nsfw` = `sexual,violence`.

--- a/gen.pollinations.ai/test/safety.test.ts
+++ b/gen.pollinations.ai/test/safety.test.ts
@@ -1,8 +1,14 @@
 import {
+    communityEndpointPrices,
+    communityModelDefinition,
+    type ProxyCommunityEndpointRuntime,
+} from "@shared/community-endpoints.ts";
+import {
     parseSafeFeatures,
     SAFETY_HEADER_NAME,
     SafeSchema,
 } from "@shared/schemas/safety.ts";
+import { encryptSecret } from "@shared/secret-encryption.ts";
 import { Hono } from "hono";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Env } from "@/env.ts";
@@ -22,6 +28,7 @@ import {
     generateCacheKey as generateTextCacheKey,
     prepareMetadata as prepareTextCacheMetadata,
 } from "@/utils/text-cache.ts";
+import { generateChatCompletion } from "../src/routes/generation-handlers.ts";
 import { prepareOpenAIImageGeneration } from "../src/routes/images.ts";
 
 const testLog = {
@@ -440,6 +447,124 @@ describe("applySafetyToChatRequest", { timeout: 30000 }, () => {
                 },
             ],
         });
+    });
+
+    it("redacts PII before sending a community model request upstream", async () => {
+        guardrailResponse = intervened(
+            {
+                sensitiveInformationPolicy: {
+                    piiEntities: [
+                        {
+                            action: "ANONYMIZED",
+                            match: "a@example.com",
+                            type: "EMAIL",
+                        },
+                    ],
+                },
+            },
+            [{ text: "email {EMAIL}" }],
+        );
+
+        const secret = "community-safety-test-secret";
+        const endpoint: ProxyCommunityEndpointRuntime = {
+            type: "proxy",
+            id: "community-endpoint-id",
+            ownerUserId: "owner-id",
+            modelId: "owner/community-model",
+            name: "community-model",
+            title: "Community Model",
+            description: null,
+            modality: "text",
+            imagePricing: "request",
+            inputModalities: ["text"],
+            baseUrl: "https://community.example.test/v1",
+            upstreamModel: "upstream-model",
+            visibility: "public",
+            paidOnly: false,
+            perUserRpm: null,
+            fallbacks: [],
+            hiddenAt: null,
+            hiddenReason: null,
+            bearerTokenCiphertext: await encryptSecret("sk_saved", secret),
+            ...communityEndpointPrices({
+                promptTextPrice: 0.1,
+                completionTextPrice: 0.1,
+            }),
+        };
+        const definition = communityModelDefinition(endpoint);
+        const upstreamFetch = vi.fn(
+            async (_input: RequestInfo | URL, init?: RequestInit) => {
+                expect(JSON.parse(String(init?.body))).toMatchObject({
+                    model: "upstream-model",
+                    messages: [{ role: "user", content: "email {EMAIL}" }],
+                });
+                expect(String(init?.body)).not.toContain("a@example.com");
+                return Response.json({
+                    model: "upstream-model",
+                    choices: [
+                        {
+                            index: 0,
+                            message: { role: "assistant", content: "ok" },
+                            finish_reason: "stop",
+                        },
+                    ],
+                    usage: {
+                        prompt_tokens: 2,
+                        completion_tokens: 1,
+                        total_tokens: 3,
+                    },
+                });
+            },
+        );
+        const app = new Hono<Env>()
+            .use("*", async (c, next) => {
+                c.set("log", testLog);
+                c.set("requestId", "community-safety-request");
+                c.set("track", {
+                    modelRequested: endpoint.modelId,
+                    resolvedModelRequested: endpoint.modelId,
+                    streamRequested: false,
+                    overrideResponseTracking() {},
+                    setPricingInput() {},
+                    failedCalls: [],
+                });
+                c.set("model", {
+                    requested: endpoint.modelId,
+                    resolved: endpoint.modelId,
+                    definition,
+                    communityEndpoint: endpoint,
+                });
+                const body = await c.req.json();
+                c.req.addValidatedData("json", body);
+                await next();
+            })
+            .post("/v1/chat/completions", generateChatCompletion);
+
+        const response = await app.request(
+            "/v1/chat/completions",
+            {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    model: endpoint.modelId,
+                    safe: "privacy",
+                    messages: [
+                        { role: "user", content: "email a@example.com" },
+                    ],
+                }),
+            },
+            {
+                ...configuredEnv,
+                BETTER_AUTH_SECRET: secret,
+                PORTKEY_GATEWAY_URL: "https://portkey.test",
+                PORTKEY: { fetch: upstreamFetch },
+            } as unknown as CloudflareBindings,
+        );
+
+        expect(response.status, await response.clone().text()).toBe(200);
+        expect(upstreamFetch).toHaveBeenCalledOnce();
+        expect(response.headers.get("X-Safety-Applied")).toBe("privacy");
+        expect(response.headers.get("X-Safety-Redacted")).toBe("EMAIL");
     });
 
     it("checks only the latest chat parts when a safe chat request has too many text parts", async () => {


### PR DESCRIPTION
- Simplifies and formats the community-model privacy notice
- Links the optional text privacy filter and Privacy Policy
- Clarifies that enabled checks run before providers and fallbacks
- Adds provider-boundary regression coverage for personal-data redaction