### PR TITLE
Never cache authenticated account responses

### DIFF
--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -24,6 +24,7 @@ import { and, desc, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import type { Context } from "hono";
 import { Hono } from "hono";
+import { createMiddleware } from "hono/factory";
 import { HTTPException } from "hono/http-exception";
 import { describeRoute, resolver } from "hono-openapi";
 import { z } from "zod";
@@ -786,11 +787,24 @@ const usageResponseSchema = z.object({
 });
 
 /**
+ * Authenticated account data must never be cached by browsers or
+  * intermediary caches (shared proxies, CDNs). Applied once here so every
+   * route mounted under accountRoutes - including nested /agents and
+    * /my-models routers - gets it, instead of repeating it per handler.
+     */
+const setPrivateNoStoreHeaders = createMiddleware<Env>(async (c, next) => {
+        await next();
+        c.header("Cache-Control", "private, no-store, max-age=0");
+        c.header("Pragma", "no-cache");
+});
+
+/**
  * Account routes - profile, balance and usage endpoints.
  * Supports both session cookies and API keys with permission checks.
  */
 export const accountRoutes = new Hono<Env>()
     .use(auth({ allowApiKey: true, allowSessionCookie: true }))
+        .use(setPrivateNoStoreHeaders)
     .route("/agents", agentsRoutes)
     .route("/my-models", communityEndpointsRoutes)
     .get(
@@ -1398,7 +1412,6 @@ export const accountRoutes = new Hono<Env>()
                 ? await getVisibleModelIdsForUser(c.env.DB, user.id)
                 : null;
 
-            c.header("Cache-Control", "private, no-store, max-age=0");
             return c.json({
                 data: keys.map((key, index) => ({
                     id: key.id,

--- a/enter.pollinations.ai/test/integration/account-caching-headers.test.ts
+++ b/enter.pollinations.ai/test/integration/account-caching-headers.test.ts
@@ -1,0 +1,43 @@
+import { SELF } from "cloudflare:test";
+import { describe, expect } from "vitest";
+import { test } from "../fixtures.ts";
+
+describe("Account routes send no-store cache headers", () => {
+  test("top-level route (GET /api/account/profile) is never cached", async ({
+    sessionToken,
+  }) => {
+    const response = await SELF.fetch(
+      "http://localhost:3000/api/account/profile",
+      {
+        headers: {
+          Cookie: `better-auth.session_token=${sessionToken}`,
+        },
+      },
+      );
+
+       expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe(
+      "private, no-store, max-age=0",
+      );
+    expect(response.headers.get("Pragma")).toBe("no-cache");
+  });
+
+         test("nested route (GET /api/account/my-models) is never cached", async ({
+           sessionToken,
+         }) => {
+           const response = await SELF.fetch(
+             "http://localhost:3000/api/account/my-models",
+             {
+               headers: {
+                 Cookie: `better-auth.session_token=${sessionToken}`,
+               },
+             },
+             );
+
+              expect(response.status).toBe(200);
+           expect(response.headers.get("Cache-Control")).toBe(
+             "private, no-store, max-age=0",
+             );
+           expect(response.headers.get("Pragma")).toBe("no-cache");
+         });
+});


### PR DESCRIPTION
Closes #13771.

Authenticated account responses under /account (profile, balance, usage, keys, and the nested /agents and /my-models routers) had no explicit cache headers, so a shared proxy or browser cache could serve one user's data to another. This adds a setPrivateNoStoreHeaders middleware, applied once via .use() on accountRoutes so it covers every route mounted under it including the nested routers, that sets Cache-Control: private, no-store, max-age=0 and Pragma: no-cache on every response. The one existing per-handler Cache-Control header in the /keys listing endpoint is now redundant and has been removed.

Added test/integration/account-caching-headers.test.ts with two focused tests, one for a top-level route (/account/profile) and one for a nested route (/account/my-models), asserting both headers are present. Ran the full local test suite and typecheck; no regressions.