### PR TITLE
feat(gen): add OpenAI-compatible model retrieval

### DIFF
--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -50,6 +50,7 @@ import {
     CreateImageRequestSchema,
     CreateImageResponseSchema,
     GetModelsResponseSchema,
+    OpenAIModelSchema,
 } from "@shared/schemas/openai.ts";
 import { SafeSchema } from "@shared/schemas/safety.ts";
 import { errorResponseDescriptions } from "@shared/utils/api-docs.ts";
@@ -244,6 +245,49 @@ async function getVisibleModelEntries(c: Context<Env>) {
     );
 }
 
+// Stable registry creation timestamp: community models are created when their
+// endpoint row is, static models when the catalog added them.
+function modelCreatedMs(entry: GenerationModelEntry): number {
+    return entry.definition.addedDate;
+}
+
+// "pollinations" for official models; the owning GitHub username (from the
+// `owner/name` community model id) for community models.
+function modelOwnedBy(entry: GenerationModelEntry): string {
+    if (entry.communityEndpoint) {
+        return entry.id.includes("/")
+            ? entry.id.slice(0, entry.id.indexOf("/"))
+            : entry.communityEndpoint.ownerUserId;
+    }
+    return "pollinations";
+}
+
+// One mapper shared by the list and retrieve OpenAI-compatible endpoints so
+// both always return the same model shape with stable metadata.
+function toOpenAiModelEntry(entry: GenerationModelEntry, now: number) {
+    return {
+        id: entry.info.name,
+        object: "model" as const,
+        created: modelCreatedMs(entry) || now,
+        owned_by: modelOwnedBy(entry),
+        input_modalities: entry.info.input_modalities,
+        output_modalities: entry.info.output_modalities,
+        supported_endpoints: entry.supportedEndpoints,
+        ...(entry.info.agent && { agent: true }),
+        ...(entry.info.base_model && { base_model: entry.info.base_model }),
+        pricing: entry.info.pricing,
+        capabilities: entry.info.capabilities,
+        ...(entry.info.tools && { tools: entry.info.tools }),
+        ...(entry.info.reasoning && { reasoning: entry.info.reasoning }),
+        ...(entry.info.context_length && {
+            context_length: entry.info.context_length,
+        }),
+        ...(entry.info.per_user_rpm !== undefined && {
+            per_user_rpm: entry.info.per_user_rpm,
+        }),
+    };
+}
+
 async function getVisibleModelEntriesForEventType(
     c: Context<Env>,
     eventType: GenerationModelEntry["eventType"],
@@ -280,7 +324,8 @@ export const proxyRoutes = new Hono<Env>()
     // Edge rate limiter: first line of defense (10 req/s per IP)
     .use("*", edgeRateLimit)
     // Optional auth for models endpoints - doesn't require auth but uses it if provided
-    .use("/v1/models", auth())
+.use("/v1/models", auth())
+    .use("/v1/models/*", auth())
     .use("/image/models", auth())
     .use("/3d/models", auth())
     .use("/video/models", auth())
@@ -324,35 +369,60 @@ export const proxyRoutes = new Hono<Env>()
             );
             const now = Date.now();
 
-            const toModelEntry = (entry: GenerationModelEntry) => ({
-                id: entry.info.name,
-                object: "model" as const,
-                created: now,
-                input_modalities: entry.info.input_modalities,
-                output_modalities: entry.info.output_modalities,
-                supported_endpoints: entry.supportedEndpoints,
-                ...(entry.info.agent && { agent: true }),
-                ...(entry.info.base_model && {
-                    base_model: entry.info.base_model,
-                }),
-                pricing: entry.info.pricing,
-                capabilities: entry.info.capabilities,
-                ...(entry.info.tools && { tools: entry.info.tools }),
-                ...(entry.info.reasoning && {
-                    reasoning: entry.info.reasoning,
-                }),
-                ...(entry.info.context_length && {
-                    context_length: entry.info.context_length,
-                }),
-                ...(entry.info.per_user_rpm !== undefined && {
-                    per_user_rpm: entry.info.per_user_rpm,
-                }),
-            });
-
             return c.json({
                 object: "list" as const,
-                data: modelEntries.map(toModelEntry),
+                data: modelEntries.map((entry) =>
+                    toOpenAiModelEntry(entry, now),
+                ),
             });
+        },
+    )
+    .get(
+        "/v1/models/:model",
+        describeRoute({
+            tags: ["🤖 Models"],
+            summary: "Retrieve Model (OpenAI-compatible)",
+            description:
+                'Returns a single model in the OpenAI-compatible format, using the same model shape as `GET /v1/models`. Aliases resolve to the canonical model ID. Missing or inaccessible models return 404. The same visibility, key-permission, community, and paid-balance rules as the list endpoint apply.',
+            responses: {
+                200: {
+                    description: "Success",
+                    content: {
+                        "application/json": {
+                            schema: resolver(OpenAIModelSchema),
+                        },
+                    },
+                },
+                ...errorResponseDescriptions(400, 404, 500),
+            },
+        }),
+        async (c) => {
+            const requestedId = c.req.param("model");
+            const allowedModels = c.var.auth?.apiKey?.permissions?.models;
+            const paidBalance = hasPaidBalance(c);
+            const entry = filterEntriesByPermissions(
+                await getVisibleModelEntries(c),
+                allowedModels,
+                paidBalance,
+            ).find(
+                (candidate) =>
+                    candidate.id === requestedId ||
+                    candidate.aliases.includes(requestedId),
+            );
+
+            if (!entry) {
+                return c.json(
+                    {
+                        error: {
+                            message: `The model '${requestedId}' does not exist or you do not have access to it.`,
+                            code: "NOT_FOUND",
+                        },
+                    },
+                    404,
+                );
+            }
+
+            return c.json(toOpenAiModelEntry(entry, Date.now()));
         },
     )
     .get(

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -324,7 +324,7 @@ export const proxyRoutes = new Hono<Env>()
     // Edge rate limiter: first line of defense (10 req/s per IP)
     .use("*", edgeRateLimit)
     // Optional auth for models endpoints - doesn't require auth but uses it if provided
-.use("/v1/models", auth())
+    .use("/v1/models", auth())
     .use("/v1/models/*", auth())
     .use("/image/models", auth())
     .use("/3d/models", auth())
@@ -383,7 +383,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "Retrieve Model (OpenAI-compatible)",
             description:
-                'Returns a single model in the OpenAI-compatible format, using the same model shape as `GET /v1/models`. Aliases resolve to the canonical model ID. Missing or inaccessible models return 404. The same visibility, key-permission, community, and paid-balance rules as the list endpoint apply.',
+                "Returns a single model in the OpenAI-compatible format, using the same model shape as `GET /v1/models`. Aliases resolve to the canonical model ID. Missing or inaccessible models return 404. The same visibility, key-permission, community, and paid-balance rules as the list endpoint apply.",
             responses: {
                 200: {
                     description: "Success",

--- a/gen.pollinations.ai/test/models-retrieve.test.ts
+++ b/gen.pollinations.ai/test/models-retrieve.test.ts
@@ -1,0 +1,89 @@
+import { SELF } from "cloudflare:test";
+import {
+    RESTRICTED_TEST_MODELS,
+    RESTRICTED_TEXT_TEST_MODEL,
+    test,
+} from "@shared/test/fixtures/index.ts";
+import { expect } from "vitest";
+
+async function fetchWorker(path: string, init: RequestInit = {}) {
+    return SELF.fetch(new Request(`https://gen.pollinations.ai${path}`, init));
+}
+
+test("retrieves a single model in the same shape as the list", async () => {
+    const [listResponse, retrieveResponse] = await Promise.all([
+        fetchWorker("/v1/models"),
+        fetchWorker(`/v1/models/${RESTRICTED_TEXT_TEST_MODEL}`),
+    ]);
+
+    expect(listResponse.status).toBe(200);
+    expect(retrieveResponse.status).toBe(200);
+
+    const listBody = (await listResponse.json()) as {
+        data: Record<string, unknown>[];
+    };
+    const retrieveBody = (await retrieveResponse.json()) as Record<
+        string,
+        unknown
+    >;
+
+    const listed = listBody.data.find(
+        (model) => model.id === RESTRICTED_TEXT_TEST_MODEL,
+    );
+    expect(listed).toBeDefined();
+    // Same shape and stable metadata as the list entry
+    expect(retrieveBody).toEqual(listed);
+    expect(retrieveBody.id).toBe(RESTRICTED_TEXT_TEST_MODEL);
+    expect(retrieveBody.object).toBe("model");
+    expect(typeof retrieveBody.created).toBe("number");
+    expect(retrieveBody.owned_by).toBe("pollinations");
+});
+
+test("resolves aliases to the canonical model ID", async () => {
+    // "openai" is the canonical id of a visible model with aliases
+    const alias = "gpt-5.4-nano";
+
+    const [canonicalResponse, aliasResponse] = await Promise.all([
+        fetchWorker("/v1/models/openai"),
+        fetchWorker(`/v1/models/${alias}`),
+    ]);
+
+    expect(canonicalResponse.status).toBe(200);
+    expect(aliasResponse.status).toBe(200);
+
+    const canonical = (await canonicalResponse.json()) as { id: string };
+    const viaAlias = (await aliasResponse.json()) as { id: string };
+
+    expect(viaAlias.id).toBe(canonical.id);
+    expect(viaAlias.id).toBe("openai");
+});
+
+test("returns 404 for missing models", async () => {
+    const response = await fetchWorker("/v1/models/does-not-exist-xyz");
+
+    expect(response.status).toBe(404);
+    const body = (await response.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBeDefined();
+});
+
+test("returns 404 for models excluded by API key permissions", async ({
+    restrictedApiKey,
+}) => {
+    // "openai" is visible publicly but outside RESTRICTED_TEST_MODELS
+    const authHeaders = { Authorization: `Bearer ${restrictedApiKey}` };
+
+    const deniedListResponse = await fetchWorker("/v1/models/openai", {
+        headers: authHeaders,
+    });
+    expect(deniedListResponse.status).toBe(404);
+
+    // Allowed models retrieve fine with the same key
+    for (const allowedModel of RESTRICTED_TEST_MODELS) {
+        const allowedResponse = await fetchWorker(`/v1/models/${allowedModel}`, {
+            headers: authHeaders,
+        });
+        expect(allowedResponse.status).toBe(200);
+        const body = (await allowedResponse.json()) as { id: string };
+        expect(body.id).toBe(allowedModel);
+    }
+});

--- a/gen.pollinations.ai/test/models-retrieve.test.ts
+++ b/gen.pollinations.ai/test/models-retrieve.test.ts
@@ -79,9 +79,12 @@ test("returns 404 for models excluded by API key permissions", async ({
 
     // Allowed models retrieve fine with the same key
     for (const allowedModel of RESTRICTED_TEST_MODELS) {
-        const allowedResponse = await fetchWorker(`/v1/models/${allowedModel}`, {
-            headers: authHeaders,
-        });
+        const allowedResponse = await fetchWorker(
+            `/v1/models/${allowedModel}`,
+            {
+                headers: authHeaders,
+            },
+        );
         expect(allowedResponse.status).toBe(200);
         const body = (await allowedResponse.json()) as { id: string };
         expect(body.id).toBe(allowedModel);

--- a/shared/error.ts
+++ b/shared/error.ts
@@ -398,7 +398,7 @@ export function getErrorCode(status: number): string {
 }
 
 export const KNOWN_ERROR_STATUS_CODES = [
-    400, 401, 402, 403, 405, 409, 422, 426, 429, 500, 502, 503,
+    400, 401, 402, 403, 404, 405, 409, 422, 426, 429, 500, 502, 503,
 ] as const;
 
 export type ErrorStatusCode = (typeof KNOWN_ERROR_STATUS_CODES)[number];

--- a/shared/schemas/openai.ts
+++ b/shared/schemas/openai.ts
@@ -527,11 +527,12 @@ export type CreateChatCompletionResponse = z.infer<
     typeof CreateChatCompletionResponseSchema
 >;
 
-const OpenAIModelSchema = z
+export const OpenAIModelSchema = z
     .object({
         id: z.string(),
         object: z.literal("model"),
         created: z.number(),
+        owned_by: z.string(),
         input_modalities: z.array(z.string()).optional(),
         output_modalities: z.array(z.string()).optional(),
         supported_endpoints: z.array(z.string()).optional(),


### PR DESCRIPTION
## Summary
`GET /v1/models/{model}` returns the same model shape as `GET /v1/models`, via **one shared response mapper** (`toOpenAiModelEntry`) so list and retrieve can never drift.

Closes #13795

## Behavior
- Aliases resolve to the canonical model ID (`gpt-5.4-nano` → `openai`)
- Missing or inaccessible models return `404` with the standard error envelope
- Stable `created`: registry `addedDate` instead of per-request `Date.now()` (fallback to now only if a definition lacks one)
- `owned_by`: `pollinations` for official models, the owner GitHub username for community models
- Visibility / key-permission / community / paid-balance rules identical to the list endpoint

## Bug found & fixed along the way
The route-level middleware `.use("/v1/models", auth())` does not cover subpaths in Hono, so `/v1/models/:model` was serving unauthenticated responses with no permission filtering. Added `.use("/v1/models/*", auth())`. The focused tests caught this: the permission test returned 200 for a model excluded by the key's allow-list before the fix.

## Changes
- `gen.pollinations.ai/src/routes/proxy.ts` — retrieve handler + shared mapper + subpath auth
- `shared/schemas/openai.ts` — `owned_by` added to `OpenAIModelSchema` (now exported)
- `shared/error.ts` — 404 registered in known error codes
- `gen.pollinations.ai/test/models-retrieve.test.ts` — 4 focused tests (shape parity with list, alias resolution, missing-model 404, key-permission 404)

## Verification
```
✓ test/models-retrieve.test.ts (4 tests)
✓ model-permissions + community-model-rate-limit + docs suites: 18 passed
npx tsc --noEmit → clean
```

No pagination, no model mutation routes, no new catalog format, no registry refactor.