### PR TITLE
[QUEST #13770] Expose quest status in the JavaScript SDK

### DIFF
--- a/packages/sdk/src/client.test.ts
+++ b/packages/sdk/src/client.test.ts
@@ -600,11 +600,48 @@ describe("Pollinations model discovery", () => {
     it("returns the model array from the registry endpoint", async () => {
         const client = newClient();
         const models = [{ name: "openai", title: "OpenAI" }];
+
         fetchMock.mockResolvedValueOnce(makeResponse(models));
 
         await expect(client.models()).resolves.toEqual(models);
         expect(fetchMock.mock.calls[0]?.[0]).toBe(
             "https://example.test/models",
+        );
+    });
+});
+
+describe("Pollinations account quests", () => {
+    it("returns the quest catalog from GET /account/quests", async () => {
+        const client = newClient();
+        const response = {
+            quests: [
+                {
+                    id: "setup-api-key",
+                    title: "Create your first API key",
+                    description: "Generate an API key in the dashboard.",
+                    category: "setup",
+                    state: "completed",
+                    status: "completed",
+                    rewardAmount: 0.25,
+                    balanceBucket: "tier",
+                    url: null,
+                    reward: {
+                        id: "reward-1",
+                        questId: "setup-api-key",
+                        title: "Create your first API key",
+                        pollenAmount: 0.25,
+                        balanceBucket: "tier",
+                        earnedAt: "2026-01-01T00:00:00.000Z",
+                        claimedAt: null,
+                    },
+                },
+            ],
+        };
+        fetchMock.mockResolvedValueOnce(makeResponse(response));
+
+        await expect(client.accountQuests()).resolves.toEqual(response);
+        expect(fetchMock.mock.calls[0]?.[0]).toBe(
+            "https://example.test/account/quests",
         );
     });
 });

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -3,6 +3,7 @@ import type {
     AccountBalance,
     AccountKey,
     AccountProfile,
+    AccountQuestsResponse,
     AudioBinaryResponse,
     AudioGenerateOptions,
     AuthorizeDeviceOptions,
@@ -1484,6 +1485,23 @@ export class Pollinations {
         const url = `${this.baseUrl}/account/key/usage${qs ? `?${qs}` : ""}`;
 
         return this.getJson<UsageResponse>(url);
+    }
+
+    /**
+     * Get the quest catalog with the authenticated account's read-only
+     * status. Requires the `usage` account permission. Claiming rewards
+     * remains dashboard-only.
+     *
+     * @example
+     * ```ts
+     * const { quests } = await pollinations.accountQuests();
+     * const open = quests.filter(q => q.status === "open");
+     * ```
+     */
+    async accountQuests(): Promise<AccountQuestsResponse> {
+        return this.getJson<AccountQuestsResponse>(
+            `${this.baseUrl}/account/quests`,
+        );
     }
 
     // ============================================================================

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -78,6 +78,9 @@ export type {
     AccountKey,
     AccountPermission,
     AccountProfile,
+    AccountQuest,
+    AccountQuestReward,
+    AccountQuestsResponse,
     AudioBinaryResponse,
     AudioContentPart,
     AudioFormat,
@@ -126,6 +129,9 @@ export type {
     PollinationsConfig,
     // Errors
     PollinationsErrorDetails,
+    // Quests
+    QuestCategory,
+    QuestStatus,
     RequestOptions,
     ResponseFormat,
     TextContentPart,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -585,6 +585,48 @@ export interface AccountProfile {
     email?: string | null;
 }
 
+/** Lane a quest renders in on the dashboard */
+export type QuestCategory =
+    | "setup"
+    | "grow"
+    | "build"
+    | "contribute"
+    | "community"
+    | "easteregg";
+
+/** Read-only completion status for one quest, from the caller's perspective */
+export type QuestStatus = "open" | "completed" | "coming_soon";
+
+/** Reward already earned for a quest, if any */
+export interface AccountQuestReward {
+    id: string;
+    questId: string | null;
+    title: string;
+    pollenAmount: number;
+    balanceBucket: string;
+    earnedAt: string;
+    claimedAt: string | null;
+}
+
+/** One quest card with the authenticated account's status */
+export interface AccountQuest {
+    id: string;
+    title: string;
+    description: string;
+    category: QuestCategory;
+    state: "available" | "completed" | "coming_soon";
+    status: QuestStatus;
+    rewardAmount: number;
+    balanceBucket: "tier" | "pack";
+    url: string | null;
+    reward: AccountQuestReward | null;
+}
+
+/** Response from GET /account/quests */
+export interface AccountQuestsResponse {
+    quests: AccountQuest[];
+}
+
 /** Account balance */
 export interface AccountBalance {
     /**


### PR DESCRIPTION
Closes #13770.

This adds a read-only accountQuests() method to the @pollinations/sdk client so JS/TS consumers can list the quest catalog and each quest's completion status without hand-rolling the fetch call. It mirrors the shape of GET /account/quests on enter.pollinations.ai: quest id, title, description, category (setup/grow/build/contribute/community/easteregg), state, status, reward amount and bucket, url, and the earned reward details when present. Claiming a reward stays dashboard-only, matching the read-only nature of the endpoint.

New types added to types.ts: QuestCategory, QuestStatus, AccountQuestReward, AccountQuest, and AccountQuestsResponse, all exported from index.ts alongside the existing account types. The client.ts method follows the same getJson<T> pattern as the neighboring accountKeyUsage() and accountUsage() methods, including a JSDoc @example block for discoverability in editor tooltips.

Tested locally: added a unit test in client.test.ts that mocks GET /account/quests and asserts the response is returned unchanged and the correct URL is hit. Ran the full vitest suite (43 passed), biome check (clean), and tsc --noEmit (no errors) before opening this PR.