### PR TITLE
feat: add 'View activity' link to community model cards

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
@@ -18,6 +18,7 @@ import {
     XIcon,
 } from "@pollinations/ui";
 import { communityEndpointPriceFieldsForModality } from "@shared/community-endpoints.ts";
+import { Link } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 import { PriceBadge, type PriceBadgeConfig } from "../models/price-badge.tsx";
 import type { PriceKind } from "../models/types.ts";

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
@@ -18,7 +18,6 @@ import {
     XIcon,
 } from "@pollinations/ui";
 import { communityEndpointPriceFieldsForModality } from "@shared/community-endpoints.ts";
-import { Link } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 import { PriceBadge, type PriceBadgeConfig } from "../models/price-badge.tsx";
 import type { PriceKind } from "../models/types.ts";
@@ -178,16 +177,12 @@ export function CommunityEndpointCard({
                     icon={<TokensIcon className="h-3.5 w-3.5" />}
                     label="Earnings"
                     value={
-                        <Link
-                            to="/activity"
-                            search={(prev) => ({
-                                ...prev,
-                                earningsModels: [endpoint.modelId],
-                            })}
+                        <a
+                            href={`/activity?earningsModels=${encodeURIComponent(endpoint.modelId)}`}
                             className="font-medium text-theme-text-soft underline underline-offset-2 transition-colors hover:text-theme-text-strong text-xs"
                         >
                             View activity
-                        </Link>
+                        </a>
                     }
                 />
             </div>

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
@@ -10,7 +10,6 @@ import {
     ExternalLinkIcon,
     GlobeIcon,
     IconButton,
-    InlineLink,
     LockIcon,
     PencilIcon,
     Surface,
@@ -179,14 +178,13 @@ export function CommunityEndpointCard({
                     icon={<TokensIcon className="h-3.5 w-3.5" />}
                     label="Earnings"
                     value={
-                        <InlineLink
-                            as={Link}
+                        <Link
                             to="/activity"
                             search={{ earningsModels: [endpoint.modelId] }}
-                            className="text-xs"
+                            className="font-medium text-theme-text-soft underline underline-offset-2 transition-colors hover:text-theme-text-strong text-xs"
                         >
                             View activity
-                        </InlineLink>
+                        </Link>
                     }
                 />
             </div>

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
@@ -180,7 +180,10 @@ export function CommunityEndpointCard({
                     value={
                         <Link
                             to="/activity"
-                            search={(prev) => ({ ...prev, earningsModels: [endpoint.modelId] })}
+                            search={(prev) => ({
+                                ...prev,
+                                earningsModels: [endpoint.modelId],
+                            })}
                             className="font-medium text-theme-text-soft underline underline-offset-2 transition-colors hover:text-theme-text-strong text-xs"
                         >
                             View activity

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
@@ -10,6 +10,7 @@ import {
     ExternalLinkIcon,
     GlobeIcon,
     IconButton,
+    InlineLink,
     LockIcon,
     PencilIcon,
     Surface,
@@ -174,6 +175,20 @@ export function CommunityEndpointCard({
                         value={<CommunityPriceBadges group={group} />}
                     />
                 ))}
+                <CommunityDetailRow
+                    icon={<TokensIcon className="h-3.5 w-3.5" />}
+                    label="Earnings"
+                    value={
+                        <InlineLink
+                            as={Link}
+                            to="/activity"
+                            search={{ earningsModels: [endpoint.modelId] }}
+                            className="text-xs"
+                        >
+                            View activity
+                        </InlineLink>
+                    }
+                />
             </div>
             <div className="mt-3">
                 <Link

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
@@ -180,7 +180,7 @@ export function CommunityEndpointCard({
                     value={
                         <Link
                             to="/activity"
-                            search={{ earningsModels: [endpoint.modelId] }}
+                            search={(prev) => ({ ...prev, earningsModels: [endpoint.modelId] })}
                             className="font-medium text-theme-text-soft underline underline-offset-2 transition-colors hover:text-theme-text-strong text-xs"
                         >
                             View activity


### PR DESCRIPTION
## Summary

Each community model card now shows an **Earnings** row with a "View activity" link that navigates to the Activity page with `earningsModels` filtered to that model's ID.

## Changes

- Added `InlineLink` import from `@pollinations/ui`
- Added `Link` import from `@tanstack/react-router`
- Added `CommunityDetailRow` with earnings link in `community-endpoint-card.tsx`

## How it works

1. User clicks "View activity" on any community model card
2. Navigates to `/activity?earningsModels=<modelId>`
3. Activity page already supports `earningsModels` search param
4. Earnings view is filtered to that specific model

## Testing

- Go to **My Models** → any community model card → see "Earnings" row with "View activity" link
- Click link → Activity page opens with earnings filtered to that model
- No new APIs, no new components, no changes to existing routing or earnings UI

Closes #13894