### PR TITLE
fix(sdk): preserve request ID from X-Request-Id header fallback

### DIFF
--- a/packages/sdk/src/error-response.test.ts
+++ b/packages/sdk/src/error-response.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { pollinationsErrorFromResponse } from "./error-response.js";
+
+function makeErrorResponse(
+    body: unknown,
+    headers: Record<string, string> = {},
+): Response {
+    const headerMap = new Map(
+        Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v]),
+    );
+    return {
+        ok: false,
+        status: 400,
+        headers: {
+            get: (name: string) => headerMap.get(name.toLowerCase()) ?? null,
+        },
+        json: async () => body,
+    } as unknown as Response;
+}
+
+describe("pollinationsErrorFromResponse", () => {
+    it("uses requestId from the error body", async () => {
+        const response = makeErrorResponse(
+            {
+                error: {
+                    message: "Bad request",
+                    code: "INVALID_REQUEST",
+                    requestId: "req-abc-123",
+                },
+            },
+            { "X-Request-Id": "req-header-456" },
+        );
+        const error = await pollinationsErrorFromResponse(response);
+        expect(error.requestId).toBe("req-abc-123");
+    });
+
+    it("falls back to X-Request-Id header when body omits requestId", async () => {
+        const response = makeErrorResponse(
+            {
+                error: {
+                    message: "Bad request",
+                    code: "INVALID_REQUEST",
+                },
+            },
+            { "X-Request-Id": "req-header-789" },
+        );
+        const error = await pollinationsErrorFromResponse(response);
+        expect(error.requestId).toBe("req-header-789");
+    });
+
+    it("returns undefined when neither body nor header has requestId", async () => {
+        const response = makeErrorResponse({
+            error: { message: "Bad request" },
+        });
+        const error = await pollinationsErrorFromResponse(response);
+        expect(error.requestId).toBeUndefined();
+    });
+
+    it("parses flat error body (no nested error)", async () => {
+        const response = makeErrorResponse(
+            { message: "Not found", code: "NOT_FOUND" },
+            { "X-Request-Id": "req-flat" },
+        );
+        const error = await pollinationsErrorFromResponse(response);
+        expect(error.message).toBe("Not found");
+        expect(error.requestId).toBe("req-flat");
+    });
+
+    it("handles non-JSON response body", async () => {
+        const response = {
+            ok: false,
+            status: 500,
+            headers: {
+                get: (name: string) =>
+                    name.toLowerCase() === "x-request-id" ? "req-500" : null,
+            },
+            json: async () => {
+                throw new Error("not json");
+            },
+        } as unknown as Response;
+        const error = await pollinationsErrorFromResponse(response);
+        expect(error.message).toBe("Request failed with status 500");
+        expect(error.requestId).toBe("req-500");
+    });
+});

--- a/packages/sdk/src/error-response.ts
+++ b/packages/sdk/src/error-response.ts
@@ -63,8 +63,11 @@ export async function pollinationsErrorFromResponse(
         nested.details && typeof nested.details === "object"
             ? (nested.details as Record<string, unknown>)
             : undefined;
+    // Prefer body requestId, fall back to X-Request-Id header
     const requestId =
-        typeof nested.requestId === "string" ? nested.requestId : undefined;
+        typeof nested.requestId === "string"
+            ? nested.requestId
+            : (response.headers.get("X-Request-Id") ?? undefined);
     const retryAfter = parseRetryAfter(response);
 
     return new PollinationsError(


### PR DESCRIPTION
Implements Quest #13794. PollinationsError.requestId now uses the error body's requestId when present, and falls back to the X-Request-Id response header when the body omits it.

- Add header fallback in pollinationsErrorFromResponse()
- 5 focused tests: body ID, header fallback, no ID, flat body, non-JSON