### PR TITLE
docs: clarify open quest selection

### DIFF
--- a/.github/ISSUE_TEMPLATE/quest.yml
+++ b/.github/ISSUE_TEMPLATE/quest.yml
@@ -10,10 +10,11 @@ body:
         Community quests are maintainer-owned tasks with a fixed Pollen reward earned after a linked PR is merged.
         Only maintainer-authored quest issues should receive the `POLLEN-QUEST` label. If a community member proposes a quest, a maintainer should create the final quest issue before labeling it.
 
-        1. Comment on this issue if you'd like to take it on — multiple devs can express interest
-        2. A maintainer picks one dev and assigns the issue to them — please wait until you're assigned before starting work
-        3. Once assigned, open a PR against `main` — **start the description with `Fixes #N`** so GitHub links it to this quest
-        4. After merge, open [enter.pollinations.ai](https://enter.pollinations.ai/quests), check quests, and claim the pending reward
+        1. Read the issue and submit a focused PR against `main`. Multiple contributors may submit solutions; no assignment is needed before starting.
+        2. **Start the PR description with `Fixes #N`** so GitHub links it to this quest.
+        3. Maintainers compare completed approaches and select the best one, preferring correctness, clarity, and minimal code.
+        4. The selected contributor is assigned before merge so the reward goes to the right person.
+        5. After merge, open [enter.pollinations.ai](https://enter.pollinations.ai/quests), check quests, and claim the pending reward.
 
         Need help? Drop a comment here or ask in [Discord #dev-talk](https://discord.com/channels/885844321461485618/920274483896516609).
     validations:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,8 @@ Before you start, please refer to the main `README.md` file of the `pollinations
 
 Look for issues that interest you and feel free to tackle them!
 
+Issues labeled `POLLEN-QUEST` are open to multiple solutions; you do not need to claim the issue or wait for assignment before starting. Link your PR with `Fixes #N`. Maintainers compare completed approaches and assign the selected contributor before merge so they can claim the stated reward.
+
 ### 2. Understand the Issue and Build an MVP
 
 Once you've selected an issue, take the time to thoroughly understand its requirements. For code contributions, focus on building a **Minimum Viable Product (MVP)** that addresses the core problem or implements the key feature described in the issue.

--- a/apps/polli/src/context/repo_info.txt
+++ b/apps/polli/src/context/repo_info.txt
@@ -29,7 +29,7 @@ Tool calling supported: openai (all), claude (all), gemini (non-search), deepsee
 
 Complete quests from the Quests dashboard at enter.pollinations.ai/quests → rewards land as Quest Pollen.
 - Lanes: onboarding, model usage, app growth, GitHub contributions
-- Contribute quests: comment on a POLLEN-QUEST GitHub issue to claim; fixed reward paid when merged
+- Contribute quests: multiple contributors may submit PRs; maintainers select and assign the best solution before merge; the selected contributor claims the fixed reward
 - In alpha — rewards and availability evolve
 - Quest Pollen spent BEFORE Paid Pollen | Paid-only models require Paid Pollen
 

--- a/enter.pollinations.ai/POLLEN_FAQ.md
+++ b/enter.pollinations.ai/POLLEN_FAQ.md
@@ -34,7 +34,7 @@ Quests reward eligible account activity and community contributions.
 
 - Browse the dashboard for current requirements, progress, and rewards.
 - Claim completed rewards from the dashboard; past qualifying activity may count.
-- Contribution quests are labeled GitHub issues with a stated reward. Get assigned, complete the issue, and claim after the work is merged.
+- Contribution quests are labeled GitHub issues with a stated reward. Multiple contributors may submit solutions without claiming the issue first. Maintainers select and assign the best completed approach before merge; the selected contributor can claim the reward afterward.
 
 Quest availability and reward amounts can change, so the dashboard and the linked issue are the source of truth.
 

--- a/enter.pollinations.ai/src/services/quests/groups/github-contributions.ts
+++ b/enter.pollinations.ai/src/services/quests/groups/github-contributions.ts
@@ -44,7 +44,7 @@ const solveGithubIssueQuest: QuestDefinition = {
     id: "solve_github_issue",
     title: "Solve a quest issue in GitHub",
     description:
-        "Pick an open POLLEN-QUEST issue, get assigned, and ship a PR. Claim your reward after merge.",
+        "Pick an open POLLEN-QUEST issue and submit a focused PR. Multiple contributors may submit; maintainers select and assign the best solution before merge.",
     category: CONTRIBUTION_CATEGORY,
     scope: "perUser",
     rewardAmount: 0,
@@ -210,10 +210,11 @@ async function loadQuestIssues(token: string): Promise<DerivedQuestIssue[]> {
 
 // State is a two-state BOARD concept: "available" = an open bounty
 // anyone can take; "completed" = off the open board. Only a genuinely open
-// issue (not completed, nobody assigned) is shown; the moment it's claimed
-// (someone's working it) or completed it leaves the board — it reappears only
-// for the user who earned it, via their reward (see the frontend). So both
-// claimed and completed map to "completed" (off-board).
+// issue (not completed, nobody assigned) is shown; the moment a maintainer
+// selects and assigns the winning contributor, or the issue is completed, it
+// leaves the board. It reappears only for the user who earned it, via their
+// reward (see the frontend). So selected and completed both map to "completed"
+// (off-board).
 function issueState(issue: DerivedQuestIssue): QuestState {
     const open = issue.state === "available" && issue.assigneeGithubId === null;
     return open ? "available" : "completed";

--- a/operations/social/prompts/brand/about.md
+++ b/operations/social/prompts/brand/about.md
@@ -34,5 +34,5 @@ Think: the tone of a well-written README, a CCC talk abstract, or a Phrack artic
 
 Earn Pollen by completing useful actions — onboarding, using models, growing an app, GitHub contributions.
 - complete a Quest, claim the reward, Pollen lands in your wallet
-- Contribute quests pay a fixed reward when your assigned GitHub issue is merged
+- Contribute quests may receive multiple PRs; maintainers select and assign the best solution before merge, then the selected contributor claims the fixed reward
 - in alpha — rewards and availability evolve


### PR DESCRIPTION
- Documents that multiple contributors may submit solutions without claiming a quest first.
- States that maintainers select and assign the best completed approach before merge.
- Aligns the quest template, contributor guide, dashboard/FAQ copy, Polli context, and social guidance.