### PR TITLE
fix(sdk): preserve request IDs in errors via X-Request-Id fallback

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -508,9 +508,10 @@ try {
   const image = await generateImage('test');
 } catch (err) {
   if (err instanceof PollinationsError) {
-    console.error(err.message);  // Error message
-    console.error(err.code);     // Error code (BAD_REQUEST, UNAUTHORIZED, INSUFFICIENT_BALANCE, etc.)
-    console.error(err.status);   // HTTP status (400, 401, 402, 403, 500)
+    console.error(err.message);    // Error message
+    console.error(err.code);       // Error code (BAD_REQUEST, UNAUTHORIZED, INSUFFICIENT_BALANCE, etc.)
+    console.error(err.status);     // HTTP status (400, 401, 402, 403, 500)
+    console.error(err.requestId);  // Server request ID — include it in support reports
   }
 }
 ```

--- a/packages/sdk/src/error-response.test.ts
+++ b/packages/sdk/src/error-response.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { pollinationsErrorFromResponse } from "./error-response.js";
+
+// Build a minimal Response good enough for the error-parsing path.
+function makeErrorResponse(
+    body: unknown,
+    init: {
+        status?: number;
+        headers?: Record<string, string>;
+    } = {},
+): Response {
+    const { status = 500, headers = {} } = init;
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: { "content-type": "application/json", ...headers },
+    });
+}
+
+describe("pollinationsErrorFromResponse request IDs", () => {
+    it("prefers the request ID from the error body", async () => {
+        const err = await pollinationsErrorFromResponse(
+            makeErrorResponse(
+                {
+                    error: {
+                        message: "boom",
+                        code: "INTERNAL_ERROR",
+                        requestId: "req-body-123",
+                    },
+                },
+                { headers: { "X-Request-Id": "req-header-456" } },
+            ),
+        );
+        expect(err.requestId).toBe("req-body-123");
+    });
+
+    it("falls back to the X-Request-Id header when the body omits it", async () => {
+        const err = await pollinationsErrorFromResponse(
+            makeErrorResponse(
+                { error: { message: "boom", code: "INTERNAL_ERROR" } },
+                { headers: { "X-Request-Id": "req-header-456" } },
+            ),
+        );
+        expect(err.requestId).toBe("req-header-456");
+    });
+
+    it("falls back to the X-Request-Id header for non-JSON bodies", async () => {
+        const err = await pollinationsErrorFromResponse(
+            new Response("<html>gateway timeout</html>", {
+                status: 504,
+                headers: { "X-Request-Id": "req-header-789" },
+            }),
+        );
+        expect(err.requestId).toBe("req-header-789");
+    });
+
+    it("leaves requestId undefined when neither body nor header has one", async () => {
+        const err = await pollinationsErrorFromResponse(
+            makeErrorResponse({
+                error: { message: "boom", code: "INTERNAL_ERROR" },
+            }),
+        );
+        expect(err.requestId).toBeUndefined();
+    });
+});

--- a/packages/sdk/src/error-response.ts
+++ b/packages/sdk/src/error-response.ts
@@ -63,8 +63,12 @@ export async function pollinationsErrorFromResponse(
         nested.details && typeof nested.details === "object"
             ? (nested.details as Record<string, unknown>)
             : undefined;
+    // Prefer the request ID from the error body; fall back to the response's
+    // X-Request-Id header so users can always include it in support reports.
     const requestId =
-        typeof nested.requestId === "string" ? nested.requestId : undefined;
+        typeof nested.requestId === "string"
+            ? nested.requestId
+            : (response.headers.get("X-Request-Id") ?? undefined);
     const retryAfter = parseRetryAfter(response);
 
     return new PollinationsError(


### PR DESCRIPTION
## Summary
- `PollinationsError.requestId` now uses the error body's request ID when present (unchanged behavior)
- Falls back to the response's `X-Request-Id` header when the body omits it — including non-JSON error bodies (HTML gateway errors) where no body field can exist

Closes #13794

## Reproduction / evidence
- Before: a 502 with an HTML body and `X-Request-Id: abc` produced `err.requestId === undefined` — users had nothing to include in support reports even though the server emitted the ID on every response
- After: same response produces `err.requestId === "abc"`

| Case | Body requestId | Header | Result |
|---|---|---|---|
| body present | req-body-123 | req-header-456 | req-body-123 (body wins) |
| body omits | - | req-header-456 | req-header-456 |
| non-JSON body | - | req-header-789 | req-header-789 |
| neither | - | - | undefined |

## Changes
- `packages/sdk/src/error-response.ts` — 4-line fallback + comment
- `packages/sdk/src/error-response.test.ts` — 4 focused tests
- `packages/sdk/README.md` — short usage example (`err.requestId`)

## Verification
```
✓ src/error-response.test.ts (4 tests)
Test Files  6 passed (6) — full SDK suite: 43 passed
npx tsc --noEmit → clean
```

No server changes, no success metadata, no interceptors/logging/tracing/compat layers added.