### PR TITLE
feat: open any model in Play from the model catalog

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
@@ -1,4 +1,4 @@
-import { CopyButton, cn, Surface, Tooltip } from "@pollinations/ui";
+import { BeakerIcon, CopyButton, cn, Surface, Tooltip } from "@pollinations/ui";
 import { WalletKindIcon } from "@pollinations/ui/wallet";
 import type { FC } from "react";
 import { calculatePerPollen, unitLabels } from "./calculations.ts";
@@ -249,6 +249,25 @@ export const ModelRow: FC<ModelRowProps> = ({ model }) => {
                     badges={outputPriceBadges}
                     className="flex flex-col gap-1 items-end"
                 />
+            </div>
+
+            <div className="shrink-0 py-3 pr-3 pl-1 flex items-center">
+                <Tooltip
+                    triggerAs="span"
+                    content="Try in Play"
+                    ariaLabel="Try in Play"
+                    displayContents
+                >
+                    <a
+                        href={`https://pollinations.ai/play?model=${encodeURIComponent(model.name)}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label="Try in Play"
+                        className="inline-flex h-6 w-6 items-center justify-center rounded text-theme-text-muted hover:text-theme-text-strong transition-colors"
+                    >
+                        <BeakerIcon className="h-4 w-4" />
+                    </a>
+                </Tooltip>
             </div>
         </Surface>
     );

--- a/pollinations.ai/src/ui/components/play/ModelSelector.tsx
+++ b/pollinations.ai/src/ui/components/play/ModelSelector.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from "react";
+import { memo, useEffect, useState } from "react";
 import { PLAY_PAGE } from "../../../copy/content/play";
 import type { Model } from "../../../hooks/useModelList";
 import { usePageCopy } from "../../../hooks/usePageCopy";
@@ -71,6 +71,11 @@ export const ModelSelector = memo(function ModelSelector({
     const { copy } = usePageCopy(PLAY_PAGE);
     const [activeCategory, setActiveCategory] =
         useState<ModelCategory>("image");
+
+    useEffect(() => {
+        const found = models.find((m) => m.id === selectedModel);
+        if (found) setActiveCategory(getModelCategory(found));
+    }, [selectedModel, models]);
 
     const categories: { key: ModelCategory; label: string }[] = [
         { key: "image", label: copy.imageLabel },

--- a/pollinations.ai/src/ui/pages/PlayPage.tsx
+++ b/pollinations.ai/src/ui/pages/PlayPage.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { PLAY_PAGE } from "../../copy/content/play";
 import { LINKS } from "../../copy/content/socialLinks";
 import { useAuth } from "../../hooks/useAuth";
@@ -14,7 +15,10 @@ import { PageContainer } from "../components/ui/page-container";
 import { Body, Title } from "../components/ui/typography";
 
 function PlayPage() {
-    const [selectedModel, setSelectedModel] = useState("flux");
+    const [searchParams] = useSearchParams();
+    const [selectedModel, setSelectedModel] = useState(
+        searchParams.get("model") ?? "flux",
+    );
     const [prompt, setPrompt] = useState("");
     const { apiKey, isLoggedIn, login } = useAuth();
     const {


### PR DESCRIPTION
Fixes #13903

## Changes

- **Model catalog** (`enter.pollinations.ai/frontend/src/components/models/model-row.tsx`): adds a compact `BeakerIcon` link on each model row with a "Try in Play" tooltip. Clicking opens `https://pollinations.ai/play?model=<model-id>` in a new tab.
- **Play page** (`pollinations.ai/src/ui/pages/PlayPage.tsx`): reads `?model=` from the URL query string and uses it as the initial selected model (falls back to `flux` when absent).
- **ModelSelector** (`pollinations.ai/src/ui/components/play/ModelSelector.tsx`): adds a `useEffect` that syncs the active category tab to the preselected model once the model list loads, so the correct tab (image/text/audio/video) is shown automatically.

No backend changes. No new playground. No new page.