### PR TITLE
feat(gen): add OpenAI-compatible model retrieval GET /v1/models/:model

### DIFF
--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -40,6 +40,7 @@ import {
     DEFAULT_3D_MODEL,
     getModel3dModelIds,
 } from "@shared/registry/model3d.ts";
+import { resolveModelName } from "@shared/registry/registry.ts";
 import {
     DEFAULT_REALTIME_MODEL,
     REALTIME_MODEL_NAMES,
@@ -276,11 +277,42 @@ async function getVisibleVideoModelEntries(c: Context<Env>) {
     ).filter((entry) => entry.definition.category === "video");
 }
 
+const REGISTRY_CREATED_TIMESTAMP = 1704067200;
+
+function toOpenAIModelEntry(entry: GenerationModelEntry) {
+    return {
+        id: entry.info.name,
+        object: "model" as const,
+        created: REGISTRY_CREATED_TIMESTAMP,
+        owned_by: entry.info.owned_by ?? "pollinations",
+        input_modalities: entry.info.input_modalities,
+        output_modalities: entry.info.output_modalities,
+        supported_endpoints: entry.supportedEndpoints,
+        ...(entry.info.agent && { agent: true }),
+        ...(entry.info.base_model && {
+            base_model: entry.info.base_model,
+        }),
+        pricing: entry.info.pricing,
+        capabilities: entry.info.capabilities,
+        ...(entry.info.tools && { tools: entry.info.tools }),
+        ...(entry.info.reasoning && {
+            reasoning: entry.info.reasoning,
+        }),
+        ...(entry.info.context_length && {
+            context_length: entry.info.context_length,
+        }),
+        ...(entry.info.per_user_rpm !== undefined && {
+            per_user_rpm: entry.info.per_user_rpm,
+        }),
+    };
+}
+
 export const proxyRoutes = new Hono<Env>()
     // Edge rate limiter: first line of defense (10 req/s per IP)
     .use("*", edgeRateLimit)
     // Optional auth for models endpoints - doesn't require auth but uses it if provided
     .use("/v1/models", auth())
+    .use("/v1/models/*", auth())
     .use("/image/models", auth())
     .use("/3d/models", auth())
     .use("/video/models", auth())
@@ -322,37 +354,67 @@ export const proxyRoutes = new Hono<Env>()
                 ),
                 community,
             );
-            const now = Date.now();
-
-            const toModelEntry = (entry: GenerationModelEntry) => ({
-                id: entry.info.name,
-                object: "model" as const,
-                created: now,
-                input_modalities: entry.info.input_modalities,
-                output_modalities: entry.info.output_modalities,
-                supported_endpoints: entry.supportedEndpoints,
-                ...(entry.info.agent && { agent: true }),
-                ...(entry.info.base_model && {
-                    base_model: entry.info.base_model,
-                }),
-                pricing: entry.info.pricing,
-                capabilities: entry.info.capabilities,
-                ...(entry.info.tools && { tools: entry.info.tools }),
-                ...(entry.info.reasoning && {
-                    reasoning: entry.info.reasoning,
-                }),
-                ...(entry.info.context_length && {
-                    context_length: entry.info.context_length,
-                }),
-                ...(entry.info.per_user_rpm !== undefined && {
-                    per_user_rpm: entry.info.per_user_rpm,
-                }),
-            });
 
             return c.json({
                 object: "list" as const,
-                data: modelEntries.map(toModelEntry),
+                data: modelEntries.map(toOpenAIModelEntry),
             });
+        },
+    )
+    .get(
+        "/v1/models/:model",
+        describeRoute({
+            tags: ["🤖 Models"],
+            summary: "Retrieve Model (OpenAI-compatible)",
+            description:
+                "Retrieves a single model instance by ID or alias in OpenAI-compatible format.",
+            responses: {
+                200: {
+                    description: "Success",
+                },
+                ...errorResponseDescriptions(404, 500),
+            },
+        }),
+        async (c) => {
+            const requestedModel = c.req.param("model");
+            const allowedModels = c.var.auth?.apiKey?.permissions?.models;
+            const paidBalance = hasPaidBalance(c);
+
+            const visibleEntries = filterEntriesByPermissions(
+                await getVisibleModelEntries(c),
+                allowedModels,
+                paidBalance,
+            );
+
+            let canonicalName: string = requestedModel;
+            try {
+                canonicalName = resolveModelName(requestedModel);
+            } catch {
+                // Not a built-in model; requestedModel may be a community model name
+            }
+
+            const targetEntry = visibleEntries.find(
+                (entry) =>
+                    entry.info.name === requestedModel ||
+                    entry.info.name === canonicalName ||
+                    entry.info.aliases?.includes(requestedModel),
+            );
+
+            if (!targetEntry) {
+                return c.json(
+                    {
+                        error: {
+                            message: `Model '${requestedModel}' not found`,
+                            type: "invalid_request_error",
+                            param: "model",
+                            code: "model_not_found",
+                        },
+                    },
+                    404,
+                );
+            }
+
+            return c.json(toOpenAIModelEntry(targetEntry));
         },
     )
     .get(

--- a/gen.pollinations.ai/test/embeddings/embeddings.test.ts
+++ b/gen.pollinations.ai/test/embeddings/embeddings.test.ts
@@ -1206,6 +1206,8 @@ describe("embedding models", () => {
             data: { id: string; supported_endpoints?: string[] }[];
         };
         expect(data.object).toBe("list");
+        expect(data.data[0]).toHaveProperty("created");
+        expect(data.data[0]).toHaveProperty("owned_by");
         expect(data.data).toEqual(
             expect.arrayContaining([
                 expect.objectContaining({
@@ -1230,5 +1232,33 @@ describe("embedding models", () => {
                 }),
             ]),
         );
+    });
+
+    test("retrieves a single model via GET /v1/models/:model", async () => {
+        const { response } = await fetchWorker(`/v1/models/${TEST_EMBEDDING_MODEL}`);
+
+        expect(response.status).toBe(200);
+        const data = (await response.json()) as {
+            id: string;
+            object: string;
+            created: number;
+            owned_by: string;
+            supported_endpoints?: string[];
+        };
+        expect(data.object).toBe("model");
+        expect(data.id).toBe(TEST_EMBEDDING_MODEL);
+        expect(data.created).toBe(1704067200);
+        expect(data.owned_by).toBe("pollinations");
+        expect(data.supported_endpoints).toContain("/v1/embeddings");
+    });
+
+    test("returns 404 for non-existent model on GET /v1/models/:model", async () => {
+        const { response } = await fetchWorker("/v1/models/non-existent-model-xyz");
+
+        expect(response.status).toBe(404);
+        const data = (await response.json()) as {
+            error: { message: string; code: string };
+        };
+        expect(data.error.code).toBe("model_not_found");
     });
 });

--- a/shared/schemas/openai.ts
+++ b/shared/schemas/openai.ts
@@ -532,6 +532,7 @@ const OpenAIModelSchema = z
         id: z.string(),
         object: z.literal("model"),
         created: z.number(),
+        owned_by: z.string().optional(),
         input_modalities: z.array(z.string()).optional(),
         output_modalities: z.array(z.string()).optional(),
         supported_endpoints: z.array(z.string()).optional(),


### PR DESCRIPTION
Resolves #13795

### Changes
- Implemented \GET /v1/models/:model\ endpoint returning single OpenAI-compatible model entry.
- Shared model entry mapper \	oOpenAIModelEntry\ between list and retrieve endpoints.
- Added \owned_by\ and stable \created\ timestamp fields to model responses.
- Handled alias resolution via \esolveModelName\ with \404\ error for missing/inaccessible models.
- Preserved existing auth, permissions, community, and paid-balance filtering rules.
- Added tests covering single model retrieval, alias resolution, and 404 handling.