### PR TITLE
fix: fall back to X-Request-Id header in PollinationsError.requestId

### DIFF
--- a/packages/sdk/src/client.test.ts
+++ b/packages/sdk/src/client.test.ts
@@ -608,3 +608,55 @@ describe("Pollinations model discovery", () => {
         );
     });
 });
+
+
+
+describe("Pollinations request ID preservation", () => {
+    it("uses requestId from error body when present", async () => {
+        const client = newClient();
+        fetchMock.mockResolvedValue(
+            makeResponse(
+                { error: { message: "bad", code: "BAD_REQUEST", requestId: "body-req-id" } },
+                { ok: false, status: 400, headers: { "X-Request-Id": "header-req-id" } },
+            ),
+        );
+
+        await expect(client.image("a cat")).rejects.toMatchObject({
+            requestId: "body-req-id",
+        });
+    });
+
+    it("falls back to X-Request-Id header when body omits requestId", async () => {
+        const client = newClient();
+        fetchMock.mockResolvedValue(
+            makeResponse(
+                { error: { message: "bad", code: "BAD_REQUEST" } },
+                { ok: false, status: 400, headers: { "X-Request-Id": "header-req-id" } },
+            ),
+        );
+
+        await expect(client.image("a cat")).rejects.toMatchObject({
+            requestId: "header-req-id",
+        });
+    });
+
+    it("leaves requestId undefined when neither body nor header provides one", async () => {
+        const client = newClient();
+        fetchMock.mockResolvedValue(
+            makeResponse(
+                { error: { message: "bad", code: "BAD_REQUEST" } },
+                { ok: false, status: 400 },
+            ),
+        );
+
+        let error: PollinationsError | undefined;
+        try {
+            await client.image("a cat");
+        } catch (caught) {
+            if (caught instanceof PollinationsError) error = caught;
+        }
+
+        expect(error).toBeInstanceOf(PollinationsError);
+        expect(error?.requestId).toBeUndefined();
+    });
+});

--- a/packages/sdk/src/error-response.ts
+++ b/packages/sdk/src/error-response.ts
@@ -64,7 +64,9 @@ export async function pollinationsErrorFromResponse(
             ? (nested.details as Record<string, unknown>)
             : undefined;
     const requestId =
-        typeof nested.requestId === "string" ? nested.requestId : undefined;
+        typeof nested.requestId === "string"
+            ? nested.requestId
+            : (response.headers.get("X-Request-Id") ?? undefined);
     const retryAfter = parseRetryAfter(response);
 
     return new PollinationsError(


### PR DESCRIPTION
Closes #13794

When the JSON error body omits `requestId`, fall back to the `X-Request-Id` response header so users can still include it when reporting issues or contacting support.

Changes:
- `packages/sdk/src/error-response.ts`: added header fallback
- `packages/sdk/src/client.test.ts`: 3 new tests covering body-wins, header-fallback, and absent-both cases