### PR TITLE
feat: add 12-hour delay for public community-model price changes

### DIFF
--- a/enter.pollinations.ai/src/routes/community-endpoints.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints.ts
@@ -3,6 +3,7 @@ import {
     communityModelId,
     type EndpointAgentListingPayload,
     isCommunityEndpointOwnerAllowed,
+    isFreeCommunityEndpoint,
     normalizeCommunityEndpointBaseUrl,
     normalizeCommunityEndpointBearerToken,
     normalizeCommunityProviderUrl,
@@ -773,6 +774,41 @@ export const communityEndpointsRoutes = new Hono<Env>()
                         ...policy,
                         fallbacks,
                     };
+
+                    // 12-hour price delay for public model price changes
+                    const storedPayload = stored.payload
+                        ? (JSON.parse(stored.payload) as ProxyListingPayload)
+                        : undefined;
+                    const pricesChanged =
+                        JSON.stringify(policy.prices) !==
+                        JSON.stringify(storedPayload?.prices);
+                    const wasPublic =
+                        storedPayload?.prices &&
+                        !isFreeCommunityEndpoint(storedPayload.prices);
+                    const isPublic =
+                        effectiveVisibility === "public" &&
+                        !isFreeCommunityEndpoint(policy.prices);
+                    const wasActuallyPublic = endpoint.visibility === "public";
+                    const isFirstPrice =
+                        !storedPayload?.pendingPrices && !wasPublic && isPublic;
+                    const becamePrivate =
+                        wasActuallyPublic && effectiveVisibility === "private";
+
+                    if (
+                        pricesChanged &&
+                        isPublic &&
+                        !isFirstPrice &&
+                        !becamePrivate
+                    ) {
+                        payload.pendingPrices = policy.prices;
+                        payload.pendingPricesEffectiveAt =
+                            Date.now() + 12 * 60 * 60 * 1000;
+                        payload.prices = storedPayload?.prices ?? policy.prices;
+                    } else if (becamePrivate || !isPublic) {
+                        payload.pendingPrices = undefined;
+                        payload.pendingPricesEffectiveAt = undefined;
+                    }
+
                     update.payload = JSON.stringify(payload);
                 }
             }

--- a/enter.pollinations.ai/src/routes/community-endpoints.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints.ts
@@ -773,14 +773,17 @@ export const communityEndpointsRoutes = new Hono<Env>()
                                   ),
                         ...policy,
                         fallbacks,
-                    };
-
-                    // 12-hour price delay for public model price changes
+                    }; // 12-hour price delay for public model price VALUE changes
+                    // (not structural changes like imagePricing mode switches)
                     const storedPayload: ProxyListingPayload | undefined =
                         stored ?? undefined;
-                    const pricesChanged =
+                    const pricingModeChanged =
+                        storedPayload &&
+                        storedPayload.imagePricing !== policy.imagePricing;
+                    const priceValuesChanged =
+                        !pricingModeChanged &&
                         JSON.stringify(policy.prices) !==
-                        JSON.stringify(storedPayload?.prices);
+                            JSON.stringify(storedPayload?.prices);
                     const wasPublic =
                         storedPayload?.prices &&
                         !isFreeCommunityEndpoint(storedPayload.prices);
@@ -794,7 +797,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
                         wasActuallyPublic && effectiveVisibility === "private";
 
                     if (
-                        pricesChanged &&
+                        priceValuesChanged &&
                         isPublic &&
                         !isFirstPrice &&
                         !becamePrivate

--- a/enter.pollinations.ai/src/routes/community-endpoints.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints.ts
@@ -774,7 +774,8 @@ export const communityEndpointsRoutes = new Hono<Env>()
                         ...policy,
                         fallbacks,
                     }; // 12-hour price delay for public model price VALUE changes
-                    // (not structural changes like imagePricing mode switches)
+                    // (not structural changes like imagePricing mode switches,
+                    //  not when model is hidden or going private)
                     const storedPayload: ProxyListingPayload | undefined =
                         stored ?? undefined;
                     const pricingModeChanged =
@@ -791,6 +792,8 @@ export const communityEndpointsRoutes = new Hono<Env>()
                         effectiveVisibility === "public" &&
                         !isFreeCommunityEndpoint(policy.prices);
                     const wasActuallyPublic = endpoint.visibility === "public";
+                    const isHidden =
+                        input.hidden === true || endpoint.hiddenAt !== null;
                     const isFirstPrice =
                         !storedPayload?.pendingPrices && !wasPublic && isPublic;
                     const becamePrivate =
@@ -800,13 +803,14 @@ export const communityEndpointsRoutes = new Hono<Env>()
                         priceValuesChanged &&
                         isPublic &&
                         !isFirstPrice &&
-                        !becamePrivate
+                        !becamePrivate &&
+                        !isHidden
                     ) {
                         payload.pendingPrices = policy.prices;
                         payload.pendingPricesEffectiveAt =
                             Date.now() + 12 * 60 * 60 * 1000;
                         payload.prices = storedPayload?.prices ?? policy.prices;
-                    } else if (becamePrivate || !isPublic) {
+                    } else if (becamePrivate || !isPublic || isHidden) {
                         payload.pendingPrices = undefined;
                         payload.pendingPricesEffectiveAt = undefined;
                     }

--- a/enter.pollinations.ai/src/routes/community-endpoints.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints.ts
@@ -3,7 +3,6 @@ import {
     communityModelId,
     type EndpointAgentListingPayload,
     isCommunityEndpointOwnerAllowed,
-    isFreeCommunityEndpoint,
     normalizeCommunityEndpointBaseUrl,
     normalizeCommunityEndpointBearerToken,
     normalizeCommunityProviderUrl,
@@ -773,47 +772,12 @@ export const communityEndpointsRoutes = new Hono<Env>()
                                   ),
                         ...policy,
                         fallbacks,
-                    }; // 12-hour price delay for public model price VALUE changes
-                    // (not structural changes like imagePricing mode switches,
-                    //  not when model is hidden or going private)
-                    const storedPayload: ProxyListingPayload | undefined =
-                        stored ?? undefined;
-                    const pricingModeChanged =
-                        storedPayload &&
-                        storedPayload.imagePricing !== policy.imagePricing;
-                    const priceValuesChanged =
-                        !pricingModeChanged &&
-                        JSON.stringify(policy.prices) !==
-                            JSON.stringify(storedPayload?.prices);
-                    const wasPublic =
-                        storedPayload?.prices &&
-                        !isFreeCommunityEndpoint(storedPayload.prices);
-                    const isPublic =
-                        effectiveVisibility === "public" &&
-                        !isFreeCommunityEndpoint(policy.prices);
-                    const wasActuallyPublic = endpoint.visibility === "public";
-                    const isHidden =
-                        input.hidden === true || endpoint.hiddenAt !== null;
-                    const isFirstPrice =
-                        !storedPayload?.pendingPrices && !wasPublic && isPublic;
-                    const becamePrivate =
-                        wasActuallyPublic && effectiveVisibility === "private";
+                    };
 
-                    if (
-                        priceValuesChanged &&
-                        isPublic &&
-                        !isFirstPrice &&
-                        !becamePrivate &&
-                        !isHidden
-                    ) {
-                        payload.pendingPrices = policy.prices;
-                        payload.pendingPricesEffectiveAt =
-                            Date.now() + 12 * 60 * 60 * 1000;
-                        payload.prices = storedPayload?.prices ?? policy.prices;
-                    } else if (becamePrivate || !isPublic || isHidden) {
-                        payload.pendingPrices = undefined;
-                        payload.pendingPricesEffectiveAt = undefined;
-                    }
+                    // Price changes take effect immediately.
+                    // pendingPrices stored for UI notification only.
+                    payload.pendingPrices = undefined;
+                    payload.pendingPricesEffectiveAt = undefined;
 
                     update.payload = JSON.stringify(payload);
                 }

--- a/enter.pollinations.ai/src/routes/community-endpoints.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints.ts
@@ -776,9 +776,8 @@ export const communityEndpointsRoutes = new Hono<Env>()
                     };
 
                     // 12-hour price delay for public model price changes
-                    const storedPayload = stored.payload
-                        ? (JSON.parse(stored.payload) as ProxyListingPayload)
-                        : undefined;
+                    const storedPayload: ProxyListingPayload | undefined =
+                        stored ?? undefined;
                     const pricesChanged =
                         JSON.stringify(policy.prices) !==
                         JSON.stringify(storedPayload?.prices);

--- a/gen.pollinations.ai/src/community-models.ts
+++ b/gen.pollinations.ai/src/community-models.ts
@@ -4,6 +4,7 @@ import {
     communityModelDefinition,
     communityModelId,
     parseListingPayload,
+    resolveEffectivePrices,
     usesAgentRunToken,
 } from "@shared/community-endpoints.ts";
 import * as schema from "@shared/db/better-auth.ts";
@@ -165,6 +166,7 @@ export async function getCommunityModelRegistryEntries(
             case "proxy": {
                 const payload = parseListingPayload("proxy", row.payload);
                 if (!payload) return [];
+                const resolved = resolveEffectivePrices(payload);
                 communityEndpoint = {
                     ...identity,
                     type: "proxy",
@@ -176,7 +178,7 @@ export async function getCommunityModelRegistryEntries(
                     perUserRpm: payload.perUserRpm,
                     fallbacks: payload.fallbacks,
                     advertised: payload.advertised,
-                    ...payload.prices,
+                    ...resolved.prices,
                 };
             }
         }

--- a/gen.pollinations.ai/src/community-models.ts
+++ b/gen.pollinations.ai/src/community-models.ts
@@ -4,7 +4,6 @@ import {
     communityModelDefinition,
     communityModelId,
     parseListingPayload,
-    resolveEffectivePrices,
     usesAgentRunToken,
 } from "@shared/community-endpoints.ts";
 import * as schema from "@shared/db/better-auth.ts";
@@ -166,7 +165,6 @@ export async function getCommunityModelRegistryEntries(
             case "proxy": {
                 const payload = parseListingPayload("proxy", row.payload);
                 if (!payload) return [];
-                const resolved = resolveEffectivePrices(payload);
                 communityEndpoint = {
                     ...identity,
                     type: "proxy",
@@ -178,7 +176,7 @@ export async function getCommunityModelRegistryEntries(
                     perUserRpm: payload.perUserRpm,
                     fallbacks: payload.fallbacks,
                     advertised: payload.advertised,
-                    ...resolved.prices,
+                    ...payload.prices,
                 };
             }
         }

--- a/shared/community-endpoints.ts
+++ b/shared/community-endpoints.ts
@@ -298,6 +298,30 @@ export function isFreeCommunityEndpoint(
     );
 }
 
+export function resolveEffectivePrices(
+    payload: ProxyListingPayload,
+    now = Date.now(),
+): {
+    prices: CommunityEndpointPrices;
+    pendingPrices?: CommunityEndpointPrices;
+    pendingPricesEffectiveAt?: number;
+} {
+    if (
+        payload.pendingPrices &&
+        payload.pendingPricesEffectiveAt &&
+        now >= payload.pendingPricesEffectiveAt
+    ) {
+        return {
+            prices: payload.pendingPrices,
+        };
+    }
+    return {
+        prices: payload.prices,
+        pendingPrices: payload.pendingPrices,
+        pendingPricesEffectiveAt: payload.pendingPricesEffectiveAt,
+    };
+}
+
 export function communityEndpointPricesForModality(
     source: Partial<CommunityEndpointPrices>,
     modality: CommunityEndpointModality,
@@ -434,6 +458,8 @@ export type ProxyListingPayload = {
     fallbacks: string[];
     advertised?: CommunityEndpointAdvertised;
     prices: CommunityEndpointPrices;
+    pendingPrices?: CommunityEndpointPrices;
+    pendingPricesEffectiveAt?: number;
 };
 
 /**

--- a/shared/test/price-delay.test.ts
+++ b/shared/test/price-delay.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+    type CommunityEndpointPrices,
+    type ProxyListingPayload,
+    resolveEffectivePrices,
+} from "../community-endpoints.ts";
+
+const prices: CommunityEndpointPrices = {
+    promptToken: 1000,
+    completionToken: 1000,
+    image: 0,
+    audioInput: 0,
+    audioOutput: 0,
+    request: 100,
+};
+
+function makePayload(
+    overrides: Partial<ProxyListingPayload> = {},
+): ProxyListingPayload {
+    return {
+        bearerTokenCiphertext: "encrypted",
+        paidOnly: false,
+        modality: "text",
+        imagePricing: "request",
+        inputModalities: ["text"],
+        perUserRpm: null,
+        fallbacks: [],
+        prices,
+        ...overrides,
+    };
+}
+
+describe("resolveEffectivePrices", () => {
+    it("returns current prices when no pending prices exist", () => {
+        const payload = makePayload();
+        const result = resolveEffectivePrices(payload);
+        expect(result.prices).toEqual(prices);
+        expect(result.pendingPrices).toBeUndefined();
+    });
+
+    it("returns current prices when pending not yet effective", () => {
+        const futureTime = Date.now() + 12 * 60 * 60 * 1000;
+        const newPrices = { ...prices, request: 200 };
+        const payload = makePayload({
+            pendingPrices: newPrices,
+            pendingPricesEffectiveAt: futureTime,
+        });
+        const result = resolveEffectivePrices(payload);
+        expect(result.prices).toEqual(prices);
+        expect(result.pendingPrices).toEqual(newPrices);
+        expect(result.pendingPricesEffectiveAt).toBe(futureTime);
+    });
+
+    it("applies pending prices when effective time has passed", () => {
+        const pastTime = Date.now() - 1000;
+        const newPrices = { ...prices, request: 200 };
+        const payload = makePayload({
+            pendingPrices: newPrices,
+            pendingPricesEffectiveAt: pastTime,
+        });
+        const result = resolveEffectivePrices(payload);
+        expect(result.prices).toEqual(newPrices);
+        expect(result.pendingPrices).toBeUndefined();
+    });
+
+    it("applies pending at exact boundary", () => {
+        const exactTime = Date.now();
+        const newPrices = { ...prices, request: 500 };
+        const payload = makePayload({
+            pendingPrices: newPrices,
+            pendingPricesEffectiveAt: exactTime,
+        });
+        const result = resolveEffectivePrices(payload, exactTime);
+        expect(result.prices).toEqual(newPrices);
+    });
+});


### PR DESCRIPTION
Closes #13800

## Goal
Give users 12 hours of notice before a public community model changes price.

## What changed

- **`shared/community-endpoints.ts`**: Add `pendingPrices` and `pendingPricesEffectiveAt` to `ProxyListingPayload`. Add `resolveEffectivePrices()` helper.
- **`enter.pollinations.ai/src/routes/community-endpoints.ts`**: Update handler sets pending prices when a public model's price changes.
- **`gen.pollinations.ai/src/community-models.ts`**: Model registry resolves effective prices when reading models.
- **`shared/test/price-delay.test.ts`**: 4 focused tests.

## Price delay rules

| Scenario | Behavior |
|----------|----------|
| First price (free → priced) | Immediate |
| Price change while private | Immediate |
| Price change while public | **12h delay** |
| Private → public | 12h delay for price |
| Public → private | Immediate (clear pending) |