### PR TITLE
feat: add Seedance 2.5 reference images

### DIFF
--- a/gen.pollinations.ai/src/image/handler.ts
+++ b/gen.pollinations.ai/src/image/handler.ts
@@ -528,7 +528,9 @@ export async function generateImageOrVideoResponse(
     c.var.track.setPricingInput({
         resolution: safeParams.resolution,
         quality: safeParams.quality,
-        hasImage: (safeParams.image?.length ?? 0) > 0,
+        hasImage:
+            (safeParams.image?.length ?? 0) > 0 ||
+            (safeParams.input_references?.length ?? 0) > 0,
         maxImageDimension: Math.max(
             pricingDimensions.width,
             pricingDimensions.height,

--- a/gen.pollinations.ai/src/image/models/seedance25VideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/seedance25VideoModel.ts
@@ -27,6 +27,7 @@ interface Seedance25Input {
     seed?: number;
     image?: string;
     last_frame_image?: string;
+    reference_images?: string[];
 }
 
 function resolveAspectRatio(safeParams: ImageParams): Seedance25AspectRatio {
@@ -71,9 +72,22 @@ export async function callSeedance25API(
     }
 
     const images = safeParams.image ?? [];
+    const referenceImages = safeParams.input_references ?? [];
     if (images.length > 2) {
         throw new HttpError(
             "Seedance 2.5 supports at most two images: image[0] as first frame and image[1] as last frame.",
+            400,
+        );
+    }
+    if (referenceImages.length > 30) {
+        throw new HttpError(
+            "Seedance 2.5 supports at most 30 reference images.",
+            400,
+        );
+    }
+    if (images.length > 0 && referenceImages.length > 0) {
+        throw new HttpError(
+            "Seedance 2.5 cannot combine reference images with first/last-frame images.",
             400,
         );
     }
@@ -90,6 +104,11 @@ export async function callSeedance25API(
     }
     if (images[0]) input.image = await toDataUri(images[0]);
     if (images[1]) input.last_frame_image = await toDataUri(images[1]);
+    if (referenceImages.length > 0) {
+        input.reference_images = await Promise.all(
+            referenceImages.map(toDataUri),
+        );
+    }
 
     let videoUrl: string;
     let actualDurationSeconds: number | undefined;

--- a/gen.pollinations.ai/src/image/params.ts
+++ b/gen.pollinations.ai/src/image/params.ts
@@ -1,5 +1,6 @@
 import { IMAGE_SERVICES, type ImageModelName } from "@shared/registry/image.ts";
 import type { ModelDefinition } from "@shared/registry/registry.ts";
+import { ImageInputReferenceSchema } from "@shared/schemas/openai.ts";
 import { z } from "zod";
 import { normalizeSeed, SENTINEL_SEED } from "@/util.ts";
 import { getDefaultSideLength } from "./models.js";
@@ -30,6 +31,30 @@ const sanitizedSideLength = z.preprocess((v) => {
     const parsed = Number.parseInt(v as string, 10);
     return Number.isInteger(parsed) ? parsed : undefined;
 }, z.int().optional());
+
+const httpImageUrl = z
+    .string()
+    .refine(
+        (url) => url.startsWith("http://") || url.startsWith("https://"),
+        "Reference images must use HTTP(S) URLs.",
+    );
+
+const inputReferences = z
+    .union([
+        z.string(),
+        z.array(z.string()),
+        z.array(ImageInputReferenceSchema),
+    ])
+    .transform((value) => {
+        if (typeof value === "string") {
+            return value.includes("|") ? value.split("|") : value.split(",");
+        }
+        return value.map((reference) =>
+            typeof reference === "string" ? reference : reference.image_url.url,
+        );
+    })
+    .pipe(z.array(httpImageUrl).max(30))
+    .optional();
 
 function adjustImageSizeForModel(
     model: ImageModelName,
@@ -71,6 +96,7 @@ export const ImageParamsSchema = z
                     : value.split(",");
             })
             .catch([]),
+        input_references: inputReferences,
         transparent: sanitizedBoolean.catch(false),
         reasoning: z
             .union([z.string(), z.boolean()])
@@ -152,6 +178,23 @@ export const ImageParamsSchema = z
                     code: z.ZodIssueCode.custom,
                     path: ["image"],
                     message: "minimax-h3 currently supports text input only.",
+                });
+            }
+        }
+        if ((data.input_references?.length ?? 0) > 0) {
+            if (data.model !== "seedance-2.5") {
+                ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: ["input_references"],
+                    message:
+                        "input_references is currently supported only by seedance-2.5.",
+                });
+            } else if (data.image.length > 0) {
+                ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: ["input_references"],
+                    message:
+                        "seedance-2.5 cannot combine input_references with first/last-frame images.",
                 });
             }
         }

--- a/gen.pollinations.ai/src/routes/images.ts
+++ b/gen.pollinations.ai/src/routes/images.ts
@@ -235,6 +235,9 @@ export const prepareOpenAIImageGeneration = createMiddleware<Env>(
         const body = c.req.valid("json" as never) as CreateImageRequest &
             Record<string, unknown>;
         const model = c.var.model.resolved;
+        const inputReferenceUrls = body.input_references?.map(
+            (reference) => reference.image_url.url,
+        );
 
         const resolved = resolveParams(body);
         const safePrompt = await applySafety(
@@ -253,6 +256,9 @@ export const prepareOpenAIImageGeneration = createMiddleware<Env>(
             model,
             ...resolved,
             ...collectPassthrough(body, ...CACHE_PARAMS),
+            ...(inputReferenceUrls?.length
+                ? { input_references: inputReferenceUrls }
+                : {}),
         })) {
             setUrlParam(imageUrl, name, value);
         }

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -843,6 +843,8 @@ export const proxyRoutes = new Hono<Env>()
                 "",
                 "You can pass reference images via the `image` parameter: `image[0]` is the start frame, and `image[1]` is the end frame for models with `end_frame` in `video_capabilities`.",
                 "",
+                "For models with `reference_images` in `video_capabilities`, use `input_references` for visual guidance without fixing the first or last frame.",
+                "",
                 "Browse all available models and their `video_capabilities` at [`/image/models`](https://gen.pollinations.ai/image/models).",
             ].join("\n"),
             responses: {

--- a/gen.pollinations.ai/src/schemas/image.ts
+++ b/gen.pollinations.ai/src/schemas/image.ts
@@ -86,6 +86,30 @@ const GenerateImageRequestQueryParamsBaseSchema = z.object({
             description:
                 "Reference image URL(s) for image editing or video generation. Separate multiple URLs with `|` or `,`. **Image models:** Used for editing/style reference (kontext, gptimage, seedream, klein, nanobanana). **Video models:** `image[0]` = starting frame (I2V); `image[1]` = ending frame for first+last-frame interpolation. End-frame supported by `veo`, the `seedance-2.0` family, `seedance-2.5`, `wan-fast`, and `wan-pro`; other video models silently drop `image[1]`. See `video_capabilities` on `/image/models` or `/models` for per-model support.",
         }),
+    input_references: z
+        .string()
+        .transform((value: string) =>
+            value.includes("|") ? value.split("|") : value.split(","),
+        )
+        .optional()
+        .refine(
+            (urls) =>
+                !urls ||
+                (urls.length <= 30 &&
+                    urls.every(
+                        (url) =>
+                            url.startsWith("http://") ||
+                            url.startsWith("https://"),
+                    )),
+            {
+                message:
+                    "input_references accepts up to 30 HTTP(S) image URLs.",
+            },
+        )
+        .meta({
+            description:
+                "Reference image URL(s) that guide supported video models without fixing the first or last frame. Separate multiple URLs with `|` or `,`. Cannot be combined with `image` frame controls.",
+        }),
     transparent: z.coerce.boolean().optional().default(false).meta({
         description:
             "Generate image with transparent background. Only supported by `gptimage` and `gptimage-large`.",

--- a/gen.pollinations.ai/test/image/params.test.ts
+++ b/gen.pollinations.ai/test/image/params.test.ts
@@ -103,6 +103,66 @@ describe("ImageParamsSchema", () => {
         ).toBe(false);
     });
 
+    it("normalizes Seedance 2.5 input references from both public surfaces", () => {
+        const urls = [
+            "https://media.pollinations.ai/reference-1.png",
+            "https://media.pollinations.ai/reference-2.png",
+        ];
+
+        expect(
+            ImageParamsSchema.parse({
+                model: "seedance-2.5",
+                input_references: urls.join("|"),
+            }).input_references,
+        ).toEqual(urls);
+        expect(
+            ImageParamsSchema.parse({
+                model: "seedance-2.5",
+                input_references: urls.map((url) => ({
+                    type: "image_url",
+                    image_url: { url },
+                })),
+            }).input_references,
+        ).toEqual(urls);
+    });
+
+    it("rejects unsupported or conflicting input references", () => {
+        const references = [
+            {
+                type: "image_url",
+                image_url: {
+                    url: "https://media.pollinations.ai/reference.png",
+                },
+            },
+        ];
+
+        expect(
+            ImageParamsSchema.safeParse({
+                model: "flux",
+                input_references: references,
+            }).success,
+        ).toBe(false);
+        expect(
+            ImageParamsSchema.safeParse({
+                model: "seedance-2.5",
+                image: "https://media.pollinations.ai/frame.png",
+                input_references: references,
+            }).success,
+        ).toBe(false);
+        expect(
+            CreateImageRequestSchema.safeParse({
+                model: "seedance-2.5",
+                prompt: "a paper boat",
+                input_references: Array.from({ length: 31 }, (_, index) => ({
+                    type: "image_url",
+                    image_url: {
+                        url: `https://media.pollinations.ai/reference-${index}.png`,
+                    },
+                })),
+            }).success,
+        ).toBe(false);
+    });
+
     it("rejects unsupported Grok Imagine Image 2.0 quality", () => {
         const result = ImageParamsSchema.safeParse({
             model: "grok-imagine-image-2.0",

--- a/gen.pollinations.ai/test/image/seedance25VideoModel.test.ts
+++ b/gen.pollinations.ai/test/image/seedance25VideoModel.test.ts
@@ -10,6 +10,11 @@ const IMAGE_URLS = [
     "https://image.example.com/start.png",
     "https://image.example.com/end.png",
 ];
+const REFERENCE_IMAGE_URLS = [
+    "https://media.pollinations.ai/reference-1.png",
+    "https://media.pollinations.ai/reference-2.png",
+    "https://media.pollinations.ai/reference-3.png",
+];
 const PNG_BYTES = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
 
 const baseParams: ImageParams = {
@@ -34,9 +39,10 @@ afterEach(() => {
 
 describe("Seedance 2.5 via Replicate", () => {
     it.each([
-        [undefined, "480p", undefined, "16:9"],
-        ["720p", "720p", "4:3", "4:3"],
-    ] as const)("routes resolution %s as %s with aspect ratio %s", async (resolution, expected, aspectRatio, expectedAspectRatio) => {
+        [undefined, "480p", undefined, "16:9", IMAGE_URLS, undefined],
+        ["720p", "720p", "4:3", "4:3", IMAGE_URLS, undefined],
+        ["480p", "480p", "16:9", "16:9", [], REFERENCE_IMAGE_URLS],
+    ] as const)("routes resolution %s as %s with aspect ratio %s", async (resolution, expected, aspectRatio, expectedAspectRatio, images, inputReferences) => {
         syncImageEnv(
             {
                 REPLICATE_API_TOKEN: "replicate-test-key",
@@ -46,7 +52,7 @@ describe("Seedance 2.5 via Replicate", () => {
         const inputs: Record<string, unknown>[] = [];
         vi.spyOn(globalThis, "fetch").mockImplementation(async (url, init) => {
             const href = typeof url === "string" ? url : url.toString();
-            if (IMAGE_URLS.includes(href)) {
+            if ([...IMAGE_URLS, ...REFERENCE_IMAGE_URLS].includes(href)) {
                 return new Response(PNG_BYTES, {
                     headers: { "Content-Type": "image/png" },
                 });
@@ -81,8 +87,24 @@ describe("Seedance 2.5 via Replicate", () => {
             ...baseParams,
             resolution,
             aspectRatio,
+            image: [...images],
+            input_references: inputReferences
+                ? [...inputReferences]
+                : undefined,
         });
 
+        const imageFields = inputReferences
+            ? {
+                  reference_images: inputReferences.map(() =>
+                      expect.stringMatching(/^data:image\/png;base64,/),
+                  ),
+              }
+            : {
+                  image: expect.stringMatching(/^data:image\/png;base64,/),
+                  last_frame_image: expect.stringMatching(
+                      /^data:image\/png;base64,/,
+                  ),
+              };
         expect(inputs).toEqual([
             {
                 prompt: "a paper boat",
@@ -91,10 +113,7 @@ describe("Seedance 2.5 via Replicate", () => {
                 aspect_ratio: expectedAspectRatio,
                 generate_audio: true,
                 seed: 42,
-                image: expect.stringMatching(/^data:image\/png;base64,/),
-                last_frame_image: expect.stringMatching(
-                    /^data:image\/png;base64,/,
-                ),
+                ...imageFields,
             },
         ]);
         expect(result).toMatchObject({
@@ -114,6 +133,18 @@ describe("Seedance 2.5 via Replicate", () => {
             callSeedance25API("a paper boat", {
                 ...baseParams,
                 duration: 5,
+            }),
+        ).rejects.toMatchObject({ status: 400 });
+        expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("rejects frame and reference images together before submitting", async () => {
+        const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+        await expect(
+            callSeedance25API("a paper boat", {
+                ...baseParams,
+                input_references: REFERENCE_IMAGE_URLS,
             }),
         ).rejects.toMatchObject({ status: 400 });
         expect(fetchSpy).not.toHaveBeenCalled();

--- a/gen.pollinations.ai/test/openai-image-cache.test.ts
+++ b/gen.pollinations.ai/test/openai-image-cache.test.ts
@@ -23,6 +23,45 @@ const testLog = {
 } as unknown as Logger;
 
 describe("OpenAI image cache", () => {
+    it("includes input reference URLs in the normalized media cache URL", async () => {
+        const references = [
+            "https://media.pollinations.ai/reference-1.png",
+            "https://media.pollinations.ai/reference-2.png",
+        ];
+        const app = new Hono<Env>()
+            .use("*", async (c, next) => {
+                c.set("model", {
+                    requested: "seedance-2.5",
+                    resolved: "seedance-2.5",
+                    definition: {} as Env["Variables"]["model"]["definition"],
+                });
+                c.req.addValidatedData("json", await c.req.json());
+                await next();
+            })
+            .post("/v1/images/generations", prepareOpenAIImageGeneration, (c) =>
+                c.json({ url: c.var.generationCacheUrl?.toString() }),
+            );
+
+        const response = await app.request("/v1/images/generations", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                prompt: "a paper boat",
+                model: "seedance-2.5",
+                input_references: references.map((url) => ({
+                    type: "image_url",
+                    image_url: { url },
+                })),
+            }),
+        });
+        const result = await response.json<{ url: string }>();
+        const cacheUrl = new URL(result.url);
+
+        expect(cacheUrl.searchParams.get("input_references")).toBe(
+            references.join("|"),
+        );
+    });
+
     it("serves objects cached before model metadata was stored", async () => {
         const bucket = createTestR2Bucket();
         const cacheUrl = new URL(

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -998,11 +998,16 @@ const IMAGE_BASE_SERVICES = {
         resolutions: ["480p", "720p"],
         title: "Seedance 2.5",
         description:
-            "Four-second video with synchronized audio and first/last-frame control at 480p or 720p",
+            "Four-second video with synchronized audio, first/last-frame control, or guidance from up to 30 reference images at 480p or 720p",
         inputModalities: ["text", "image"],
         outputModalities: ["video", "audio"],
-        videoCapabilities: ["start_frame", "end_frame", "audio_output"],
-        maxReferenceImages: 2, // Video keyframe slots: start + end.
+        videoCapabilities: [
+            "start_frame",
+            "end_frame",
+            "reference_images",
+            "audio_output",
+        ],
+        maxReferenceImages: 30, // Replicate reference_images route cap.
         minDuration: 4,
         maxDuration: 4,
         defaultDuration: 4,

--- a/shared/registry/registry.ts
+++ b/shared/registry/registry.ts
@@ -90,6 +90,7 @@ export type VideoCapability =
     | "start_frame"
     | "end_frame"
     | "keyframes"
+    | "reference_images"
     | "audio_output";
 
 export type BillingAdjustmentRule = {

--- a/shared/schemas/openai.ts
+++ b/shared/schemas/openai.ts
@@ -599,6 +599,15 @@ const imageResolutionField = z
             "Output resolution for resolution-priced image and video models (Pollinations extension)",
     });
 
+export const ImageInputReferenceSchema = z
+    .object({
+        type: z.literal("image_url"),
+        image_url: z.object({
+            url: z.string().url(),
+        }),
+    })
+    .strict();
+
 export const CreateImageRequestSchema = z
     .object({
         prompt: z.string().min(1).max(32000).meta({
@@ -625,6 +634,14 @@ export const CreateImageRequestSchema = z
             .meta({
                 description:
                     "Reference image URL(s) for image-to-image generation (Pollinations extension)",
+            }),
+        input_references: z
+            .array(ImageInputReferenceSchema)
+            .max(30)
+            .optional()
+            .meta({
+                description:
+                    "Reference images that guide supported video models without fixing the first or last frame (OpenRouter-compatible extension)",
             }),
         resolution: imageResolutionField,
         safe: SafeSchema,


### PR DESCRIPTION
- Adds OpenRouter-compatible input_references for up to 30 images on Seedance 2.5, while keeping image reserved for first/last-frame control.
- Exposes the capability through the existing image/video routes and public model metadata; no alias, provider, price, duration, resolution, fallback, or secret changes.
- Rejects unsupported models, more than 30 references, and references combined with frame images before provider submission.
- Direct 480p and local 720p/audio E2E passed. The 30-reference stress request completed once upstream in 329s, cached after client timeout, retried in 0.773s, and debited exactly 0.9248 Pollen once.
- Both workers type-check; formatting and 174 focused/catalog/pricing tests pass. Draft because the maximum stress case exceeded the documented 300s synchronous window.