### PR TITLE
feat: show tool-calling model capability

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/model-icons.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-icons.tsx
@@ -11,6 +11,7 @@ import {
     ReasoningIcon,
     SearchIcon,
     SpeakerIcon,
+    ToolIcon,
     VideoIcon,
 } from "@pollinations/ui";
 import type { FC } from "react";
@@ -41,6 +42,7 @@ export const MODALITY_ICON: Record<InputModality, Icon> = {
 /** Capability glyphs (reasoning/web search/code execution). */
 export const CAPABILITY_ICON: Record<DisplayCapability, Icon> = {
     agent: BotIcon,
+    tool_calling: ToolIcon,
     reasoning: ReasoningIcon,
     web_search: SearchIcon,
     code_execution: CodeIcon,

--- a/enter.pollinations.ai/frontend/src/components/models/model-info.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-info.ts
@@ -84,6 +84,7 @@ export const getModelModalityLabel = (model: ModelPrice): string => {
 
 export type DisplayCapability =
     | "agent"
+    | "tool_calling"
     | "reasoning"
     | "web_search"
     | "code_execution";
@@ -94,6 +95,7 @@ export const getModelCapabilities = (
     const keys: DisplayCapability[] = [];
 
     if (model.agent) keys.push("agent");
+    if (hasToolCalling(model)) keys.push("tool_calling");
     if (hasReasoning(model)) keys.push("reasoning");
     if (hasSearch(model)) keys.push("web_search");
     if (hasCodeExecution(model)) keys.push("code_execution");
@@ -105,6 +107,7 @@ export const getModelCapabilityLabel = (model: ModelPrice): string => {
     const labels: string[] = [];
 
     if (model.agent) labels.push("Agent");
+    if (hasToolCalling(model)) labels.push("Tool calling");
     if (hasReasoning(model)) labels.push("Reasoning");
     if (hasSearch(model)) labels.push("Web search");
     if (hasCodeExecution(model)) labels.push("Code execution");
@@ -116,6 +119,9 @@ const hasCapability = (
     model: ModelPrice,
     capability: ModelCapability,
 ): boolean => model.capabilities.includes(capability);
+
+const hasToolCalling = (model: ModelPrice): boolean =>
+    hasCapability(model, "tool_calling");
 
 const hasReasoning = (model: ModelPrice): boolean =>
     hasCapability(model, "reasoning");

--- a/enter.pollinations.ai/test/pricing-data.test.ts
+++ b/enter.pollinations.ai/test/pricing-data.test.ts
@@ -34,6 +34,8 @@ import { getModelPricesFromCatalog } from "../frontend/src/components/models/mod
 import { getCommunityModelIcon } from "../frontend/src/components/models/model-icons.tsx";
 import {
     getModelBrandLogoPath,
+    getModelCapabilities,
+    getModelCapabilityLabel,
     hasPollinationsTools,
 } from "../frontend/src/components/models/model-info.ts";
 import { ModelRow } from "../frontend/src/components/models/model-row.tsx";
@@ -346,6 +348,21 @@ test("Pollinations tools are shown only for agents with the MCP capability", () 
     expect(
         renderToStaticMarkup(createElement(ModelRow, { model: toolsAgent })),
     ).toContain(">Tools</span>");
+});
+
+test("tool calling is shown through the shared model capability display", () => {
+    const model: ComponentProps<typeof ModelRow>["model"] = {
+        name: "example/tools-model",
+        type: "text",
+        capabilities: ["tool_calling"],
+        prices: [],
+    };
+
+    expect(getModelCapabilities(model)).toEqual(["tool_calling"]);
+    expect(getModelCapabilityLabel(model)).toBe("Tool calling");
+    expect(renderToStaticMarkup(createElement(ModelRow, { model }))).toContain(
+        'aria-label="Tool calling"',
+    );
 });
 
 test("cached modality adjustments remain visible without a matching base row", () => {

--- a/packages/ui/src/primitives/icons/index.tsx
+++ b/packages/ui/src/primitives/icons/index.tsx
@@ -280,6 +280,14 @@ export function TerminalIcon(props: IconProps) {
     );
 }
 
+export function ToolIcon(props: IconProps) {
+    return (
+        <svg aria-hidden="true" viewBox="0 0 24 24" {...strokeProps} {...props}>
+            <path d="M14.7 6.3a4 4 0 0 0-5-5l2.1 2.1-2.4 2.4-2.1-2.1a4 4 0 0 0 5 5l7.4 7.4a2 2 0 0 1-2.8 2.8l-7.4-7.4" />
+        </svg>
+    );
+}
+
 export function TargetIcon(props: IconProps) {
     return (
         <svg aria-hidden="true" viewBox="0 0 24 24" {...strokeProps} {...props}>


### PR DESCRIPTION
- Shows the existing `tool_calling` capability on shared desktop and mobile model cards
- Uses a generic tool icon without conflating it with Pollinations MCP tools
- Adds focused rendering coverage

Checks:
- `npx vitest run test/pricing-data.test.ts`
- `npm run typecheck --workspace pollinations-enter`
- `npm run build:frontend --workspace pollinations-enter`