### PR TITLE
feat(sdk): expose developer earnings via accountEarnings()

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -17,6 +17,8 @@ import type {
     DeviceAuthorization,
     DeviceCodeResponse,
     DeviceTokenResponse,
+    EarningsOptions,
+    EarningsResponse,
     ImageEditOptions,
     ImageGenerateOptions,
     ImageGenerateV1Options,
@@ -1446,6 +1448,21 @@ export class Pollinations {
         const url = `${this.baseUrl}/account/usage/daily${qs ? `?${qs}` : ""}`;
 
         return this.getJson<DailyUsageResponse>(url);
+    }
+
+    /**
+     * Get developer earnings.
+     */
+    async accountEarnings(
+        options: EarningsOptions = {},
+    ): Promise<EarningsResponse> {
+        const params = new URLSearchParams();
+        if (options.days !== undefined) {
+            params.set("days", String(options.days));
+        }
+        const qs = params.toString() ? `?${params.toString()}` : "";
+        const url = `${this.baseUrl}/account/earnings${qs}`;
+        return this.getJson<EarningsResponse>(url);
     }
 
     /**

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -101,6 +101,8 @@ export type {
     DeviceAuthorization,
     DeviceCodeResponse,
     DeviceTokenResponse,
+    EarningsOptions,
+    EarningsResponse,
     FileContentPart,
     FunctionDefinition,
     ImageContentPart,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -680,6 +680,26 @@ export interface DailyUsageResponse {
     count: number;
 }
 
+export interface EarningsOptions {
+    days?: number;
+}
+
+export interface EarningsRow {
+    date: string;
+    source: string;
+    entity_id: string;
+    entity_name: string;
+    requests: number;
+    baseline_price: number;
+    cost_usd: number;
+    reward_rate: number;
+}
+
+export interface EarningsResponse {
+    daily: EarningsRow[];
+    perEntity: EarningsRow[];
+}
+
 /** API key validation response */
 export interface KeyInfo {
     valid: boolean;


### PR DESCRIPTION
Implements Quest #13769. Adds accountEarnings() to the JavaScript SDK as a thin typed client for GET /account/earnings.

- Add EarningsRow, EarningsResponse, EarningsOptions types
- Add accountEarnings({ days }) method to Pollinations client
- Export new types from package index
- 2 focused tests covering default and custom days