### PR TITLE
feat: prevent caching of authenticated account responses

### DIFF
--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -791,6 +791,11 @@ const usageResponseSchema = z.object({
  */
 export const accountRoutes = new Hono<Env>()
     .use(auth({ allowApiKey: true, allowSessionCookie: true }))
+    .use(async (c, next) => {
+        await next();
+        c.header("Cache-Control", "private, no-store, max-age=0");
+        c.header("Pragma", "no-cache");
+    })
     .route("/agents", agentsRoutes)
     .route("/my-models", communityEndpointsRoutes)
     .get(


### PR DESCRIPTION
Implements Quest #13771. All routes under /account now return Cache-Control: private, no-store, max-age=0 and Pragma: no-cache.

- Add centralized no-cache middleware to accountRoutes (once, not per-handler)
- Remove redundant Cache-Control header from individual key-list handler
- Add focused tests for top-level and nested account responses