### PR TITLE
Preserve server request ID on SDK errors

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -517,6 +517,20 @@ try {
 
 Common error codes: `400` invalid params, `401` missing/invalid key, `402` insufficient balance, `403` permission denied, `500` server error.
 
+The error carries the server-generated request ID when available (from the
+error body, falling back to the `X-Request-Id` response header), so you can
+include it in support reports:
+
+```javascript
+try {
+  await generateImage('test');
+} catch (err) {
+  if (err instanceof PollinationsError && err.requestId) {
+    console.error('requestId:', err.requestId); // e.g. "req_abc123"
+  }
+}
+```
+
 ## Advanced: Client Class
 
 ```javascript

--- a/packages/sdk/src/client.test.ts
+++ b/packages/sdk/src/client.test.ts
@@ -608,3 +608,67 @@ describe("Pollinations model discovery", () => {
         );
     });
 });
+
+describe("Pollinations request ID preservation", () => {
+    it("uses requestId from the error body when present", async () => {
+        const client = newClient();
+        fetchMock.mockResolvedValueOnce(
+            makeResponse(
+                {
+                    error: {
+                        message: "bad",
+                        code: "BAD_REQUEST",
+                        requestId: "body-req-id",
+                    },
+                },
+                {
+                    ok: false,
+                    status: 400,
+                    headers: { "X-Request-Id": "hdr-1" },
+                },
+            ),
+        );
+
+        await expect(client.image("a cat")).rejects.toMatchObject({
+            requestId: "body-req-id",
+        });
+    });
+
+    it("falls back to the X-Request-Id header when the body omits it", async () => {
+        const client = newClient();
+        fetchMock.mockResolvedValueOnce(
+            makeResponse(
+                { error: { message: "bad", code: "BAD_REQUEST" } },
+                {
+                    ok: false,
+                    status: 400,
+                    headers: { "X-Request-Id": "hdr-2" },
+                },
+            ),
+        );
+
+        await expect(client.image("a cat")).rejects.toMatchObject({
+            requestId: "hdr-2",
+        });
+    });
+
+    it("leaves requestId undefined when neither body nor header has one", async () => {
+        const client = newClient();
+        fetchMock.mockResolvedValueOnce(
+            makeResponse(
+                { error: { message: "bad", code: "BAD_REQUEST" } },
+                { ok: false, status: 400 },
+            ),
+        );
+
+        let error: PollinationsError | undefined;
+        try {
+            await client.image("a cat");
+        } catch (caught) {
+            if (caught instanceof PollinationsError) error = caught;
+        }
+
+        expect(error).toBeInstanceOf(PollinationsError);
+        expect(error?.requestId).toBeUndefined();
+    });
+});

--- a/packages/sdk/src/error-response.ts
+++ b/packages/sdk/src/error-response.ts
@@ -64,7 +64,9 @@ export async function pollinationsErrorFromResponse(
             ? (nested.details as Record<string, unknown>)
             : undefined;
     const requestId =
-        typeof nested.requestId === "string" ? nested.requestId : undefined;
+        typeof nested.requestId === "string"
+            ? nested.requestId
+            : (response.headers.get("X-Request-Id") ?? undefined);
     const retryAfter = parseRetryAfter(response);
 
     return new PollinationsError(


### PR DESCRIPTION
PollinationsError.requestId now prefers the error body's requestId and
falls back to the X-Request-Id response header, so users can include it
in support reports. Covered by focused tests and a short README usage
example.

Closes #13794