### PR TITLE
fix: exclude Mistral regional pricing variants

### DIFF
--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -338,7 +338,7 @@ export const portkeyConfig: PortkeyConfigMap = {
                 max_tokens: 64000,
                 provider: {
                     only: ["mistral"],
-                    ignore: ["mistral/zdr"],
+                    ignore: ["mistral/zdr", "mistral/us", "mistral/eu"],
                     allow_fallbacks: false,
                 },
             },

--- a/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
+++ b/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
@@ -272,13 +272,13 @@ describe("resolveModelConfig", () => {
         });
     });
 
-    it("excludes Mistral's higher-priced ZDR variant", () => {
+    it("excludes Mistral's non-standard endpoint variants", () => {
         const result = resolveModelConfig(messages, { model: "mistral" });
 
         expect(result.options.model).toBe("mistralai/mistral-small-2603");
         expect(result.options.provider).toEqual({
             only: ["mistral"],
-            ignore: ["mistral/zdr"],
+            ignore: ["mistral/zdr", "mistral/us", "mistral/eu"],
             allow_fallbacks: false,
         });
     });


### PR DESCRIPTION
- Excludes OpenRouter's `mistral/us` and `mistral/eu` endpoint variants, which cost 10% more than the configured Mistral sheet.
- Keeps `mistral` pinned to the standard Mistral endpoint at $0.15/M input, $0.015/M cached input, and $0.60/M output with OpenRouter fallback disabled.
- Preserves the canonical name, aliases, `paidOnly: true`, multiplier 1, capabilities, and no Pollinations fallback.
- Adds a resolver assertion for the complete endpoint exclusion list.

Verified against [OpenRouter's exact endpoint catalog](https://openrouter.ai/api/v1/models/mistralai/mistral-small-2603/endpoints) and direct/local E2E probes. Gen resolver tests, permissions tests, typecheck, cache/billing checks, all declared capabilities and aliases, and a fresh 5-request burst pass.
