### PR TITLE
feat(sdk): expose accountQuests() method for quest status (#13770)

### DIFF
--- a/packages/sdk/src/client.test.ts
+++ b/packages/sdk/src/client.test.ts
@@ -608,3 +608,38 @@ describe("Pollinations model discovery", () => {
         );
     });
 });
+
+describe("Pollinations account quests", () => {
+    it("returns quest data from GET /account/quests", async () => {
+        const client = newClient();
+        const quests = [
+            {
+                id: "q1",
+                title: "First Quest",
+                description: "A quest",
+                category: "setup" as const,
+                state: "completed" as const,
+                status: "completed" as const,
+                rewardAmount: 100,
+                balanceBucket: "tier" as const,
+                url: null,
+                reward: null,
+            },
+        ];
+        fetchMock.mockResolvedValueOnce(makeResponse({ quests }));
+
+        const result = await client.accountQuests();
+        expect(result.quests).toEqual(quests);
+        expect(fetchMock.mock.calls[0]?.[0]).toBe(
+            "https://example.test/account/quests",
+        );
+    });
+
+    it("returns an empty quests array when no quests exist", async () => {
+        const client = newClient();
+        fetchMock.mockResolvedValueOnce(makeResponse({ quests: [] }));
+
+        const result = await client.accountQuests();
+        expect(result.quests).toEqual([]);
+    });
+});

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -3,6 +3,7 @@ import type {
     AccountBalance,
     AccountKey,
     AccountProfile,
+    AccountQuestsResponse,
     AudioBinaryResponse,
     AudioGenerateOptions,
     AuthorizeDeviceOptions,
@@ -1396,6 +1397,19 @@ export class Pollinations {
      */
     async accountBalance(): Promise<AccountBalance> {
         return this.getJson<AccountBalance>(`${this.baseUrl}/account/balance`);
+    }
+
+    /**
+     * Get authenticated quest status
+     *
+     * @example
+     * ```ts
+     * const { quests } = await pollinations.accountQuests();
+     * quests.forEach(q => console.log(q.title, q.status));
+     * ```
+     */
+    async accountQuests(): Promise<AccountQuestsResponse> {
+        return this.getJson<AccountQuestsResponse>(`${this.baseUrl}/account/quests`);
     }
 
     /**

--- a/packages/sdk/src/helpers.ts
+++ b/packages/sdk/src/helpers.ts
@@ -29,6 +29,7 @@ import {
 } from "./extras.js";
 import type {
     AccountBalance,
+    AccountQuestsResponse,
     AccountKey,
     AccountProfile,
     AudioGenerateOptions,
@@ -495,6 +496,13 @@ export async function getProfile(): Promise<AccountProfile> {
  */
 export async function getBalance(): Promise<AccountBalance> {
     return getClient().accountBalance();
+}
+
+/**
+ * Get quest status
+ */
+export async function getQuests(): Promise<AccountQuestsResponse> {
+    return getClient().accountQuests();
 }
 
 /**

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -49,6 +49,7 @@ export {
     generateVideo,
     getBalance,
     getDailyUsage,
+    getQuests,
     getImageModels,
     getKeyUsage,
     getModels,
@@ -75,6 +76,7 @@ export {
 // Export all types
 export type {
     AccountBalance,
+    AccountQuestsResponse,
     AccountKey,
     AccountPermission,
     AccountProfile,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -602,6 +602,39 @@ export interface AccountBalance {
         paid: number;
     };
 }
+/** Quest category */
+export type QuestCategory = "setup" | "grow" | "build" | "contribute" | "community" | "easteregg";
+
+/** Quest reward information */
+export interface AccountQuestReward {
+    id: string;
+    questId: string | null;
+    title: string;
+    pollenAmount: number;
+    balanceBucket: "tier" | "pack";
+    earnedAt: string;
+    claimedAt: string | null;
+}
+
+/** A single quest with status and optional reward */
+export interface AccountQuest {
+    id: string;
+    title: string;
+    description: string;
+    category: QuestCategory;
+    state: "available" | "completed" | "coming_soon";
+    status: "open" | "completed" | "coming_soon";
+    rewardAmount: number;
+    balanceBucket: "tier" | "pack";
+    url: string | null;
+    reward: AccountQuestReward | null;
+}
+
+/** Response from GET /account/quests */
+export interface AccountQuestsResponse {
+    quests: AccountQuest[];
+}
+
 
 /** Usage record */
 export interface UsageRecord {


### PR DESCRIPTION
Fixes #13770

Adds `accountQuests()` to the Pollinations SDK client as a thin typed wrapper around `GET /account/quests`.

- **types.ts** — `QuestCategory`, `AccountQuestReward`, `AccountQuest`, `AccountQuestsResponse`
- **client.ts** — `accountQuests()` method (mirrors `accountProfile()` pattern)
- **helpers.ts** — `getQuests()` convenience wrapper
- **index.ts** — exports for method, helper, and types
- **client.test.ts** — two focused request tests

No server changes. No caching, polling, hooks, or compatibility layers.