### PR TITLE
fix(enter): never cache authenticated account responses

### DIFF
--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -791,6 +791,14 @@ const usageResponseSchema = z.object({
  */
 export const accountRoutes = new Hono<Env>()
     .use(auth({ allowApiKey: true, allowSessionCookie: true }))
+    // Authenticated account responses must never be stored by browsers or
+    // intermediary caches. Applied once here so every route under /account,
+    // including nested agent and community-model routes, inherits the policy.
+    .use("*", async (c, next) => {
+        c.header("Cache-Control", "private, no-store, max-age=0");
+        c.header("Pragma", "no-cache");
+        await next();
+    })
     .route("/agents", agentsRoutes)
     .route("/my-models", communityEndpointsRoutes)
     .get(
@@ -1398,7 +1406,6 @@ export const accountRoutes = new Hono<Env>()
                 ? await getVisibleModelIdsForUser(c.env.DB, user.id)
                 : null;
 
-            c.header("Cache-Control", "private, no-store, max-age=0");
             return c.json({
                 data: keys.map((key, index) => ({
                     id: key.id,

--- a/enter.pollinations.ai/test/account-cache-control.test.ts
+++ b/enter.pollinations.ai/test/account-cache-control.test.ts
@@ -1,0 +1,49 @@
+import { SELF } from "cloudflare:test";
+import { describe, expect } from "vitest";
+import { test } from "./fixtures.ts";
+
+/**
+ * Authenticated account responses must never be stored by browsers or
+ * intermediary caches. The policy is applied once at the account
+ * router, every route under /account — including nested agent and
+ * community-model routes — inherits it.
+ */
+describe("account routes cache-control policy", () => {
+    test("top-level account response is no-store headers", async ({
+        sessionToken,
+    }) => {
+        const response = await SELF.fetch(
+            "http://localhost:3000/api/account/profile",
+            {
+                headers: {
+                    Cookie: `better-auth.session_token=${sessionToken}`,
+                },
+            },
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("Cache-Control")).toBe(
+            "private, no-store, max-age=0",
+        );
+        expect(response.headers.get("Pragma")).toBe("no-cache");
+    });
+
+    test("nested account response returns no-store headers", async ({
+        sessionToken,
+    }) => {
+        const response = await SELF.fetch(
+            "http://localhost:3000/api/account/agents",
+            {
+                headers: {
+                    Cookie: `better-auth.session_token=${sessionToken}`,
+                },
+            },
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("Cache-Control")).toBe(
+            "private, no-store, max-age=0",
+        );
+        expect(response.headers.get("Pragma")).toBe("no-cache");
+    });
+});


### PR DESCRIPTION
## Summary
All routes under `/account` — including nested agent and community-model routes (`/account/agents`, `/account/my-models`) — now return:

```
Cache-Control: private, no-store, max-age=0
Pragma: no-cache
```

The policy is applied **once** at the account router (shared middleware after auth), and the existing redundant per-handler header in the keys handler is removed.

Closes #13771

## Evidence
- Before: `GET /api/account/profile` returned no cache directives → shared intermediate caches could store authenticated responses; only one nested route set the header manually
- After: top-level and every nested account response carry the policy

## Changes
- `enter.pollinations.ai/src/routes/account.ts` — +7/-1 (one middleware, one redundant header removed)
- `enter.pollinations.ai/test/account-cache-control.test.ts` — 2 focused tests (one top-level, one nested response)

## Verification
```
✓ test/account-cache-control.test.ts (2 tests)
Full account regression sweep: 9 files, 86 tests passed
npx tsc --noEmit → clean
```

No general cache framework, no response body changes, public-route caching untouched.