### PR TITLE
feat: add GET /v1/models/:model (OpenAI-compatible model retrieval)

### DIFF
--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -49,11 +49,13 @@ import {
     CreateChatCompletionResponseSchema,
     CreateImageRequestSchema,
     CreateImageResponseSchema,
+    GetModelResponseSchema,
     GetModelsResponseSchema,
 } from "@shared/schemas/openai.ts";
 import { SafeSchema, type SafeValue } from "@shared/schemas/safety.ts";
 import { errorResponseDescriptions } from "@shared/utils/api-docs.ts";
 import { createFactory } from "hono/factory";
+import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 import {
     applySafety,
@@ -249,6 +251,23 @@ const modelsListHandler =
         );
     };
 
+function toOpenAIModelEntry(entry: GenerationModelEntry) {
+    return {
+        id: entry.id,
+        object: "model" as const,
+        created: entry.info.added_date ?? 0,
+        owned_by: entry.info.brand,
+        input_modalities: entry.info.input_modalities,
+        output_modalities: entry.info.output_modalities,
+        supported_endpoints: entry.supportedEndpoints,
+        ...(entry.info.tools && { tools: entry.info.tools }),
+        ...(entry.info.reasoning && { reasoning: entry.info.reasoning }),
+        ...(entry.info.context_length && {
+            context_length: entry.info.context_length,
+        }),
+    };
+}
+
 async function getVisibleModelEntries(c: Context<Env>) {
     return (await getGenerationModelRegistry(c.env)).visibleEntries(
         c.var.auth?.user?.id,
@@ -310,6 +329,7 @@ export const proxyRoutes = new Hono<Env>()
     .use("*", edgeRateLimit)
     // Optional auth for models endpoints - doesn't require auth but uses it if provided
     .use("/v1/models", auth())
+    .use("/v1/models/:model", auth())
     .use("/image/models", auth())
     .use("/3d/models", auth())
     .use("/video/models", auth())
@@ -344,28 +364,73 @@ export const proxyRoutes = new Hono<Env>()
                 allowedModels,
                 paidBalance,
             );
-            const now = Date.now();
-
-            const toModelEntry = (entry: GenerationModelEntry) => ({
-                id: entry.info.name,
-                object: "model" as const,
-                created: now,
-                input_modalities: entry.info.input_modalities,
-                output_modalities: entry.info.output_modalities,
-                supported_endpoints: entry.supportedEndpoints,
-                ...(entry.info.tools && { tools: entry.info.tools }),
-                ...(entry.info.reasoning && {
-                    reasoning: entry.info.reasoning,
-                }),
-                ...(entry.info.context_length && {
-                    context_length: entry.info.context_length,
-                }),
-            });
-
             return c.json({
                 object: "list" as const,
-                data: modelEntries.map(toModelEntry),
+                data: modelEntries.map(toOpenAIModelEntry),
             });
+        },
+    )
+    .get(
+        "/v1/models/:model",
+        describeRoute({
+            tags: ["🤖 Models"],
+            summary: "Retrieve Model (OpenAI-compatible)",
+            description:
+                "Returns metadata for a single model by ID or alias. The response uses the canonical model ID. Returns 404 if the model does not exist or is inaccessible to the caller.",
+            responses: {
+                200: {
+                    description: "Success",
+                    content: {
+                        "application/json": {
+                            schema: resolver(GetModelResponseSchema),
+                        },
+                    },
+                },
+                ...errorResponseDescriptions(400, 401, 404, 500),
+            },
+        }),
+        async (c) => {
+            const modelId = c.req.param("model");
+            const registry = await getGenerationModelRegistry(c.env);
+            const entry = registry.resolve(modelId);
+
+            if (!entry) {
+                throw new HTTPException(404, {
+                    message: `Model '${modelId}' not found`,
+                });
+            }
+
+            // Check visibility (private community models only visible to their owner)
+            if (!entry.visible) {
+                const endpoint = entry.communityEndpoint;
+                const userId = c.var.auth?.user?.id;
+                if (
+                    !endpoint ||
+                    endpoint.visibility !== "private" ||
+                    endpoint.ownerUserId !== userId
+                ) {
+                    throw new HTTPException(404, {
+                        message: `Model '${modelId}' not found`,
+                    });
+                }
+            }
+
+            // Check API key model permissions
+            const allowedModels = c.var.auth?.apiKey?.permissions?.models;
+            if (allowedModels && !allowedModels.includes(entry.id)) {
+                throw new HTTPException(404, {
+                    message: `Model '${modelId}' not found`,
+                });
+            }
+
+            // Check paid balance for paid-only models
+            if (entry.info.paid_only && hasPaidBalance(c) === false) {
+                throw new HTTPException(404, {
+                    message: `Model '${modelId}' not found`,
+                });
+            }
+
+            return c.json(toOpenAIModelEntry(entry));
         },
     )
     .get(

--- a/gen.pollinations.ai/test/model-permissions.test.ts
+++ b/gen.pollinations.ai/test/model-permissions.test.ts
@@ -193,3 +193,73 @@ test("requires paid balance for Recraft vector", async ({
     );
     expect(generation.status).toBe(402);
 });
+
+test("retrieves a model by ID from GET /v1/models/:model", async () => {
+    const response = await fetchWorker("/v1/models/openai-fast");
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+        id: string;
+        object: string;
+        created: number;
+        owned_by: string;
+    };
+    expect(body.id).toBe("openai-fast");
+    expect(body.object).toBe("model");
+    expect(typeof body.created).toBe("number");
+    expect(typeof body.owned_by).toBe("string");
+});
+
+test("GET /v1/models/:model resolves alias to canonical model ID", async () => {
+    const response = await fetchWorker("/v1/models/gpt-5-nano");
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { id: string; object: string };
+    expect(body.id).toBe("openai-fast");
+    expect(body.object).toBe("model");
+});
+
+test("GET /v1/models/:model returns 404 for unknown model", async () => {
+    const response = await fetchWorker("/v1/models/does-not-exist-xyz");
+    expect(response.status).toBe(404);
+});
+
+test("GET /v1/models/:model returns 404 for model excluded by API key permissions", async ({
+    restrictedApiKey,
+}) => {
+    const response = await fetchWorker("/v1/models/openai", {
+        headers: { Authorization: `Bearer ${restrictedApiKey}` },
+    });
+    expect(response.status).toBe(404);
+});
+
+test("GET /v1/models/:model returns 404 for paid-only model without paid balance", async ({
+    apiKey,
+}) => {
+    const response = await fetchWorker("/v1/models/krea", {
+        headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    expect(response.status).toBe(404);
+});
+
+test("GET /v1/models/:model returns paid-only model when caller has paid balance", async ({
+    paidApiKey,
+}) => {
+    const response = await fetchWorker("/v1/models/krea", {
+        headers: { Authorization: `Bearer ${paidApiKey}` },
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { id: string };
+    expect(body.id).toBe("krea");
+});
+
+test("GET /v1/models and GET /v1/models/:model return the same created timestamp", async () => {
+    const listResponse = await fetchWorker("/v1/models");
+    const listBody = (await listResponse.json()) as {
+        data: { id: string; created: number }[];
+    };
+    const fromList = listBody.data.find((m) => m.id === "openai-fast");
+    expect(fromList).toBeDefined();
+
+    const retrieveResponse = await fetchWorker("/v1/models/openai-fast");
+    const fromRetrieve = (await retrieveResponse.json()) as { created: number };
+    expect(fromRetrieve.created).toBe(fromList!.created);
+});

--- a/shared/error.ts
+++ b/shared/error.ts
@@ -343,7 +343,7 @@ export function getErrorCode(status: number): string {
 }
 
 export const KNOWN_ERROR_STATUS_CODES = [
-    400, 401, 402, 403, 405, 409, 422, 426, 429, 500, 502, 503,
+    400, 401, 402, 403, 404, 405, 409, 422, 426, 429, 500, 502, 503,
 ] as const;
 
 export type ErrorStatusCode = (typeof KNOWN_ERROR_STATUS_CODES)[number];

--- a/shared/schemas/openai.ts
+++ b/shared/schemas/openai.ts
@@ -506,11 +506,12 @@ export type CreateChatCompletionResponse = z.infer<
     typeof CreateChatCompletionResponseSchema
 >;
 
-const OpenAIModelSchema = z
+export const OpenAIModelSchema = z
     .object({
         id: z.string(),
         object: z.literal("model"),
         created: z.number(),
+        owned_by: z.string().optional(),
         input_modalities: z.array(z.string()).optional(),
         output_modalities: z.array(z.string()).optional(),
         supported_endpoints: z.array(z.string()).optional(),
@@ -521,6 +522,8 @@ const OpenAIModelSchema = z
     .meta({
         description: "OpenAI-compatible model object with capability metadata",
     });
+
+export const GetModelResponseSchema = OpenAIModelSchema;
 
 export const GetModelsResponseSchema = z
     .object({


### PR DESCRIPTION
## Summary

- Adds `GET /v1/models/:model` endpoint that retrieves a single model by ID or alias and returns the same OpenAI-compatible shape as `GET /v1/models`
- Alias lookup resolves to the canonical model ID (e.g. `gpt-5-nano` → `openai-fast`)
- Returns `404` for unknown, hidden, permission-excluded, or paid-only (without balance) models
- Adds `owned_by` field (model brand) to the OpenAI model schema
- Switches `created` from `Date.now()` to `entry.info.added_date ?? 0` for a stable, registry-sourced timestamp
- Extracts a shared `toOpenAIModelEntry()` mapper used by both list and retrieve routes
- Adds `404` to `KNOWN_ERROR_STATUS_CODES` for consistent error formatting

## Test plan

- [x] Returns correct model shape for a valid model ID
- [x] Resolves alias to canonical model ID
- [x] Returns 404 for unknown model
- [x] Returns 404 for model excluded by API key permissions
- [x] Returns 404 for paid-only model without paid balance
- [x] Returns paid-only model when caller has paid balance
- [x] List and retrieve responses return the same stable `created` timestamp
- [x] TypeScript clean (`tsc --noEmit`)
- [x] Biome clean

Fixes #13795

🤖 Generated with [Claude Code](https://claude.com/claude-code)