### PR TITLE
fix: price Nova Canvas by output dimensions

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -1231,6 +1231,11 @@ exports[`effective cost and price per model — snapshot 1`] = `
     "cost": {
       "completionImageTokens": 0.04,
     },
+    "costVariants": {
+      "2048": {
+        "completionImageTokens": 0.06,
+      },
+    },
     "price": {
       "completionImageTokens": 0.04,
     },

--- a/enter.pollinations.ai/test/cost-variants.test.ts
+++ b/enter.pollinations.ai/test/cost-variants.test.ts
@@ -415,6 +415,23 @@ describe("request-mode cost variants", () => {
 });
 
 describe("resolution cost variants", () => {
+    it.each([
+        [1024, 1024, 0.04, undefined],
+        [1008, 1040, 0.06, "2048"],
+        [1024, 1040, 0.06, "2048"],
+        [2048, 2048, 0.06, "2048"],
+    ] as const)("nova-canvas bills %sx%s at $%s/image", (width, height, rate, variant) => {
+        const billing = bill(
+            "nova-canvas",
+            { completionImageTokens: 1 },
+            { maxImageDimension: Math.max(width, height) },
+        );
+
+        expect(billing.costVariant).toBe(variant);
+        expect(billing.cost.totalCost).toBeCloseTo(rate, 12);
+        expect(billing.price.totalPrice).toBeCloseTo(rate, 12);
+    });
+
     it("p-video bills the 720p base and 1080p variant", () => {
         expect(
             bill("p-video", { completionVideoSeconds: 10 }).cost.totalCost,

--- a/gen.pollinations.ai/src/image/handler.ts
+++ b/gen.pollinations.ai/src/image/handler.ts
@@ -33,6 +33,7 @@ import {
 } from "./createAndReturnVideos.ts";
 import { getImageEnv, syncImageEnv } from "./env.ts";
 import { setKleinVpcBinding } from "./models/fluxKleinModel.ts";
+import { clampNovaCanvasDimensions } from "./models/novaCanvasModel.ts";
 import { type ImageParams, ImageParamsSchema } from "./params.ts";
 import { sanitizeString, sleep } from "./util.ts";
 import {
@@ -520,10 +521,18 @@ export async function generateImageOrVideoResponse(
         definition.inputModalities?.includes("image")
             ? await resolveEditDimensionsForImage(parsedParams)
             : parsedParams;
+    const pricingDimensions =
+        c.var.model.resolved === "nova-canvas"
+            ? clampNovaCanvasDimensions(safeParams.width, safeParams.height)
+            : safeParams;
     c.var.track.setPricingInput({
         resolution: safeParams.resolution,
         quality: safeParams.quality,
         hasImage: (safeParams.image?.length ?? 0) > 0,
+        maxImageDimension: Math.max(
+            pricingDimensions.width,
+            pricingDimensions.height,
+        ),
         megapixels: (safeParams.width * safeParams.height) / 1_000_000,
     });
 

--- a/gen.pollinations.ai/src/image/models/novaCanvasModel.ts
+++ b/gen.pollinations.ai/src/image/models/novaCanvasModel.ts
@@ -33,7 +33,7 @@ interface ImageGenerationResult {
  * - 320-4096px per side, divisible by 16
  * - Total pixels < 4,194,304
  */
-function clampDimensions(
+export function clampNovaCanvasDimensions(
     width: number,
     height: number,
 ): { width: number; height: number } {
@@ -67,7 +67,7 @@ export async function callNovaCanvasAPI(
         throw new HttpError("AWS credentials not configured", 500);
     }
 
-    const { width, height } = clampDimensions(
+    const { width, height } = clampNovaCanvasDimensions(
         safeParams.width || 1024,
         safeParams.height || 1024,
     );

--- a/gen.pollinations.ai/test/image/costVariants-e2e.test.ts
+++ b/gen.pollinations.ai/test/image/costVariants-e2e.test.ts
@@ -9,10 +9,32 @@ import {
     teardownFetchMock,
 } from "@shared/test/mocks/fetch.ts";
 import { createMockTinybird } from "@shared/test/mocks/tinybird.ts";
-import { afterEach, expect } from "vitest";
+import { afterEach, expect, vi } from "vitest";
 import { syncImageEnv } from "../../src/image/env.ts";
 import worker from "../../src/index.ts";
 import { withInlineGenerationCoordinator } from "../helpers/inline-generation-coordinator.ts";
+
+const bedrockMocks = vi.hoisted(() => ({
+    calls: [] as Record<string, unknown>[],
+}));
+
+vi.mock("@aws-sdk/client-bedrock-runtime", () => ({
+    BedrockRuntimeClient: vi.fn().mockImplementation(() => ({
+        send: vi.fn().mockImplementation(async (command) => {
+            bedrockMocks.calls.push(JSON.parse(command.body));
+            return {
+                body: new TextEncoder().encode(
+                    JSON.stringify({ images: ["iVBORw0KGgo="] }),
+                ),
+            };
+        }),
+    })),
+    InvokeModelCommand: vi.fn().mockImplementation((input) => input),
+}));
+
+vi.mock("@smithy/fetch-http-handler", () => ({
+    FetchHttpHandler: vi.fn(),
+}));
 
 const INPUT_IMAGE_URL = "https://media.example.test/input.png";
 const OUTPUT_IMAGE_URL = "https://media.example.test/output.png";
@@ -189,6 +211,49 @@ test("qwen-image selects text-to-image and edit billing from the real handler in
         tokenPriceCompletionImage: 0.03,
         totalCost: 0.03,
         totalPrice: 0.03,
+    });
+});
+
+test("nova-canvas bills the final dimensions sent to Bedrock", async ({
+    paidApiKey,
+    mocks,
+}) => {
+    await mocks.enable("tinybird");
+    bedrockMocks.calls = [];
+
+    await generate(
+        "/image/billing-nova-low?model=nova-canvas&width=1025&height=1024&seed=105",
+        paidApiKey,
+    );
+    await generate(
+        "/image/billing-nova-high?model=nova-canvas&width=1008&height=1040&seed=106",
+        paidApiKey,
+    );
+
+    expect(
+        bedrockMocks.calls.map((call) => call.imageGenerationConfig),
+    ).toEqual([
+        expect.objectContaining({ width: 1024, height: 1024 }),
+        expect.objectContaining({ width: 1008, height: 1040 }),
+    ]);
+    expect(mocks.tinybird.state.events).toHaveLength(2);
+    expect(mocks.tinybird.state.events[0]).toMatchObject({
+        modelRequested: "nova-canvas",
+        modelUsed: "nova-canvas",
+        tokenCountCompletionImage: 1,
+        tokenPriceCompletionImage: 0.04,
+        totalCost: 0.04,
+        totalPrice: 0.04,
+    });
+    expect(mocks.tinybird.state.events[0].costVariant).toBeUndefined();
+    expect(mocks.tinybird.state.events[1]).toMatchObject({
+        modelRequested: "nova-canvas",
+        modelUsed: "nova-canvas",
+        costVariant: "2048",
+        tokenCountCompletionImage: 1,
+        tokenPriceCompletionImage: 0.06,
+        totalCost: 0.06,
+        totalPrice: 0.06,
     });
 });
 

--- a/shared/registry/cost-variants.ts
+++ b/shared/registry/cost-variants.ts
@@ -19,6 +19,7 @@ export type PricingInput = {
     resolution?: string;
     quality?: string;
     hasImage?: boolean;
+    maxImageDimension?: number;
     megapixels?: number;
     searchContextSize?: "low" | "high";
     hasDiarization?: boolean;

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -1171,9 +1171,27 @@ const IMAGE_BASE_SERVICES = {
         category: "image",
         addedDate: new Date("2026-03-23").getTime(),
         priceMultiplier: 1,
+        // AWS Cost Explorer Nova Canvas Standard meters, verified 2026-08-24.
         cost: {
             completionImageTokens: 0.04, // per image
         },
+        ...defineCostVariants(
+            {
+                "2048": {
+                    completionImageTokens: 0.06, // per image when either side exceeds 1024px
+                },
+            },
+            ({ input }) =>
+                (input?.maxImageDimension ?? 0) > 1024 ? "2048" : undefined,
+            {
+                "2048": {
+                    label: "2048 tier",
+                    description:
+                        "Applies when either output dimension exceeds 1024 pixels.",
+                },
+            },
+            "1024 tier",
+        ),
         title: "Nova Canvas",
         description: "Image generation with editing and inpainting tools",
         inputModalities: ["text", "image"],


### PR DESCRIPTION
- Adds Nova Canvas Standard exact AWS dimension tiers: $0.04 when both final dimensions are at most 1024px; $0.06 when either exceeds 1024px.
- Selects pricing from the same 16px-aligned dimensions sent to `amazon.nova-canvas-v1:0`, so requests such as 1025px that normalize to 1024px remain on the lower tier.
- Preserves `nova-canvas`, `amazon-nova-canvas`, Bedrock, `paidOnly: false`, multiplier 1, Pollinations GPU off, and no fallback.
- AWS Cost Explorer evidence for the controlled 2026-08-22 14:00 UTC batch: 3 × 1024 Standard = $0.12 and 4 × 2048 Standard = $0.24. Direct dimensions confirmed `1008×1040` is the higher tier. Source: https://aws.amazon.com/bedrock/pricing/
- Tests: Gen focused suite (5), Enter cost/snapshot suite (55), Gen and Enter typechecks, Biome.