### PR TITLE
feat(cli): add polli earnings command to the CLI

### DIFF
--- a/packages/polli-cli/README.md
+++ b/packages/polli-cli/README.md
@@ -92,6 +92,8 @@ Keys can't be edited — to change a name, budget, or model list, revoke and rec
 polli usage                  # pollen balance
 polli usage --history        # recent requests
 polli usage --daily          # daily spend
+polli earnings               # developer earnings summary (last 30 days)
+polli earnings --days 7      # developer earnings for custom date range
 polli quests --claimable     # only rewards ready to claim
 polli agents list            # managed prompt agents
 polli my-models list         # invite-only community text, image, and transcription models

--- a/packages/polli-cli/src/commands/earnings.test.ts
+++ b/packages/polli-cli/src/commands/earnings.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { earningsCommand } from "./earnings.js";
+
+describe("earningsCommand", () => {
+    it("is configured with correct command name and description", () => {
+        expect(earningsCommand.name()).toBe("earnings");
+        expect(earningsCommand.description()).toContain("earnings");
+    });
+
+    it("defines --days option with default value 30", () => {
+        const option = earningsCommand.options.find(
+            (opt) => opt.long === "--days",
+        );
+        expect(option).toBeDefined();
+        expect(option?.defaultValue).toBe("30");
+    });
+});

--- a/packages/polli-cli/src/commands/earnings.ts
+++ b/packages/polli-cli/src/commands/earnings.ts
@@ -1,0 +1,90 @@
+import chalk from "chalk";
+import { Command } from "commander";
+import { gen, requireKey } from "../lib/api.js";
+import {
+    getOutputMode,
+    printError,
+    printResult,
+    printTable,
+} from "../lib/output.js";
+
+export interface DeveloperEarningsRow {
+    date: string;
+    entity_id: string;
+    entity_name: string;
+    source: string;
+    requests: number;
+    paid_requests: number;
+    tier_requests: number;
+    baseline_price: number;
+    pollen_earned: number;
+    paid_earned: number;
+    tier_earned: number;
+    cost_usd: number;
+    reward_rate: number;
+}
+
+export interface DeveloperEarningsResponse {
+    daily: DeveloperEarningsRow[];
+    perEntity: DeveloperEarningsRow[];
+}
+
+export const earningsCommand = new Command("earnings")
+    .description("Show developer earnings summary and breakdown")
+    .option("--days <n>", "Number of days to include", "30")
+    .action(async (opts) => {
+        const key = requireKey();
+
+        const days = Number(opts.days);
+        if (!Number.isInteger(days) || days < 1) {
+            printError("--days must be a positive integer");
+            process.exit(1);
+        }
+
+        try {
+            const data = await gen<DeveloperEarningsResponse>(
+                `/account/earnings?days=${days}`,
+                { apiKey: key },
+            );
+
+            if (getOutputMode() !== "human") {
+                printResult(data);
+                return;
+            }
+
+            const totalEarned = data.perEntity.reduce(
+                (sum, row) => sum + (row.pollen_earned || 0),
+                0,
+            );
+            const totalRequests = data.perEntity.reduce(
+                (sum, row) => sum + (row.requests || 0),
+                0,
+            );
+
+            console.log(
+                chalk.bold(
+                    `Total Pollen Earned: ${chalk.green(totalEarned.toFixed(2))} across ${totalRequests} requests (${days} days)\n`,
+                ),
+            );
+
+            if (data.perEntity.length > 0) {
+                console.log(chalk.bold("Earnings by Entity:"));
+                printTable(
+                    data.perEntity.map((r) => ({
+                        entity: r.entity_name || r.entity_id,
+                        source: r.source,
+                        requests: r.requests,
+                        pollen: r.pollen_earned != null ? r.pollen_earned.toFixed(2) : "0.00",
+                        usd_basis: r.cost_usd != null ? `$${r.cost_usd.toFixed(4)}` : "-",
+                    })),
+                );
+            } else {
+                console.log(chalk.dim("No developer earnings in this period."));
+            }
+        } catch (err) {
+            printError(
+                `Failed to fetch earnings: ${err instanceof Error ? err.message : "unknown"}`,
+            );
+            process.exit(1);
+        }
+    });

--- a/packages/polli-cli/src/index.ts
+++ b/packages/polli-cli/src/index.ts
@@ -5,6 +5,7 @@ import { Command } from "commander";
 import { agentsCommand } from "./commands/agents.js";
 import { authCommand } from "./commands/auth.js";
 import { docsCommand } from "./commands/docs.js";
+import { earningsCommand } from "./commands/earnings.js";
 import { createGenCommand } from "./commands/gen/index.js";
 import { keysCommand } from "./commands/keys.js";
 import { modelsCommand } from "./commands/models.js";
@@ -63,6 +64,7 @@ program
 program.addCommand(authCommand);
 program.addCommand(keysCommand);
 program.addCommand(usageCommand);
+program.addCommand(earningsCommand);
 program.addCommand(questsCommand);
 program.addCommand(agentsCommand);
 program.addCommand(myModelsCommand);


### PR DESCRIPTION
Resolves #13768

### Changes
- Added \polli earnings\ command presenting developer earnings total and table breakdowns.
- Added \--days N\ option (default: 30) to query custom time ranges.
- Supported \--json\ mode via \getOutputMode()\.
- Added unit tests in \arnings.test.ts\.
- Updated CLI \README.md\ documentation.