### PR TITLE
fix(sdk): preserve request IDs in JavaScript SDK errors

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -508,9 +508,10 @@ try {
   const image = await generateImage('test');
 } catch (err) {
   if (err instanceof PollinationsError) {
-    console.error(err.message);  // Error message
-    console.error(err.code);     // Error code (BAD_REQUEST, UNAUTHORIZED, INSUFFICIENT_BALANCE, etc.)
-    console.error(err.status);   // HTTP status (400, 401, 402, 403, 500)
+    console.error(err.message);   // Error message
+    console.error(err.code);      // Error code (BAD_REQUEST, UNAUTHORIZED, INSUFFICIENT_BALANCE, etc.)
+    console.error(err.status);    // HTTP status (400, 401, 402, 403, 500)
+    console.error(err.requestId); // Request ID for support reports
   }
 }
 ```

--- a/packages/sdk/src/error-response.test.ts
+++ b/packages/sdk/src/error-response.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import { pollinationsErrorFromResponse } from "./error-response.js";
+import { PollinationsError } from "./types.js";
+
+function createMockResponse(
+    body: unknown,
+    options: {
+        status?: number;
+        headers?: Record<string, string>;
+    } = {},
+): Response {
+    const { status = 500, headers = {} } = options;
+    const headerMap = new Map<string, string>(
+        Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v]),
+    );
+
+    return {
+        status,
+        headers: {
+            get: (name: string) => headerMap.get(name.toLowerCase()) ?? null,
+        },
+        json: async () => {
+            if (typeof body === "string") {
+                return JSON.parse(body);
+            }
+            if (body === null || body === undefined) {
+                throw new Error("Invalid JSON");
+            }
+            return body;
+        },
+    } as unknown as Response;
+}
+
+describe("pollinationsErrorFromResponse", () => {
+    it("extracts requestId from nested error body", async () => {
+        const response = createMockResponse(
+            {
+                error: {
+                    message: "Rate limit exceeded",
+                    code: "RATE_LIMIT_EXCEEDED",
+                    requestId: "req_body_nested_123",
+                },
+            },
+            { status: 429 },
+        );
+
+        const error = await pollinationsErrorFromResponse(response);
+
+        expect(error).toBeInstanceOf(PollinationsError);
+        expect(error.message).toBe("Rate limit exceeded");
+        expect(error.code).toBe("RATE_LIMIT_EXCEEDED");
+        expect(error.status).toBe(429);
+        expect(error.requestId).toBe("req_body_nested_123");
+    });
+
+    it("extracts requestId from flat error body", async () => {
+        const response = createMockResponse(
+            {
+                message: "Unauthorized",
+                code: "UNAUTHORIZED",
+                requestId: "req_body_flat_456",
+            },
+            { status: 401 },
+        );
+
+        const error = await pollinationsErrorFromResponse(response);
+
+        expect(error).toBeInstanceOf(PollinationsError);
+        expect(error.requestId).toBe("req_body_flat_456");
+    });
+
+    it("falls back to x-request-id header when body omits requestId", async () => {
+        const response = createMockResponse(
+            {
+                error: {
+                    message: "Internal Server Error",
+                    code: "INTERNAL_ERROR",
+                },
+            },
+            {
+                status: 500,
+                headers: { "x-request-id": "req_header_789" },
+            },
+        );
+
+        const error = await pollinationsErrorFromResponse(response);
+
+        expect(error).toBeInstanceOf(PollinationsError);
+        expect(error.requestId).toBe("req_header_789");
+    });
+
+    it("falls back to X-Request-Id header on non-JSON responses", async () => {
+        const response = createMockResponse(null, {
+            status: 502,
+            headers: { "X-Request-Id": "req_header_bad_gateway" },
+        });
+
+        const error = await pollinationsErrorFromResponse(response);
+
+        expect(error).toBeInstanceOf(PollinationsError);
+        expect(error.message).toBe("Request failed with status 502");
+        expect(error.requestId).toBe("req_header_bad_gateway");
+    });
+
+    it("prioritizes body requestId over header x-request-id when both exist", async () => {
+        const response = createMockResponse(
+            {
+                error: {
+                    message: "Quota reached",
+                    requestId: "req_from_body",
+                },
+            },
+            {
+                status: 402,
+                headers: { "x-request-id": "req_from_header" },
+            },
+        );
+
+        const error = await pollinationsErrorFromResponse(response);
+
+        expect(error.requestId).toBe("req_from_body");
+    });
+
+    it("leaves requestId undefined when not present in body or headers", async () => {
+        const response = createMockResponse(
+            {
+                error: {
+                    message: "Generic error",
+                },
+            },
+            { status: 500 },
+        );
+
+        const error = await pollinationsErrorFromResponse(response);
+
+        expect(error.requestId).toBeUndefined();
+    });
+});

--- a/packages/sdk/src/error-response.ts
+++ b/packages/sdk/src/error-response.ts
@@ -63,8 +63,17 @@ export async function pollinationsErrorFromResponse(
         nested.details && typeof nested.details === "object"
             ? (nested.details as Record<string, unknown>)
             : undefined;
-    const requestId =
-        typeof nested.requestId === "string" ? nested.requestId : undefined;
+    const headerRequestId =
+        response.headers?.get?.("x-request-id") ??
+        response.headers?.get?.("X-Request-Id") ??
+        undefined;
+    const bodyRequestId =
+        typeof nested.requestId === "string" && nested.requestId.length > 0
+            ? nested.requestId
+            : typeof record.requestId === "string" && record.requestId.length > 0
+              ? record.requestId
+              : undefined;
+    const requestId = bodyRequestId || headerRequestId || undefined;
     const retryAfter = parseRetryAfter(response);
 
     return new PollinationsError(


### PR DESCRIPTION
Resolves #13794

### Changes
- Updated \pollinationsErrorFromResponse\ to preserve the \equestId\ from the error body (\
ested.requestId\ or \ecord.requestId\).
- Added fallback to the \X-Request-Id\ response header when omitted from the response body.
- Added comprehensive unit tests in \rror-response.test.ts\.
- Updated SDK \README.md\ error handling example to demonstrate accessing \rr.requestId\.