### PR TITLE
Add polli earnings command

### DIFF
--- a/packages/polli-cli/README.md
+++ b/packages/polli-cli/README.md
@@ -92,6 +92,7 @@ Keys can't be edited — to change a name, budget, or model list, revoke and rec
 polli usage                  # pollen balance
 polli usage --history        # recent requests
 polli usage --daily          # daily spend
+polli earnings               # developer earnings (BYOP apps + community models)
 polli quests --claimable     # only rewards ready to claim
 polli agents list            # managed prompt agents
 polli my-models list         # invite-only community text, image, and transcription models

--- a/packages/polli-cli/SKILL.md
+++ b/packages/polli-cli/SKILL.md
@@ -39,6 +39,7 @@ Install: `npm i -g @pollinations/cli@latest` (provides the `polli` binary).
 | Filter models by type | `polli models --type image` |
 | Model health + latency | `polli models --stats` (default 60m, `--window <min>`) |
 | Check balance | `polli usage` |
+| Show developer earnings | `polli earnings` (`--days <n>`, default 30) |
 | List your quests + claim state | `polli quests` (filters: `--open --claimable --claimed --coming-soon`) |
 | Manage prompt agents | `polli agents list` |
 | Manage invite-only community models | `polli my-models list` |
@@ -149,8 +150,11 @@ polli usage --history    # recent individual requests
 polli usage --daily      # daily cost summary
 polli quests             # your quests + claim state (open/claimable/claimed/coming)
 polli quests --claimable # only rewards ready to claim
+polli earnings           # developer earnings total + per-entity breakdown
 ```
 **History is eventually consistent** — a request you just made may not appear for 30–60s. When matching costs to freshly-generated media, use `--limit 50` and filter by timestamp, and retry if the expected entry is missing. `polli usage --json` returns `{"pollen": <number>}` — the current balance only; use `--history --json` or `--daily --json` for cost breakdowns.
+
+**Developer earnings** (`polli earnings`) reads `GET /account/earnings`: a per-entity rollup for BYOP apps and community models with additive totals. `--days <n>` sets the rolling window (1–90, default 30). `--json` returns `{days, totals, perEntity}`; API keys need `account:usage`.
 
 ### Manage my-models
 ```bash

--- a/packages/polli-cli/src/commands/earnings.ts
+++ b/packages/polli-cli/src/commands/earnings.ts
@@ -1,0 +1,141 @@
+import { Command, InvalidArgumentError } from "commander";
+import { gen, requireKey } from "../lib/api.js";
+import {
+    fail,
+    getOutputMode,
+    printInfo,
+    printResult,
+    printTable,
+} from "../lib/output.js";
+
+export const MAX_EARNINGS_DAYS = 90;
+const DEFAULT_EARNINGS_DAYS = 30;
+
+export interface EarningsRow {
+    date: string;
+    entity_id: string;
+    entity_name: string;
+    source: string;
+    requests: number;
+    paid_requests: number;
+    tier_requests: number;
+    baseline_price: number;
+    pollen_earned: number;
+    paid_earned: number;
+    tier_earned: number;
+    cost_usd: number;
+    reward_rate: number;
+}
+
+export interface EarningsResponse {
+    daily: EarningsRow[];
+    perEntity: EarningsRow[];
+}
+
+export interface EarningsTotals {
+    requests: number;
+    paid_requests: number;
+    tier_requests: number;
+    pollen_earned: number;
+    cost_usd: number;
+}
+
+/** Additive totals across per-entity rollups. */
+export function summarizeEarnings(response: EarningsResponse): EarningsTotals {
+    const rows = response.perEntity ?? [];
+    return rows.reduce<EarningsTotals>(
+        (totals, row) => ({
+            requests: totals.requests + row.requests,
+            paid_requests: totals.paid_requests + row.paid_requests,
+            tier_requests: totals.tier_requests + row.tier_requests,
+            pollen_earned: totals.pollen_earned + row.pollen_earned,
+            cost_usd: totals.cost_usd + row.cost_usd,
+        }),
+        {
+            requests: 0,
+            paid_requests: 0,
+            tier_requests: 0,
+            pollen_earned: 0,
+            cost_usd: 0,
+        },
+    );
+}
+
+/** Parse and validate a --days value; returns null when invalid. */
+export function parseEarningsDays(value: string): number | null {
+    const days = Number(value);
+    if (!Number.isInteger(days) || days < 1 || days > MAX_EARNINGS_DAYS) {
+        return null;
+    }
+    return days;
+}
+
+function renderHuman(
+    days: number,
+    totals: EarningsTotals,
+    perEntity: EarningsRow[],
+): void {
+    if (perEntity.length === 0) {
+        printInfo(`No earnings in the last ${days} day(s).`);
+        return;
+    }
+
+    printInfo(
+        `${totals.pollen_earned.toFixed(4)} pollen earned from ${totals.requests} request(s) in the last ${days} day(s)`,
+    );
+    printTable(
+        perEntity.map((row) => ({
+            entity: row.entity_name,
+            source: row.source,
+            requests: row.requests,
+            earned: row.pollen_earned.toFixed(4),
+            basis_usd: row.cost_usd.toFixed(2),
+            rate: `${(row.reward_rate * 100).toFixed(1)}%`,
+        })),
+        ["entity", "source", "requests", "earned", "basis_usd", "rate"],
+    );
+}
+
+const parseDays = (value: string): number => {
+    const days = parseEarningsDays(value);
+    if (days === null) {
+        throw new InvalidArgumentError(
+            `must be an integer between 1 and ${MAX_EARNINGS_DAYS}`,
+        );
+    }
+    return days;
+};
+
+export const earningsCommand = new Command("earnings")
+    .description("Show developer earnings from BYOP apps and community models")
+    .option(
+        "--days <n>",
+        `Rolling window in days (1-${MAX_EARNINGS_DAYS}, default ${DEFAULT_EARNINGS_DAYS})`,
+        parseDays,
+        DEFAULT_EARNINGS_DAYS,
+    )
+    .action(async (opts) => {
+        try {
+            const data = await gen<EarningsResponse>(
+                `/account/earnings?days=${opts.days}`,
+                { apiKey: requireKey() },
+            );
+
+            if (getOutputMode() === "json") {
+                printResult({
+                    days: opts.days,
+                    totals: summarizeEarnings(data),
+                    perEntity: data.perEntity ?? [],
+                });
+                return;
+            }
+
+            renderHuman(
+                opts.days,
+                summarizeEarnings(data),
+                data.perEntity ?? [],
+            );
+        } catch (err) {
+            fail("Failed to fetch earnings", err);
+        }
+    });

--- a/packages/polli-cli/src/index.ts
+++ b/packages/polli-cli/src/index.ts
@@ -5,6 +5,7 @@ import { Command } from "commander";
 import { agentsCommand } from "./commands/agents.js";
 import { authCommand } from "./commands/auth.js";
 import { docsCommand } from "./commands/docs.js";
+import { earningsCommand } from "./commands/earnings.js";
 import { createGenCommand } from "./commands/gen/index.js";
 import { keysCommand } from "./commands/keys.js";
 import { modelsCommand } from "./commands/models.js";
@@ -63,6 +64,7 @@ program
 program.addCommand(authCommand);
 program.addCommand(keysCommand);
 program.addCommand(usageCommand);
+program.addCommand(earningsCommand);
 program.addCommand(questsCommand);
 program.addCommand(agentsCommand);
 program.addCommand(myModelsCommand);

--- a/packages/polli-cli/test/earnings.e2e.test.ts
+++ b/packages/polli-cli/test/earnings.e2e.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+    type EarningsResponse,
+    earningsCommand,
+} from "../src/commands/earnings.js";
+import { setKeyOverride } from "../src/lib/config.js";
+import { setOutputMode } from "../src/lib/output.js";
+
+const apiPayload: EarningsResponse = {
+    daily: [
+        {
+            date: "2026-08-24",
+            entity_id: "app_1",
+            entity_name: "My App",
+            source: "byop_markup",
+            requests: 10,
+            paid_requests: 4,
+            tier_requests: 6,
+            baseline_price: 0.5,
+            pollen_earned: 1.5,
+            paid_earned: 0.9,
+            tier_earned: 0.6,
+            cost_usd: 2,
+            reward_rate: 0.15,
+        },
+    ],
+    perEntity: [
+        {
+            date: "",
+            entity_id: "app_1",
+            entity_name: "My App",
+            source: "byop_markup",
+            requests: 10,
+            paid_requests: 4,
+            tier_requests: 6,
+            baseline_price: 0.5,
+            pollen_earned: 1.5,
+            paid_earned: 0.9,
+            tier_earned: 0.6,
+            cost_usd: 2,
+            reward_rate: 0.15,
+        },
+    ],
+};
+
+describe("polli earnings end-to-end", () => {
+    let stdout: string[];
+    let stderr: string[];
+
+    beforeEach(() => {
+        stdout = [];
+        stderr = [];
+        vi.spyOn(process.stdout, "write").mockImplementation(((chunk) => {
+            stdout.push(String(chunk));
+            return true;
+        }) as typeof process.stdout.write);
+        vi.spyOn(process.stderr, "write").mockImplementation(((chunk) => {
+            stderr.push(String(chunk));
+            return true;
+        }) as typeof process.stderr.write);
+        setKeyOverride("test-key");
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+    });
+
+    it("requests the right endpoint and renders totals + table", async () => {
+        setOutputMode("human");
+        const fetchMock = vi
+            .fn()
+            .mockResolvedValue(
+                new Response(JSON.stringify(apiPayload), { status: 200 }),
+            );
+        vi.stubGlobal("fetch", fetchMock);
+
+        await earningsCommand.parseAsync(["--days", "7"], { from: "user" });
+
+        const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+        expect(url).toBe("https://gen.pollinations.ai/account/earnings?days=7");
+        expect(init.headers).toMatchObject({
+            Authorization: "Bearer test-key",
+        });
+
+        const output = stdout.join("") + stderr.join("");
+        expect(output).toContain("1.5000 pollen earned");
+        expect(output).toContain("My App");
+        expect(output).toContain("byop_markup");
+    });
+
+    it("emits machine-readable totals in --json mode", async () => {
+        setOutputMode("json");
+        vi.stubGlobal(
+            "fetch",
+            vi
+                .fn()
+                .mockResolvedValue(
+                    new Response(JSON.stringify(apiPayload), { status: 200 }),
+                ),
+        );
+
+        await earningsCommand.parseAsync(["--days", "30"], { from: "user" });
+
+        const payload = JSON.parse(stdout.join(""));
+        expect(payload.days).toBe(30);
+        expect(payload.totals).toEqual({
+            requests: 10,
+            paid_requests: 4,
+            tier_requests: 6,
+            pollen_earned: 1.5,
+            cost_usd: 2,
+        });
+        expect(payload.perEntity).toHaveLength(1);
+        expect(payload.perEntity[0].entity_name).toBe("My App");
+    });
+
+    it("prints a friendly note for an empty period", async () => {
+        setOutputMode("human");
+        vi.stubGlobal(
+            "fetch",
+            vi.fn().mockResolvedValue(
+                new Response(JSON.stringify({ daily: [], perEntity: [] }), {
+                    status: 200,
+                }),
+            ),
+        );
+
+        await earningsCommand.parseAsync(["--days", "90"], { from: "user" });
+
+        expect(stderr.join("")).toContain("No earnings in the last 90 day(s)");
+    });
+});

--- a/packages/polli-cli/test/earnings.test.ts
+++ b/packages/polli-cli/test/earnings.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+    type EarningsResponse,
+    type EarningsRow,
+    parseEarningsDays,
+    summarizeEarnings,
+} from "../src/commands/earnings.js";
+
+const row = (over: Partial<EarningsRow> = {}): EarningsRow => ({
+    date: "",
+    entity_id: "e1",
+    entity_name: "My App",
+    source: "byop_markup",
+    requests: 10,
+    paid_requests: 4,
+    tier_requests: 6,
+    baseline_price: 0.5,
+    pollen_earned: 1.5,
+    paid_earned: 0.9,
+    tier_earned: 0.6,
+    cost_usd: 2,
+    reward_rate: 0.15,
+    ...over,
+});
+
+describe("parseEarningsDays", () => {
+    it("accepts integers within the API window", () => {
+        expect(parseEarningsDays("1")).toBe(1);
+        expect(parseEarningsDays("30")).toBe(30);
+        expect(parseEarningsDays("90")).toBe(90);
+    });
+
+    it.each(["0", "-5", "91", "abc", "3.5", ""])("rejects %s", (value) => {
+        expect(parseEarningsDays(value)).toBeNull();
+    });
+});
+
+describe("summarizeEarnings", () => {
+    it("totals additive fields across entities", () => {
+        const response: EarningsResponse = {
+            daily: [],
+            perEntity: [
+                row(),
+                row({
+                    entity_id: "m1",
+                    entity_name: "model-x",
+                    source: "community_model",
+                    requests: 5,
+                    pollen_earned: 0.5,
+                    cost_usd: 1,
+                }),
+            ],
+        };
+        expect(summarizeEarnings(response)).toEqual({
+            requests: 15,
+            paid_requests: 8,
+            tier_requests: 12,
+            pollen_earned: 2,
+            cost_usd: 3,
+        });
+    });
+
+    it("handles an empty period", () => {
+        expect(summarizeEarnings({ daily: [], perEntity: [] })).toEqual({
+            requests: 0,
+            paid_requests: 0,
+            tier_requests: 0,
+            pollen_earned: 0,
+            cost_usd: 0,
+        });
+    });
+
+    it("treats a missing perEntity array as zero totals", () => {
+        const response = { daily: [] } as unknown as EarningsResponse;
+        expect(summarizeEarnings(response).pollen_earned).toBe(0);
+    });
+});


### PR DESCRIPTION
Show developer earnings from BYOP apps and community models via
GET /account/earnings: per-entity rollup with additive totals,
--days rolling window (1-90, default 30), and global --json output
of {days, totals, perEntity}. Invalid --days fails fast through
commander argument validation with a clear message. Documented in
README and SKILL.md; covered by unit tests plus fetch-level
end-to-end tests for human, json, and empty-period rendering.

Closes #13768