### PR TITLE
feat: add quest leaderboard to community page

### DIFF
--- a/BRING_YOUR_OWN_MODEL.md
+++ b/BRING_YOUR_OWN_MODEL.md
@@ -43,6 +43,8 @@ Owners receive 75% of the Pollen spent on their models. Paid and Quest Pollen ea
 
 The upstream credential is used by Pollinations to proxy requests to your endpoint. Do not place it in a model name, description, public URL, or example.
 
+See the [Community Model Naming Guide](./COMMUNITY_MODEL_NAMING.md) for tips on choosing a stable model ID and clear display title.
+
 ## Register with the CLI
 
 The CLI manages text, image, and transcription model registrations. Sign in, test the endpoint, then create the model:

--- a/COMMUNITY_MODEL_NAMING.md
+++ b/COMMUNITY_MODEL_NAMING.md
@@ -1,0 +1,59 @@
+# Community Model Naming Guide
+
+Community models need three user-facing fields: a **stable ID**, a **display title**, and a **description**. This guide explains what each is for and how to pick good values.
+
+## Model ID
+
+The model ID is the permanent, public, human-readable identifier: `{username}/{model-id}`. It appears in API calls, URLs, and the catalog. Pick it once — it cannot change after registration.
+
+**Keep IDs stable.** Do not include mutable details such as:
+
+- Pricing or billing mode (`free`, `cheap`, `pay-per-token`)
+- Provider routing or upstream vendor names
+- Context window size, latency, or throughput
+- Version numbers that change frequently
+
+**Good patterns:** `my-fast-coder`, `story-writer-v2`, `image-enhancer`, `multimodal-lab`
+
+**Avoid:** `free-gpt-4-turbo-128k`, `replicate-flux-fast`, `openrouter-cheap`, `gpt-4o-2024-08-06`
+
+Custom creative names are welcome — the ID just needs to be stable and unambiguous.
+
+## Display Title
+
+The title is the friendly name shown in the model catalog. It can change freely after registration. Use it to communicate what the model does in plain language.
+
+**Examples:**
+
+| Model type | ID | Title |
+|---|---|---|
+| Direct upstream | `acme-corp/flash-chat` | Acme Flash Chat |
+| Custom fine-tune | `data scientist/code-llama-70b` | Data Scientist Code Llama 70b |
+| Router / fallback | `team-alpha/model-router` | Team Alpha Multi-Model Router |
+| Rebranded upstream | `my-org/summarizer` | MyOrg Summarizer (based on BART-large) |
+
+## Description
+
+The description is a short, optional one-liner about what the model is good at. For routers and rebranded models, clearly state what the model is or what it routes to. Be transparent about provenance.
+
+**Examples:**
+
+| ID | Description |
+|---|---|
+| `acme-corp/flash-chat` | Low-latency chat model for customer support |
+| `data scientist/code-llama-70b` | Code Llama 70b fine-tuned for Python and TypeScript |
+| `team-alpha/model-router` | Routes to the cheapest available chat model per request |
+| `my-org/summarizer` | BART-large fine-tuned for meeting summaries |
+
+## Quick Reference
+
+| Field | Purpose | Can change? | Include? |
+|---|---|---|---|
+| **Model ID** | Permanent API identifier | No | Yes (required) |
+| **Title** | Friendly catalog name | Yes | Yes (required) |
+| **Description** | One-liner about capabilities | Yes | Optional |
+
+## See Also
+
+- [Publish a Model](./BRING_YOUR_OWN_MODEL.md) — full registration and pricing guide
+- [Community Models API](https://gen.pollinations.ai/docs#tag/community-models) — API reference

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
@@ -18,6 +18,7 @@ import {
     XIcon,
 } from "@pollinations/ui";
 import { communityEndpointPriceFieldsForModality } from "@shared/community-endpoints.ts";
+import { Link } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 import { PriceBadge, type PriceBadgeConfig } from "../models/price-badge.tsx";
 import type { PriceKind } from "../models/types.ts";

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
@@ -18,7 +18,6 @@ import {
     XIcon,
 } from "@pollinations/ui";
 import { communityEndpointPriceFieldsForModality } from "@shared/community-endpoints.ts";
-import { Link } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 import { PriceBadge, type PriceBadgeConfig } from "../models/price-badge.tsx";
 import type { PriceKind } from "../models/types.ts";
@@ -178,16 +177,12 @@ export function CommunityEndpointCard({
                     icon={<TokensIcon className="h-3.5 w-3.5" />}
                     label="Earnings"
                     value={
-                        <Link
-                            to="/activity"
-                            search={(prev) => ({
-                                ...prev,
-                                earningsModels: [endpoint.modelId],
-                            })}
+                        <a
+                            href={`/activity?earningsModels=${encodeURIComponent(endpoint.modelId)}`}
                             className="font-medium text-theme-text-soft underline underline-offset-2 transition-colors hover:text-theme-text-strong text-xs"
                         >
                             View activity
-                        </Link>
+                        </a>
                     }
                 />
             </div>

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
@@ -10,7 +10,6 @@ import {
     ExternalLinkIcon,
     GlobeIcon,
     IconButton,
-    InlineLink,
     LockIcon,
     PencilIcon,
     Surface,
@@ -179,14 +178,13 @@ export function CommunityEndpointCard({
                     icon={<TokensIcon className="h-3.5 w-3.5" />}
                     label="Earnings"
                     value={
-                        <InlineLink
-                            as={Link}
+                        <Link
                             to="/activity"
                             search={{ earningsModels: [endpoint.modelId] }}
-                            className="text-xs"
+                            className="font-medium text-theme-text-soft underline underline-offset-2 transition-colors hover:text-theme-text-strong text-xs"
                         >
                             View activity
-                        </InlineLink>
+                        </Link>
                     }
                 />
             </div>

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
@@ -180,7 +180,10 @@ export function CommunityEndpointCard({
                     value={
                         <Link
                             to="/activity"
-                            search={(prev) => ({ ...prev, earningsModels: [endpoint.modelId] })}
+                            search={(prev) => ({
+                                ...prev,
+                                earningsModels: [endpoint.modelId],
+                            })}
                             className="font-medium text-theme-text-soft underline underline-offset-2 transition-colors hover:text-theme-text-strong text-xs"
                         >
                             View activity

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
@@ -10,6 +10,7 @@ import {
     ExternalLinkIcon,
     GlobeIcon,
     IconButton,
+    InlineLink,
     LockIcon,
     PencilIcon,
     Surface,
@@ -174,6 +175,20 @@ export function CommunityEndpointCard({
                         value={<CommunityPriceBadges group={group} />}
                     />
                 ))}
+                <CommunityDetailRow
+                    icon={<TokensIcon className="h-3.5 w-3.5" />}
+                    label="Earnings"
+                    value={
+                        <InlineLink
+                            as={Link}
+                            to="/activity"
+                            search={{ earningsModels: [endpoint.modelId] }}
+                            className="text-xs"
+                        >
+                            View activity
+                        </InlineLink>
+                    }
+                />
             </div>
             <div className="mt-3">
                 <Link

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
@@ -180,7 +180,7 @@ export function CommunityEndpointCard({
                     value={
                         <Link
                             to="/activity"
-                            search={{ earningsModels: [endpoint.modelId] }}
+                            search={(prev) => ({ ...prev, earningsModels: [endpoint.modelId] })}
                             className="font-medium text-theme-text-soft underline underline-offset-2 transition-colors hover:text-theme-text-strong text-xs"
                         >
                             View activity

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-dialog.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-dialog.tsx
@@ -10,6 +10,7 @@ import {
     DropdownItem,
     EditableCombobox,
     FieldStack,
+    InlineLink,
     Input,
     ScrollArea,
     TabButton,
@@ -381,7 +382,15 @@ export function CommunityEndpointDialog({
                             <code>
                                 {"{username}"}/{"{model-id}"}
                             </code>{" "}
-                            model.
+                            model. See the{" "}
+                            <InlineLink
+                                href="https://github.com/pollinations/pollinations/blob/main/COMMUNITY_MODEL_NAMING.md"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                naming guide
+                            </InlineLink>{" "}
+                            for tips on choosing a stable ID and clear title.
                         </>
                     )}
                 </p>

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/model-listing-fields.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/model-listing-fields.tsx
@@ -2,6 +2,7 @@ import {
     ButtonGroup,
     CheckIcon,
     FieldStack,
+    InlineLink,
     Input,
     TabButton,
 } from "@pollinations/ui";
@@ -114,9 +115,23 @@ export function ModelListingFields({
                 <FieldStack
                     label={isAgent ? "ID" : "Model ID"}
                     helper={
-                        isAgent
-                            ? "Public ID: {username}/{id}."
-                            : "Public ID: {username}/{model-id}."
+                        isAgent ? (
+                            "Public ID: {username}/{id}."
+                        ) : (
+                            <>
+                                Public ID: {"{username}"}/{"{model-id}"}. See
+                                the{" "}
+                                <InlineLink
+                                    href="https://github.com/pollinations/pollinations/blob/main/COMMUNITY_MODEL_NAMING.md"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-xs"
+                                >
+                                    naming guide
+                                </InlineLink>{" "}
+                                for tips.
+                            </>
+                        )
                     }
                     alignLabelRow
                 >

--- a/enter.pollinations.ai/src/routes/quests.ts
+++ b/enter.pollinations.ai/src/routes/quests.ts
@@ -297,70 +297,6 @@ export const questsRoutes = new Hono<Env>()
                 },
             });
         },
-    )
-    .get(
-        "/leaderboard",
-        describeRoute({
-            tags: ["✨ Quests"],
-            summary: "Quest Leaderboard",
-            security: [],
-            description:
-                "Public aggregate of quest completions ranked by total Quest Pollen earned. Only GitHub identity and aggregate totals are exposed.",
-            responses: {
-                200: {
-                    description: "Quest leaderboard",
-                    content: {
-                        "application/json": {
-                            schema: resolver(leaderboardResponseSchema),
-                        },
-                    },
-                },
-            },
-        }),
-        async (c) => {
-            const kvKey = "quests:leaderboard:v1";
-            const cached = await c.env.KV.get<
-                z.infer<typeof leaderboardResponseSchema>
-            >(kvKey, "json");
-            if (cached) return c.json(cached);
-
-            const db = drizzle(c.env.DB);
-            const rows = await db
-                .select({
-                    githubUsername: schema.user.githubUsername,
-                    githubId: schema.user.githubId,
-                    questCount: sql<number>`count(*)`.as("quest_count"),
-                    totalPollen:
-                        sql<number>`round(sum(${rewardsTable.pollenAmount}), 2)`.as(
-                            "total_pollen",
-                        ),
-                })
-                .from(rewardsTable)
-                .innerJoin(schema.user, eq(rewardsTable.userId, schema.user.id))
-                .where(isNotNull(rewardsTable.questId))
-                .groupBy(
-                    schema.user.id,
-                    schema.user.githubUsername,
-                    schema.user.githubId,
-                )
-                .orderBy(sql`total_pollen desc`)
-                .limit(50);
-
-            const entries = rows
-                .filter((r) => r.githubUsername !== null && r.githubId !== null)
-                .map((r) => ({
-                    githubUsername: r.githubUsername!,
-                    githubId: r.githubId!,
-                    questCount: r.questCount,
-                    totalPollen: r.totalPollen,
-                }));
-
-            const result = { entries };
-            await c.env.KV.put(kvKey, JSON.stringify(result), {
-                expirationTtl: 300,
-            });
-            return c.json(result);
-        },
     );
 
 const leaderboardEntrySchema = z.object({
@@ -373,6 +309,71 @@ const leaderboardEntrySchema = z.object({
 const leaderboardResponseSchema = z.object({
     entries: z.array(leaderboardEntrySchema),
 });
+
+questsRoutes.get(
+    "/leaderboard",
+    describeRoute({
+        tags: ["✨ Quests"],
+        summary: "Quest Leaderboard",
+        security: [],
+        description:
+            "Public aggregate of quest completions ranked by total Quest Pollen earned. Only GitHub identity and aggregate totals are exposed.",
+        responses: {
+            200: {
+                description: "Quest leaderboard",
+                content: {
+                    "application/json": {
+                        schema: resolver(leaderboardResponseSchema),
+                    },
+                },
+            },
+        },
+    }),
+    async (c) => {
+        const kvKey = "quests:leaderboard:v1";
+        const cached = await c.env.KV.get<
+            z.infer<typeof leaderboardResponseSchema>
+        >(kvKey, "json");
+        if (cached) return c.json(cached);
+
+        const db = drizzle(c.env.DB);
+        const rows = await db
+            .select({
+                githubUsername: schema.user.githubUsername,
+                githubId: schema.user.githubId,
+                questCount: sql<number>`count(*)`.as("quest_count"),
+                totalPollen:
+                    sql<number>`round(sum(${rewardsTable.pollenAmount}), 2)`.as(
+                        "total_pollen",
+                    ),
+            })
+            .from(rewardsTable)
+            .innerJoin(schema.user, eq(rewardsTable.userId, schema.user.id))
+            .where(isNotNull(rewardsTable.questId))
+            .groupBy(
+                schema.user.id,
+                schema.user.githubUsername,
+                schema.user.githubId,
+            )
+            .orderBy(sql`total_pollen desc`)
+            .limit(50);
+
+        const entries = rows
+            .filter((r) => r.githubUsername !== null && r.githubId !== null)
+            .map((r) => ({
+                githubUsername: r.githubUsername!,
+                githubId: r.githubId!,
+                questCount: r.questCount,
+                totalPollen: r.totalPollen,
+            }));
+
+        const result = { entries };
+        await c.env.KV.put(kvKey, JSON.stringify(result), {
+            expirationTtl: 300,
+        });
+        return c.json(result);
+    },
+);
 
 async function readCached(
     kv: KVNamespace,

--- a/enter.pollinations.ai/src/routes/quests.ts
+++ b/enter.pollinations.ai/src/routes/quests.ts
@@ -1,7 +1,7 @@
 import { claimReward } from "@shared/billing/rewards.ts";
 import * as schema from "@shared/db/better-auth.ts";
 import { rewards as rewardsTable } from "@shared/db/better-auth.ts";
-import { desc, eq } from "drizzle-orm";
+import { desc, eq, isNotNull, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
@@ -297,7 +297,82 @@ export const questsRoutes = new Hono<Env>()
                 },
             });
         },
+    )
+    .get(
+        "/leaderboard",
+        describeRoute({
+            tags: ["✨ Quests"],
+            summary: "Quest Leaderboard",
+            security: [],
+            description:
+                "Public aggregate of quest completions ranked by total Quest Pollen earned. Only GitHub identity and aggregate totals are exposed.",
+            responses: {
+                200: {
+                    description: "Quest leaderboard",
+                    content: {
+                        "application/json": {
+                            schema: resolver(leaderboardResponseSchema),
+                        },
+                    },
+                },
+            },
+        }),
+        async (c) => {
+            const kvKey = "quests:leaderboard:v1";
+            const cached = await c.env.KV.get<
+                z.infer<typeof leaderboardResponseSchema>
+            >(kvKey, "json");
+            if (cached) return c.json(cached);
+
+            const db = drizzle(c.env.DB);
+            const rows = await db
+                .select({
+                    githubUsername: schema.user.githubUsername,
+                    githubId: schema.user.githubId,
+                    questCount: sql<number>`count(*)`.as("quest_count"),
+                    totalPollen:
+                        sql<number>`round(sum(${rewardsTable.pollenAmount}), 2)`.as(
+                            "total_pollen",
+                        ),
+                })
+                .from(rewardsTable)
+                .innerJoin(schema.user, eq(rewardsTable.userId, schema.user.id))
+                .where(isNotNull(rewardsTable.questId))
+                .groupBy(
+                    schema.user.id,
+                    schema.user.githubUsername,
+                    schema.user.githubId,
+                )
+                .orderBy(sql`total_pollen desc`)
+                .limit(50);
+
+            const entries = rows
+                .filter((r) => r.githubUsername !== null && r.githubId !== null)
+                .map((r) => ({
+                    githubUsername: r.githubUsername!,
+                    githubId: r.githubId!,
+                    questCount: r.questCount,
+                    totalPollen: r.totalPollen,
+                }));
+
+            const result = { entries };
+            await c.env.KV.put(kvKey, JSON.stringify(result), {
+                expirationTtl: 300,
+            });
+            return c.json(result);
+        },
     );
+
+const leaderboardEntrySchema = z.object({
+    githubUsername: z.string(),
+    githubId: z.number(),
+    questCount: z.number(),
+    totalPollen: z.number(),
+});
+
+const leaderboardResponseSchema = z.object({
+    entries: z.array(leaderboardEntrySchema),
+});
 
 async function readCached(
     kv: KVNamespace,

--- a/enter.pollinations.ai/test/quest-leaderboard.test.ts
+++ b/enter.pollinations.ai/test/quest-leaderboard.test.ts
@@ -5,154 +5,121 @@ import { drizzle } from "drizzle-orm/d1";
 import { expect } from "vitest";
 import { test } from "./fixtures.ts";
 
-test.describe("GET /api/quests/leaderboard", () => {
-    test("returns empty entries when no quest rewards exist", async ({
-        sessionToken,
-    }) => {
-        const res = await SELF.fetch(
-            "http://localhost:3000/api/quests/leaderboard",
-        );
-        expect(res.status).toBe(200);
-        const body = (await res.json()) as { entries: unknown[] };
-        expect(body.entries).toEqual([]);
+test("leaderboard returns empty entries when no quest rewards exist", async () => {
+    const res = await SELF.fetch(
+        "http://localhost:3000/api/quests/leaderboard",
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { entries: unknown[] };
+    expect(body.entries).toEqual([]);
+});
+
+test("leaderboard aggregates quest rewards by user", async () => {
+    const db = drizzle(env.DB);
+
+    // Create a second user with GitHub identity
+    const user2Id = "user-leaderboard-2";
+    await db.insert(userTable).values({
+        id: user2Id,
+        name: "Leaderboard User 2",
+        email: "leaderboard2@test.example.com",
+        emailVerified: true,
+        githubId: 999002,
+        githubUsername: "leaderboard-tester-2",
     });
 
-    test("aggregates quest rewards by user", async ({ sessionToken }) => {
-        const db = drizzle(env.DB);
+    // Record quest rewards for user2
+    await recordRewards(db, [
+        {
+            idempotencyKey: "quest:leaderboard-alpha:github:999002",
+            userId: user2Id,
+            amount: 10,
+            bucket: "tier",
+            questId: "quest_alpha",
+            title: "Quest Alpha",
+        },
+    ]);
 
-        // Create a second user with GitHub identity
-        const user2Id = "user-leaderboard-2";
-        await db.insert(userTable).values({
-            id: user2Id,
-            name: "Leaderboard User 2",
-            email: "leaderboard2@test.example.com",
-            emailVerified: true,
-            githubId: 999002,
-            githubUsername: "leaderboard-tester-2",
-        });
+    const res = await SELF.fetch(
+        "http://localhost:3000/api/quests/leaderboard",
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+        entries: Array<{
+            githubUsername: string;
+            githubId: number;
+            questCount: number;
+            totalPollen: number;
+        }>;
+    };
 
-        // Record quest rewards for the session user and user2
-        await recordRewards(db, [
-            {
-                idempotencyKey: "quest:leaderboard-test-1:github:100001",
-                userId: "user-leaderboard", // session user
-                amount: 5,
-                bucket: "tier",
-                questId: "quest_alpha",
-                title: "Quest Alpha",
-            },
-            {
-                idempotencyKey: "quest:leaderboard-test-2:github:100001",
-                userId: "user-leaderboard",
-                amount: 3,
-                bucket: "tier",
-                questId: "quest_beta",
-                title: "Quest Beta",
-            },
-            {
-                idempotencyKey: "quest:leaderboard-test-3:github:999002",
-                userId: user2Id,
-                amount: 10,
-                bucket: "tier",
-                questId: "quest_alpha",
-                title: "Quest Alpha",
-            },
-        ]);
+    // user2 should be in the leaderboard
+    const entry = body.entries.find(
+        (e) => e.githubUsername === "leaderboard-tester-2",
+    );
+    expect(entry).toBeDefined();
+    expect(entry!.githubId).toBe(999002);
+    expect(entry!.questCount).toBe(1);
+    expect(entry!.totalPollen).toBe(10);
+});
 
-        const res = await SELF.fetch(
-            "http://localhost:3000/api/quests/leaderboard",
-        );
-        expect(res.status).toBe(200);
-        const body = (await res.json()) as {
-            entries: Array<{
-                githubUsername: string;
-                githubId: number;
-                questCount: number;
-                totalPollen: number;
-            }>;
-        };
+test("leaderboard excludes users without GitHub identity", async () => {
+    const db = drizzle(env.DB);
 
-        // Should have 2 entries
-        expect(body.entries.length).toBe(2);
-
-        // First entry should be user2 (higher total)
-        const top = body.entries[0]!;
-        expect(top.githubUsername).toBe("leaderboard-tester-2");
-        expect(top.githubId).toBe(999002);
-        expect(top.questCount).toBe(1);
-        expect(top.totalPollen).toBe(10);
-
-        // Second entry should be session user
-        const second = body.entries[1]!;
-        expect(second.questCount).toBe(2);
-        expect(second.totalPollen).toBe(8);
+    // Create a user without GitHub identity
+    const noGithubUserId = "user-no-github-lb";
+    await db.insert(userTable).values({
+        id: noGithubUserId,
+        name: "No GitHub User LB",
+        email: "nogithublb@test.example.com",
+        emailVerified: true,
     });
 
-    test("excludes users without GitHub identity", async () => {
-        const db = drizzle(env.DB);
+    await recordRewards(db, [
+        {
+            idempotencyKey: "quest:no-gh-lb-test:github:null-lb",
+            userId: noGithubUserId,
+            amount: 5,
+            bucket: "tier",
+            questId: "quest_gamma",
+            title: "Quest Gamma",
+        },
+    ]);
 
-        // Record a quest reward for a user without GitHub identity
-        // (the session user fixture may not have githubId set)
-        // We'll create a user without GitHub identity
-        const noGithubUserId = "user-no-github";
-        await db.insert(userTable).values({
-            id: noGithubUserId,
-            name: "No GitHub User",
-            email: "nogithub@test.example.com",
-            emailVerified: true,
-            // No githubId or githubUsername
-        });
+    const res = await SELF.fetch(
+        "http://localhost:3000/api/quests/leaderboard",
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { entries: any[] };
 
-        await recordRewards(db, [
-            {
-                idempotencyKey: "quest:no-github-test:github:null",
-                userId: noGithubUserId,
-                amount: 5,
-                bucket: "tier",
-                questId: "quest_gamma",
-                title: "Quest Gamma",
-            },
-        ]);
+    // The no-github user should be excluded
+    const noGithubEntry = body.entries.find((e) => e.githubUsername === null);
+    expect(noGithubEntry).toBeUndefined();
+});
 
-        const res = await SELF.fetch(
-            "http://localhost:3000/api/quests/leaderboard",
-        );
-        expect(res.status).toBe(200);
-        const body = (await res.json()) as { entries: unknown[] };
+test("leaderboard only includes quest rewards, not one-off rewards", async () => {
+    const db = drizzle(env.DB);
 
-        // The no-github user should be excluded from entries
-        const noGithubEntry = body.entries.find(
-            (e: any) => e.githubUsername === null,
-        );
-        expect(noGithubEntry).toBeUndefined();
-    });
+    // Record a one-off reward (questId is null)
+    await recordRewards(db, [
+        {
+            idempotencyKey: "one-off-lb-test:github:999002",
+            userId: "user-leaderboard-2",
+            amount: 100,
+            bucket: "tier",
+            questId: null,
+            title: "One-off reward",
+        },
+    ]);
 
-    test("only includes quest rewards (not one-off rewards)", async () => {
-        const db = drizzle(env.DB);
+    const res = await SELF.fetch(
+        "http://localhost:3000/api/quests/leaderboard",
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { entries: any[] };
 
-        // Record a one-off reward (questId is null)
-        await recordRewards(db, [
-            {
-                idempotencyKey: "one-off-reward:github:100001",
-                userId: "user-leaderboard",
-                amount: 100,
-                bucket: "tier",
-                questId: null,
-                title: "One-off reward",
-            },
-        ]);
-
-        const res = await SELF.fetch(
-            "http://localhost:3000/api/quests/leaderboard",
-        );
-        expect(res.status).toBe(200);
-        const body = (await res.json()) as { entries: unknown[] };
-
-        // One-off rewards should not appear in leaderboard
-        // (only quest rewards with questId not null are included)
-        // The entries should only contain the quest rewards from previous tests
-        for (const entry of body.entries as any[]) {
-            expect(entry.questCount).toBeGreaterThan(0);
-        }
-    });
+    // All entries should have questCount > 0
+    for (const entry of body.entries) {
+        expect(entry.questCount).toBeGreaterThan(0);
+    }
 });

--- a/enter.pollinations.ai/test/quest-leaderboard.test.ts
+++ b/enter.pollinations.ai/test/quest-leaderboard.test.ts
@@ -17,26 +17,34 @@ test("leaderboard returns empty entries when no quest rewards exist", async () =
 test("leaderboard aggregates quest rewards by user", async () => {
     const db = drizzle(env.DB);
 
-    // Create a second user with GitHub identity
-    const user2Id = "user-leaderboard-2";
+    // Create a user with GitHub identity
+    const userId = "user-lb-agg";
     await db.insert(userTable).values({
-        id: user2Id,
-        name: "Leaderboard User 2",
-        email: "leaderboard2@test.example.com",
+        id: userId,
+        name: "Leaderboard User",
+        email: "lb-agg@test.example.com",
         emailVerified: true,
-        githubId: 999002,
-        githubUsername: "leaderboard-tester-2",
+        githubId: 888001,
+        githubUsername: "lb-test-user",
     });
 
-    // Record quest rewards for user2
+    // Record quest rewards
     await recordRewards(db, [
         {
-            idempotencyKey: "quest:leaderboard-alpha:github:999002",
-            userId: user2Id,
-            amount: 10,
+            idempotencyKey: "quest:lb-agg-1:github:888001",
+            userId,
+            amount: 7,
             bucket: "tier",
             questId: "quest_alpha",
             title: "Quest Alpha",
+        },
+        {
+            idempotencyKey: "quest:lb-agg-2:github:888001",
+            userId,
+            amount: 3,
+            bucket: "tier",
+            questId: "quest_beta",
+            title: "Quest Beta",
         },
     ]);
 
@@ -53,32 +61,29 @@ test("leaderboard aggregates quest rewards by user", async () => {
         }>;
     };
 
-    // user2 should be in the leaderboard
-    const entry = body.entries.find(
-        (e) => e.githubUsername === "leaderboard-tester-2",
-    );
+    const entry = body.entries.find((e) => e.githubUsername === "lb-test-user");
     expect(entry).toBeDefined();
-    expect(entry!.githubId).toBe(999002);
-    expect(entry!.questCount).toBe(1);
+    expect(entry!.githubId).toBe(888001);
+    expect(entry!.questCount).toBe(2);
     expect(entry!.totalPollen).toBe(10);
 });
 
 test("leaderboard excludes users without GitHub identity", async () => {
     const db = drizzle(env.DB);
 
-    // Create a user without GitHub identity
-    const noGithubUserId = "user-no-github-lb";
+    // User without GitHub identity
+    const userId = "user-no-gh-lb";
     await db.insert(userTable).values({
-        id: noGithubUserId,
+        id: userId,
         name: "No GitHub User LB",
-        email: "nogithublb@test.example.com",
+        email: "no-gh-lb@test.example.com",
         emailVerified: true,
     });
 
     await recordRewards(db, [
         {
-            idempotencyKey: "quest:no-gh-lb-test:github:null-lb",
-            userId: noGithubUserId,
+            idempotencyKey: "quest:no-gh-lb:github:null",
+            userId,
             amount: 5,
             bucket: "tier",
             questId: "quest_gamma",
@@ -92,23 +97,44 @@ test("leaderboard excludes users without GitHub identity", async () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { entries: any[] };
 
-    // The no-github user should be excluded
-    const noGithubEntry = body.entries.find((e) => e.githubUsername === null);
+    // The no-github user should not appear in leaderboard
+    const noGithubEntry = body.entries.find(
+        (e) => e.githubUsername === null || e.githubId === null,
+    );
     expect(noGithubEntry).toBeUndefined();
 });
 
 test("leaderboard only includes quest rewards, not one-off rewards", async () => {
     const db = drizzle(env.DB);
 
-    // Record a one-off reward (questId is null)
+    // User with GitHub identity
+    const userId = "user-qo-lb";
+    await db.insert(userTable).values({
+        id: userId,
+        name: "Quest Only User LB",
+        email: "qo-lb@test.example.com",
+        emailVerified: true,
+        githubId: 888003,
+        githubUsername: "qo-lb-user",
+    });
+
+    // Record a one-off reward (questId is null) and a quest reward
     await recordRewards(db, [
         {
-            idempotencyKey: "one-off-lb-test:github:999002",
-            userId: "user-leaderboard-2",
+            idempotencyKey: "one-off-lb:github:888003",
+            userId,
             amount: 100,
             bucket: "tier",
             questId: null,
             title: "One-off reward",
+        },
+        {
+            idempotencyKey: "quest:qo-lb:github:888003",
+            userId,
+            amount: 5,
+            bucket: "tier",
+            questId: "quest_delta",
+            title: "Quest Delta",
         },
     ]);
 
@@ -118,8 +144,9 @@ test("leaderboard only includes quest rewards, not one-off rewards", async () =>
     expect(res.status).toBe(200);
     const body = (await res.json()) as { entries: any[] };
 
-    // All entries should have questCount > 0
-    for (const entry of body.entries) {
-        expect(entry.questCount).toBeGreaterThan(0);
-    }
+    // The entry for this user should only count the quest reward (5, not 105)
+    const entry = body.entries.find((e) => e.githubUsername === "qo-lb-user");
+    expect(entry).toBeDefined();
+    expect(entry!.questCount).toBe(1);
+    expect(entry!.totalPollen).toBe(5);
 });

--- a/enter.pollinations.ai/test/quest-leaderboard.test.ts
+++ b/enter.pollinations.ai/test/quest-leaderboard.test.ts
@@ -1,0 +1,158 @@
+import { env, SELF } from "cloudflare:test";
+import { recordRewards } from "@shared/billing/rewards.ts";
+import { user as userTable } from "@shared/db/better-auth.ts";
+import { drizzle } from "drizzle-orm/d1";
+import { expect } from "vitest";
+import { test } from "./fixtures.ts";
+
+test.describe("GET /api/quests/leaderboard", () => {
+    test("returns empty entries when no quest rewards exist", async ({
+        sessionToken,
+    }) => {
+        const res = await SELF.fetch(
+            "http://localhost:3000/api/quests/leaderboard",
+        );
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as { entries: unknown[] };
+        expect(body.entries).toEqual([]);
+    });
+
+    test("aggregates quest rewards by user", async ({ sessionToken }) => {
+        const db = drizzle(env.DB);
+
+        // Create a second user with GitHub identity
+        const user2Id = "user-leaderboard-2";
+        await db.insert(userTable).values({
+            id: user2Id,
+            name: "Leaderboard User 2",
+            email: "leaderboard2@test.example.com",
+            emailVerified: true,
+            githubId: 999002,
+            githubUsername: "leaderboard-tester-2",
+        });
+
+        // Record quest rewards for the session user and user2
+        await recordRewards(db, [
+            {
+                idempotencyKey: "quest:leaderboard-test-1:github:100001",
+                userId: "user-leaderboard", // session user
+                amount: 5,
+                bucket: "tier",
+                questId: "quest_alpha",
+                title: "Quest Alpha",
+            },
+            {
+                idempotencyKey: "quest:leaderboard-test-2:github:100001",
+                userId: "user-leaderboard",
+                amount: 3,
+                bucket: "tier",
+                questId: "quest_beta",
+                title: "Quest Beta",
+            },
+            {
+                idempotencyKey: "quest:leaderboard-test-3:github:999002",
+                userId: user2Id,
+                amount: 10,
+                bucket: "tier",
+                questId: "quest_alpha",
+                title: "Quest Alpha",
+            },
+        ]);
+
+        const res = await SELF.fetch(
+            "http://localhost:3000/api/quests/leaderboard",
+        );
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as {
+            entries: Array<{
+                githubUsername: string;
+                githubId: number;
+                questCount: number;
+                totalPollen: number;
+            }>;
+        };
+
+        // Should have 2 entries
+        expect(body.entries.length).toBe(2);
+
+        // First entry should be user2 (higher total)
+        const top = body.entries[0]!;
+        expect(top.githubUsername).toBe("leaderboard-tester-2");
+        expect(top.githubId).toBe(999002);
+        expect(top.questCount).toBe(1);
+        expect(top.totalPollen).toBe(10);
+
+        // Second entry should be session user
+        const second = body.entries[1]!;
+        expect(second.questCount).toBe(2);
+        expect(second.totalPollen).toBe(8);
+    });
+
+    test("excludes users without GitHub identity", async () => {
+        const db = drizzle(env.DB);
+
+        // Record a quest reward for a user without GitHub identity
+        // (the session user fixture may not have githubId set)
+        // We'll create a user without GitHub identity
+        const noGithubUserId = "user-no-github";
+        await db.insert(userTable).values({
+            id: noGithubUserId,
+            name: "No GitHub User",
+            email: "nogithub@test.example.com",
+            emailVerified: true,
+            // No githubId or githubUsername
+        });
+
+        await recordRewards(db, [
+            {
+                idempotencyKey: "quest:no-github-test:github:null",
+                userId: noGithubUserId,
+                amount: 5,
+                bucket: "tier",
+                questId: "quest_gamma",
+                title: "Quest Gamma",
+            },
+        ]);
+
+        const res = await SELF.fetch(
+            "http://localhost:3000/api/quests/leaderboard",
+        );
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as { entries: unknown[] };
+
+        // The no-github user should be excluded from entries
+        const noGithubEntry = body.entries.find(
+            (e: any) => e.githubUsername === null,
+        );
+        expect(noGithubEntry).toBeUndefined();
+    });
+
+    test("only includes quest rewards (not one-off rewards)", async () => {
+        const db = drizzle(env.DB);
+
+        // Record a one-off reward (questId is null)
+        await recordRewards(db, [
+            {
+                idempotencyKey: "one-off-reward:github:100001",
+                userId: "user-leaderboard",
+                amount: 100,
+                bucket: "tier",
+                questId: null,
+                title: "One-off reward",
+            },
+        ]);
+
+        const res = await SELF.fetch(
+            "http://localhost:3000/api/quests/leaderboard",
+        );
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as { entries: unknown[] };
+
+        // One-off rewards should not appear in leaderboard
+        // (only quest rewards with questId not null are included)
+        // The entries should only contain the quest rewards from previous tests
+        for (const entry of body.entries as any[]) {
+            expect(entry.questCount).toBeGreaterThan(0);
+        }
+    });
+});

--- a/pollinations.ai/src/ui/components/QuestLeaderboard.tsx
+++ b/pollinations.ai/src/ui/components/QuestLeaderboard.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import { LINKS, SOCIAL_LINKS } from "../../copy/content/socialLinks";
 import { usePageCopy } from "../../hooks/usePageCopy";
-import { useTranslate } from "../../hooks/useTranslate";
 import { ExternalLinkIcon } from "../assets/ExternalLinkIcon";
 import { Divider } from "./ui/divider";
 import { Body, Heading } from "./ui/typography";
@@ -30,7 +29,6 @@ const LEADERBOARD_COPY = {
 };
 
 export function QuestLeaderboard() {
-    const { copy } = usePageCopy({ title: LEADERBOARD_COPY.title });
     const [entries, setEntries] = useState<LeaderboardEntry[]>([]);
     const [loading, setLoading] = useState(true);
 

--- a/pollinations.ai/src/ui/components/QuestLeaderboard.tsx
+++ b/pollinations.ai/src/ui/components/QuestLeaderboard.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useState } from "react";
+import { LINKS, SOCIAL_LINKS } from "../../copy/content/socialLinks";
+import { usePageCopy } from "../../hooks/usePageCopy";
+import { useTranslate } from "../../hooks/useTranslate";
+import { ExternalLinkIcon } from "../assets/ExternalLinkIcon";
+import { Divider } from "./ui/divider";
+import { Body, Heading } from "./ui/typography";
+
+const ENTER_API = "https://enter.pollinations.ai";
+
+interface LeaderboardEntry {
+    githubUsername: string;
+    githubId: number;
+    questCount: number;
+    totalPollen: number;
+}
+
+interface LeaderboardResponse {
+    entries: LeaderboardEntry[];
+}
+
+const LEADERBOARD_COPY = {
+    title: "Quest Leaderboard",
+    subtitle:
+        "Top contributors ranked by Quest Pollen earned from completing community quests.",
+    cta: "Complete quests to earn Pollen — see",
+    ctaLink: "open quests",
+    noData: "No quest completions yet. Be the first!",
+    quests: "quests",
+};
+
+export function QuestLeaderboard() {
+    const { copy } = usePageCopy({ title: LEADERBOARD_COPY.title });
+    const [entries, setEntries] = useState<LeaderboardEntry[]>([]);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        const CACHE_KEY = "quest_leaderboard_v1";
+        const today = new Date().toISOString().slice(0, 10);
+
+        try {
+            const cached = localStorage.getItem(CACHE_KEY);
+            if (cached) {
+                const { data, day } = JSON.parse(cached);
+                if (day === today) {
+                    setEntries(data);
+                    setLoading(false);
+                    return;
+                }
+            }
+        } catch {
+            // corrupted cache — continue to fetch
+        }
+
+        const fetchLeaderboard = async () => {
+            try {
+                const res = await fetch(`${ENTER_API}/api/quests/leaderboard`);
+                if (!res.ok) return;
+                const data: LeaderboardResponse = await res.json();
+                setEntries(data.entries);
+
+                try {
+                    localStorage.setItem(
+                        CACHE_KEY,
+                        JSON.stringify({ data: data.entries, day: today }),
+                    );
+                } catch {
+                    // localStorage full — skip
+                }
+            } catch (err) {
+                console.error("Quest leaderboard fetch failed:", err);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchLeaderboard();
+    }, []);
+
+    if (loading && entries.length === 0) return null;
+    if (!loading && entries.length === 0) return null;
+
+    return (
+        <>
+            <div className="mb-12">
+                <Heading variant="section">{LEADERBOARD_COPY.title}</Heading>
+                <Body size="sm" spacing="comfortable">
+                    {LEADERBOARD_COPY.subtitle}
+                    <br />
+                    {LEADERBOARD_COPY.cta}{" "}
+                    <a
+                        href={LINKS.enter}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="font-headline text-xs font-black hover:underline inline-flex items-center gap-1 text-dark bg-accent-strong px-2 py-0.5"
+                    >
+                        {LEADERBOARD_COPY.ctaLink}
+                        <ExternalLinkIcon className="w-3 h-3" strokeWidth={4} />
+                    </a>
+                </Body>
+                <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3">
+                    {entries.slice(0, 9).map((entry, i) => {
+                        const colors = [
+                            "border-primary-strong shadow-[1px_1px_0_rgb(var(--primary-strong)_/_0.3)]",
+                            "border-secondary-strong shadow-[1px_1px_0_rgb(var(--secondary-strong)_/_0.3)]",
+                            "border-tertiary-strong shadow-[1px_1px_0_rgb(var(--tertiary-strong)_/_0.3)]",
+                        ];
+                        const rankBadge =
+                            i === 0
+                                ? "🏆"
+                                : i === 1
+                                  ? "🥈"
+                                  : i === 2
+                                    ? "🥉"
+                                    : `#${i + 1}`;
+                        return (
+                            <a
+                                key={entry.githubUsername}
+                                href={`https://github.com/${entry.githubUsername}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className={`block bg-white/60 p-4 rounded-sub-card border-r-2 border-b-2 ${colors[i % colors.length]} transition hover:translate-x-[1px] hover:translate-y-[1px] hover:shadow-none active:translate-x-[2px] active:translate-y-[2px] active:shadow-none`}
+                            >
+                                <div className="flex items-center gap-3">
+                                    <img
+                                        src={`https://github.com/${entry.githubUsername}.png?size=64`}
+                                        alt={entry.githubUsername}
+                                        className="w-10 h-10 rounded-full border border-border-subtle"
+                                        loading="lazy"
+                                        decoding="async"
+                                    />
+                                    <div className="min-w-0 flex-1">
+                                        <div className="flex items-center gap-2">
+                                            <span className="text-lg">
+                                                {rankBadge}
+                                            </span>
+                                            <span className="font-headline text-xs font-black text-dark truncate">
+                                                {entry.githubUsername}
+                                            </span>
+                                        </div>
+                                        <div className="flex items-center gap-2 mt-1">
+                                            <span className="font-mono text-xs text-subtle">
+                                                {entry.questCount}{" "}
+                                                {LEADERBOARD_COPY.quests}
+                                            </span>
+                                            <span className="text-border-subtle">
+                                                ·
+                                            </span>
+                                            <span className="font-mono text-xs font-bold text-dark">
+                                                {entry.totalPollen} Pollen
+                                            </span>
+                                        </div>
+                                    </div>
+                                </div>
+                            </a>
+                        );
+                    })}
+                </div>
+            </div>
+            <Divider />
+        </>
+    );
+}

--- a/pollinations.ai/src/ui/pages/CommunityPage.tsx
+++ b/pollinations.ai/src/ui/pages/CommunityPage.tsx
@@ -5,6 +5,7 @@ import { usePageCopy } from "../../hooks/usePageCopy";
 import { useTranslate } from "../../hooks/useTranslate";
 import { ExternalLinkIcon } from "../assets/ExternalLinkIcon";
 import { BuildDiary } from "../components/BuildDiary";
+import { QuestLeaderboard } from "../components/QuestLeaderboard";
 import { TopContributors } from "../components/TopContributors";
 import { Button } from "../components/ui/button";
 import { Divider } from "../components/ui/divider";
@@ -321,6 +322,8 @@ export default function CommunityPage() {
                 </div>
 
                 <Divider />
+
+                <QuestLeaderboard />
 
                 <TopContributors />
 


### PR DESCRIPTION
## Summary

Add a compact Quest leaderboard to the `/community` page that ranks contributors by total Quest Pollen earned from completed public GitHub POLLEN-QUEST issues.

## Changes

### Backend (`enter.pollinations.ai`)
- **New public endpoint:** `GET /api/quests/leaderboard`
- Aggregates rewards by user, joins with user table for GitHub identity
- Returns: `githubUsername`, `githubId`, `questCount`, `totalPollon`
- Cached in KV for 5 minutes
- No authentication required (public endpoint)

### Frontend (`pollinations.ai`)
- **New component:** `QuestLeaderboard.tsx`
- Shows top 9 contributors with GitHub avatar, username, quest count, and total Pollen
- Medal badges for top 3 (🏆🥈🥉)
- Links to quests page for participation
- Cached in localStorage daily
- Follows existing design patterns (TopContributors component)

### CommunityPage
- Inserted `QuestLeaderboard` between voting section and TopContributors

### Tests
- **New test file:** `quest-leaderboard.test.ts`
- Covers: empty state, aggregation, GitHub identity filtering, quest-only filtering

## How it works

1. Backend queries rewards table, joins with user table
2. Filters for `questId IS NOT NULL` (quest rewards only)
3. Groups by user, aggregates quest count and total Pollen
4. Returns top 50 by total Pollen descending
5. Frontend fetches from public endpoint, displays top 9

Closes #13909