### PR TITLE
fix(enter): prevent caching of authenticated account responses

### DIFF
--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -790,6 +790,11 @@ const usageResponseSchema = z.object({
  * Supports both session cookies and API keys with permission checks.
  */
 export const accountRoutes = new Hono<Env>()
+    .use(async (c, next) => {
+        await next();
+        c.header("Cache-Control", "private, no-store, max-age=0");
+        c.header("Pragma", "no-cache");
+    })
     .use(auth({ allowApiKey: true, allowSessionCookie: true }))
     .route("/agents", agentsRoutes)
     .route("/my-models", communityEndpointsRoutes)
@@ -1398,7 +1403,6 @@ export const accountRoutes = new Hono<Env>()
                 ? await getVisibleModelIdsForUser(c.env.DB, user.id)
                 : null;
 
-            c.header("Cache-Control", "private, no-store, max-age=0");
             return c.json({
                 data: keys.map((key, index) => ({
                     id: key.id,

--- a/enter.pollinations.ai/test/integration/account-profile.test.ts
+++ b/enter.pollinations.ai/test/integration/account-profile.test.ts
@@ -88,4 +88,38 @@ describe("GET /api/account/profile", () => {
         expect(data).toHaveProperty("name");
         expect(data).toHaveProperty("email");
     });
+
+    test("returns Cache-Control: private, no-store, max-age=0 and Pragma: no-cache on top-level and nested account routes", async ({
+        sessionToken,
+    }) => {
+        const topLevelResponse = await SELF.fetch(
+            "http://localhost:3000/api/account/profile",
+            {
+                headers: {
+                    Cookie: `better-auth.session_token=${sessionToken}`,
+                },
+            },
+        );
+
+        expect(topLevelResponse.status).toBe(200);
+        expect(topLevelResponse.headers.get("Cache-Control")).toBe(
+            "private, no-store, max-age=0",
+        );
+        expect(topLevelResponse.headers.get("Pragma")).toBe("no-cache");
+
+        const nestedResponse = await SELF.fetch(
+            "http://localhost:3000/api/account/my-models",
+            {
+                headers: {
+                    Cookie: `better-auth.session_token=${sessionToken}`,
+                },
+            },
+        );
+
+        expect(nestedResponse.status).toBe(200);
+        expect(nestedResponse.headers.get("Cache-Control")).toBe(
+            "private, no-store, max-age=0",
+        );
+        expect(nestedResponse.headers.get("Pragma")).toBe("no-cache");
+    });
 });


### PR DESCRIPTION
Resolves #13771

### Changes
- Applied \Cache-Control: private, no-store, max-age=0\ and \Pragma: no-cache\ middleware once at the top of \ccountRoutes\ in \nter.pollinations.ai/src/routes/account.ts\.
- Removed redundant header setters in individual account route handlers.
- Added tests verifying cache control headers on top-level (\/api/account/profile\) and nested (\/api/account/my-models\) responses.