### PR TITLE
feat(cli): add polli earnings command

### DIFF
--- a/packages/polli-cli/README.md
+++ b/packages/polli-cli/README.md
@@ -92,6 +92,7 @@ Keys can't be edited — to change a name, budget, or model list, revoke and rec
 polli usage                  # pollen balance
 polli usage --history        # recent requests
 polli usage --daily          # daily spend
+polli earnings               # developer earnings from apps & community models
 polli quests --claimable     # only rewards ready to claim
 polli agents list            # managed prompt agents
 polli my-models list         # invite-only community text, image, and transcription models

--- a/packages/polli-cli/src/commands/earnings.test.ts
+++ b/packages/polli-cli/src/commands/earnings.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { daysError, summarizeBySource } from "./earnings.js";
+
+describe("daysError", () => {
+    it("accepts positive integers", () => {
+        expect(daysError("1")).toBeNull();
+        expect(daysError("30")).toBeNull();
+        expect(daysError("90")).toBeNull();
+    });
+
+    it("rejects non-integers and non-positive values", () => {
+        expect(daysError("0")).toMatch(/positive integer/);
+        expect(daysError("-5")).toMatch(/positive integer/);
+        expect(daysError("abc")).toMatch(/positive integer/);
+        expect(daysError("7.5")).toMatch(/positive integer/);
+        expect(daysError("")).toMatch(/positive integer/);
+    });
+
+    it("rejects values above the API's 90-day window", () => {
+        expect(daysError("91")).toMatch(/90 or less/);
+    });
+});
+
+describe("summarizeBySource", () => {
+    const daily = [
+        {
+            date: "2026-08-23",
+            entity_id: "pk_a",
+            entity_name: "app-a",
+            source: "byop_markup",
+            requests: 4,
+            baseline_price: 2,
+            pollen_earned: 0.5,
+            paid_earned: 0.125,
+            tier_earned: 0.375,
+            cost_usd: 0.02,
+            reward_rate: 0.25,
+        },
+        {
+            date: "2026-08-23",
+            entity_id: "mdl_b",
+            entity_name: "model-b",
+            source: "community_model",
+            requests: 10,
+            baseline_price: 5,
+            pollen_earned: 1,
+            paid_earned: 1,
+            tier_earned: 0,
+            cost_usd: 0.05,
+            reward_rate: 0.2,
+        },
+        {
+            date: "2026-08-24",
+            entity_id: "pk_a",
+            entity_name: "app-a",
+            source: "byop_markup",
+            requests: 6,
+            baseline_price: 3,
+            pollen_earned: 0.75,
+            paid_earned: 0.25,
+            tier_earned: 0.5,
+            cost_usd: 0.03,
+            reward_rate: 0.25,
+        },
+    ];
+
+    it("rolls daily buckets into additive totals per source", () => {
+        const summary = summarizeBySource(daily);
+
+        expect(summary).toHaveLength(2);
+
+        const byop = summary.find((s) => s.source === "byop_markup");
+        expect(byop).toEqual({
+            source: "byop_markup",
+            requests: 10,
+            pollenEarned: 1.25,
+            usdBasis: 0.05,
+        });
+
+        const community = summary.find((s) => s.source === "community_model");
+        expect(community).toEqual({
+            source: "community_model",
+            requests: 10,
+            pollenEarned: 1,
+            usdBasis: 0.05,
+        });
+    });
+
+    it("returns an empty summary for empty input", () => {
+        expect(summarizeBySource([])).toEqual([]);
+    });
+});

--- a/packages/polli-cli/src/commands/earnings.ts
+++ b/packages/polli-cli/src/commands/earnings.ts
@@ -1,0 +1,135 @@
+import chalk from "chalk";
+import { Command } from "commander";
+import { gen, requireKey } from "../lib/api.js";
+import {
+    getOutputMode,
+    printError,
+    printResult,
+    printTable,
+} from "../lib/output.js";
+
+export interface EarningsRow {
+    date: string;
+    entity_id: string;
+    entity_name: string;
+    source: string;
+    requests: number;
+    baseline_price: number;
+    pollen_earned: number;
+    paid_earned: number;
+    tier_earned: number;
+    cost_usd: number;
+    reward_rate: number;
+}
+
+export interface EarningsResponse {
+    daily: EarningsRow[];
+    perEntity: EarningsRow[];
+}
+
+/** Validate the --days option; returns an error message when invalid. */
+export function daysError(days: string): string | null {
+    const n = Number(days);
+    if (!Number.isInteger(n) || n < 1) {
+        return "--days must be a positive integer";
+    }
+    if (n > 90) {
+        return "--days must be 90 or less (API limit)";
+    }
+    return null;
+}
+
+/** Roll the daily buckets into additive totals per earning source. */
+export function summarizeBySource(daily: EarningsRow[]): {
+    source: string;
+    requests: number;
+    pollenEarned: number;
+    usdBasis: number;
+}[] {
+    const bySource = new Map<
+        string,
+        { requests: number; pollenEarned: number; usdBasis: number }
+    >();
+    for (const row of daily) {
+        const agg = bySource.get(row.source) ?? {
+            requests: 0,
+            pollenEarned: 0,
+            usdBasis: 0,
+        };
+        agg.requests += row.requests;
+        agg.pollenEarned += row.pollen_earned;
+        agg.usdBasis += row.cost_usd;
+        bySource.set(row.source, agg);
+    }
+    return [...bySource.entries()].map(([source, agg]) => ({
+        source,
+        ...agg,
+    }));
+}
+
+export const earningsCommand = new Command("earnings")
+    .description(
+        "Show your Pollinations earnings from BYOP apps and community models",
+    )
+    .option("--days <n>", "Number of days to include", "30")
+    .action(async (opts) => {
+        const key = requireKey();
+        const err = daysError(opts.days);
+        if (err) {
+            printError(err);
+            process.exit(1);
+        }
+
+        try {
+            const data = await gen<EarningsResponse>(
+                `/account/earnings?days=${opts.days}`,
+                { apiKey: key },
+            );
+
+            if (getOutputMode() === "json") {
+                printResult({ daily: data.daily, perEntity: data.perEntity });
+                return;
+            }
+
+            const total = data.perEntity.reduce(
+                (sum, e) => sum + e.pollen_earned,
+                0,
+            );
+            const summary = summarizeBySource(data.daily);
+            console.log(
+                chalk.bold(
+                    `Earned ${total.toFixed(4)} pollen in the last ${opts.days} day(s)`,
+                ),
+            );
+
+            if (summary.length > 0) {
+                console.log();
+                printTable(
+                    summary.map((s) => ({
+                        source: s.source,
+                        requests: s.requests,
+                        "pollen earned": s.pollenEarned.toFixed(4),
+                        "usd basis": `$${s.usdBasis.toFixed(4)}`,
+                    })),
+                );
+            }
+
+            if (data.perEntity.length > 0) {
+                console.log(chalk.dim("\nBy app / community model:"));
+                printTable(
+                    data.perEntity.map((e) => ({
+                        name: e.entity_name,
+                        type: e.source,
+                        requests: e.requests,
+                        earned: e.pollen_earned.toFixed(4),
+                    })),
+                    ["name", "type", "requests", "earned"],
+                );
+            }
+        } catch (e) {
+            printError(
+                `Failed to fetch earnings: ${e instanceof Error ? e.message : "unknown"}`,
+            );
+            process.exit(1);
+        }
+    });

--- a/packages/polli-cli/src/index.ts
+++ b/packages/polli-cli/src/index.ts
@@ -5,13 +5,13 @@ import { Command } from "commander";
 import { agentsCommand } from "./commands/agents.js";
 import { authCommand } from "./commands/auth.js";
 import { docsCommand } from "./commands/docs.js";
+import { earningsCommand } from "./commands/earnings.js";
 import { createGenCommand } from "./commands/gen/index.js";
 import { keysCommand } from "./commands/keys.js";
 import { modelsCommand } from "./commands/models.js";
 import { myModelsCommand } from "./commands/my-models.js";
 import { questsCommand } from "./commands/quests.js";
 import { uploadCommand } from "./commands/upload.js";
-import { earningsCommand } from "./commands/earnings.js";
 import { usageCommand } from "./commands/usage.js";
 
 import { setKeyOverride } from "./lib/config.js";

--- a/packages/polli-cli/src/index.ts
+++ b/packages/polli-cli/src/index.ts
@@ -11,6 +11,7 @@ import { modelsCommand } from "./commands/models.js";
 import { myModelsCommand } from "./commands/my-models.js";
 import { questsCommand } from "./commands/quests.js";
 import { uploadCommand } from "./commands/upload.js";
+import { earningsCommand } from "./commands/earnings.js";
 import { usageCommand } from "./commands/usage.js";
 
 import { setKeyOverride } from "./lib/config.js";
@@ -62,6 +63,7 @@ program
 // Auth & account
 program.addCommand(authCommand);
 program.addCommand(keysCommand);
+program.addCommand(earningsCommand);
 program.addCommand(usageCommand);
 program.addCommand(questsCommand);
 program.addCommand(agentsCommand);


### PR DESCRIPTION
## Summary

```
$ polli earnings
Earned 1.2500 pollen in the last 30 day(s)

source           requests  pollen earned  usd basis
byop_markup      10        1.2500         $0.0500

By app / community model:
name       type          requests  earned
storyforge byop_markup   10        1.2500
```

- `polli earnings --days N` supports the API's recent time range (validated 1–90)
- global `--json` returns the raw machine-readable `{daily, perEntity}` payload
- invalid input (`--days abc`, `--days 91`, `--days -5`) produces a clear error and exit 1

Closes #13768

## Changes
- `packages/polli-cli/src/commands/earnings.ts` — follows the established `usage.ts` request/output patterns; pure helpers (`daysError`, `summarizeBySource`) split out for testability
- `packages/polli-cli/src/index.ts` — registers the command
- `packages/polli-cli/README.md` — one-line doc in the CLI examples block
- `packages/polli-cli/src/commands/earnings.test.ts` — focused tests for validation + per-source rollup

## Verification
```
✓ src/commands/earnings.test.ts (5 tests)
Full CLI suite: 10 passed
npx tsc --noEmit → only pre-existing upstream error in src/lib/api.ts (verified identical on clean checkout)
```

No new server functionality, no Tinybird queries from the CLI.