### PR TITLE
fix: align Qwen3.8 27B pricing

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -1594,18 +1594,18 @@ exports[`effective cost and price per model — snapshot 1`] = `
   },
   "qwen3.8-27b": {
     "cost": {
-      "completionTextTokens": 0.000003,
-      "promptCachedTokens": 0.00000004,
-      "promptImageTokens": 0.0000004,
-      "promptTextTokens": 0.0000004,
-      "promptVideoTokens": 0.0000004,
+      "completionTextTokens": 0.00000275,
+      "promptCachedTokens": 0.000000035,
+      "promptImageTokens": 0.00000035,
+      "promptTextTokens": 0.00000035,
+      "promptVideoTokens": 0.00000035,
     },
     "price": {
-      "completionTextTokens": 0.000003,
-      "promptCachedTokens": 0.00000004,
-      "promptImageTokens": 0.0000004,
-      "promptTextTokens": 0.0000004,
-      "promptVideoTokens": 0.0000004,
+      "completionTextTokens": 0.00000275,
+      "promptCachedTokens": 0.000000035,
+      "promptImageTokens": 0.00000035,
+      "promptTextTokens": 0.00000035,
+      "promptVideoTokens": 0.00000035,
     },
   },
   "qwen3.8-max": {

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -1931,12 +1931,12 @@ export const TEXT_SERVICES = {
         paidOnly: true,
         priceMultiplier: 1,
         cost: {
-            // OpenRouter Chutes FP8 route rates (2026-08-18).
-            promptTextTokens: perMillion(0.4),
-            promptCachedTokens: perMillion(0.04),
-            promptImageTokens: perMillion(0.4),
-            promptVideoTokens: perMillion(0.4),
-            completionTextTokens: perMillion(3),
+            // OpenRouter Chutes FP8 route rates (2026-08-24).
+            promptTextTokens: perMillion(0.35),
+            promptCachedTokens: perMillion(0.035),
+            promptImageTokens: perMillion(0.35),
+            promptVideoTokens: perMillion(0.35),
+            completionTextTokens: perMillion(2.75),
         },
         title: "Qwen3.8 27B",
         description:


### PR DESCRIPTION
- Updates the pinned OpenRouter Chutes FP8 cost sheet from $0.40/$0.04/$3.00 to $0.35/$0.035/$2.75 per 1M input/cache-read/output tokens.
- Applies the same verified input rate to text, image, and video inputs; `priceMultiplier: 1` keeps user pricing aligned exactly.
- Preserves the canonical name, paid-only status, Chutes pin, disabled provider fallback, capabilities, and no Pollinations fallback.
- Verified against the [exact OpenRouter endpoint listing](https://openrouter.ai/api/v1/models/qwen/qwen3.8-27b/endpoints) and direct Chutes responses for text, image, video, and cache-read usage.
- Local E2E verified `/v1/models`, non-streaming and streaming usage, output-cache HIT, exact wallet debit/tracking, 51 pricing tests, both service typechecks, and Biome.