### PR TITLE
fix: restore Azure Kontext generation

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -895,7 +895,7 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "completionImageTokens": 0.04,
     },
     "price": {
-      "completionImageTokens": 0.04,
+      "completionImageTokens": 0.03,
     },
   },
   "krea": {

--- a/gen.pollinations.ai/src/image/models/azureFluxKontextModel.ts
+++ b/gen.pollinations.ai/src/image/models/azureFluxKontextModel.ts
@@ -12,14 +12,24 @@ import {
     requireSafePrompt,
 } from "../utils/azureContentSafety.ts";
 import { logGptImageError } from "../utils/gptImageLogger.ts";
-import {
-    base64ToBuffer,
-    bufferToUint8Array,
-    downloadUserImage,
-} from "../utils/imageDownload.ts";
+import { base64ToBuffer, downloadUserImage } from "../utils/imageDownload.ts";
 
 const logError = debug("pollinations:error");
 const logCloudflare = debug("pollinations:cloudflare");
+const AZURE_FLUX_KONTEXT_ENDPOINT =
+    "https://myceli-prod-eastus.cognitiveservices.azure.com/providers/blackforestlabs/v1/flux-kontext-pro?api-version=preview";
+
+function greatestCommonDivisor(a: number, b: number): number {
+    while (b !== 0) {
+        [a, b] = [b, a % b];
+    }
+    return a || 1;
+}
+
+function toAspectRatio(width: number, height: number): string {
+    const divisor = greatestCommonDivisor(width, height);
+    return `${width / divisor}:${height / divisor}`;
+}
 
 /**
  * Calls the Azure Flux Kontext API to generate or edit images
@@ -35,8 +45,6 @@ export async function callAzureFluxKontext(
     userInfo: AuthResult,
 ): Promise<ImageGenerationResult> {
     const apiKey = getImageEnv("AZURE_MYCELI_PROD_API_KEY");
-    const baseUrl =
-        "https://myceli-prod-eastus.services.ai.azure.com/openai/deployments/FLUX.1-Kontext-pro";
 
     if (!apiKey) {
         throw new Error(
@@ -44,52 +52,27 @@ export async function callAzureFluxKontext(
         );
     }
 
-    // Check if we need to use the edits endpoint instead of generations
     const isEditMode = safeParams.image.length > 0;
-
-    // Add the appropriate endpoint path and API version
-    let endpoint: string;
-    if (isEditMode) {
-        endpoint = `${baseUrl}/images/edits?api-version=2025-04-01-preview`;
-        logCloudflare("Using Azure Flux Kontext in edit mode");
-    } else {
-        endpoint = `${baseUrl}/images/generations?api-version=2025-04-01-preview`;
-        logCloudflare("Using Azure Flux Kontext in generation mode");
-    }
+    logCloudflare(
+        `Using Azure Flux Kontext in ${isEditMode ? "edit" : "generation"} mode`,
+    );
 
     logCloudflare("Checking prompt safety...");
     await requireSafePrompt(prompt, safeParams, userInfo);
 
-    // Map safeParams to Azure API parameters
-    const size = `${safeParams.width}x${safeParams.height}`;
-
-    // Build request body for generation mode
-    const requestBody = {
+    const requestBody: Record<string, unknown> = {
         prompt: sanitizeString(prompt),
-        size: size,
-        n: 1,
         model: "FLUX.1-Kontext-pro",
+        output_format: "png",
+        num_images: 1,
     };
 
-    logCloudflare("Calling Azure Flux Kontext API with params:", requestBody);
-
-    let response = null;
-
     if (isEditMode) {
-        // For edit mode, use FormData (multipart/form-data)
-        const formData = new FormData();
-
-        // Add the prompt
-        formData.append("prompt", sanitizeString(prompt));
-        formData.append("model", "FLUX.1-Kontext-pro");
-
-        // Handle images based on their type
         try {
-            // Process the first image (Flux Kontext typically uses single image)
             const imageUrl = safeParams.image[0];
             logCloudflare(`Fetching image from URL: ${imageUrl}`);
 
-            const { buffer, mimeType } = await downloadUserImage(imageUrl);
+            const { buffer } = await downloadUserImage(imageUrl);
 
             logCloudflare("Checking safety of input image");
             const imageSafetyResult = await analyzeImageSafety(buffer);
@@ -106,50 +89,43 @@ export async function callAzureFluxKontext(
                 );
                 throw error;
             }
-
-            // Create a Blob and append to FormData
-            const extension = `.${mimeType.split("/")[1]}`;
-            const imageBlob = new Blob([bufferToUint8Array(buffer)], {
-                type: mimeType,
-            });
-            formData.append("image", imageBlob, `image${extension}`);
+            requestBody.input_image = buffer.toString("base64");
         } catch (error) {
             logError("Error processing image for editing:", error);
             if (error instanceof HttpError) throw error;
             throw new Error(`Failed to process image: ${error.message}`);
         }
-
-        // Log the endpoint for debugging
-        logCloudflare(`Sending edit request to endpoint: ${endpoint}`);
-
-        // Send the edit request
-        response = await fetch(endpoint, {
-            method: "POST",
-            headers: {
-                Authorization: `Bearer ${apiKey}`,
-            },
-            // biome-ignore lint: linter is confused here
-            body: formData as any,
-        });
-
-        logCloudflare(`Edit request response status: ${response.status}`);
     } else {
-        // Standard JSON request for generation
-        response = await fetch(endpoint, {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-                Authorization: `Bearer ${apiKey}`,
-            },
-            body: JSON.stringify(requestBody),
-        });
-
-        logCloudflare(`Generation request response status: ${response.status}`);
+        requestBody.aspect_ratio = toAspectRatio(
+            safeParams.width,
+            safeParams.height,
+        );
     }
+
+    logCloudflare("Calling Azure Flux Kontext API with params:", {
+        ...requestBody,
+        input_image: requestBody.input_image ? "[base64]" : undefined,
+    });
+
+    const response = await fetch(AZURE_FLUX_KONTEXT_ENDPOINT, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify(requestBody),
+    });
+
+    logCloudflare(`Kontext request response status: ${response.status}`);
 
     if (!response.ok) {
         const errorText = await response.text();
-        throw new HttpError(errorText, response.status, undefined, endpoint);
+        throw new HttpError(
+            errorText,
+            response.status,
+            undefined,
+            AZURE_FLUX_KONTEXT_ENDPOINT,
+        );
     }
 
     const data = (await response.json()) as {
@@ -166,7 +142,7 @@ export async function callAzureFluxKontext(
             "Invalid response from Azure Flux Kontext API",
             500,
             undefined,
-            endpoint,
+            AZURE_FLUX_KONTEXT_ENDPOINT,
         );
     }
 

--- a/gen.pollinations.ai/test/image/azureFluxKontextModel.test.ts
+++ b/gen.pollinations.ai/test/image/azureFluxKontextModel.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuthResult } from "../../src/image/createAndReturnImages.ts";
+import { syncImageEnv } from "../../src/image/env.ts";
+import { callAzureFluxKontext } from "../../src/image/models/azureFluxKontextModel.ts";
+import type { ImageParams } from "../../src/image/params.ts";
+
+const ENDPOINT =
+    "https://myceli-prod-eastus.cognitiveservices.azure.com/providers/blackforestlabs/v1/flux-kontext-pro?api-version=preview";
+const INPUT_IMAGE_URL = "https://example.com/reference.jpg";
+const INPUT_IMAGE = Buffer.from([0xff, 0xd8, 0xff, 0xdb]);
+const OUTPUT_IMAGE = Buffer.from("kontext-output");
+const USER_INFO = {} as AuthResult;
+
+const baseParams: ImageParams = {
+    model: "kontext",
+    width: 1024,
+    height: 1024,
+    dimensionsExplicit: false,
+    seed: 42,
+    safe: false,
+    quality: "medium",
+    image: [],
+    transparent: false,
+    reasoning: "balanced",
+    audio: false,
+    duration: 0,
+};
+
+beforeEach(() => {
+    syncImageEnv(
+        { AZURE_MYCELI_PROD_API_KEY: "test-azure-key" } as CloudflareBindings,
+        ["AZURE_MYCELI_PROD_API_KEY"],
+    );
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe("callAzureFluxKontext", () => {
+    it("generates through the Azure BFL route with the requested aspect ratio", async () => {
+        let requestBody: Record<string, unknown> | undefined;
+        const fetchSpy = vi
+            .spyOn(globalThis, "fetch")
+            .mockImplementation(async (url, init) => {
+                expect(url.toString()).toBe(ENDPOINT);
+                expect(init?.headers).toMatchObject({
+                    Authorization: "Bearer test-azure-key",
+                    "Content-Type": "application/json",
+                });
+                requestBody = JSON.parse(init?.body as string);
+                return Response.json({
+                    data: [{ b64_json: OUTPUT_IMAGE.toString("base64") }],
+                });
+            });
+
+        const result = await callAzureFluxKontext(
+            "wide landscape",
+            { ...baseParams, width: 1792, height: 1024 },
+            USER_INFO,
+        );
+
+        expect(fetchSpy).toHaveBeenCalledOnce();
+        expect(requestBody).toEqual({
+            prompt: "wide landscape",
+            model: "FLUX.1-Kontext-pro",
+            output_format: "png",
+            num_images: 1,
+            aspect_ratio: "7:4",
+        });
+        expect(result.buffer.equals(OUTPUT_IMAGE)).toBe(true);
+        expect(result.trackingData).toMatchObject({
+            actualModel: "kontext",
+            usage: { completionImageTokens: 1 },
+        });
+    });
+
+    it("edits through the same route with the safety-checked image as base64", async () => {
+        let requestBody: Record<string, unknown> | undefined;
+        vi.spyOn(globalThis, "fetch").mockImplementation(async (url, init) => {
+            if (url.toString() === INPUT_IMAGE_URL) {
+                return new Response(INPUT_IMAGE, {
+                    headers: { "Content-Type": "image/jpeg" },
+                });
+            }
+            expect(url.toString()).toBe(ENDPOINT);
+            requestBody = JSON.parse(init?.body as string);
+            return Response.json({
+                data: [{ b64_json: OUTPUT_IMAGE.toString("base64") }],
+            });
+        });
+
+        await callAzureFluxKontext(
+            "make it red",
+            { ...baseParams, image: [INPUT_IMAGE_URL] },
+            USER_INFO,
+        );
+
+        expect(requestBody).toEqual({
+            prompt: "make it red",
+            model: "FLUX.1-Kontext-pro",
+            output_format: "png",
+            num_images: 1,
+            input_image: INPUT_IMAGE.toString("base64"),
+        });
+    });
+
+    it("preserves upstream client errors", async () => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+            Response.json(
+                { error: { message: "aspect ratio is out of range" } },
+                { status: 400 },
+            ),
+        );
+
+        await expect(
+            callAzureFluxKontext("bad ratio", baseParams, USER_INFO),
+        ).rejects.toMatchObject({
+            status: 400,
+            upstreamUrl: ENDPOINT,
+        });
+    });
+});

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -50,7 +50,7 @@ const IMAGE_BASE_SERVICES = {
         brand: "Black Forest Labs",
         category: "image",
         addedDate: new Date("2025-10-07").getTime(),
-        priceMultiplier: 1,
+        priceMultiplier: 0.75,
         cost: {
             completionImageTokens: 0.04, // per image
         },


### PR DESCRIPTION
- Replaces the Azure OpenAI deployment URL that now rejects Kontext with Azure's supported Black Forest Labs provider route.
- Restores both text-to-image and single-reference image editing without adding aliases, fallback, or a Pollinations GPU route.
- Keeps Azure cost at $0.04/image and applies the approved `0.75` multiplier, making the public price $0.03/image.
- Adds focused route, request-shape, edit, tracking, and upstream-error tests; focused tests and both service typechecks pass.
- Verified direct Azure generation/edit plus local end-to-end generation, editing, catalog pricing, one-time billing, identical-request cache hits, and a 5/5 safe burst.