### PR TITLE
FOR #13794 "[Quest] preserve request i ds in java script sdk errors #13794"

### DIFF
--- a/packages/sdk/src/client.test.ts
+++ b/packages/sdk/src/client.test.ts
@@ -608,3 +608,57 @@ describe("Pollinations model discovery", () => {
         );
     });
 });
+
+describe("Pollinations API error handling", () => {
+    it("sets requestId from the X-Request-Id header if omitted from the body", async () => {
+        const client = newClient();
+        fetchMock.mockResolvedValueOnce(
+            makeResponse(
+                { error: { message: "Something went wrong" } },
+                {
+                    ok: false,
+                    status: 500,
+                    headers: { "x-request-id": "header-req-id" },
+                },
+            ),
+        );
+
+        let caughtError: PollinationsError | undefined;
+        try {
+            await client.image("test");
+        } catch (err) {
+            if (err instanceof PollinationsError) {
+                caughtError = err;
+            }
+        }
+
+        expect(caughtError).toBeInstanceOf(PollinationsError);
+        expect(caughtError?.requestId).toBe("header-req-id");
+    });
+
+    it("prioritizes requestId from the body over the X-Request-Id header", async () => {
+        const client = newClient();
+        fetchMock.mockResolvedValueOnce(
+            makeResponse(
+                { error: { message: "Failed", requestId: "body-req-id" } },
+                {
+                    ok: false,
+                    status: 400,
+                    headers: { "x-request-id": "header-req-id" },
+                },
+            ),
+        );
+
+        let caughtError: PollinationsError | undefined;
+        try {
+            await client.image("test");
+        } catch (err) {
+            if (err instanceof PollinationsError) {
+                caughtError = err;
+            }
+        }
+
+        expect(caughtError).toBeInstanceOf(PollinationsError);
+        expect(caughtError?.requestId).toBe("body-req-id");
+    });
+});

--- a/packages/sdk/src/error-response.ts
+++ b/packages/sdk/src/error-response.ts
@@ -64,7 +64,9 @@ export async function pollinationsErrorFromResponse(
             ? (nested.details as Record<string, unknown>)
             : undefined;
     const requestId =
-        typeof nested.requestId === "string" ? nested.requestId : undefined;
+        (typeof nested.requestId === "string"
+            ? nested.requestId
+            : response.headers.get("x-request-id")) ?? undefined;
     const retryAfter = parseRetryAfter(response);
 
     return new PollinationsError(


### PR DESCRIPTION
FOR #13794 "[Quest] preserve request i ds in java script sdk errors #13794"
This PR updates `pollinationsErrorFromResponse` to preserve the `X-Request-Id` server response header on `PollinationsError` when the JSON error body does not include a `requestId`. 

This helps users include the server-generated request ID in support reports, particularly for 4xx/5xx responses where the body might be minimal or lack request context.

Minimal tests have been added to verify this fallback behavior.