### PR TITLE
feat: expose agents through A2A

### DIFF
--- a/gen.pollinations.ai/package.json
+++ b/gen.pollinations.ai/package.json
@@ -35,6 +35,7 @@
         "wrangler": "^4.52.1"
     },
     "dependencies": {
+        "@a2a-js/sdk": "^1.0.1",
         "@aws-sdk/client-bedrock-runtime": "^3.1040.0",
         "@aws-sdk/client-s3": "^3.1040.0",
         "@hono/standard-validator": "^0.2.2",

--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -4,6 +4,7 @@ import {
     SELF,
     waitOnExecutionContext,
 } from "cloudflare:test";
+import { AgentCard, Message, Role } from "@a2a-js/sdk";
 import type { Logger } from "@logtape/logtape";
 import { verifyAgentRunToken } from "@shared/auth/agent-run-token.ts";
 import { COMMUNITY_MODEL_ALLOWED_GITHUB_IDS } from "@shared/auth/github-id-list.ts";
@@ -2703,6 +2704,144 @@ fixtureTest(
         for (const r of invalidResponses) {
             expect(r.status).toBe(400);
         }
+    },
+);
+
+fixtureTest(
+    "publishes agent cards and accepts stateless A2A messages",
+    async ({ apiKey }) => {
+        const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;
+        const modelName = `a2a-${crypto.randomUUID().slice(0, 8)}`;
+        const modelId = communityModelId(ownerGithubUsername, modelName);
+        const ownerUserId = await createTestUser({
+            githubId: nextAllowedGithubId(),
+            githubUsername: ownerGithubUsername,
+        });
+        await insertCommunityEndpoints({
+            id: `endpoint-${crypto.randomUUID()}`,
+            ownerUserId,
+            type: "endpoint_agent",
+            visibility: "public",
+            name: modelName,
+            title: "A2A Test Agent",
+            description: "Answers concise test questions.",
+            baseUrl: "https://agent.example.com/v1",
+            upstreamModel: "test-agent",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+
+        const fetchMock = vi.fn(async (input, init) => {
+            const request = new Request(input, init);
+            if (isPortkeyChatCompletionsRequest(request)) {
+                await expect(request.json()).resolves.toMatchObject({
+                    model: "test-agent",
+                    messages: [{ role: "user", content: "Hello agent" }],
+                    stream: false,
+                });
+                return Response.json({
+                    id: "chatcmpl_a2a",
+                    object: "chat.completion",
+                    model: "test-agent",
+                    choices: [
+                        {
+                            index: 0,
+                            message: {
+                                role: "assistant",
+                                content: "Hello from A2A",
+                            },
+                            finish_reason: "stop",
+                        },
+                    ],
+                    usage: {
+                        prompt_tokens: 2,
+                        completion_tokens: 3,
+                        total_tokens: 5,
+                    },
+                });
+            }
+            if (isBillingFetch(request)) return Response.json({ data: [] });
+            throw new Error(`Unexpected fetch: ${request.url}`);
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const cardUrl = `https://gen.pollinations.ai/a2a/agents/${ownerGithubUsername}/${modelName}/agent-card.json`;
+        const cardResponse = await fetchGen(cardUrl);
+        expect(cardResponse.status).toBe(200);
+        expect(cardResponse.headers.get("content-type")).toContain(
+            "application/a2a+json",
+        );
+        const card = AgentCard.fromJSON(await cardResponse.json());
+        expect(card).toMatchObject({
+            name: "A2A Test Agent",
+            description: "Answers concise test questions.",
+            supportedInterfaces: [
+                {
+                    url: "https://gen.pollinations.ai/a2a",
+                    protocolBinding: "JSONRPC",
+                    protocolVersion: "1.0",
+                    tenant: modelId,
+                },
+            ],
+            capabilities: { streaming: false, pushNotifications: false },
+            defaultInputModes: ["text/plain"],
+            defaultOutputModes: ["text/plain"],
+        });
+
+        const modelsResponse = await fetchGen(
+            "https://gen.pollinations.ai/v1/models?community=true",
+        );
+        const models = (await modelsResponse.json()) as {
+            data: { id: string; agent_card_url?: string }[];
+        };
+        expect(models.data.find((model) => model.id === modelId)).toMatchObject(
+            {
+                agent_card_url: cardUrl,
+            },
+        );
+
+        const response = await fetchGen(
+            new Request("https://gen.pollinations.ai/a2a", {
+                method: "POST",
+                headers: {
+                    "A2A-Version": "1.0",
+                    Authorization: `Bearer ${apiKey}`,
+                    "Content-Type": "application/a2a+json",
+                },
+                body: JSON.stringify({
+                    jsonrpc: "2.0",
+                    id: "request-1",
+                    method: "SendMessage",
+                    params: {
+                        tenant: modelId,
+                        message: {
+                            messageId: "message-1",
+                            contextId: "context-1",
+                            role: "ROLE_USER",
+                            parts: [{ text: "Hello agent" }],
+                        },
+                    },
+                }),
+            }),
+        );
+        expect(response.status).toBe(200);
+        expect(response.headers.get("a2a-version")).toBe("1.0");
+        const body = (await response.json()) as {
+            jsonrpc: string;
+            id: string;
+            result: { message: unknown };
+        };
+        expect(body).toMatchObject({ jsonrpc: "2.0", id: "request-1" });
+        expect(Message.fromJSON(body.result.message)).toMatchObject({
+            contextId: "context-1",
+            role: Role.ROLE_AGENT,
+            parts: [
+                {
+                    content: { $case: "text", value: "Hello from A2A" },
+                    mediaType: "text/plain",
+                },
+            ],
+        });
     },
 );
 

--- a/gen.pollinations.ai/src/env.ts
+++ b/gen.pollinations.ai/src/env.ts
@@ -10,6 +10,17 @@ import type { ModelVariables } from "./middleware/model.ts";
 import type { TrackVariables } from "./middleware/track.ts";
 import type { TextVariables } from "./text/types.ts";
 
+export type A2aJsonRpcRequest = {
+    jsonrpc: "2.0";
+    id: string | number | null;
+    method: string;
+    params?: unknown;
+};
+
+export type A2aVariables = {
+    a2aRequest: A2aJsonRpcRequest;
+};
+
 export type Env = {
     Bindings: CloudflareBindings;
     Variables: RequestIdVariables &
@@ -22,5 +33,6 @@ export type Env = {
         SafetyVariables &
         TrackVariables &
         ModelVariables &
-        TextVariables;
+        TextVariables &
+        A2aVariables;
 };

--- a/gen.pollinations.ai/src/index.ts
+++ b/gen.pollinations.ai/src/index.ts
@@ -25,6 +25,7 @@ import { cors } from "hono/cors";
 import { HTTPException } from "hono/http-exception";
 import type { Env } from "@/env.ts";
 import { logger } from "@/middleware/logger.ts";
+import { a2aRoutes } from "./routes/a2a.ts";
 import { audioRoutes } from "./routes/audio.ts";
 import { buildMergedOpenApiSpec, createDocsRoutes } from "./routes/docs.ts";
 import { modelStatusRoutes } from "./routes/model-status.ts";
@@ -145,6 +146,7 @@ app.use("*", cors(PERMISSIVE_CORS_OPTIONS))
     })
     .route("/docs", createDocsRoutes(app))
     .route("/v1/audio", audioRoutes)
+    .route("/a2a", a2aRoutes)
     // Conventional, discoverable alias for the merged OpenAPI spec. JSON-only;
     // the ?format=yaml passthrough stays on /docs/open-api/generate-schema.
     // Must be registered before the "/" proxy catch-all or it gets shadowed.

--- a/gen.pollinations.ai/src/routes/a2a.ts
+++ b/gen.pollinations.ai/src/routes/a2a.ts
@@ -1,0 +1,352 @@
+import {
+    A2A_CONTENT_TYPE,
+    A2A_PROTOCOL_VERSION,
+    A2A_VERSION_HEADER,
+    AgentCard,
+    Message,
+    Role,
+    SendMessageRequest,
+} from "@a2a-js/sdk";
+import {
+    ContentTypeNotSupportedError,
+    PushNotificationNotSupportedError,
+    RequestMalformedError,
+    TaskNotFoundError,
+    toJsonRpcError,
+    VersionNotSupportedError,
+} from "@a2a-js/sdk/errors";
+import { getPublicOrigin } from "@shared/public-origin.ts";
+import {
+    CreateChatCompletionRequestSchema,
+    CreateChatCompletionResponseSchema,
+} from "@shared/schemas/openai.ts";
+import { type Context, Hono } from "hono";
+import { createMiddleware } from "hono/factory";
+import type { A2aJsonRpcRequest, Env } from "@/env.ts";
+import { auth } from "@/middleware/auth.ts";
+import { balance } from "@/middleware/balance.ts";
+import { resolveModelDefinition } from "@/middleware/model.ts";
+import { frontendKeyRateLimit } from "@/middleware/rate-limit-durable.ts";
+import { edgeRateLimit } from "@/middleware/rate-limit-edge.ts";
+import {
+    applySafetyToChatRequest,
+    withSafetyHeaders,
+} from "@/middleware/safety.ts";
+import { track } from "@/middleware/track.ts";
+import { handleChatCompletionLocal } from "@/text/handler.ts";
+import { generationAccess } from "@/utils/generation-access.ts";
+import {
+    type GenerationModelEntry,
+    getGenerationModelRegistry,
+} from "../model-registry.ts";
+import { textBodyLimit } from "./generation-handlers.ts";
+
+export function agentCardUrl(origin: string, modelId: string): string {
+    const [owner, ...nameParts] = modelId.split("/");
+    return `${origin}/a2a/agents/${encodeURIComponent(owner)}/${encodeURIComponent(nameParts.join("/"))}/agent-card.json`;
+}
+
+export function buildAgentCard(
+    entry: GenerationModelEntry,
+    origin: string,
+): AgentCard {
+    const endpoint = entry.communityEndpoint;
+    if (!endpoint || !entry.info.agent) {
+        throw new Error(`${entry.id} is not an agent listing`);
+    }
+    const description = entry.info.description || entry.info.title;
+    const provider =
+        endpoint.providerName && endpoint.providerUrl
+            ? {
+                  organization: endpoint.providerName,
+                  url: endpoint.providerUrl,
+              }
+            : undefined;
+
+    return {
+        name: entry.info.title,
+        description,
+        supportedInterfaces: [
+            {
+                url: `${origin}/a2a`,
+                protocolBinding: "JSONRPC",
+                protocolVersion: A2A_PROTOCOL_VERSION,
+                tenant: entry.id,
+            },
+        ],
+        provider,
+        version: "1.0.0",
+        capabilities: {
+            streaming: false,
+            pushNotifications: false,
+            extendedAgentCard: false,
+            extensions: [],
+        },
+        securitySchemes: {
+            pollinationsApiKey: {
+                scheme: {
+                    $case: "httpAuthSecurityScheme",
+                    value: {
+                        description:
+                            "Pollinations API key from https://enter.pollinations.ai/keys",
+                        scheme: "Bearer",
+                        bearerFormat: "Pollinations API key",
+                    },
+                },
+            },
+        },
+        securityRequirements: [
+            { schemes: { pollinationsApiKey: { list: [] } } },
+        ],
+        defaultInputModes: ["text/plain"],
+        defaultOutputModes: ["text/plain"],
+        skills: [
+            {
+                id: entry.id.replace(/[^a-zA-Z0-9_-]/g, "-"),
+                name: entry.info.title,
+                description,
+                tags: ["assistant"],
+                examples: [],
+                inputModes: [],
+                outputModes: [],
+                securityRequirements: [],
+            },
+        ],
+        signatures: [],
+    };
+}
+
+function jsonRpcError(id: A2aJsonRpcRequest["id"], error: unknown): Response {
+    return Response.json(
+        { jsonrpc: "2.0", id, error: toJsonRpcError(error) },
+        {
+            headers: {
+                [A2A_VERSION_HEADER]: A2A_PROTOCOL_VERSION,
+                "Content-Type": A2A_CONTENT_TYPE,
+            },
+        },
+    );
+}
+
+function parseJsonRpcRequest(value: unknown): A2aJsonRpcRequest {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+        throw new RequestMalformedError("Invalid JSON-RPC request");
+    }
+    const request = value as Record<string, unknown>;
+    if (
+        request.jsonrpc !== "2.0" ||
+        request.method !== "SendMessage" ||
+        !(
+            typeof request.id === "string" ||
+            typeof request.id === "number" ||
+            request.id === null
+        )
+    ) {
+        throw new RequestMalformedError(
+            "Only A2A v1 SendMessage requests are supported",
+        );
+    }
+    return request as A2aJsonRpcRequest;
+}
+
+function requestTenant(request: A2aJsonRpcRequest): string {
+    const params = request.params;
+    if (!params || typeof params !== "object" || Array.isArray(params)) {
+        throw new RequestMalformedError("SendMessage params are required");
+    }
+    const tenant = (params as Record<string, unknown>).tenant;
+    if (typeof tenant !== "string" || !tenant.trim()) {
+        throw new RequestMalformedError(
+            "SendMessage params.tenant is required",
+        );
+    }
+    return tenant;
+}
+
+const resolveA2aAgent = createMiddleware<Env>(async (c, next) => {
+    let request: A2aJsonRpcRequest;
+    try {
+        request = parseJsonRpcRequest(await c.req.raw.clone().json());
+    } catch (error) {
+        return jsonRpcError(null, error);
+    }
+
+    const requestedVersion = c.req.header(A2A_VERSION_HEADER);
+    if (requestedVersion !== A2A_PROTOCOL_VERSION) {
+        return jsonRpcError(
+            request.id,
+            new VersionNotSupportedError(
+                `Use A2A-Version: ${A2A_PROTOCOL_VERSION}`,
+            ),
+        );
+    }
+
+    let tenant: string;
+    try {
+        tenant = requestTenant(request);
+    } catch (error) {
+        return jsonRpcError(request.id, error);
+    }
+
+    const registry = await getGenerationModelRegistry(c.env);
+    const entry = registry
+        .visibleEntries(c.var.auth.user?.id)
+        .find((candidate) => candidate.id === tenant && candidate.info.agent);
+    if (!entry) {
+        return jsonRpcError(
+            request.id,
+            new RequestMalformedError("Unknown agent tenant"),
+        );
+    }
+
+    c.set("a2aRequest", request);
+    c.set(
+        "model",
+        await resolveModelDefinition(
+            entry.id,
+            "generate.text",
+            c.env,
+            c.var.auth.user?.id,
+        ),
+    );
+    await next();
+});
+
+function userText(params: ReturnType<typeof SendMessageRequest.fromJSON>) {
+    const message = params.message;
+    if (!message || message.role !== Role.ROLE_USER) {
+        throw new RequestMalformedError("A user message is required");
+    }
+    if (message.taskId) {
+        throw new TaskNotFoundError("This stateless agent has no saved tasks");
+    }
+    if (params.configuration?.taskPushNotificationConfig) {
+        throw new PushNotificationNotSupportedError();
+    }
+    if (
+        params.configuration?.acceptedOutputModes.length &&
+        !params.configuration.acceptedOutputModes.includes("text/plain")
+    ) {
+        throw new ContentTypeNotSupportedError("This agent returns text/plain");
+    }
+
+    return {
+        message,
+        text: message.parts
+            .map((part) => {
+                if (
+                    part.content?.$case !== "text" ||
+                    (part.mediaType && part.mediaType !== "text/plain")
+                ) {
+                    throw new ContentTypeNotSupportedError(
+                        "This agent accepts text/plain parts",
+                    );
+                }
+                return part.content.value;
+            })
+            .join("\n"),
+    };
+}
+
+async function invokeAgent(
+    c: Context<Env>,
+    params: ReturnType<typeof SendMessageRequest.fromJSON>,
+): Promise<{ message: Message; headers: Headers }> {
+    const { message, text } = userText(params);
+    if (!text.trim()) {
+        throw new RequestMalformedError("Message text is required");
+    }
+
+    const requestBody = await applySafetyToChatRequest(
+        c,
+        CreateChatCompletionRequestSchema.parse({
+            model: c.var.model.resolved,
+            messages: [{ role: "user", content: text }],
+            stream: false,
+        }),
+    );
+    const response = await handleChatCompletionLocal(c, requestBody);
+    const responseBody = await response.clone().json();
+    if (!response.ok) {
+        throw new Error(
+            typeof responseBody === "object" &&
+                responseBody !== null &&
+                "error" in responseBody
+                ? JSON.stringify(responseBody.error)
+                : `Agent request failed with HTTP ${response.status}`,
+        );
+    }
+    const completion = CreateChatCompletionResponseSchema.parse(responseBody);
+    const content = completion.choices[0]?.message?.content || "";
+
+    return {
+        headers: response.headers,
+        message: {
+            messageId: crypto.randomUUID(),
+            contextId: message.contextId || crypto.randomUUID(),
+            taskId: "",
+            role: Role.ROLE_AGENT,
+            parts: [
+                {
+                    content: { $case: "text", value: content },
+                    mediaType: "text/plain",
+                    filename: "",
+                    metadata: undefined,
+                },
+            ],
+            metadata: undefined,
+            extensions: [],
+            referenceTaskIds: [],
+        },
+    };
+}
+
+async function handleA2aRequest(c: Context<Env>): Promise<Response> {
+    const request = c.var.a2aRequest;
+    try {
+        const params = SendMessageRequest.fromJSON(request.params);
+        const { message, headers } = await invokeAgent(c, params);
+        headers.set(A2A_VERSION_HEADER, A2A_PROTOCOL_VERSION);
+        headers.set("Content-Type", A2A_CONTENT_TYPE);
+        return withSafetyHeaders(
+            c,
+            Response.json(
+                {
+                    jsonrpc: "2.0",
+                    id: request.id,
+                    result: { message: Message.toJSON(message) },
+                },
+                { headers },
+            ),
+        );
+    } catch (error) {
+        return jsonRpcError(request.id, error);
+    }
+}
+
+export const a2aRoutes = new Hono<Env>()
+    .use("*", edgeRateLimit)
+    .use("/agents/*", auth())
+    .get("/agents/:owner/:name/agent-card.json", async (c) => {
+        const modelId = `${c.req.param("owner")}/${c.req.param("name")}`;
+        const entry = (await getGenerationModelRegistry(c.env))
+            .visibleEntries(c.var.auth.user?.id)
+            .find((candidate) => candidate.id === modelId);
+        if (!entry?.info.agent) return c.notFound();
+
+        return Response.json(
+            AgentCard.toJSON(buildAgentCard(entry, getPublicOrigin(c))),
+            { headers: { "Content-Type": A2A_CONTENT_TYPE } },
+        );
+    })
+    .use("*", auth())
+    .use("*", frontendKeyRateLimit)
+    .use("*", balance)
+    .post(
+        "/",
+        textBodyLimit,
+        resolveA2aAgent,
+        track("generate.text"),
+        generationAccess,
+        handleA2aRequest,
+    );

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -30,6 +30,7 @@ const resolver = <T extends Parameters<typeof baseResolver>[0]>(schema: T) =>
     baseResolver(schema, { reused: "ref" });
 
 import { validator } from "@shared/middleware/validator.ts";
+import { getPublicOrigin } from "@shared/public-origin.ts";
 import { AUDIO_VOICES } from "@shared/registry/audio.ts";
 import {
     DEFAULT_IMAGE_MODEL,
@@ -78,6 +79,7 @@ import {
     type GenerationModelEntry,
     getGenerationModelRegistry,
 } from "../model-registry.ts";
+import { agentCardUrl } from "./a2a.ts";
 import { handleSimpleAudio } from "./audio.ts";
 import {
     generateChatCompletion,
@@ -227,7 +229,15 @@ const modelsListHandler = (
                         paidBalance,
                     ),
                     community,
-                ).map((entry) => entry.info),
+                ).map((entry) => ({
+                    ...entry.info,
+                    ...(entry.info.agent && {
+                        agent_card_url: agentCardUrl(
+                            getPublicOrigin(c),
+                            entry.id,
+                        ),
+                    }),
+                })),
             );
         },
     ] as const;
@@ -326,6 +336,9 @@ export const proxyRoutes = new Hono<Env>()
                 output_modalities: entry.info.output_modalities,
                 supported_endpoints: entry.supportedEndpoints,
                 ...(entry.info.agent && { agent: true }),
+                ...(entry.info.agent && {
+                    agent_card_url: agentCardUrl(getPublicOrigin(c), entry.id),
+                }),
                 ...(entry.info.base_model && {
                     base_model: entry.info.base_model,
                 }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -856,6 +856,7 @@
       "name": "pollinations-gen",
       "version": "1.0.0",
       "dependencies": {
+        "@a2a-js/sdk": "^1.0.1",
         "@aws-sdk/client-bedrock-runtime": "^3.1040.0",
         "@aws-sdk/client-s3": "^3.1040.0",
         "@hono/standard-validator": "^0.2.2",
@@ -1392,6 +1393,35 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/@a2a-js/sdk": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@a2a-js/sdk/-/sdk-1.0.1.tgz",
+      "integrity": "sha512-CJQdh3Wzwo8qIx5UUkSJ7+7BEI16PB+MXMHHNSmx8JQsQed2HlQgvx1ENOiKUfYA3PlcEvxIwv14dBblhDuPmw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jose": "^6.2.3",
+        "uuid": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.10.2",
+        "@grpc/grpc-js": "^1.11.0",
+        "express": "^4.21.2 || ^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@bufbuild/protobuf": {
+          "optional": true
+        },
+        "@grpc/grpc-js": {
+          "optional": true
+        },
+        "express": {
+          "optional": true
+        }
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -19204,6 +19234,15 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
     },
     "node_modules/vfile": {
       "version": "6.0.3",

--- a/shared/registry/model-info.ts
+++ b/shared/registry/model-info.ts
@@ -45,6 +45,7 @@ export const ModelInfoSchema = z.object({
     brand_url: z.string().url().optional(),
     community: z.boolean().optional(),
     agent: z.boolean().optional(),
+    agent_card_url: z.string().url().optional(),
     base_model: z.string().optional(),
     per_user_rpm: z.number().positive().nullable().optional(),
     pricing: z

--- a/shared/schemas/openai.ts
+++ b/shared/schemas/openai.ts
@@ -536,6 +536,7 @@ const OpenAIModelSchema = z
         output_modalities: z.array(z.string()).optional(),
         supported_endpoints: z.array(z.string()).optional(),
         agent: z.boolean().optional(),
+        agent_card_url: z.string().url().optional(),
         base_model: z.string().optional(),
         pricing: z.record(z.string(), z.string()).optional(),
         capabilities: z.array(z.string()).optional(),


### PR DESCRIPTION
- Adds A2A v1 Agent Cards for public agents and owner-visible private agents.
- Advertises each card from model-list responses and routes a shared JSON-RPC interface through the card tenant.
- Supports stateless SendMessage using existing agent auth, safety, generation, billing, and telemetry.
- Uses the stable official A2A JavaScript SDK and keeps streaming, tasks, and push notifications explicitly disabled.
- Tests card discovery, model-list linkage, invocation, and billing-path integration.