### PR TITLE
feat(sdk): expose developer earnings in the JavaScript SDK

### DIFF
--- a/packages/sdk/src/client.test.ts
+++ b/packages/sdk/src/client.test.ts
@@ -608,3 +608,53 @@ describe("Pollinations model discovery", () => {
         );
     });
 });
+
+describe("Pollinations.accountEarnings", () => {
+    it("fetches GET /account/earnings and passes options", async () => {
+        const client = newClient();
+        const responseData = {
+            daily: [
+                {
+                    date: "2026-08-24",
+                    entity_id: "app_1",
+                    entity_name: "My BYOP App",
+                    source: "byop_markup",
+                    requests: 100,
+                    paid_requests: 80,
+                    tier_requests: 20,
+                    baseline_price: 1.0,
+                    pollen_earned: 5.0,
+                    paid_earned: 4.0,
+                    tier_earned: 1.0,
+                    cost_usd: 1.2,
+                    reward_rate: 0.1,
+                },
+            ],
+            perEntity: [
+                {
+                    date: "",
+                    entity_id: "app_1",
+                    entity_name: "My BYOP App",
+                    source: "byop_markup",
+                    requests: 100,
+                    paid_requests: 80,
+                    tier_requests: 20,
+                    baseline_price: 1.0,
+                    pollen_earned: 5.0,
+                    paid_earned: 4.0,
+                    tier_earned: 1.0,
+                    cost_usd: 1.2,
+                    reward_rate: 0.1,
+                },
+            ],
+        };
+
+        fetchMock.mockResolvedValueOnce(makeResponse(responseData));
+
+        const result = await client.accountEarnings({ days: 30 });
+        expect(result).toEqual(responseData);
+        expect(fetchMock.mock.calls[0]?.[0]).toBe(
+            "https://example.test/account/earnings?days=30",
+        );
+    });
+});

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -17,6 +17,8 @@ import type {
     DeviceAuthorization,
     DeviceCodeResponse,
     DeviceTokenResponse,
+    EarningsOptions,
+    EarningsResponse,
     ImageEditOptions,
     ImageGenerateOptions,
     ImageGenerateV1Options,
@@ -1446,6 +1448,30 @@ export class Pollinations {
         const url = `${this.baseUrl}/account/usage/daily${qs ? `?${qs}` : ""}`;
 
         return this.getJson<DailyUsageResponse>(url);
+    }
+
+    /**
+     * Get developer earnings
+     *
+     * @example
+     * ```ts
+     * const { daily, perEntity } = await pollinations.accountEarnings({ days: 30 });
+     * perEntity.forEach(e => console.log(e.entity_name, e.pollen_earned));
+     * ```
+     */
+    async accountEarnings(
+        options: EarningsOptions = {},
+    ): Promise<EarningsResponse> {
+        const params = new URLSearchParams();
+        if (options.format) params.set("format", options.format);
+        if (options.days) params.set("days", String(options.days));
+        if (options.granularity) params.set("granularity", options.granularity);
+        if (options.period) params.set("period", options.period);
+
+        const qs = params.toString();
+        const url = `${this.baseUrl}/account/earnings${qs ? `?${qs}` : ""}`;
+
+        return this.getJson<EarningsResponse>(url, options.signal);
     }
 
     /**

--- a/packages/sdk/src/helpers.ts
+++ b/packages/sdk/src/helpers.ts
@@ -40,6 +40,8 @@ import type {
     DailyUsageOptions,
     DailyUsageResponse,
     DeviceAuthorization,
+    EarningsOptions,
+    EarningsResponse,
     ImageEditOptions,
     ImageGenerateOptions,
     ImageGenerateV1Options,
@@ -520,6 +522,15 @@ export async function getDailyUsage(
     options?: DailyUsageOptions,
 ): Promise<DailyUsageResponse> {
     return getClient().accountUsageDaily(options);
+}
+
+/**
+ * Get developer earnings
+ */
+export async function accountEarnings(
+    options?: EarningsOptions,
+): Promise<EarningsResponse> {
+    return getClient().accountEarnings(options);
 }
 
 /**

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -34,6 +34,7 @@ export {
 } from "./extras.js";
 // Helper functions
 export {
+    accountEarnings,
     authorizeDevice,
     authorizeUrl,
     chat,
@@ -98,9 +99,12 @@ export type {
     CreateKeyOptions,
     DailyUsageRecord,
     DailyUsageResponse,
+    DeveloperEarningsRow,
     DeviceAuthorization,
     DeviceCodeResponse,
     DeviceTokenResponse,
+    EarningsOptions,
+    EarningsResponse,
     FileContentPart,
     FunctionDefinition,
     ImageContentPart,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -632,6 +632,41 @@ export interface UsageResponse {
     count: number;
 }
 
+/** Developer earnings row details */
+export interface DeveloperEarningsRow {
+    date: string;
+    entity_id: string;
+    entity_name: string;
+    source: "byop_markup" | "community_model" | string;
+    requests: number;
+    paid_requests: number;
+    tier_requests: number;
+    baseline_price: number;
+    pollen_earned: number;
+    paid_earned: number;
+    tier_earned: number;
+    cost_usd: number;
+    reward_rate: number;
+}
+
+/** Options for fetching developer earnings */
+export interface EarningsOptions extends RequestOptions {
+    /** Response format (default: 'json') */
+    format?: "json" | "csv";
+    /** Number of days to include (default: 30) */
+    days?: number;
+    /** Exact period granularity */
+    granularity?: "day" | "week" | "month";
+    /** Exact period, e.g. YYYY-MM-DD, YYYY-WNN, or YYYY-MM */
+    period?: string;
+}
+
+/** Response for GET /account/earnings */
+export interface EarningsResponse {
+    daily: DeveloperEarningsRow[];
+    perEntity: DeveloperEarningsRow[];
+}
+
 /** Options for fetching usage */
 export interface UsageOptions {
     /** Response format (default: 'json') */


### PR DESCRIPTION
Resolves #13769

### Changes
- Added \ccountEarnings(options?: EarningsOptions)\ client method calling \GET /account/earnings\.
- Exported typed interfaces \DeveloperEarningsRow\, \EarningsOptions\, and \EarningsResponse\.
- Exported \ccountEarnings\ helper function.
- Added unit test in \client.test.ts\ covering method call with query options.