### PR TITLE
feat: add 12-hour delay to community model price changes (#13800)

### DIFF
--- a/enter.pollinations.ai/drizzle/0055_price_change_delay.sql
+++ b/enter.pollinations.ai/drizzle/0055_price_change_delay.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `community_endpoint` ADD `pending_payload` text;--> statement-breakpoint
+ALTER TABLE `community_endpoint` ADD `pending_visibility` text;--> statement-breakpoint
+ALTER TABLE `community_endpoint` ADD `pending_at` integer;

--- a/enter.pollinations.ai/src/routes/community-endpoints.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints.ts
@@ -1,4 +1,5 @@
 import {
+    PRICE_CHANGE_DELAY_MS,
     type CommunityEndpointVisibility,
     communityModelId,
     type EndpointAgentListingPayload,
@@ -37,6 +38,7 @@ import {
     changesProxyPayload,
     deriveCreateProxyPolicy,
     deriveUpdatedProxyPolicy,
+    pricesOrPaidOnlyChanged,
 } from "./community-endpoints/proxy-policy.ts";
 import {
     assertValidUpdate,
@@ -709,13 +711,14 @@ export const communityEndpointsRoutes = new Hono<Env>()
                 update.hiddenReason = input.hidden ? "Hidden by owner" : null;
                 update.hiddenBy = input.hidden ? "owner" : null;
             }
-            const effectiveVisibility = input.visibility ?? endpoint.visibility;
-            await enforcePublishingAccess(db, user.id, effectiveVisibility);
-            update.visibility = effectiveVisibility;
+            const desiredVisibility = input.visibility ?? endpoint.visibility;
+            await enforcePublishingAccess(db, user.id, desiredVisibility);
             if (endpoint.type === "prompt_agent") {
                 // Prompt configuration is edited through /account/agents.
                 // This route only updates shared listing state such as hidden.
+                update.visibility = desiredVisibility;
             } else if (endpoint.type === "endpoint_agent") {
+                update.visibility = desiredVisibility;
                 if (!parseListingPayload("endpoint_agent", endpoint.payload)) {
                     throw new Error(
                         `Invalid endpoint_agent payload for ${endpoint.id}`,
@@ -733,14 +736,39 @@ export const communityEndpointsRoutes = new Hono<Env>()
                     });
                 }
             } else {
-                const stored = parseListingPayload("proxy", endpoint.payload);
+                // Proxy: apply 12-hour delay for price/visibility changes on
+                // public-facing models. Pending is stored separately and used
+                // as the effective state once its deadline passes.
+                const pendingReady =
+                    endpoint.pendingAt !== null &&
+                    Date.now() >=
+                        endpoint.pendingAt.getTime() + PRICE_CHANGE_DELAY_MS;
+
+                // Effective current state: apply pending if its deadline passed.
+                const effectivePayloadStr =
+                    pendingReady && endpoint.pendingPayload
+                        ? endpoint.pendingPayload
+                        : endpoint.payload;
+                const effectiveVisibility = (
+                    pendingReady && endpoint.pendingVisibility
+                        ? endpoint.pendingVisibility
+                        : endpoint.visibility
+                ) as CommunityEndpointVisibility;
+
+                const stored = parseListingPayload(
+                    "proxy",
+                    effectivePayloadStr,
+                );
                 if (!stored) {
                     throw new Error(`Invalid proxy payload for ${endpoint.id}`);
                 }
+
+                const resolvedVisibility =
+                    input.visibility ?? effectiveVisibility;
                 const policy = deriveUpdatedProxyPolicy(
                     stored,
                     input,
-                    effectiveVisibility,
+                    resolvedVisibility,
                 );
                 const fallbacks =
                     input.fallbacks === undefined
@@ -753,27 +781,95 @@ export const communityEndpointsRoutes = new Hono<Env>()
                               ownerUserId: user.id,
                               ...policy,
                           });
+
                 if (input.baseUrl !== undefined) {
                     update.baseUrl = normalizeInputBaseUrl(input.baseUrl);
                 }
                 if (input.upstreamModel !== undefined) {
                     update.upstreamModel = input.upstreamModel;
                 }
-                if (changesProxyPayload(input)) {
-                    const payload: ProxyListingPayload = {
-                        bearerTokenCiphertext:
-                            input.bearerToken === undefined
-                                ? stored.bearerTokenCiphertext
-                                : await encryptSecret(
-                                      normalizeInputBearerToken(
-                                          input.bearerToken,
-                                      ),
-                                      c.env.BETTER_AUTH_SECRET,
-                                  ),
-                        ...policy,
-                        fallbacks,
-                    };
-                    update.payload = JSON.stringify(payload);
+
+                // Always build the new payload when any proxy field changes.
+                const newPayload: ProxyListingPayload = {
+                    bearerTokenCiphertext:
+                        input.bearerToken === undefined
+                            ? stored.bearerTokenCiphertext
+                            : await encryptSecret(
+                                  normalizeInputBearerToken(input.bearerToken),
+                                  c.env.BETTER_AUTH_SECRET,
+                              ),
+                    ...policy,
+                    fallbacks,
+                };
+                const newPayloadJson = JSON.stringify(newPayload);
+
+                // Determine whether this update requires a 12-hour notice period.
+                // Rule: public model price/paidOnly change, or private→public.
+                const isGoingPublic =
+                    resolvedVisibility === "public" &&
+                    effectiveVisibility === "private";
+                const isPriceChangingOnPublicModel =
+                    effectiveVisibility === "public" &&
+                    changesProxyPayload(input) &&
+                    pricesOrPaidOnlyChanged(
+                        policy.prices,
+                        stored.prices,
+                        policy.paidOnly,
+                        stored.paidOnly,
+                        policy.imagePricing,
+                        stored.imagePricing,
+                    );
+                const needsDelay =
+                    isGoingPublic || isPriceChangingOnPublicModel;
+
+                if (needsDelay) {
+                    // If the previous pending is now ready, apply it to the
+                    // payload column before storing the new pending on top.
+                    if (pendingReady) {
+                        update.payload = effectivePayloadStr;
+                        update.visibility = effectiveVisibility;
+                    }
+                    update.pendingPayload = newPayloadJson;
+                    update.pendingVisibility = isGoingPublic ? "public" : null;
+                    update.pendingAt = new Date();
+                } else {
+                    // Immediate update: apply payload and visibility directly.
+                    if (changesProxyPayload(input)) {
+                        update.payload = newPayloadJson;
+                    }
+                    update.visibility = resolvedVisibility;
+
+                    // If the model is private with a queued public transition,
+                    // preserve that transition and fold any proxy changes into
+                    // the pending payload so they fire together when the deadline
+                    // passes.
+                    const hasPendingPublicVisibility =
+                        !pendingReady &&
+                        endpoint.pendingAt !== null &&
+                        endpoint.pendingVisibility === "public";
+                    if (
+                        hasPendingPublicVisibility &&
+                        input.visibility === undefined
+                    ) {
+                        if (changesProxyPayload(input)) {
+                            const pendingPolicy = deriveUpdatedProxyPolicy(
+                                stored,
+                                input,
+                                "public",
+                            );
+                            update.pendingPayload = JSON.stringify({
+                                bearerTokenCiphertext:
+                                    newPayload.bearerTokenCiphertext,
+                                ...pendingPolicy,
+                                fallbacks,
+                            } satisfies ProxyListingPayload);
+                        }
+                        // pendingAt and pendingVisibility remain unchanged.
+                    } else {
+                        update.pendingPayload = null;
+                        update.pendingVisibility = null;
+                        update.pendingAt = null;
+                    }
                 }
             }
             const [row] = await db

--- a/enter.pollinations.ai/src/routes/community-endpoints/presenter.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints/presenter.ts
@@ -1,4 +1,5 @@
 import {
+    PRICE_CHANGE_DELAY_MS,
     communityEndpointTitle,
     communityModelId,
     normalizeCommunityEndpointAdvertised,
@@ -11,6 +12,10 @@ import {
 } from "./schemas.ts";
 
 type CommunityEndpointRow = typeof schema.communityEndpoint.$inferSelect;
+
+function pendingIsReady(pendingAt: Date | null): boolean {
+    return pendingAt !== null && Date.now() >= pendingAt.getTime() + PRICE_CHANGE_DELAY_MS;
+}
 
 export function toCommunityEndpointResponse(
     row: CommunityEndpointRow,
@@ -56,11 +61,34 @@ export function toCommunityEndpointResponse(
         });
     }
 
-    const payload = parseListingPayload("proxy", row.payload);
+    const ready = pendingIsReady(row.pendingAt);
+
+    // If pending is ready, use pending values as the effective current state.
+    const effectivePayloadStr = ready && row.pendingPayload ? row.pendingPayload : row.payload;
+    const effectiveVisibility = ready && row.pendingVisibility ? row.pendingVisibility : row.visibility;
+
+    const payload = parseListingPayload("proxy", effectivePayloadStr);
     if (!payload) throw new Error(`Invalid proxy payload for ${row.id}`);
     const { bearerTokenCiphertext: _credential, prices, ...proxy } = payload;
+
+    // Include pending info when a change is queued but not yet effective.
+    let pending = null;
+    if (!ready && row.pendingAt && row.pendingPayload) {
+        const pendingPayload = parseListingPayload("proxy", row.pendingPayload);
+        if (pendingPayload) {
+            const effectiveAt = new Date(row.pendingAt.getTime() + PRICE_CHANGE_DELAY_MS);
+            pending = {
+                effectiveAt: effectiveAt.toISOString(),
+                ...(row.pendingVisibility === "public" ? { visibility: "public" as const } : {}),
+                paidOnly: pendingPayload.paidOnly,
+                ...pendingPayload.prices,
+            };
+        }
+    }
+
     return CommunityEndpointResponseSchema.parse({
         ...common,
+        visibility: effectiveVisibility,
         type: row.type,
         ...proxy,
         advertised: normalizeCommunityEndpointAdvertised(
@@ -68,5 +96,6 @@ export function toCommunityEndpointResponse(
             payload.modality,
         ),
         ...prices,
+        pending,
     });
 }

--- a/enter.pollinations.ai/src/routes/community-endpoints/proxy-policy.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints/proxy-policy.ts
@@ -231,3 +231,18 @@ export function changesProxyPayload(input: ProxyUpdateInput): boolean {
         ...COMMUNITY_ENDPOINT_PRICE_FIELDS.map(({ key }) => input[key]),
     ].some((value) => value !== undefined);
 }
+
+export function pricesOrPaidOnlyChanged(
+    newPrices: CommunityEndpointPrices,
+    oldPrices: CommunityEndpointPrices,
+    newPaidOnly: boolean,
+    oldPaidOnly: boolean,
+    newImagePricing: CommunityEndpointImagePricing,
+    oldImagePricing: CommunityEndpointImagePricing,
+): boolean {
+    if (newPaidOnly !== oldPaidOnly) return true;
+    if (newImagePricing !== oldImagePricing) return true;
+    return COMMUNITY_ENDPOINT_PRICE_FIELDS.some(
+        ({ key }) => newPrices[key] !== oldPrices[key],
+    );
+}

--- a/gen.pollinations.ai/src/community-models.ts
+++ b/gen.pollinations.ai/src/community-models.ts
@@ -4,6 +4,8 @@ import {
     communityModelDefinition,
     communityModelId,
     parseListingPayload,
+    PRICE_CHANGE_DELAY_MS,
+    PRICE_CHANGE_DELAY_MS,
     usesAgentRunToken,
 } from "@shared/community-endpoints.ts";
 import * as schema from "@shared/db/better-auth.ts";
@@ -76,6 +78,9 @@ export async function getCommunityModelRegistryEntries(
             baseUrl: schema.communityEndpoint.baseUrl,
             upstreamModel: schema.communityEndpoint.upstreamModel,
             payload: schema.communityEndpoint.payload,
+            pendingPayload: schema.communityEndpoint.pendingPayload,
+            pendingVisibility: schema.communityEndpoint.pendingVisibility,
+            pendingAt: schema.communityEndpoint.pendingAt,
             visibility: schema.communityEndpoint.visibility,
             hiddenAt: schema.communityEndpoint.hiddenAt,
             hiddenReason: schema.communityEndpoint.hiddenReason,
@@ -88,6 +93,7 @@ export async function getCommunityModelRegistryEntries(
         )
         .where(isNotNull(schema.user.githubUsername));
 
+    const now = Date.now();
     return rows.flatMap((row): CommunityModelRegistryEntry[] => {
         if (!row.ownerGithubUsername) return [];
         const baseUrl =
@@ -96,6 +102,17 @@ export async function getCommunityModelRegistryEntries(
                 : row.baseUrl;
         if (!baseUrl || !row.upstreamModel) return [];
         const modelId = communityModelId(row.ownerGithubUsername, row.name);
+
+        // Apply pending price/visibility change if its 12-hour deadline has passed.
+        const pendingReady =
+            row.pendingAt !== null &&
+            now >= row.pendingAt.getTime() + PRICE_CHANGE_DELAY_MS;
+        const effectivePayload =
+            pendingReady && row.pendingPayload ? row.pendingPayload : row.payload;
+        const effectiveVisibility =
+            pendingReady && row.pendingVisibility
+                ? row.pendingVisibility
+                : row.visibility;
         const identity = {
             id: row.id,
             ownerUserId: row.ownerUserId,
@@ -107,7 +124,7 @@ export async function getCommunityModelRegistryEntries(
             providerUrl: row.providerUrl,
             baseUrl,
             upstreamModel: row.upstreamModel,
-            visibility: row.visibility,
+            visibility: effectiveVisibility,
             hiddenAt: row.hiddenAt ? row.hiddenAt.getTime() : null,
             hiddenReason: row.hiddenReason,
         };

--- a/shared/community-endpoints.ts
+++ b/shared/community-endpoints.ts
@@ -18,6 +18,9 @@ import { readResponseBytes } from "./response-bytes.ts";
 
 export const LEGACY_COMMUNITY_MODEL_PREFIX = "community/";
 export const COMMUNITY_MODEL_REWARD_RATE = 0.75;
+// A new price or private→public transition on a public model is queued for
+// 12 hours before it takes effect. First price on a new model is immediate.
+export const PRICE_CHANGE_DELAY_MS = 12 * 60 * 60 * 1000;
 export const COMMUNITY_ENDPOINT_MODALITIES = [
     "text",
     "image",

--- a/shared/db/better-auth.ts
+++ b/shared/db/better-auth.ts
@@ -232,6 +232,12 @@ export const communityEndpoint = sqliteTable("community_endpoint", {
   hiddenAt: integer("hidden_at", { mode: "timestamp" }),
   hiddenReason: text("hidden_reason"),
   hiddenBy: text("hidden_by"),
+  // Pending price/visibility change for public-facing community models.
+  // A new price or private→public transition on a public model is stored here
+  // and applied automatically after PRICE_CHANGE_DELAY_MS (12 hours).
+  pendingPayload: text("pending_payload"),
+  pendingVisibility: text("pending_visibility"),
+  pendingAt: integer("pending_at", { mode: "timestamp" }),
   createdAt: integer("created_at", { mode: "timestamp" })
     .defaultNow()
     .notNull(),


### PR DESCRIPTION
## Summary

Adds a 12-hour delay to community model price changes as requested in issue #13800.

## Changes

- **Schema**: Added , , and  columns to  table
- **Queue logic**: When a public model's price, paidOnly, or imagePricing changes (or a private model becomes public), the change is queued for 12 hours before taking effect
- **API response**: Returns a  field with  timestamp while waiting
- **Display logic**: The generation API () respects pending changes when calculating effective visibility

## Files Modified

-  - Added pending fields to schema
-  - Added  constant
-  - Queue logic on update handler
-  - Returns effective state + pending info
-  - Added  helper
-  - Uses effective visibility with pending applied

## New Files

-  - Migration adding pending fields
