### PR TITLE
[QUEST #13794] Preserve request IDs in JavaScript SDK errors — requestId fallback to X-Request-Id

### DIFF
--- a/packages/sdk/src/client.test.ts
+++ b/packages/sdk/src/client.test.ts
@@ -226,6 +226,63 @@ describe("Pollinations request attempts", () => {
         expect(error).toBeInstanceOf(PollinationsError);
         expect(error?.retryAfter).toBeUndefined();
     });
+
+    it("prefers nested requestId when present on the error body", async () => {
+        const client = newClient();
+        fetchMock.mockResolvedValue(
+            makeResponse(
+                { error: { message: "bad request", code: "BAD_REQUEST", requestId: "body-123" } },
+                { ok: false, status: 400 },
+            ),
+        );
+
+        let error: PollinationsError | undefined;
+        try {
+            await client.image("a cat");
+        } catch (caught) {
+            if (caught instanceof PollinationsError) error = caught;
+        }
+
+        expect(error?.requestId).toBe("body-123");
+    });
+
+    it("falls back to X-Request-Id header when the body omits requestId", async () => {
+        const client = newClient();
+        fetchMock.mockResolvedValue(
+            makeResponse(
+                { error: { message: "server error", code: "INTERNAL" } },
+                { ok: false, status: 500, headers: { "x-request-id": "header-abc" } },
+            ),
+        );
+
+        let error: PollinationsError | undefined;
+        try {
+            await client.image("a cat");
+        } catch (caught) {
+            if (caught instanceof PollinationsError) error = caught;
+        }
+
+        expect(error?.requestId).toBe("header-abc");
+    });
+
+    it("leaves requestId undefined when neither body nor header provides one", async () => {
+        const client = newClient();
+        fetchMock.mockResolvedValue(
+            makeResponse(
+                { error: { message: "fail", code: "UNKNOWN" } },
+                { ok: false, status: 500 },
+            ),
+        );
+
+        let error: PollinationsError | undefined;
+        try {
+            await client.image("a cat");
+        } catch (caught) {
+            if (caught instanceof PollinationsError) error = caught;
+        }
+
+        expect(error?.requestId).toBeUndefined();
+    });
 });
 
 describe("Pollinations media upload", () => {

--- a/packages/sdk/src/error-response.ts
+++ b/packages/sdk/src/error-response.ts
@@ -64,7 +64,9 @@ export async function pollinationsErrorFromResponse(
             ? (nested.details as Record<string, unknown>)
             : undefined;
     const requestId =
-        typeof nested.requestId === "string" ? nested.requestId : undefined;
+        typeof nested.requestId === "string"
+            ? nested.requestId
+            : response.headers.get("x-request-id") ?? undefined;
     const retryAfter = parseRetryAfter(response);
 
     return new PollinationsError(


### PR DESCRIPTION
Closes #13794

## Goal
Preserve the server-generated request ID in JavaScript SDK errors.

## Outcome
- `PollinationsError.requestId` prefers the JSON body `requestId` when present.
- Falls back to the response header `X-Request-Id` otherwise.
- Leaves `requestId` as undefined` when neither source provides one.

## Files changed
- `packages/sdk/src/error-response.ts`: add header fallback after body parsing
- `packages/sdk/src/client.test.ts`: three focused tests covering body ID, header fallback, and undefined case

## Verification
\`\`\`
cd packages/sdk
npx vitest run src/client.test.ts
\`\`\`
Result: \`15 passed (15)\`

## Notes
- Minimal change: no server response changes, no interceptors, no logging/tracing changes.
- Parent issue: #11203
- Reviewer hint: @voodoohop
