### PR TITLE
feat: add metadata and filters to Models search

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/model-filter.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-filter.ts
@@ -1,0 +1,89 @@
+import { getModelDisplayName } from "./model-info.ts";
+import type { ModelPrice } from "./types.ts";
+
+type FilterToken = { key: string; value: string };
+
+export type ParsedQuery = {
+    filters: FilterToken[];
+    terms: string[];
+};
+
+// Matches key:value tokens where key is word chars/hyphens, value is non-whitespace
+const FILTER_RE = /(\w[\w-]*):([\S]+)/g;
+
+export function parseQuery(raw: string): ParsedQuery {
+    const lower = raw.trim().toLowerCase();
+    const filters: FilterToken[] = [];
+    let cleanText = "";
+    let lastIndex = 0;
+
+    for (const match of lower.matchAll(FILTER_RE)) {
+        cleanText += lower.slice(lastIndex, match.index);
+        lastIndex = (match.index ?? 0) + match[0].length;
+        filters.push({ key: match[1], value: match[2] });
+    }
+    cleanText += lower.slice(lastIndex);
+
+    const terms = cleanText.trim().split(/\s+/).filter(Boolean);
+    return { filters, terms };
+}
+
+function communityOwner(model: ModelPrice): string | undefined {
+    if (!model.community) return undefined;
+    const slash = model.name.indexOf("/");
+    return slash > 0 ? model.name.slice(0, slash) : undefined;
+}
+
+function matchesFilter(model: ModelPrice, key: string, value: string): boolean {
+    switch (key) {
+        case "access":
+            if (value === "paid") return model.paidOnly === true;
+            if (value === "free") return model.free === true;
+            if (value === "quest") return !model.paidOnly && !model.free;
+            return false;
+        case "owner": {
+            const owner = communityOwner(model);
+            return owner !== undefined && owner === value;
+        }
+        case "id":
+            return model.name.toLowerCase().includes(value);
+        case "type":
+            if (value === "agent") return model.agent === true;
+            return model.type === value;
+        case "capability":
+            // Accept both underscore and hyphen forms (e.g. tool_calling / tool-calling)
+            return model.capabilities.some(
+                (cap) => cap === value || cap.replace(/_/g, "-") === value,
+            );
+        default:
+            return false;
+    }
+}
+
+export function matchesModel(model: ModelPrice, parsed: ParsedQuery): boolean {
+    for (const filter of parsed.filters) {
+        if (!matchesFilter(model, filter.key, filter.value)) return false;
+    }
+
+    if (parsed.terms.length > 0) {
+        const displayName = getModelDisplayName(model) ?? "";
+        const haystack = [
+            model.name,
+            displayName,
+            model.description ?? "",
+            model.brand ?? "",
+            model.baseModel ?? "",
+            ...(model.inputModalities ?? []),
+            ...(model.outputModalities ?? []),
+            ...model.capabilities,
+        ]
+            .join(" ")
+            .toLowerCase();
+
+        for (const term of parsed.terms) {
+            if (!haystack.includes(term)) return false;
+        }
+    }
+
+    return true;
+}

--- a/enter.pollinations.ai/frontend/src/components/models/models.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/models.tsx
@@ -1,9 +1,15 @@
 import {
     Alert,
+    BotIcon,
+    Button,
+    ChevronIcon,
     Chip,
     ClockIcon,
+    Dropdown,
+    DropdownItem,
     ExternalLinkButton,
     GitHubIcon,
+    InlineLink,
     Input,
     SearchIcon,
     Section,
@@ -11,25 +17,26 @@ import {
     TabButton,
     TokensIcon,
     TrendUpIcon,
+    UsageIcon,
 } from "@pollinations/ui";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import {
     type FC,
+    type KeyboardEvent,
     useCallback,
     useEffect,
     useMemo,
     useRef,
     useState,
 } from "react";
-import { CommunityEndpoints } from "../community-endpoints";
 import {
     type ApiModelInfo,
     fetchModelCatalog,
     getModelPricesFromCatalog,
 } from "./model-catalog.ts";
-import { getModelDisplayCategory } from "./model-categories.ts";
-import { getModelDisplayName } from "./model-info.ts";
-import type { ModelSortDirection, ModelSortKey } from "./model-search.ts";
+import { matchesModel, parseQuery } from "./model-filter.ts";
+import type { ModelScope, ModelSort } from "./model-search.ts";
+import { sortModels } from "./model-sort.ts";
 import {
     type SectionType,
     sectionLabels,
@@ -38,25 +45,63 @@ import {
 import type { ModelPrice } from "./types.ts";
 import { useModelStats } from "./use-model-stats.ts";
 
-type ModelsProps = {
-    // Render the owner-scoped "My Models" section (logged-in dashboard only).
-    showCommunityEndpoints?: boolean;
-    // Allowlisted owners can make their models public; everyone else is limited
-    // to private, owner-only models.
-    canPublish?: boolean;
-};
-
-const SECTION_ORDER: SectionType[] = [
+const POLLINATIONS_SECTION_ORDER: SectionType[] = [
     "all",
+    "text",
     "image",
     "video",
     "3d",
     "audio",
     "realtime",
-    "text",
-    "community-text",
-    "community-image",
     "embedding",
+];
+
+const COMMUNITY_SECTION_ORDER: SectionType[] = [
+    "all",
+    "text",
+    "image",
+    "agent",
+];
+const SCOPE_ORDER: ModelScope[] = ["pollinations", "community"];
+
+const SCOPE_LABELS: Record<ModelScope, string> = {
+    pollinations: "Official",
+    community: "Community",
+};
+
+const SORT_OPTIONS: Array<{
+    value: ModelSort;
+    label: string;
+    accessibleLabel: string;
+}> = [
+    { value: "newest", label: "Newest", accessibleLabel: "Newest" },
+    { value: "oldest", label: "Oldest", accessibleLabel: "Oldest" },
+    {
+        value: "price-low",
+        label: "Price: Low",
+        accessibleLabel: "Lowest price first",
+    },
+    {
+        value: "price-high",
+        label: "Price: High",
+        accessibleLabel: "Highest price first",
+    },
+    { value: "title", label: "Name: A–Z", accessibleLabel: "Name: A to Z" },
+    {
+        value: "title-desc",
+        label: "Name: Z–A",
+        accessibleLabel: "Name: Z to A",
+    },
+    {
+        value: "brand",
+        label: "Publisher: A–Z",
+        accessibleLabel: "Publisher: A to Z",
+    },
+    {
+        value: "brand-desc",
+        label: "Publisher: Z–A",
+        accessibleLabel: "Publisher: Z to A",
+    },
 ];
 
 const SEARCH_LABELS: Record<SectionType, string> = {
@@ -67,24 +112,9 @@ const SEARCH_LABELS: Record<SectionType, string> = {
     audio: "audio",
     realtime: "realtime",
     text: "text",
-    "community-text": "community text",
-    "community-image": "community image",
     embedding: "embedding",
+    agent: "agent",
 };
-
-const DEFAULT_SORT_DIRECTIONS: Record<ModelSortKey, ModelSortDirection> = {
-    name: "asc",
-    perPollen: "desc",
-    input: "asc",
-    output: "asc",
-};
-
-function matchesQuery(model: ModelPrice, query: string): boolean {
-    if (!query) return true;
-    const displayName = getModelDisplayName(model) ?? "";
-    const haystack = `${displayName} ${model.brand ?? ""}`.toLowerCase();
-    return haystack.includes(query);
-}
 
 function categorizeModels(
     models: ModelPrice[],
@@ -97,31 +127,56 @@ function categorizeModels(
         audio: [],
         realtime: [],
         text: [],
-        "community-text": [],
-        "community-image": [],
         embedding: [],
+        agent: [],
     };
 
     for (const model of models) {
-        categorized[getModelDisplayCategory(model.type, model.community)].push(
-            model,
-        );
+        categorized[model.agent ? "agent" : model.type].push(model);
     }
     return categorized;
 }
 
-export const Models: FC<ModelsProps> = ({
-    showCommunityEndpoints = false,
-    canPublish = false,
-}) => {
+function handleSortMenuKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    if (
+        event.key !== "ArrowDown" &&
+        event.key !== "ArrowUp" &&
+        event.key !== "Home" &&
+        event.key !== "End"
+    ) {
+        return;
+    }
+
+    const items = Array.from(
+        event.currentTarget.querySelectorAll<HTMLElement>(
+            '[role="menuitemradio"]',
+        ),
+    );
+    if (items.length === 0) return;
+
+    const currentIndex = items.indexOf(document.activeElement as HTMLElement);
+    const nextIndex =
+        event.key === "Home"
+            ? 0
+            : event.key === "End"
+              ? items.length - 1
+              : event.key === "ArrowDown"
+                ? (currentIndex + 1) % items.length
+                : (currentIndex - 1 + items.length) % items.length;
+
+    event.preventDefault();
+    items[nextIndex]?.focus();
+}
+
+export const Models: FC = () => {
     const navigate = useNavigate({ from: "/models" });
     const modelSearch = useSearch({ from: "/_dashboard/models" });
+    const activeScope = modelSearch.scope ?? "pollinations";
     const activeTab = modelSearch.category ?? "all";
+    const activeSort = modelSearch.sort ?? "newest";
     const urlSearch = modelSearch.q ?? "";
     const [search, setSearch] = useState(urlSearch);
     const lastPushedSearchRef = useRef(urlSearch);
-    const sortKey = modelSearch.sort ?? "perPollen";
-    const sortDir = modelSearch.dir ?? DEFAULT_SORT_DIRECTIONS[sortKey];
     const [catalogModels, setCatalogModels] = useState<ApiModelInfo[]>([]);
     const [catalogError, setCatalogError] = useState<string | null>(null);
     const { stats } = useModelStats();
@@ -129,21 +184,36 @@ export const Models: FC<ModelsProps> = ({
         () => getModelPricesFromCatalog(catalogModels, stats),
         [catalogModels, stats],
     );
-    const query = search.trim().toLowerCase();
+    const parsedQuery = useMemo(() => parseQuery(search), [search]);
+    const hasQuery =
+        parsedQuery.filters.length > 0 || parsedQuery.terms.length > 0;
+    const scopedModels = useMemo(
+        () =>
+            allModels.filter(
+                (model) =>
+                    Boolean(model.community) === (activeScope === "community"),
+            ),
+        [activeScope, allModels],
+    );
     const filteredModels = useMemo(
         () =>
-            query ? allModels.filter((m) => matchesQuery(m, query)) : allModels,
-        [allModels, query],
+            hasQuery
+                ? scopedModels.filter((model) =>
+                      matchesModel(model, parsedQuery),
+                  )
+                : scopedModels,
+        [hasQuery, parsedQuery, scopedModels],
     );
 
     const loadModelCatalog = useCallback(
-        (options: { refresh?: boolean } = {}) =>
-            fetchModelCatalog(options)
+        () =>
+            fetchModelCatalog()
                 .then((models) => {
                     setCatalogModels(models);
                     setCatalogError(null);
                 })
-                .catch(() => {
+                .catch((error) => {
+                    console.error("Model catalog fetch failed:", error);
                     setCatalogModels([]);
                     setCatalogError("Could not load models.");
                 }),
@@ -155,20 +225,31 @@ export const Models: FC<ModelsProps> = ({
     }, [loadModelCatalog]);
 
     const sectionModels = useMemo(
-        () => categorizeModels(filteredModels),
-        [filteredModels],
+        () => categorizeModels(sortModels(filteredModels, activeSort)),
+        [activeSort, filteredModels],
     );
+    const sectionOrder =
+        activeScope === "community"
+            ? COMMUNITY_SECTION_ORDER
+            : POLLINATIONS_SECTION_ORDER;
+    const hasAgents = scopedModels.some((model) => model.agent);
+    const scopeLabel = SCOPE_LABELS[activeScope];
     const searchLabel = SEARCH_LABELS[activeTab];
+    const searchTarget =
+        activeTab === "all"
+            ? `${scopeLabel} models`
+            : `${scopeLabel} ${searchLabel} models`;
 
     const pushSearch = useCallback(
         (nextSearch: string) => {
-            if (nextSearch === lastPushedSearchRef.current) return;
+            const normalizedSearch = nextSearch.trim();
+            if (normalizedSearch === lastPushedSearchRef.current) return;
 
-            lastPushedSearchRef.current = nextSearch;
+            lastPushedSearchRef.current = normalizedSearch;
             void navigate({
                 search: (previous) => ({
                     ...previous,
-                    q: nextSearch || undefined,
+                    q: normalizedSearch || undefined,
                 }),
                 replace: true,
             });
@@ -202,25 +283,40 @@ export const Models: FC<ModelsProps> = ({
         });
     };
 
-    const onSort = (key: ModelSortKey) => {
-        const nextDirection =
-            key === sortKey
-                ? sortDir === "asc"
-                    ? "desc"
-                    : "asc"
-                : DEFAULT_SORT_DIRECTIONS[key];
-
+    const setActiveScope = (scope: ModelScope) => {
         void navigate({
             search: (previous) => ({
                 ...previous,
-                sort: key === "perPollen" ? undefined : key,
-                dir:
-                    nextDirection === DEFAULT_SORT_DIRECTIONS[key]
-                        ? undefined
-                        : nextDirection,
+                scope: scope === "pollinations" ? undefined : scope,
+                category:
+                    scope === "community"
+                        ? previous.category === "text" ||
+                          previous.category === "image" ||
+                          previous.category === "agent"
+                            ? previous.category
+                            : undefined
+                        : previous.category === "agent"
+                          ? undefined
+                          : previous.category,
             }),
         });
     };
+
+    const setActiveSort = (sort: ModelSort) => {
+        void navigate({
+            search: (previous) => ({
+                ...previous,
+                sort: sort === "newest" ? undefined : sort,
+            }),
+        });
+    };
+
+    const activeSortLabel =
+        SORT_OPTIONS.find(({ value }) => value === activeSort)?.label ??
+        "Newest";
+    const activeSortAccessibleLabel =
+        SORT_OPTIONS.find(({ value }) => value === activeSort)
+            ?.accessibleLabel ?? "Newest";
 
     return (
         <div className="flex flex-col gap-6">
@@ -252,57 +348,174 @@ export const Models: FC<ModelsProps> = ({
                 }
             >
                 <div className="mb-4 flex flex-col items-start gap-3">
-                    <div className="flex flex-wrap gap-1.5">
-                        {SECTION_ORDER.map((section) => (
-                            <TabButton
-                                key={section}
-                                active={activeTab === section}
-                                onClick={() => setActiveTab(section)}
-                                ariaLabel={
-                                    section === "community-text" ||
-                                    section === "community-image"
-                                        ? `${sectionLabels[section]} alpha models`
-                                        : undefined
-                                }
-                            >
-                                <span className="inline-flex items-center gap-1.5">
-                                    {sectionLabels[section]}
-                                    {(section === "community-text" ||
-                                        section === "community-image") && (
-                                        <Chip intent="alpha" size="sm">
-                                            Alpha
-                                        </Chip>
-                                    )}
-                                </span>
-                            </TabButton>
-                        ))}
+                    <div className="flex flex-col gap-2">
+                        <div className="flex flex-wrap gap-1.5">
+                            {SCOPE_ORDER.map((scope) => (
+                                <TabButton
+                                    key={scope}
+                                    active={activeScope === scope}
+                                    onClick={() => setActiveScope(scope)}
+                                    size="lg"
+                                    ariaLabel={
+                                        scope === "community"
+                                            ? "Community alpha models"
+                                            : undefined
+                                    }
+                                >
+                                    <span className="inline-flex items-center gap-1.5">
+                                        {SCOPE_LABELS[scope]}
+                                        {scope === "community" && (
+                                            <Chip intent="alpha" size="sm">
+                                                Alpha
+                                            </Chip>
+                                        )}
+                                    </span>
+                                </TabButton>
+                            ))}
+                        </div>
+                        <div className="flex flex-wrap gap-1.5">
+                            {sectionOrder.map((section) => {
+                                const showAgentsNew =
+                                    section === "agent" && hasAgents;
+                                return (
+                                    <TabButton
+                                        key={section}
+                                        active={activeTab === section}
+                                        onClick={() => setActiveTab(section)}
+                                        ariaLabel={
+                                            showAgentsNew
+                                                ? "Agents, new"
+                                                : undefined
+                                        }
+                                    >
+                                        <span className="inline-flex items-center gap-1.5">
+                                            {sectionLabels[section]}
+                                            {showAgentsNew && (
+                                                <Chip intent="new" size="sm">
+                                                    New
+                                                </Chip>
+                                            )}
+                                        </span>
+                                    </TabButton>
+                                );
+                            })}
+                        </div>
                     </div>
-                    <div className="relative w-full sm:w-72">
-                        <SearchIcon className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-theme-text-muted" />
-                        <Input
-                            type="search"
-                            value={search}
-                            onChange={(e) => setSearch(e.target.value)}
-                            onBlur={() => pushSearch(search)}
-                            placeholder={`Search ${searchLabel} models…`}
-                            aria-label={`Search ${searchLabel} models`}
-                            className="w-full pl-9"
-                        />
+                    <div className="flex w-full items-center justify-between gap-2">
+                        <div className="relative min-w-0 max-w-md flex-1">
+                            <SearchIcon className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-theme-text-muted" />
+                            <Input
+                                type="search"
+                                value={search}
+                                onChange={(event) =>
+                                    setSearch(event.target.value)
+                                }
+                                onBlur={() => {
+                                    const normalizedSearch = search.trim();
+                                    setSearch(normalizedSearch);
+                                    pushSearch(normalizedSearch);
+                                }}
+                                placeholder={`Search ${searchTarget}… (type: access: owner:)`}
+                                aria-label={`Search ${searchTarget}`}
+                                className="w-full pl-9"
+                            />
+                        </div>
+                        <Dropdown
+                            align="end"
+                            className="w-max p-2"
+                            trigger={(open) => (
+                                <Button
+                                    type="button"
+                                    size="md"
+                                    aria-label={`Sort models by ${activeSortAccessibleLabel}`}
+                                    className="shrink-0 justify-end gap-2"
+                                >
+                                    <span className="text-right">
+                                        {activeSortLabel}
+                                    </span>
+                                    <ChevronIcon expanded={open} />
+                                </Button>
+                            )}
+                        >
+                            {(close) => (
+                                <div
+                                    role="menu"
+                                    aria-label="Sort models"
+                                    onKeyDown={handleSortMenuKeyDown}
+                                    className="flex flex-col gap-1"
+                                >
+                                    {SORT_OPTIONS.map((option) => (
+                                        <DropdownItem
+                                            key={option.value}
+                                            role="menuitemradio"
+                                            aria-label={option.accessibleLabel}
+                                            aria-checked={
+                                                activeSort === option.value
+                                            }
+                                            onClick={() => {
+                                                setActiveSort(option.value);
+                                                close();
+                                            }}
+                                            className={
+                                                activeSort === option.value
+                                                    ? "justify-end bg-theme-bg-active text-right text-theme-text-strong"
+                                                    : "justify-end text-right"
+                                            }
+                                        >
+                                            <span className="flex-1 text-right">
+                                                {option.label}
+                                            </span>
+                                        </DropdownItem>
+                                    ))}
+                                </div>
+                            )}
+                        </Dropdown>
                     </div>
                 </div>
+                {activeScope === "community" && (
+                    <Alert
+                        intent="warning"
+                        title="Community model privacy"
+                        className="mb-4"
+                    >
+                        <p>
+                            Requests go to independent providers and configured
+                            fallbacks, which handle your data under their own
+                            policies.
+                        </p>
+                        <p className="mt-2">
+                            <strong>Avoid sensitive data.</strong> For text
+                            input, you can use our optional{" "}
+                            <InlineLink
+                                href="https://gen.pollinations.ai/docs#tag/Safety"
+                                showIcon={false}
+                            >
+                                privacy filter
+                            </InlineLink>
+                            . See our{" "}
+                            <InlineLink
+                                href="https://pollinations.ai/privacy"
+                                showIcon={false}
+                            >
+                                Privacy Policy
+                            </InlineLink>
+                            .
+                        </p>
+                    </Alert>
+                )}
                 {catalogError && (
                     <Alert intent="danger" className="mb-4">
                         {catalogError}
                     </Alert>
                 )}
-                {query && sectionModels[activeTab].length === 0 ? (
+                {hasQuery && sectionModels[activeTab].length === 0 ? (
                     <p className="py-8 text-center text-sm text-theme-text-muted">
-                        No {sectionLabels[activeTab].toLowerCase()} models match
-                        “{search.trim()}”.
+                        No {searchTarget.toLowerCase()} match "{search.trim()}".
                     </p>
                 ) : (
                     <div className="overflow-x-auto md:overflow-visible [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
                         <UnifiedModelTable
+                            listKey={`${activeScope}:${activeTab}:${search.trim()}:${activeSort}`}
                             allModels={sectionModels.all}
                             imageModels={sectionModels.image}
                             videoModels={sectionModels.video}
@@ -310,21 +523,23 @@ export const Models: FC<ModelsProps> = ({
                             audioModels={sectionModels.audio}
                             realtimeModels={sectionModels.realtime}
                             textModels={sectionModels.text}
-                            communityTextModels={
-                                sectionModels["community-text"]
-                            }
-                            communityImageModels={
-                                sectionModels["community-image"]
-                            }
                             embeddingModels={sectionModels.embedding}
+                            agentModels={sectionModels.agent}
                             activeTab={activeTab}
-                            sortKey={sortKey}
-                            sortDir={sortDir}
-                            onSort={onSort}
                         />
                     </div>
                 )}
                 <div className="mt-4 space-y-2 border-t border-divider pt-4 text-[13px] leading-snug text-theme-text-muted">
+                    {activeTab === "agent" && (
+                        <p className="flex items-start gap-1.5">
+                            <BotIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                            <span>
+                                <strong>agent pricing</strong> — listed rates
+                                are for the agent&apos;s base model running its
+                                saved instructions.
+                            </span>
+                        </p>
+                    )}
                     <p className="flex items-start gap-1.5">
                         <SparklesIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
                         <span>
@@ -335,7 +550,8 @@ export const Models: FC<ModelsProps> = ({
                     <p className="flex items-start gap-1.5">
                         <TokensIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
                         <span>
-                            <strong>/M</strong> — per million tokens.
+                            <strong>/K · /M</strong> — rates per thousand or
+                            million tokens.
                         </span>
                     </p>
                     <p className="flex items-start gap-1.5">
@@ -345,16 +561,15 @@ export const Models: FC<ModelsProps> = ({
                             TTS is estimated from text length.
                         </span>
                     </p>
+                    <p className="flex items-start gap-1.5">
+                        <UsageIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                        <span>
+                            <strong>requests /pollen</strong> — estimated from
+                            the median observed cost over the last 7 days.
+                        </span>
+                    </p>
                 </div>
             </Section>
-            {showCommunityEndpoints && (
-                <CommunityEndpoints
-                    canPublish={canPublish}
-                    onChange={() => {
-                        void loadModelCatalog({ refresh: true });
-                    }}
-                />
-            )}
         </div>
     );
 };

--- a/enter.pollinations.ai/test/model-filter.test.ts
+++ b/enter.pollinations.ai/test/model-filter.test.ts
@@ -1,0 +1,249 @@
+import {
+    matchesModel,
+    parseQuery,
+} from "@frontend/components/models/model-filter.ts";
+import type { ModelPrice } from "@frontend/components/models/types.ts";
+import { describe, expect, it } from "vitest";
+
+function model(overrides: Partial<ModelPrice> = {}): ModelPrice {
+    return {
+        name: "test-model",
+        type: "text",
+        capabilities: [],
+        prices: [],
+        ...overrides,
+    };
+}
+
+describe("parseQuery", () => {
+    it("returns empty results for an empty string", () => {
+        expect(parseQuery("")).toEqual({ filters: [], terms: [] });
+        expect(parseQuery("   ")).toEqual({ filters: [], terms: [] });
+    });
+
+    it("parses free-text terms", () => {
+        expect(parseQuery("gpt flux")).toEqual({
+            filters: [],
+            terms: ["gpt", "flux"],
+        });
+    });
+
+    it("parses a single key:value filter", () => {
+        expect(parseQuery("access:paid")).toEqual({
+            filters: [{ key: "access", value: "paid" }],
+            terms: [],
+        });
+    });
+
+    it("parses multiple filters", () => {
+        expect(parseQuery("type:text access:free")).toEqual({
+            filters: [
+                { key: "type", value: "text" },
+                { key: "access", value: "free" },
+            ],
+            terms: [],
+        });
+    });
+
+    it("separates filters from free-text terms", () => {
+        expect(parseQuery("gpt access:paid reasoning")).toEqual({
+            filters: [{ key: "access", value: "paid" }],
+            terms: ["gpt", "reasoning"],
+        });
+    });
+
+    it("normalises to lowercase", () => {
+        expect(parseQuery("GPT Access:Paid")).toEqual({
+            filters: [{ key: "access", value: "paid" }],
+            terms: ["gpt"],
+        });
+    });
+
+    it("handles owner filter with slash in value", () => {
+        expect(parseQuery("owner:voodoohop")).toEqual({
+            filters: [{ key: "owner", value: "voodoohop" }],
+            terms: [],
+        });
+    });
+});
+
+describe("matchesModel — free-text", () => {
+    it("matches against model name", () => {
+        const m = model({ name: "flux-pro" });
+        expect(matchesModel(m, parseQuery("flux"))).toBe(true);
+        expect(matchesModel(m, parseQuery("gemini"))).toBe(false);
+    });
+
+    it("matches against displayName / title", () => {
+        const m = model({ displayName: "GPT 4o" });
+        expect(matchesModel(m, parseQuery("gpt"))).toBe(true);
+    });
+
+    it("matches against description", () => {
+        const m = model({ description: "Fast reasoning model" });
+        expect(matchesModel(m, parseQuery("reasoning"))).toBe(true);
+    });
+
+    it("matches against brand", () => {
+        const m = model({ brand: "OpenAI" });
+        expect(matchesModel(m, parseQuery("openai"))).toBe(true);
+    });
+
+    it("matches against baseModel", () => {
+        const m = model({ baseModel: "llama-3" });
+        expect(matchesModel(m, parseQuery("llama"))).toBe(true);
+    });
+
+    it("matches against input modalities", () => {
+        const m = model({ inputModalities: ["text", "image"] });
+        expect(matchesModel(m, parseQuery("image"))).toBe(true);
+    });
+
+    it("matches against output modalities", () => {
+        const m = model({ outputModalities: ["audio"] });
+        expect(matchesModel(m, parseQuery("audio"))).toBe(true);
+    });
+
+    it("matches against capabilities", () => {
+        const m = model({ capabilities: ["reasoning"] });
+        expect(matchesModel(m, parseQuery("reasoning"))).toBe(true);
+    });
+
+    it("requires all free-text terms to match", () => {
+        const m = model({ name: "openai-gpt", brand: "OpenAI" });
+        expect(matchesModel(m, parseQuery("openai gpt"))).toBe(true);
+        expect(matchesModel(m, parseQuery("openai flux"))).toBe(false);
+    });
+
+    it("returns true for an empty query", () => {
+        expect(matchesModel(model(), parseQuery(""))).toBe(true);
+    });
+});
+
+describe("matchesModel — access filter", () => {
+    it("access:paid matches paidOnly models", () => {
+        expect(
+            matchesModel(model({ paidOnly: true }), parseQuery("access:paid")),
+        ).toBe(true);
+        expect(
+            matchesModel(model({ paidOnly: false }), parseQuery("access:paid")),
+        ).toBe(false);
+        expect(matchesModel(model(), parseQuery("access:paid"))).toBe(false);
+    });
+
+    it("access:free matches free models", () => {
+        expect(
+            matchesModel(model({ free: true }), parseQuery("access:free")),
+        ).toBe(true);
+        expect(
+            matchesModel(model({ free: false }), parseQuery("access:free")),
+        ).toBe(false);
+    });
+
+    it("access:quest matches models that are neither paid-only nor free", () => {
+        expect(matchesModel(model(), parseQuery("access:quest"))).toBe(true);
+        expect(
+            matchesModel(model({ paidOnly: true }), parseQuery("access:quest")),
+        ).toBe(false);
+        expect(
+            matchesModel(model({ free: true }), parseQuery("access:quest")),
+        ).toBe(false);
+    });
+
+    it("unknown access value matches nothing", () => {
+        expect(matchesModel(model(), parseQuery("access:unknown"))).toBe(false);
+    });
+});
+
+describe("matchesModel — owner filter", () => {
+    it("matches community models by github login prefix", () => {
+        const m = model({ name: "voodoohop/my-model", community: true });
+        expect(matchesModel(m, parseQuery("owner:voodoohop"))).toBe(true);
+        expect(matchesModel(m, parseQuery("owner:other"))).toBe(false);
+    });
+
+    it("does not match non-community models", () => {
+        const m = model({ name: "voodoohop/my-model", community: false });
+        expect(matchesModel(m, parseQuery("owner:voodoohop"))).toBe(false);
+    });
+});
+
+describe("matchesModel — id filter", () => {
+    it("matches model name substring", () => {
+        const m = model({ name: "gpt-4o-mini" });
+        expect(matchesModel(m, parseQuery("id:gpt-4o"))).toBe(true);
+        expect(matchesModel(m, parseQuery("id:claude"))).toBe(false);
+    });
+});
+
+describe("matchesModel — type filter", () => {
+    it("matches model type", () => {
+        expect(
+            matchesModel(model({ type: "image" }), parseQuery("type:image")),
+        ).toBe(true);
+        expect(
+            matchesModel(model({ type: "text" }), parseQuery("type:image")),
+        ).toBe(false);
+    });
+
+    it("type:agent matches agent models", () => {
+        expect(
+            matchesModel(model({ agent: true }), parseQuery("type:agent")),
+        ).toBe(true);
+        expect(
+            matchesModel(model({ agent: false }), parseQuery("type:agent")),
+        ).toBe(false);
+    });
+});
+
+describe("matchesModel — capability filter", () => {
+    it("matches capability by exact name", () => {
+        const m = model({ capabilities: ["reasoning", "tool_calling"] });
+        expect(matchesModel(m, parseQuery("capability:reasoning"))).toBe(true);
+        expect(matchesModel(m, parseQuery("capability:tool_calling"))).toBe(
+            true,
+        );
+    });
+
+    it("accepts hyphen form of capability names", () => {
+        const m = model({ capabilities: ["tool_calling"] });
+        expect(matchesModel(m, parseQuery("capability:tool-calling"))).toBe(
+            true,
+        );
+    });
+
+    it("returns false for unknown capability", () => {
+        const m = model({ capabilities: ["reasoning"] });
+        expect(matchesModel(m, parseQuery("capability:web_search"))).toBe(
+            false,
+        );
+    });
+});
+
+describe("matchesModel — combined filters and terms", () => {
+    it("applies all conditions together", () => {
+        const m = model({
+            name: "openai/gpt-agent",
+            community: true,
+            type: "text",
+            agent: true,
+            paidOnly: true,
+            capabilities: ["reasoning"],
+        });
+
+        expect(
+            matchesModel(
+                m,
+                parseQuery("gpt owner:openai type:agent access:paid"),
+            ),
+        ).toBe(true);
+
+        // fails because type:image does not match
+        expect(
+            matchesModel(
+                m,
+                parseQuery("gpt owner:openai type:image access:paid"),
+            ),
+        ).toBe(false);
+    });
+});


### PR DESCRIPTION
Closes #13907

## Summary

- Extracts search logic into `model-filter.ts` with a `parseQuery` / `matchesModel` API
- Free-text now searches model id, title, description, brand, base model, input/output modalities, and capabilities (was: display name + brand only)
- Adds `key:value` filter syntax discoverable via the search placeholder hint

**Supported filters:**
| Filter | Matches |
|---|---|
| `access:paid` | models requiring Paid Pollen (`paidOnly: true`) |
| `access:free` | free models (`free: true`) |
| `access:quest` | models accessible with Quest Pollen (neither paid-only nor free) |
| `owner:<login>` | community models by GitHub username |
| `id:<fragment>` | models whose id contains the fragment |
| `type:<type>` | model type (`text`, `image`, `video`, `audio`, `3d`, `embedding`, `realtime`, `agent`) |
| `capability:<c>` | models with the given capability (underscore or hyphen form) |

Filters and free-text terms can be combined; all conditions must match.

## Files changed

- `enter.pollinations.ai/frontend/src/components/models/model-filter.ts` — new pure-logic module with `parseQuery` and `matchesModel`
- `enter.pollinations.ai/frontend/src/components/models/models.tsx` — removes inline `matchesQuery`, uses new filter; updates placeholder hint
- `enter.pollinations.ai/test/model-filter.test.ts` — focused unit tests for parsing and all filter types