### PR TITLE
fix: revoke community model publishing access

### DIFF
--- a/shared/auth/github-id-list.ts
+++ b/shared/auth/github-id-list.ts
@@ -38,7 +38,6 @@ export const COMMUNITY_MODEL_ALLOWED_GITHUB_IDS = [
     36392751, // chigwell
     228795921, //novastardev
     30191185, // rekty
-    145819645, // rodrigookk
     85689068, // pegalink
     147928812, // iotserver24
     24752658, // zero2launch


### PR DESCRIPTION
- Removes rodrigookk from the community-model publisher allowlist
- Prevents the account from making private endpoints public again
- Existing public listings were separately changed to private in production