### PR TITLE
feat: show context window and video duration in Models dashboard

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/model-catalog.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-catalog.ts
@@ -30,6 +30,10 @@ export type ApiModelInfo = {
     tools?: boolean;
     reasoning?: boolean;
     context_length?: number;
+    min_duration?: number;
+    max_duration?: number;
+    default_duration?: number;
+    allowed_durations?: number[];
     voices?: string[];
     is_specialized?: boolean;
     paid_only?: boolean;
@@ -196,6 +200,9 @@ function baseModelPrice(model: ApiModelInfo): ModelPrice | null {
         inputSortPrice,
         outputSortPrice,
         prices: [],
+        contextLength: model.context_length,
+        minDuration: model.min_duration,
+        maxDuration: model.max_duration,
     };
 }
 

--- a/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
@@ -55,6 +55,18 @@ export const ModelId: FC<ModelIdProps> = ({ name }) => (
     </CopyButton>
 );
 
+function formatContextK(n: number): string {
+    if (n >= 1_000_000) {
+        const m = n / 1_000_000;
+        return `${Number.isInteger(m) ? m : m.toFixed(1)}M`;
+    }
+    return `${Math.round(n / 1000)}k`;
+}
+
+function formatDurationRange(min: number, max: number): string {
+    return min === max ? `${min}s` : `${min}–${max}s`;
+}
+
 export const ModelRow: FC<ModelRowProps> = ({ model }) => {
     const modelDisplayName = getModelDisplayName(model);
     const modelDescription = getModelDescriptionWithoutName(model);
@@ -180,45 +192,95 @@ export const ModelRow: FC<ModelRowProps> = ({ model }) => {
                         <ModelId name={model.name} />
                     </div>
                     {(inputModalities.length > 0 ||
-                        capabilities.length > 0) && (
+                        capabilities.length > 0 ||
+                        model.contextLength != null ||
+                        (model.type === "video" &&
+                            model.minDuration != null &&
+                            model.maxDuration != null)) && (
                         <div className="flex min-w-0 flex-wrap items-center gap-2">
-                            <div className="inline-flex items-center gap-2.5 text-theme-text-muted">
-                                {inputModalities.length > 0 && (
-                                    <Tooltip content={modalityLabel}>
-                                        <span className="inline-flex items-center gap-2">
-                                            {inputModalities.map((key) => {
-                                                const Icon = MODALITY_ICON[key];
-                                                return (
-                                                    <Icon
-                                                        key={key}
-                                                        className="h-4 w-4"
-                                                    />
-                                                );
-                                            })}
-                                        </span>
-                                    </Tooltip>
-                                )}
-                                {inputModalities.length > 0 &&
-                                    capabilities.length > 0 && (
-                                        <span className="h-3.5 w-px bg-current opacity-30" />
+                            {(inputModalities.length > 0 ||
+                                capabilities.length > 0) && (
+                                <div className="inline-flex items-center gap-2.5 text-theme-text-muted">
+                                    {inputModalities.length > 0 && (
+                                        <Tooltip content={modalityLabel}>
+                                            <span className="inline-flex items-center gap-2">
+                                                {inputModalities.map((key) => {
+                                                    const Icon =
+                                                        MODALITY_ICON[key];
+                                                    return (
+                                                        <Icon
+                                                            key={key}
+                                                            className="h-4 w-4"
+                                                        />
+                                                    );
+                                                })}
+                                            </span>
+                                        </Tooltip>
                                     )}
-                                {capabilities.length > 0 && (
-                                    <Tooltip content={capabilityLabel}>
-                                        <span className="inline-flex items-center gap-2 text-theme-text-soft">
-                                            {capabilities.map((key) => {
-                                                const Icon =
-                                                    CAPABILITY_ICON[key];
-                                                return (
-                                                    <Icon
-                                                        key={key}
-                                                        className="h-4 w-4"
-                                                    />
-                                                );
-                                            })}
+                                    {inputModalities.length > 0 &&
+                                        capabilities.length > 0 && (
+                                            <span className="h-3.5 w-px bg-current opacity-30" />
+                                        )}
+                                    {capabilities.length > 0 && (
+                                        <Tooltip content={capabilityLabel}>
+                                            <span className="inline-flex items-center gap-2 text-theme-text-soft">
+                                                {capabilities.map((key) => {
+                                                    const Icon =
+                                                        CAPABILITY_ICON[key];
+                                                    return (
+                                                        <Icon
+                                                            key={key}
+                                                            className="h-4 w-4"
+                                                        />
+                                                    );
+                                                })}
+                                            </span>
+                                        </Tooltip>
+                                    )}
+                                </div>
+                            )}
+                            {model.contextLength != null && (
+                                <Tooltip
+                                    content={
+                                        <span>
+                                            <strong className="font-semibold text-theme-text-strong">
+                                                Context window:
+                                            </strong>{" "}
+                                            {model.contextLength.toLocaleString()}{" "}
+                                            tokens
+                                        </span>
+                                    }
+                                >
+                                    <span className="whitespace-nowrap text-xs tabular-nums text-theme-text-muted">
+                                        {formatContextK(model.contextLength)}{" "}
+                                        ctx
+                                    </span>
+                                </Tooltip>
+                            )}
+                            {model.type === "video" &&
+                                model.minDuration != null &&
+                                model.maxDuration != null && (
+                                    <Tooltip
+                                        content={
+                                            <span>
+                                                <strong className="font-semibold text-theme-text-strong">
+                                                    Duration:
+                                                </strong>{" "}
+                                                {formatDurationRange(
+                                                    model.minDuration,
+                                                    model.maxDuration,
+                                                )}
+                                            </span>
+                                        }
+                                    >
+                                        <span className="whitespace-nowrap text-xs tabular-nums text-theme-text-muted">
+                                            {formatDurationRange(
+                                                model.minDuration,
+                                                model.maxDuration,
+                                            )}
                                         </span>
                                     </Tooltip>
                                 )}
-                            </div>
                         </div>
                     )}
                 </div>

--- a/enter.pollinations.ai/frontend/src/components/models/types.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/types.ts
@@ -59,6 +59,9 @@ export type ModelPrice = {
     prices: ModelPriceLine[];
     // Real usage data from Tinybird (rolling 7-day average)
     realAvgCost?: number;
+    contextLength?: number;
+    minDuration?: number;
+    maxDuration?: number;
 };
 
 export type Modalities = {

--- a/enter.pollinations.ai/test/model-calculations.test.ts
+++ b/enter.pollinations.ai/test/model-calculations.test.ts
@@ -47,3 +47,34 @@ describe("model per-pollen calculations", () => {
         expect(calculatePerPollen(freeModel)).toBe("∞");
     });
 });
+
+describe("model limit fields", () => {
+    it("maps context_length from the catalog to contextLength on ModelPrice", () => {
+        const [m] = getModelPricesFromCatalog([
+            {
+                name: "text-model",
+                category: "text",
+                context_length: 128000,
+                pricing: { currency: "pollen", promptTextTokens: "0.000001" },
+            },
+        ]);
+        expect(m.contextLength).toBe(128000);
+    });
+
+    it("maps video duration fields from the catalog to ModelPrice", () => {
+        const [m] = getModelPricesFromCatalog([
+            {
+                name: "video-model",
+                category: "video",
+                min_duration: 4,
+                max_duration: 8,
+                pricing: {
+                    currency: "pollen",
+                    completionVideoSeconds: "0.05",
+                },
+            },
+        ]);
+        expect(m.minDuration).toBe(4);
+        expect(m.maxDuration).toBe(8);
+    });
+});


### PR DESCRIPTION
Fixes #13905

## Changes

- **types.ts**: add `contextLength`, `minDuration`, `maxDuration` to `ModelPrice`
- **model-catalog.ts**: extend `ApiModelInfo` with `min_duration`, `max_duration`, `default_duration`, `allowed_durations`; map `context_length`, `min_duration`, `max_duration` through `baseModelPrice()`
- **model-row.tsx**: render `"Xk ctx"` with tooltip (e.g. "Context window: 128,000 tokens") for models that have `context_length`; render `"X–Ys"` or `"Xs"` with tooltip for video models that expose `min_duration`/`max_duration`
- **model-calculations.test.ts**: two new tests verifying limit fields flow end-to-end through the catalog mapping

No API changes, no registry changes, no pricing changes, no new model-detail views.