### PR TITLE
fix(account): disable cache on account routes to prevent stale private data

### DIFF
--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -791,6 +791,11 @@ const usageResponseSchema = z.object({
  */
 export const accountRoutes = new Hono<Env>()
     .use(auth({ allowApiKey: true, allowSessionCookie: true }))
+    .use("/*", async (c, next) => {
+        c.header("Cache-Control", "private, no-store, max-age=0");
+        c.header("Pragma", "no-cache");
+        await next();
+    })
     .route("/agents", agentsRoutes)
     .route("/my-models", communityEndpointsRoutes)
     .get(


### PR DESCRIPTION
Resolves #13771.

## Problem
Responses from `/account/*` routes could be cached by intermediate CDNs/proxies and return stale private data to other users.

## Fix
Added anti-cache headers across all `/account/*` routes:
- `Cache-Control: private, no-store, max-age=0`
- `Pragma: no-cache`

## Scope
- Profile
- Balance
- Usage
- API keys
- Earnings
- Agents
- Community models

## Files changed
- `enter.pollinations.ai/src/routes/account.ts`

## Verification
- Diff: 1 file, 6 insertions / 1 deletion
- Commit created on `fix/13771-account-cache-control`
- No secrets/tokens introduced
