### PR TITLE
feat(sdk): expose quest status in the JavaScript SDK

### DIFF
--- a/packages/sdk/src/client.test.ts
+++ b/packages/sdk/src/client.test.ts
@@ -608,3 +608,33 @@ describe("Pollinations model discovery", () => {
         );
     });
 });
+
+describe("Pollinations.accountQuests", () => {
+    it("fetches GET /account/quests and returns typed quest response", async () => {
+        const client = newClient();
+        const responseData = {
+            quests: [
+                {
+                    id: "quest_1",
+                    title: "First Generation",
+                    description: "Generate your first image",
+                    category: "getting_started",
+                    state: "available",
+                    status: "open",
+                    rewardAmount: 10,
+                    balanceBucket: "tier",
+                    url: null,
+                    reward: null,
+                },
+            ],
+        };
+
+        fetchMock.mockResolvedValueOnce(makeResponse(responseData));
+
+        const result = await client.accountQuests();
+        expect(result).toEqual(responseData);
+        expect(fetchMock.mock.calls[0]?.[0]).toBe(
+            "https://example.test/account/quests",
+        );
+    });
+});

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -3,6 +3,7 @@ import type {
     AccountBalance,
     AccountKey,
     AccountProfile,
+    AccountQuestsResponse,
     AudioBinaryResponse,
     AudioGenerateOptions,
     AuthorizeDeviceOptions,
@@ -1396,6 +1397,24 @@ export class Pollinations {
      */
     async accountBalance(): Promise<AccountBalance> {
         return this.getJson<AccountBalance>(`${this.baseUrl}/account/balance`);
+    }
+
+    /**
+     * Get account quest status
+     *
+     * @example
+     * ```ts
+     * const { quests } = await pollinations.accountQuests();
+     * quests.forEach(q => console.log(q.title, q.status));
+     * ```
+     */
+    async accountQuests(
+        options: RequestOptions = {},
+    ): Promise<AccountQuestsResponse> {
+        return this.getJson<AccountQuestsResponse>(
+            `${this.baseUrl}/account/quests`,
+            options.signal,
+        );
     }
 
     /**

--- a/packages/sdk/src/helpers.ts
+++ b/packages/sdk/src/helpers.ts
@@ -31,6 +31,7 @@ import type {
     AccountBalance,
     AccountKey,
     AccountProfile,
+    AccountQuestsResponse,
     AudioGenerateOptions,
     AuthorizeDeviceOptions,
     AuthorizeOptions,
@@ -47,6 +48,8 @@ import type {
     KeyUsageOptions,
     Message,
     ModelInfo,
+    PollinationsConfig,
+    RequestOptions,
     TextGenerateOptions,
     TranscribeOptions,
     TranscriptionResponse,
@@ -495,6 +498,15 @@ export async function getProfile(): Promise<AccountProfile> {
  */
 export async function getBalance(): Promise<AccountBalance> {
     return getClient().accountBalance();
+}
+
+/**
+ * Get account quest status
+ */
+export async function accountQuests(
+    options?: RequestOptions,
+): Promise<AccountQuestsResponse> {
+    return getClient().accountQuests(options);
 }
 
 /**

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -34,6 +34,7 @@ export {
 } from "./extras.js";
 // Helper functions
 export {
+    accountQuests,
     authorizeDevice,
     authorizeUrl,
     chat,
@@ -78,6 +79,9 @@ export type {
     AccountKey,
     AccountPermission,
     AccountProfile,
+    AccountQuest,
+    AccountQuestReward,
+    AccountQuestsResponse,
     AudioBinaryResponse,
     AudioContentPart,
     AudioFormat,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -603,6 +603,36 @@ export interface AccountBalance {
     };
 }
 
+/** Account quest reward details */
+export interface AccountQuestReward {
+    id: string;
+    questId: string | null;
+    title: string;
+    pollenAmount: number;
+    balanceBucket: string;
+    earnedAt: string;
+    claimedAt: string | null;
+}
+
+/** Account quest details */
+export interface AccountQuest {
+    id: string;
+    title: string;
+    description: string;
+    category: string;
+    state: "available" | "completed" | "coming_soon";
+    status: "open" | "completed" | "coming_soon";
+    rewardAmount: number;
+    balanceBucket: "tier" | "pack";
+    url: string | null;
+    reward: AccountQuestReward | null;
+}
+
+/** Response for GET /account/quests */
+export interface AccountQuestsResponse {
+    quests: AccountQuest[];
+}
+
 /** Usage record */
 export interface UsageRecord {
     timestamp: string;


### PR DESCRIPTION
Resolves #13770

### Changes
- Added \ccountQuests()\ client method calling \GET /account/quests\.
- Exported typed interfaces \AccountQuest\, \AccountQuestReward\, and \AccountQuestsResponse\.
- Exported \ccountQuests\ helper function.
- Added unit test in \client.test.ts\ covering method call.