### PR TITLE
fix: suppress credits from overdrawn requests

### DIFF
--- a/gen.pollinations.ai/src/byop-markup.test.ts
+++ b/gen.pollinations.ai/src/byop-markup.test.ts
@@ -794,6 +794,59 @@ describe("BYOP markup", () => {
         );
     });
 
+    it("suppresses generation credits when the payer goes negative", async () => {
+        const { payerId, devId, pkId } = await setupPayerAndDev();
+        const ownerId = await createBalanceUser("community-owner");
+
+        const { markup, communityModelReward, billedPrice } =
+            await handleBalanceDeduction({
+                db,
+                isBilledUsage: true,
+                totalPrice: 2,
+                userId: payerId,
+                byopClientKeyId: pkId,
+                communityModelReward: {
+                    userId: ownerId,
+                    rewardRate: COMMUNITY_MODEL_REWARD_RATE,
+                },
+            });
+
+        expect(billedPrice).toBe(
+            roundPollenLedgerAmount(2 + computeDevCredit(2)),
+        );
+        expect(markup).toBeNull();
+        expect(communityModelReward).toBeNull();
+        expect((await getUserBalance(db, payerId)).tierBalance).toBeLessThan(0);
+        expect((await getUserBalance(db, devId)).tierBalance).toBe(0);
+        expect((await getUserBalance(db, ownerId)).tierBalance).toBe(0);
+    });
+
+    it("still credits a community owner when the payer reaches zero", async () => {
+        const payerId = await createBalanceUser("payer", {
+            tier: 1,
+            pack: 0,
+        });
+        const ownerId = await createBalanceUser("community-owner");
+
+        const { communityModelReward } = await handleBalanceDeduction({
+            db,
+            isBilledUsage: true,
+            totalPrice: 1,
+            userId: payerId,
+            communityModelReward: {
+                userId: ownerId,
+                rewardRate: COMMUNITY_MODEL_REWARD_RATE,
+            },
+        });
+
+        expect(communityModelReward).not.toBeNull();
+        expect((await getUserBalance(db, payerId)).tierBalance).toBe(0);
+        expect((await getUserBalance(db, ownerId)).tierBalance).toBeCloseTo(
+            COMMUNITY_MODEL_REWARD_RATE,
+            10,
+        );
+    });
+
     it("does not charge or reward a community model owner for their own request", async () => {
         const ownerId = await createBalanceUser("community-owner", {
             tier: 2,

--- a/shared/billing/deduction.ts
+++ b/shared/billing/deduction.ts
@@ -35,10 +35,26 @@ export async function atomicDeductUserBalance(
     userId: string,
     amount: number,
     isPaidOnly = false,
-): Promise<{ ok: boolean; bucket: Bucket | null; packBalance: number | null }> {
-    if (amount <= 0) return { ok: true, bucket: null, packBalance: null };
+): Promise<{
+    ok: boolean;
+    bucket: Bucket | null;
+    packBalance: number | null;
+    postDeductionBalance: number | null;
+}> {
+    if (amount <= 0) {
+        return {
+            ok: true,
+            bucket: null,
+            packBalance: null,
+            postDeductionBalance: null,
+        };
+    }
 
-    const row = await db.get<{ bucket: Bucket; packBalance: number | null }>(
+    const row = await db.get<{
+        bucket: Bucket;
+        tierBalance: number | null;
+        packBalance: number | null;
+    }>(
         sql`
         WITH decision AS MATERIALIZED (
             SELECT
@@ -67,6 +83,7 @@ export async function atomicDeductUserBalance(
         WHERE id = (SELECT id FROM decision)
         RETURNING
             (SELECT bucket FROM decision) AS bucket,
+            tier_balance AS tierBalance,
             pack_balance AS packBalance
     `,
     );
@@ -75,6 +92,11 @@ export async function atomicDeductUserBalance(
         ok: !!row,
         bucket: row?.bucket ?? null,
         packBalance: row?.packBalance ?? null,
+        postDeductionBalance: row
+            ? row.bucket === "tier"
+                ? row.tierBalance
+                : row.packBalance
+            : null,
     };
 }
 

--- a/shared/billing/track-helpers.ts
+++ b/shared/billing/track-helpers.ts
@@ -210,13 +210,13 @@ export async function handleBalanceDeduction(params: DeductionParams): Promise<{
     }
 
     // 1. Resolve the two independent "who else gets money" inputs.
-    const markup = await resolveDevMarkup(
+    let markup = await resolveDevMarkup(
         db,
         byopClientKeyId,
         totalPrice,
         userId,
     );
-    const communityModelReward = resolveCommunityModelReward(
+    let communityModelReward = resolveCommunityModelReward(
         communityModelRewardInput,
         totalPrice,
         userId,
@@ -241,6 +241,20 @@ export async function handleBalanceDeduction(params: DeductionParams): Promise<{
             );
             payerBucket = deduction.bucket;
             postDeductionPackBalance = deduction.postDeductionPackBalance;
+            if (
+                deduction.postDeductionBalance != null &&
+                deduction.postDeductionBalance < 0
+            ) {
+                markup = null;
+                communityModelReward = null;
+                log.warn(
+                    "Suppressed generation credits because the payer's {bucket} balance is negative after deduction ({balance})",
+                    {
+                        bucket: payerBucket,
+                        balance: deduction.postDeductionBalance,
+                    },
+                );
+            }
         }
 
         // API key budgets are decremented by the amount the user authorized the
@@ -424,14 +438,16 @@ async function deductUserBalance(
 ): Promise<{
     bucket: Bucket | null;
     postDeductionPackBalance: number | null;
+    postDeductionBalance: number | null;
 }> {
     try {
-        const { ok, bucket, packBalance } = await atomicDeductUserBalance(
-            db,
-            userId,
-            amount,
-            modelPaidOnly ?? false,
-        );
+        const { ok, bucket, packBalance, postDeductionBalance } =
+            await atomicDeductUserBalance(
+                db,
+                userId,
+                amount,
+                modelPaidOnly ?? false,
+            );
         if (!ok) {
             throw new Error(
                 `User balance deduction affected 0 rows for ${userId}`,
@@ -453,6 +469,7 @@ async function deductUserBalance(
         return {
             bucket,
             postDeductionPackBalance: bucket === "pack" ? packBalance : null,
+            postDeductionBalance,
         };
     } catch (error) {
         log.error("Failed to decrement user balance for {userId}: {error}", {


### PR DESCRIPTION
- Suppresses community-owner rewards when the payer bucket goes negative
- Applies the same rule to BYOP developer credits
- Keeps the completed request charge and negative-balance behavior unchanged
- Preserves credits when the payer reaches exactly zero