### PR TITLE
fix: allow keyless retries for cached media generations

### DIFF
--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -1045,10 +1045,10 @@ export const proxyRoutes = new Hono<Env>()
         validator("json", CreateImageRequestSchema),
         resolveModel("generate.image"),
         track("generate.image"),
-        generationAccess,
         every(prepareOpenAIImageGeneration, formatOpenAIImageGeneration),
         prepareGenerationRequest,
         imageCache,
+        generationAccess,
         deduplicateGeneration,
         every(apiKeyBudgetReservation, handleImageGeneration),
     )

--- a/gen.pollinations.ai/test/index.test.ts
+++ b/gen.pollinations.ai/test/index.test.ts
@@ -845,6 +845,7 @@ fixtureTest(
         expect(generation.usage.total_tokens).toBe(1);
         await waitOnExecutionContext(generationContext);
 
+        // Completed media stays public when the caller retries without a key.
         const urlContext = createExecutionContext();
         const urlResponse = await worker.fetch(
             new Request(
@@ -852,7 +853,6 @@ fixtureTest(
                 {
                     method: "POST",
                     headers: {
-                        Authorization: `Bearer ${paidApiKey}`,
                         "Content-Type": "application/json",
                     },
                     body: JSON.stringify({


### PR DESCRIPTION
- Moves the `/v1/images/generations` cache lookup before generation access checks.
- Lets an identical keyless retry receive completed cached media after the original client disconnects.
- Keeps cache misses behind the existing authentication, permission, balance, deduplication, and billing path.
- Extends the existing full-route test to replay a cached POST without its original API key.

Tests: `npx vitest run test/index.test.ts`; `npx vitest run test/openai-image-cache.test.ts`; `npm run typecheck`