### PR TITLE
fix: add endpoint agent request example

### DIFF
--- a/gen.pollinations.ai/src/routes/docs-samples.ts
+++ b/gen.pollinations.ai/src/routes/docs-samples.ts
@@ -20,6 +20,20 @@ export const CODE_SAMPLES: Record<
   }'`,
         },
     ],
+    "post /account/my-models/endpoint-agents": [
+        {
+            label: "Create endpoint agent",
+            lang: "Shell",
+            source: `curl https://gen.pollinations.ai/account/my-models/endpoint-agents \
+  -H "Authorization: Bearer YOUR_SECRET_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "my-agent",
+    "title": "My Agent",
+    "baseUrl": "https://agent.example.com/v1"
+  }'`,
+        },
+    ],
     "post /v1/chat/completions": [
         {
             label: "cURL",


### PR DESCRIPTION
- Adds the missing JSON body to the generated Endpoint Agent POST example.
- Fixes the API-reference validator failure after production deployment.
- Keeps generated APIDOCS.md out of the feature PR.

Validation:
- Biome
- Gen typecheck

The live docs workflow will pass after this sample reaches Gen production.
