### PR TITLE
fix: exclude Mistral ZDR pricing variant

### DIFF
--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -331,11 +331,18 @@ export const portkeyConfig: PortkeyConfigMap = {
         "mistralai/mistral-small-3.2-24b-instruct",
         "deepinfra/fp8",
     ),
-    "mistral-small-2603": createPinnedOpenRouterConfig(
-        "mistralai/mistral-small-2603",
-        "mistral",
-        64000,
-    ),
+    "mistral-small-2603": () =>
+        createOpenRouterModelConfig({
+            model: "mistralai/mistral-small-2603",
+            defaultOptions: {
+                max_tokens: 64000,
+                provider: {
+                    only: ["mistral"],
+                    ignore: ["mistral/zdr"],
+                    allow_fallbacks: false,
+                },
+            },
+        }),
 
     // -- Azure (Myceli Prod — eastus, Mistral Large) -------------------------
     "Mistral-Large-3": () =>

--- a/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
+++ b/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
@@ -261,7 +261,6 @@ describe("resolveModelConfig", () => {
         ["gemma-4-31b", "google/gemma-4-31b-it", "novita/bf16"],
         ["mimo-v2.5", "xiaomi/mimo-v2.5", "xiaomi/fp8"],
         ["mimo-v2.5-pro", "xiaomi/mimo-v2.5-pro", "xiaomi/fp8"],
-        ["mistral", "mistralai/mistral-small-2603", "mistral"],
         ["llama-scout", "meta-llama/llama-4-scout", "deepinfra/fp8"],
     ])("pins %s to %s through %s without fallback", (model, route, provider) => {
         const result = resolveModelConfig(messages, { model });
@@ -269,6 +268,17 @@ describe("resolveModelConfig", () => {
         expect(result.options.model).toBe(route);
         expect(result.options.provider).toEqual({
             only: [provider],
+            allow_fallbacks: false,
+        });
+    });
+
+    it("excludes Mistral's higher-priced ZDR variant", () => {
+        const result = resolveModelConfig(messages, { model: "mistral" });
+
+        expect(result.options.model).toBe("mistralai/mistral-small-2603");
+        expect(result.options.provider).toEqual({
+            only: ["mistral"],
+            ignore: ["mistral/zdr"],
             allow_fallbacks: false,
         });
     });


### PR DESCRIPTION
- Excludes the 10%-higher `mistral/zdr` endpoint from the existing OpenRouter Mistral pin.
- Keeps `mistralai/mistral-small-2603`, provider fallback disabled, and the verified standard sheet at $0.15/$0.015/$0.60 per 1M input/cache/output tokens.
- Preserves the canonical name, aliases, capabilities, paid-only access, multiplier, GPU status, and no Pollinations fallback.
- Direct OpenRouter probe selected Mistral and reconciled the standard sheet exactly; the [endpoint catalog](https://openrouter.ai/api/v1/models/mistralai/mistral-small-2603/endpoints) still lists the ZDR sheet at $0.165/$0.0165/$0.66.
- Local E2E passed text, vision, tools, reasoning, JSON, streaming, every alias, five-request burst, prompt cache, output-cache HIT, wallet/tracking settlement, 41 resolver tests, typecheck, and Biome.