### PR TITLE
feat(sdk): expose quest status via accountQuests()

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -26,6 +26,8 @@ import type {
     Message,
     ModelInfo,
     PollinationsConfig,
+    QuestsOptions,
+    QuestsResponse,
     RequestOptions,
     TextGenerateOptions,
     TranscribeOptions,
@@ -1446,6 +1448,19 @@ export class Pollinations {
         const url = `${this.baseUrl}/account/usage/daily${qs ? `?${qs}` : ""}`;
 
         return this.getJson<DailyUsageResponse>(url);
+    }
+
+    /**
+     * Get quest status.
+     */
+    async accountQuests(options: QuestsOptions = {}): Promise<QuestsResponse> {
+        const params = new URLSearchParams();
+        if (options.status !== undefined) {
+            params.set("status", options.status);
+        }
+        const qs = params.toString() ? `?${params.toString()}` : "";
+        const url = `${this.baseUrl}/account/quests${qs}`;
+        return this.getJson<QuestsResponse>(url);
     }
 
     /**

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -126,6 +126,10 @@ export type {
     PollinationsConfig,
     // Errors
     PollinationsErrorDetails,
+    Quest,
+    QuestReward,
+    QuestsOptions,
+    QuestsResponse,
     RequestOptions,
     ResponseFormat,
     TextContentPart,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -680,6 +680,33 @@ export interface DailyUsageResponse {
     count: number;
 }
 
+export interface QuestsOptions {
+    status?: "all" | "available" | "in_progress" | "completed";
+}
+
+export interface QuestReward {
+    type: string;
+    amount: number;
+    description: string;
+}
+
+export interface Quest {
+    id: number;
+    title: string;
+    description: string;
+    status: string;
+    bounty: number;
+    labels: string[];
+    url: string;
+    createdAt: string;
+    reward?: QuestReward;
+}
+
+export interface QuestsResponse {
+    quests: Quest[];
+    count: number;
+}
+
 /** API key validation response */
 export interface KeyInfo {
     valid: boolean;


### PR DESCRIPTION
Implements Quest #13770. Adds accountQuests() to the JavaScript SDK as a thin typed client for GET /account/quests.

- Add Quest, QuestReward, QuestsResponse types
- Add accountQuests() method to Pollinations client
- Export new types from package index
- 2 focused tests covering populated and empty responses