### PR TITLE
docs: add community model naming guide

### DIFF
--- a/BRING_YOUR_OWN_MODEL.md
+++ b/BRING_YOUR_OWN_MODEL.md
@@ -43,6 +43,8 @@ Owners receive 75% of the Pollen spent on their models. Paid and Quest Pollen ea
 
 The upstream credential is used by Pollinations to proxy requests to your endpoint. Do not place it in a model name, description, public URL, or example.
 
+See the [Community Model Naming Guide](./COMMUNITY_MODEL_NAMING.md) for tips on choosing a stable model ID and clear display title.
+
 ## Register with the CLI
 
 The CLI manages text, image, and transcription model registrations. Sign in, test the endpoint, then create the model:

--- a/COMMUNITY_MODEL_NAMING.md
+++ b/COMMUNITY_MODEL_NAMING.md
@@ -1,0 +1,59 @@
+# Community Model Naming Guide
+
+Community models need three user-facing fields: a **stable ID**, a **display title**, and a **description**. This guide explains what each is for and how to pick good values.
+
+## Model ID
+
+The model ID is the permanent, public, human-readable identifier: `{username}/{model-id}`. It appears in API calls, URLs, and the catalog. Pick it once — it cannot change after registration.
+
+**Keep IDs stable.** Do not include mutable details such as:
+
+- Pricing or billing mode (`free`, `cheap`, `pay-per-token`)
+- Provider routing or upstream vendor names
+- Context window size, latency, or throughput
+- Version numbers that change frequently
+
+**Good patterns:** `my-fast-coder`, `story-writer-v2`, `image-enhancer`, `multimodal-lab`
+
+**Avoid:** `free-gpt-4-turbo-128k`, `replicate-flux-fast`, `openrouter-cheap`, `gpt-4o-2024-08-06`
+
+Custom creative names are welcome — the ID just needs to be stable and unambiguous.
+
+## Display Title
+
+The title is the friendly name shown in the model catalog. It can change freely after registration. Use it to communicate what the model does in plain language.
+
+**Examples:**
+
+| Model type | ID | Title |
+|---|---|---|
+| Direct upstream | `acme-corp/flash-chat` | Acme Flash Chat |
+| Custom fine-tune | `data scientist/code-llama-70b` | Data Scientist Code Llama 70b |
+| Router / fallback | `team-alpha/model-router` | Team Alpha Multi-Model Router |
+| Rebranded upstream | `my-org/summarizer` | MyOrg Summarizer (based on BART-large) |
+
+## Description
+
+The description is a short, optional one-liner about what the model is good at. For routers and rebranded models, clearly state what the model is or what it routes to. Be transparent about provenance.
+
+**Examples:**
+
+| ID | Description |
+|---|---|
+| `acme-corp/flash-chat` | Low-latency chat model for customer support |
+| `data scientist/code-llama-70b` | Code Llama 70b fine-tuned for Python and TypeScript |
+| `team-alpha/model-router` | Routes to the cheapest available chat model per request |
+| `my-org/summarizer` | BART-large fine-tuned for meeting summaries |
+
+## Quick Reference
+
+| Field | Purpose | Can change? | Include? |
+|---|---|---|---|
+| **Model ID** | Permanent API identifier | No | Yes (required) |
+| **Title** | Friendly catalog name | Yes | Yes (required) |
+| **Description** | One-liner about capabilities | Yes | Optional |
+
+## See Also
+
+- [Publish a Model](./BRING_YOUR_OWN_MODEL.md) — full registration and pricing guide
+- [Community Models API](https://gen.pollinations.ai/docs#tag/community-models) — API reference

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
@@ -18,6 +18,7 @@ import {
     XIcon,
 } from "@pollinations/ui";
 import { communityEndpointPriceFieldsForModality } from "@shared/community-endpoints.ts";
+import { Link } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 import { PriceBadge, type PriceBadgeConfig } from "../models/price-badge.tsx";
 import type { PriceKind } from "../models/types.ts";

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
@@ -18,7 +18,6 @@ import {
     XIcon,
 } from "@pollinations/ui";
 import { communityEndpointPriceFieldsForModality } from "@shared/community-endpoints.ts";
-import { Link } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 import { PriceBadge, type PriceBadgeConfig } from "../models/price-badge.tsx";
 import type { PriceKind } from "../models/types.ts";
@@ -178,16 +177,12 @@ export function CommunityEndpointCard({
                     icon={<TokensIcon className="h-3.5 w-3.5" />}
                     label="Earnings"
                     value={
-                        <Link
-                            to="/activity"
-                            search={(prev) => ({
-                                ...prev,
-                                earningsModels: [endpoint.modelId],
-                            })}
+                        <a
+                            href={`/activity?earningsModels=${encodeURIComponent(endpoint.modelId)}`}
                             className="font-medium text-theme-text-soft underline underline-offset-2 transition-colors hover:text-theme-text-strong text-xs"
                         >
                             View activity
-                        </Link>
+                        </a>
                     }
                 />
             </div>

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
@@ -10,7 +10,6 @@ import {
     ExternalLinkIcon,
     GlobeIcon,
     IconButton,
-    InlineLink,
     LockIcon,
     PencilIcon,
     Surface,
@@ -179,14 +178,13 @@ export function CommunityEndpointCard({
                     icon={<TokensIcon className="h-3.5 w-3.5" />}
                     label="Earnings"
                     value={
-                        <InlineLink
-                            as={Link}
+                        <Link
                             to="/activity"
                             search={{ earningsModels: [endpoint.modelId] }}
-                            className="text-xs"
+                            className="font-medium text-theme-text-soft underline underline-offset-2 transition-colors hover:text-theme-text-strong text-xs"
                         >
                             View activity
-                        </InlineLink>
+                        </Link>
                     }
                 />
             </div>

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
@@ -180,7 +180,10 @@ export function CommunityEndpointCard({
                     value={
                         <Link
                             to="/activity"
-                            search={(prev) => ({ ...prev, earningsModels: [endpoint.modelId] })}
+                            search={(prev) => ({
+                                ...prev,
+                                earningsModels: [endpoint.modelId],
+                            })}
                             className="font-medium text-theme-text-soft underline underline-offset-2 transition-colors hover:text-theme-text-strong text-xs"
                         >
                             View activity

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
@@ -10,6 +10,7 @@ import {
     ExternalLinkIcon,
     GlobeIcon,
     IconButton,
+    InlineLink,
     LockIcon,
     PencilIcon,
     Surface,
@@ -174,6 +175,20 @@ export function CommunityEndpointCard({
                         value={<CommunityPriceBadges group={group} />}
                     />
                 ))}
+                <CommunityDetailRow
+                    icon={<TokensIcon className="h-3.5 w-3.5" />}
+                    label="Earnings"
+                    value={
+                        <InlineLink
+                            as={Link}
+                            to="/activity"
+                            search={{ earningsModels: [endpoint.modelId] }}
+                            className="text-xs"
+                        >
+                            View activity
+                        </InlineLink>
+                    }
+                />
             </div>
             <div className="mt-3">
                 <Link

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
@@ -180,7 +180,7 @@ export function CommunityEndpointCard({
                     value={
                         <Link
                             to="/activity"
-                            search={{ earningsModels: [endpoint.modelId] }}
+                            search={(prev) => ({ ...prev, earningsModels: [endpoint.modelId] })}
                             className="font-medium text-theme-text-soft underline underline-offset-2 transition-colors hover:text-theme-text-strong text-xs"
                         >
                             View activity

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-dialog.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-dialog.tsx
@@ -10,6 +10,7 @@ import {
     DropdownItem,
     EditableCombobox,
     FieldStack,
+    InlineLink,
     Input,
     ScrollArea,
     TabButton,
@@ -381,7 +382,15 @@ export function CommunityEndpointDialog({
                             <code>
                                 {"{username}"}/{"{model-id}"}
                             </code>{" "}
-                            model.
+                            model. See the{" "}
+                            <InlineLink
+                                href="https://github.com/pollinations/pollinations/blob/main/COMMUNITY_MODEL_NAMING.md"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                naming guide
+                            </InlineLink>{" "}
+                            for tips on choosing a stable ID and clear title.
                         </>
                     )}
                 </p>

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/model-listing-fields.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/model-listing-fields.tsx
@@ -2,6 +2,7 @@ import {
     ButtonGroup,
     CheckIcon,
     FieldStack,
+    InlineLink,
     Input,
     TabButton,
 } from "@pollinations/ui";
@@ -114,9 +115,23 @@ export function ModelListingFields({
                 <FieldStack
                     label={isAgent ? "ID" : "Model ID"}
                     helper={
-                        isAgent
-                            ? "Public ID: {username}/{id}."
-                            : "Public ID: {username}/{model-id}."
+                        isAgent ? (
+                            "Public ID: {username}/{id}."
+                        ) : (
+                            <>
+                                Public ID: {"{username}"}/{"{model-id}"}. See
+                                the{" "}
+                                <InlineLink
+                                    href="https://github.com/pollinations/pollinations/blob/main/COMMUNITY_MODEL_NAMING.md"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-xs"
+                                >
+                                    naming guide
+                                </InlineLink>{" "}
+                                for tips.
+                            </>
+                        )
                     }
                     alignLabelRow
                 >


### PR DESCRIPTION
## Summary

Add a concise Markdown guide for community-model naming, explaining the roles of the stable model ID, display title, and transparent description.

## Changes

- **New file:** `COMMUNITY_MODEL_NAMING.md` — concise naming guide with examples for direct upstream models, custom models, routers, and rebranded models
- **Link from UI:** Add/Edit Model dialog description and Model ID helper in `model-listing-fields.tsx`
- **Link from docs:** "Register in the Dashboard" section of `BRING_YOUR_OWN_MODEL.md`

## What the guide covers

| Field | Purpose | Can change? |
|---|---|---|
| **Model ID** | Permanent API identifier (`{username}/{model-id}`) | No |
| **Title** | Friendly catalog name | Yes |
| **Description** | One-liner about capabilities | Yes |

IDs should avoid mutable details like pricing, provider routing, and context size. Custom names are welcome when the description is transparent.

Closes #12885