### PR TITLE
fix: clarify Activity timestamps use UTC

### DIFF
--- a/enter.pollinations.ai/frontend/src/routes/_dashboard.activity.tsx
+++ b/enter.pollinations.ai/frontend/src/routes/_dashboard.activity.tsx
@@ -95,7 +95,8 @@ function ActivityPage() {
                         minDate={ACTIVITY_MIN_DATE}
                     />
                     <p className="text-micro text-theme-text-muted">
-                        Usage refreshes hourly. Times are shown in UTC.
+                        Usage refreshes hourly. All dates and times are shown in
+                        UTC.
                     </p>
                 </div>
                 <UsageSection


### PR DESCRIPTION
- Clarifies that every date and time on the Activity page uses UTC
- Keeps the period picker, API windows, chart buckets, and event timestamps consistent
- Avoids partially localizing labels while the underlying periods remain UTC

Fixes #13651

Test: `/Users/thomash/Documents/GitHub/pollinations/node_modules/.bin/biome check enter.pollinations.ai/frontend/src/routes/_dashboard.activity.tsx`