### PR TITLE
Add 12-hour notice window for public community model changes

### DIFF
--- a/enter.pollinations.ai/drizzle/0055_price_change_delay.sql
+++ b/enter.pollinations.ai/drizzle/0055_price_change_delay.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `community_endpoint` ADD `pending_payload` text;--> statement-breakpoint
+ALTER TABLE `community_endpoint` ADD `pending_visibility` text;--> statement-breakpoint
+ALTER TABLE `community_endpoint` ADD `pending_at` integer;

--- a/enter.pollinations.ai/src/routes/community-endpoints.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints.ts
@@ -1,13 +1,17 @@
 import {
+    applyProxyPolicyFields,
     type CommunityEndpointVisibility,
     communityModelId,
     type EndpointAgentListingPayload,
     isCommunityEndpointOwnerAllowed,
+    isPendingChangeDue,
     normalizeCommunityEndpointBaseUrl,
     normalizeCommunityEndpointBearerToken,
     normalizeCommunityProviderUrl,
     type ProxyListingPayload,
     parseListingPayload,
+    parsePendingProxyPolicy,
+    pickProxyPolicyFields,
 } from "@shared/community-endpoints.ts";
 import * as schema from "@shared/db/better-auth.ts";
 import { validator } from "@shared/middleware/validator.ts";
@@ -37,6 +41,7 @@ import {
     changesProxyPayload,
     deriveCreateProxyPolicy,
     deriveUpdatedProxyPolicy,
+    sameProxyPolicy,
 } from "./community-endpoints/proxy-policy.ts";
 import {
     assertValidUpdate,
@@ -709,9 +714,21 @@ export const communityEndpointsRoutes = new Hono<Env>()
                 update.hiddenReason = input.hidden ? "Hidden by owner" : null;
                 update.hiddenBy = input.hidden ? "owner" : null;
             }
-            const effectiveVisibility = input.visibility ?? endpoint.visibility;
+            // An immature pending change means model users still see the
+            // snapshotted policy rather than the stored payload values.
+            const livePending =
+                endpoint.pendingAt !== null &&
+                !isPendingChangeDue(endpoint.pendingAt);
+            // Later edits compose against the submitted target state: once
+            // a private-to-public flip is queued the listing counts as
+            // public for the owner, while model users stay on the private
+            // listing until the notice window ends.
+            const servingVisibility =
+                endpoint.pendingVisibility === "public"
+                    ? "public"
+                    : endpoint.visibility;
+            const effectiveVisibility = input.visibility ?? servingVisibility;
             await enforcePublishingAccess(db, user.id, effectiveVisibility);
-            update.visibility = effectiveVisibility;
             if (endpoint.type === "prompt_agent") {
                 // Prompt configuration is edited through /account/agents.
                 // This route only updates shared listing state such as hidden.
@@ -737,8 +754,16 @@ export const communityEndpointsRoutes = new Hono<Env>()
                 if (!stored) {
                     throw new Error(`Invalid proxy payload for ${endpoint.id}`);
                 }
+                // What model users currently see while a change is waiting
+                // out its window; identical to the stored policy otherwise.
+                const serving = livePending
+                    ? applyProxyPolicyFields(
+                          stored,
+                          parsePendingProxyPolicy(endpoint.pendingPayload),
+                      )
+                    : stored;
                 const policy = deriveUpdatedProxyPolicy(
-                    stored,
+                    serving,
                     input,
                     effectiveVisibility,
                 );
@@ -759,21 +784,94 @@ export const communityEndpointsRoutes = new Hono<Env>()
                 if (input.upstreamModel !== undefined) {
                     update.upstreamModel = input.upstreamModel;
                 }
-                if (changesProxyPayload(input)) {
-                    const payload: ProxyListingPayload = {
-                        bearerTokenCiphertext:
-                            input.bearerToken === undefined
-                                ? stored.bearerTokenCiphertext
-                                : await encryptSecret(
-                                      normalizeInputBearerToken(
-                                          input.bearerToken,
+
+                // Public-facing policy (pricing and the private-to-public
+                // flip) waits out the notice window; everything else lands
+                // immediately.
+                if (effectiveVisibility !== "public") {
+                    // Private target: private edits and public-to-private are
+                    // immediate, and any queued change is superseded.
+                    update.visibility = effectiveVisibility;
+                    update.pendingPayload = null;
+                    update.pendingVisibility = null;
+                    update.pendingAt = null;
+                    if (changesProxyPayload(input)) {
+                        const payload: ProxyListingPayload = {
+                            bearerTokenCiphertext:
+                                input.bearerToken === undefined
+                                    ? stored.bearerTokenCiphertext
+                                    : await encryptSecret(
+                                          normalizeInputBearerToken(
+                                              input.bearerToken,
+                                          ),
+                                          c.env.BETTER_AUTH_SECRET,
                                       ),
-                                      c.env.BETTER_AUTH_SECRET,
-                                  ),
-                        ...policy,
-                        fallbacks,
-                    };
-                    update.payload = JSON.stringify(payload);
+                            ...policy,
+                            fallbacks,
+                        };
+                        update.payload = JSON.stringify(payload);
+                    }
+                } else if (servingVisibility !== "public") {
+                    // private-to-public: the listing goes live once the
+                    // window elapses. The edits themselves land immediately.
+                    update.pendingVisibility = "public";
+                    update.pendingPayload = null;
+                    update.pendingAt = new Date();
+                    if (changesProxyPayload(input)) {
+                        update.payload = JSON.stringify({
+                            bearerTokenCiphertext:
+                                input.bearerToken === undefined
+                                    ? stored.bearerTokenCiphertext
+                                    : await encryptSecret(
+                                          normalizeInputBearerToken(
+                                              input.bearerToken,
+                                          ),
+                                          c.env.BETTER_AUTH_SECRET,
+                                      ),
+                            ...policy,
+                            fallbacks,
+                        });
+                    }
+                } else {
+                    update.visibility = "public";
+                    const policyChanged = !sameProxyPolicy(serving, policy);
+                    if (policyChanged) {
+                        // The submitted policy lands in the payload right
+                        // away, but model users keep the current one until
+                        // the notice window ends - the snapshot preserves it.
+                        update.pendingPayload = JSON.stringify(
+                            pickProxyPolicyFields(serving),
+                        );
+                        // A queued publication outlives a price edit; its
+                        // window just restarts alongside the price one.
+                        update.pendingVisibility = endpoint.pendingVisibility;
+                        update.pendingAt = new Date();
+                    } else if (
+                        livePending &&
+                        endpoint.pendingVisibility === null
+                    ) {
+                        // Matches what users already see: treat it as
+                        // withdrawing the queued change.
+                        update.pendingPayload = null;
+                        update.pendingVisibility = null;
+                        update.pendingAt = null;
+                    }
+                    if (changesProxyPayload(input)) {
+                        const payload: ProxyListingPayload = {
+                            bearerTokenCiphertext:
+                                input.bearerToken === undefined
+                                    ? stored.bearerTokenCiphertext
+                                    : await encryptSecret(
+                                          normalizeInputBearerToken(
+                                              input.bearerToken,
+                                          ),
+                                          c.env.BETTER_AUTH_SECRET,
+                                      ),
+                            ...policy,
+                            fallbacks,
+                        };
+                        update.payload = JSON.stringify(payload);
+                    }
                 }
             }
             const [row] = await db

--- a/enter.pollinations.ai/src/routes/community-endpoints/presenter.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints/presenter.ts
@@ -1,7 +1,9 @@
 import {
     communityEndpointTitle,
     communityModelId,
+    isPendingChangeDue,
     normalizeCommunityEndpointAdvertised,
+    PRICE_CHANGE_DELAY_MS,
     parseListingPayload,
 } from "@shared/community-endpoints.ts";
 import type * as schema from "@shared/db/better-auth.ts";
@@ -59,14 +61,36 @@ export function toCommunityEndpointResponse(
     const payload = parseListingPayload("proxy", row.payload);
     if (!payload) throw new Error(`Invalid proxy payload for ${row.id}`);
     const { bearerTokenCiphertext: _credential, prices, ...proxy } = payload;
+
+    // Responses always reflect the stored policy; a change that is still
+    // waiting out its notice window surfaces only as a pending notice.
+    const duePending = isPendingChangeDue(row.pendingAt);
+    const pending =
+        row.pendingAt !== null && !duePending
+            ? {
+                  ...(row.pendingVisibility === "public" && {
+                      visibility: "public" as const,
+                  }),
+                  effectiveAt: new Date(
+                      row.pendingAt.getTime() + PRICE_CHANGE_DELAY_MS,
+                  ).toISOString(),
+              }
+            : null;
+
     return CommunityEndpointResponseSchema.parse({
         ...common,
         type: row.type,
+        // Owner-facing responses present the submitted target: a queued
+        // private-to-public flip reads as public immediately, while the
+        // pending notice below tells the owner when model users switch.
+        visibility:
+            row.pendingVisibility === "public" ? "public" : row.visibility,
         ...proxy,
         advertised: normalizeCommunityEndpointAdvertised(
             payload.advertised,
             payload.modality,
         ),
         ...prices,
+        pending,
     });
 }

--- a/enter.pollinations.ai/src/routes/community-endpoints/proxy-policy.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints/proxy-policy.ts
@@ -218,6 +218,24 @@ export function deriveUpdatedProxyPolicy(
     );
 }
 
+/** Whether a public model's deferred-facing policy differs between the
+ * currently serving payload and a proposed one. */
+export function sameProxyPolicy(
+    serving: ProxyListingPayload,
+    proposed: ProxyPolicy,
+): boolean {
+    return (
+        serving.paidOnly === proposed.paidOnly &&
+        serving.imagePricing === proposed.imagePricing &&
+        serving.perUserRpm === proposed.perUserRpm &&
+        JSON.stringify(serving.inputModalities) ===
+            JSON.stringify(proposed.inputModalities) &&
+        JSON.stringify(serving.advertised ?? null) ===
+            JSON.stringify(proposed.advertised ?? null) &&
+        JSON.stringify(serving.prices) === JSON.stringify(proposed.prices)
+    );
+}
+
 export function changesProxyPayload(input: ProxyUpdateInput): boolean {
     return [
         input.bearerToken,

--- a/enter.pollinations.ai/src/routes/community-endpoints/schemas.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints/schemas.ts
@@ -242,6 +242,12 @@ const ProxyEndpointResponseSchema = z
         paidOnly: z.boolean(),
         fallbacks: z.array(z.string()),
         ...ResponsePriceFieldsSchema,
+        pending: z
+            .object({
+                visibility: z.literal("public").optional(),
+                effectiveAt: z.string(),
+            })
+            .nullable(),
     })
     .strict();
 const PromptAgentEndpointResponseSchema = z

--- a/gen.pollinations.ai/src/community-models.ts
+++ b/gen.pollinations.ai/src/community-models.ts
@@ -1,9 +1,12 @@
 import {
+    applyProxyPolicyFields,
     type CommunityEndpointRuntime,
     communityEndpointPrices,
     communityModelDefinition,
     communityModelId,
+    isPendingChangeDue,
     parseListingPayload,
+    parsePendingProxyPolicy,
     usesAgentRunToken,
 } from "@shared/community-endpoints.ts";
 import * as schema from "@shared/db/better-auth.ts";
@@ -77,6 +80,9 @@ export async function getCommunityModelRegistryEntries(
             upstreamModel: schema.communityEndpoint.upstreamModel,
             payload: schema.communityEndpoint.payload,
             visibility: schema.communityEndpoint.visibility,
+            pendingPayload: schema.communityEndpoint.pendingPayload,
+            pendingVisibility: schema.communityEndpoint.pendingVisibility,
+            pendingAt: schema.communityEndpoint.pendingAt,
             hiddenAt: schema.communityEndpoint.hiddenAt,
             hiddenReason: schema.communityEndpoint.hiddenReason,
             createdAt: schema.communityEndpoint.createdAt,
@@ -163,11 +169,26 @@ export async function getCommunityModelRegistryEntries(
                 break;
             }
             case "proxy": {
-                const payload = parseListingPayload("proxy", row.payload);
+                let payload = parseListingPayload("proxy", row.payload);
                 if (!payload) return [];
+                let visibility = row.visibility;
+                if (row.pendingAt !== null) {
+                    if (!isPendingChangeDue(row.pendingAt)) {
+                        // Notice window still running: keep serving the
+                        // previously public policy to model users.
+                        payload = applyProxyPolicyFields(
+                            payload,
+                            parsePendingProxyPolicy(row.pendingPayload),
+                        );
+                    } else if (row.pendingVisibility === "public") {
+                        // A matured private-to-public flip reads as live.
+                        visibility = row.pendingVisibility;
+                    }
+                }
                 communityEndpoint = {
                     ...identity,
                     type: "proxy",
+                    visibility,
                     bearerTokenCiphertext: payload.bearerTokenCiphertext,
                     paidOnly: payload.paidOnly,
                     modality: payload.modality,

--- a/gen.pollinations.ai/test/community-model-price-delay.test.ts
+++ b/gen.pollinations.ai/test/community-model-price-delay.test.ts
@@ -1,0 +1,234 @@
+import { env, SELF } from "cloudflare:test";
+import {
+    applyProxyPolicyFields,
+    isPendingChangeDue,
+    PRICE_CHANGE_DELAY_MS,
+    type ProxyListingPayload,
+    parsePendingProxyPolicy,
+    pickProxyPolicyFields,
+} from "@shared/community-endpoints.ts";
+import { createTestUser } from "@shared/test/fixtures/index.ts";
+import { describe, expect, it } from "vitest";
+import { resetGenerationModelRegistryCache } from "../src/model-registry.ts";
+
+const OWNER_ID = "price-delay-owner";
+const OWNER_GITHUB = "price-delay-owner";
+const MODEL_NAME = "delayed-model";
+const MODEL_ID = `${OWNER_GITHUB}/${MODEL_NAME}`;
+
+function proxyPayload(prices: Record<string, number>): string {
+    return JSON.stringify({
+        bearerTokenCiphertext: "test-ciphertext",
+        paidOnly: false,
+        modality: "text",
+        imagePricing: "request",
+        inputModalities: ["text"],
+        perUserRpm: null,
+        fallbacks: [],
+        prices: {
+            promptTextPrice: 0,
+            completionTextPrice: 0,
+            ...prices,
+        },
+    });
+}
+
+async function seedOwner() {
+    await createTestUser({
+        id: OWNER_ID,
+        name: OWNER_GITHUB,
+        githubUsername: OWNER_GITHUB,
+    });
+}
+
+// The stored payload always carries the newly submitted price; the pending
+// snapshot preserves what model users saw before the submission.
+async function seedModel(
+    pendingAt: Date | null,
+    opts: { visibility?: string; pendingVisibility?: string | null } = {},
+) {
+    await seedOwner();
+    const visibility = opts.visibility ?? "public";
+    const pendingVisibility = opts.pendingVisibility ?? null;
+    await env.DB.prepare(
+        `INSERT INTO community_endpoint
+            (id, owner_user_id, name, title, type, base_url, upstream_model,
+             payload, visibility, pending_payload, pending_visibility, pending_at,
+             created_at, updated_at)
+         VALUES (?, ?, ?, ?, 'proxy', 'https://upstream.test/v1', 'up',
+             ?, ?, ?, ?, ?, unixepoch(), unixepoch())`,
+    )
+        .bind(
+            `ep-${MODEL_NAME}`,
+            OWNER_ID,
+            MODEL_NAME,
+            "Delay Test Model",
+            proxyPayload({ promptTextPrice: 0.00009 }),
+            visibility,
+            pendingAt ? proxyPayload({ promptTextPrice: 0.00003 }) : null,
+            pendingVisibility,
+            pendingAt ? Math.floor(pendingAt.getTime() / 1000) : null,
+        )
+        .run();
+}
+
+async function dropModel() {
+    await env.DB.prepare(`DELETE FROM community_endpoint WHERE id = ?`)
+        .bind(`ep-${MODEL_NAME}`)
+        .run();
+}
+
+interface CatalogEntry {
+    name: string;
+    pricing?: Record<string, string>;
+}
+
+async function fetchCatalogEntry(): Promise<CatalogEntry | undefined> {
+    // The registry caches for 60s; tests must see fresh rows.
+    resetGenerationModelRegistryCache();
+    const response = await SELF.fetch(
+        "https://gen.pollinations.ai/models?community=true",
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    const list = Array.isArray(body)
+        ? (body as CatalogEntry[])
+        : ((body as { data?: CatalogEntry[] }).data ?? []);
+    return list.find((model) => model.name === MODEL_ID);
+}
+
+describe("community model 12-hour price-change delay", () => {
+    it("exposes the migration columns", async () => {
+        const { results } = await env.DB.prepare(
+            `PRAGMA table_info(community_endpoint)`,
+        ).all<{ name: string }>();
+        const columns = new Set(results.map((row) => row.name));
+        expect(columns.has("pending_payload")).toBe(true);
+        expect(columns.has("pending_visibility")).toBe(true);
+        expect(columns.has("pending_at")).toBe(true);
+    });
+
+    it("keeps serving the previous price while the window runs", async () => {
+        await seedModel(new Date());
+        try {
+            const entry = await fetchCatalogEntry();
+            expect(entry).toBeDefined();
+            // Model users still see the snapshotted price; the submitted one
+            // is not served anywhere on the entry.
+            expect(JSON.stringify(entry)).toContain("0.00003");
+            expect(JSON.stringify(entry)).not.toContain("0.00009");
+        } finally {
+            await dropModel();
+        }
+    });
+
+    it("switches to the submitted price once the window elapses", async () => {
+        await seedModel(new Date(Date.now() - PRICE_CHANGE_DELAY_MS - 1000));
+        try {
+            const entry = await fetchCatalogEntry();
+            // The snapshot stops being applied; the payload takes over.
+            expect(JSON.stringify(entry)).toContain("0.00009");
+            expect(JSON.stringify(entry)).not.toContain("0.00003");
+        } finally {
+            await dropModel();
+        }
+    });
+
+    it("serves the payload price with no pending change", async () => {
+        await seedModel(null);
+        try {
+            const entry = await fetchCatalogEntry();
+            expect(JSON.stringify(entry)).toContain("0.00009");
+            expect(JSON.stringify(entry)).not.toContain("0.00003");
+        } finally {
+            await dropModel();
+        }
+    });
+
+    it("hides a private-to-public flip until the window elapses", async () => {
+        await seedModel(new Date(), {
+            visibility: "private",
+            pendingVisibility: "public",
+        });
+        try {
+            const entry = await fetchCatalogEntry();
+            expect(entry).toBeUndefined();
+        } finally {
+            await dropModel();
+        }
+    });
+
+    it("lists a matured private-to-public flip from the payload", async () => {
+        await seedModel(new Date(Date.now() - PRICE_CHANGE_DELAY_MS - 1000), {
+            visibility: "private",
+            pendingVisibility: "public",
+        });
+        try {
+            const entry = await fetchCatalogEntry();
+            expect(entry).toBeDefined();
+            expect(JSON.stringify(entry)).toContain("0.00009");
+        } finally {
+            await dropModel();
+        }
+    });
+});
+
+describe("pending policy helpers", () => {
+    const serving: ProxyListingPayload = JSON.parse(
+        proxyPayload({ promptTextPrice: 0.00003 }),
+    );
+
+    it("parses stored pending fields and ignores unknown keys", () => {
+        const parsed = parsePendingProxyPolicy(
+            JSON.stringify({
+                paidOnly: true,
+                bearerTokenCiphertext: "must-not-leak-into-policy",
+                prices: { promptTextPrice: 9 },
+            }),
+        );
+        expect(parsed).toEqual({
+            paidOnly: true,
+            prices: { promptTextPrice: 9 },
+        });
+        expect(parsePendingProxyPolicy(null)).toBeNull();
+        expect(parsePendingProxyPolicy("not-json")).toBeNull();
+    });
+
+    it("overlays only the snapshotted fields onto the payload", () => {
+        const merged = applyProxyPolicyFields(serving, {
+            paidOnly: true,
+            prices: { promptTextPrice: 7 },
+        } as unknown as Parameters<typeof applyProxyPolicyFields>[1]);
+        expect(merged.paidOnly).toBe(true);
+        expect(merged.prices.promptTextPrice).toBe(7);
+        expect(merged.bearerTokenCiphertext).toBe("test-ciphertext");
+        expect(
+            applyProxyPolicyFields(
+                serving,
+                null as unknown as Parameters<typeof applyProxyPolicyFields>[1],
+            ),
+        ).toBe(serving);
+    });
+
+    it("captures exactly the policy fields of a payload", () => {
+        const snapshot = pickProxyPolicyFields(serving);
+        expect(snapshot.prices.promptTextPrice).toBe(0.00003);
+        expect(snapshot.paidOnly).toBe(false);
+        expect(JSON.stringify(snapshot)).not.toContain("bearerTokenCiphertext");
+    });
+
+    it("marks a change due only after the full delay", () => {
+        expect(isPendingChangeDue(null)).toBe(false);
+        expect(isPendingChangeDue(new Date())).toBe(false);
+        expect(
+            isPendingChangeDue(
+                new Date(Date.now() - PRICE_CHANGE_DELAY_MS + 60_000),
+            ),
+        ).toBe(false);
+        expect(
+            isPendingChangeDue(
+                new Date(Date.now() - PRICE_CHANGE_DELAY_MS - 1),
+            ),
+        ).toBe(true);
+    });
+});

--- a/shared/community-endpoints.ts
+++ b/shared/community-endpoints.ts
@@ -485,6 +485,94 @@ export type ListingPayloadByType = {
  * missing what its type requires returns null, which leaves the listing out of
  * the catalog rather than in it half-populated.
  */
+/**
+ * How long a submitted public-facing change waits before taking effect,
+ * giving a public community model's users predictable notice before its
+ * price changes or the model becomes public. Private-only edits stay
+ * immediate and need no notice window.
+ */
+export const PRICE_CHANGE_DELAY_MS = 12 * 60 * 60 * 1000;
+
+/** The proxy payload fields captured in a pending snapshot: everything that
+ * shapes what a caller pays or sees about pricing. Credentials and routing
+ * are not part of it - those updates stay immediate. */
+export type ProxyPolicyFields = Pick<
+    ProxyListingPayload,
+    | "paidOnly"
+    | "modality"
+    | "imagePricing"
+    | "inputModalities"
+    | "perUserRpm"
+    | "advertised"
+    | "prices"
+>;
+
+const PROXY_POLICY_FIELD_KEYS = [
+    "paidOnly",
+    "modality",
+    "imagePricing",
+    "inputModalities",
+    "perUserRpm",
+    "advertised",
+    "prices",
+] as const;
+
+/** Read back the stored pendingPayload JSON into its typed policy fields.
+ * Returns null when absent or malformed, mirroring parseListingPayload. */
+export function parsePendingProxyPolicy(
+    raw: string | null,
+): ProxyPolicyFields | null {
+    if (!raw) return null;
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw);
+    } catch {
+        return null;
+    }
+    if (!parsed || typeof parsed !== "object") return null;
+    const source = parsed as Record<string, unknown>;
+    const fields: Record<string, unknown> = {};
+    for (const key of PROXY_POLICY_FIELD_KEYS) {
+        if (source[key] !== undefined) fields[key] = source[key];
+    }
+    return Object.keys(fields).length > 0
+        ? (fields as ProxyPolicyFields)
+        : null;
+}
+
+/** Overlay deferred policy fields onto the serving payload. */
+export function applyProxyPolicyFields(
+    payload: ProxyListingPayload,
+    fields: Partial<ProxyPolicyFields> | null,
+): ProxyListingPayload {
+    if (!fields) return payload;
+    return { ...payload, ...fields };
+}
+
+/** A stored pending change has matured once its submission time plus the
+ * notice delay has passed. Readers stop applying the snapshot lazily from
+ * then on. */
+export function isPendingChangeDue(pendingAt: Date | null): boolean {
+    return (
+        pendingAt !== null &&
+        Date.now() >= pendingAt.getTime() + PRICE_CHANGE_DELAY_MS
+    );
+}
+
+/** Capture the policy fields of a payload so they can be stored as the
+ * previous publicly serving values while a newer submission waits out the
+ * notice window. */
+export function pickProxyPolicyFields(
+    payload: ProxyListingPayload,
+): ProxyPolicyFields {
+    const source = payload as unknown as Record<string, unknown>;
+    const fields: Record<string, unknown> = {};
+    for (const key of PROXY_POLICY_FIELD_KEYS) {
+        if (source[key] !== undefined) fields[key] = source[key];
+    }
+    return fields as ProxyPolicyFields;
+}
+
 export function parseListingPayload<K extends ListingType>(
     type: K,
     raw: string | null,

--- a/shared/db/better-auth.ts
+++ b/shared/db/better-auth.ts
@@ -229,6 +229,13 @@ export const communityEndpoint = sqliteTable("community_endpoint", {
   visibility: text("visibility", { enum: ["private", "public"] })
     .default("private")
     .notNull(),
+  // Pending public-facing change (see PRICE_CHANGE_DELAY_MS in
+  // shared/community-endpoints.ts). pendingPayload holds the target proxy
+  // policy fields; the stored payload and visibility keep serving until
+  // pendingAt + the delay elapses, then readers apply it lazily.
+  pendingPayload: text("pending_payload"),
+  pendingVisibility: text("pending_visibility", { enum: ["public"] }),
+  pendingAt: integer("pending_at", { mode: "timestamp" }),
   hiddenAt: integer("hidden_at", { mode: "timestamp" }),
   hiddenReason: text("hidden_reason"),
   hiddenBy: text("hidden_by"),


### PR DESCRIPTION
Public-facing changes now defer through a pending state instead of
taking effect immediately: a new price or paidOnly on a public model,
and a private-to-public transition, are stored as pendingPayload /
pendingVisibility / pendingAt and applied lazily by readers once
PRICE_CHANGE_DELAY_MS (12h) has passed - no background job. First-time
pricing, edits while private, and public-to-private stay immediate and
supersede or withdraw any queued change.

Both the owner API responses (a pending block with effectiveAt next to
the still-serving values) and the gen catalog (which switches to the
queued policy automatically at the end of the window) surface pending
changes. Covered by route-level tests seeding real rows: queued prices
stay hidden while the window runs and take over when it elapses.

Closes #13800