### PR TITLE
feat: add video as a community-model modality

### DIFF
--- a/enter.pollinations.ai/src/routes/community-endpoints.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints.ts
@@ -1,229 +1,69 @@
 import {
-    COMMUNITY_ENDPOINT_DESCRIPTION_MAX_LENGTH,
-    COMMUNITY_ENDPOINT_IMAGE_PRICING_MODES,
-    COMMUNITY_ENDPOINT_MODALITIES,
-    COMMUNITY_ENDPOINT_PRICE_FIELDS,
-    COMMUNITY_ENDPOINT_TITLE_MAX_LENGTH,
-    COMMUNITY_ENDPOINT_VISIBILITIES,
-    type CommunityEndpointPriceKey,
+    applyPendingProxyPricing,
     type CommunityEndpointVisibility,
-    communityEndpointPriceFieldsForModality,
-    communityEndpointPrices,
-    communityEndpointPricesForModality,
-    communityEndpointTitle,
     communityModelId,
+    type EndpointAgentListingPayload,
     isCommunityEndpointOwnerAllowed,
-    MAX_COMMUNITY_PRICE_PER_IMAGE,
-    MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS,
-    MAX_COMMUNITY_PRICE_PER_TOKEN,
-    MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS,
-    MIN_COMMUNITY_PRICE_PER_TOKEN,
     normalizeCommunityEndpointBaseUrl,
     normalizeCommunityEndpointBearerToken,
-    normalizeCommunityEndpointImagePricing,
-    normalizeCommunityEndpointModality,
+    normalizeCommunityProviderUrl,
+    type ProxyListingPayload,
+    parseListingPayload,
+    pendingCommunityEndpointChangeIsReady,
 } from "@shared/community-endpoints.ts";
 import * as schema from "@shared/db/better-auth.ts";
 import { validator } from "@shared/middleware/validator.ts";
 import { encryptSecret } from "@shared/secret-encryption.ts";
-import { and, eq } from "drizzle-orm";
+import { and, desc, eq, or } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import type { Context } from "hono";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { describeRoute, resolver } from "hono-openapi";
-import { z } from "zod";
 import type { Env } from "../env.ts";
 import { auth } from "../middleware/auth.ts";
 import {
     listCommunityEndpointModels,
     testCommunityEndpoint,
     testCommunityImageEndpoint,
+    testCommunityTranscriptionEndpoint,
+    testCommunityVideoEndpoint,
 } from "../services/community-endpoint-openai.ts";
-import { hasDirectAccountPermission } from "./account-permissions.ts";
+import { requireAccountPermission } from "./account-permissions.ts";
+import {
+    type FallbackPrimary,
+    fallbackTargetRejection,
+    resolveFallbacks,
+} from "./community-endpoints/fallbacks.ts";
+import { toCommunityEndpointResponse } from "./community-endpoints/presenter.ts";
+import {
+    changesProxyPayload,
+    deriveCreateProxyPolicy,
+    deriveUpdatedProxyPolicy,
+    hasProxyPricingInput,
+    proxyPricingChanged,
+    withoutProxyPricingChanges,
+} from "./community-endpoints/proxy-policy.ts";
+import {
+    assertValidUpdate,
+    CommunityEndpointDeleteResponseSchema,
+    CommunityEndpointListResponseSchema,
+    CommunityEndpointModelsResponseSchema,
+    CommunityEndpointResponseSchema,
+    CommunityEndpointTestResponseSchema,
+    CommunityProviderProfileInputSchema,
+    CommunityProviderProfileResponseSchema,
+    CreateEndpointAgentSchema,
+    CreateEndpointSchema,
+    EndpointAgentResponseSchema,
+    FallbackCandidatesResponseSchema,
+    ModelListSchema,
+    TestEndpointSchema,
+    UpdateEndpointSchema,
+} from "./community-endpoints/schemas.ts";
 
-const ModalitySchema = z
-    .enum(COMMUNITY_ENDPOINT_MODALITIES)
-    .describe(
-        'Upstream API family. "text" uses `/v1/chat/completions`; "image" uses `/v1/images/generations` and optionally `/v1/images/edits` when the endpoint test succeeds.',
-    );
-const ImagePricingSchema = z
-    .enum(COMMUNITY_ENDPOINT_IMAGE_PRICING_MODES)
-    .describe(
-        'Image models only. "request": the generated-image price is charged once per generation. "tokens": provider-returned OpenAI image token usage is charged against per-token prices. Detected by the endpoint test.',
-    );
-const PriceSchema = z
-    .number()
-    .finite()
-    .min(0)
-    .refine((price) => price === 0 || price >= MIN_COMMUNITY_PRICE_PER_TOKEN, {
-        message: `Price must be 0 (free) or at least ${MIN_COMMUNITY_PRICE_PER_TOKEN} per token (${MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS} per 1M tokens)`,
-    })
-    .describe(
-        'Pollen price. Token rates are per token internally (the dashboard displays per 1M); `completionImagePrice` is per generated image when `imagePricing` is "request".',
-    );
-const UpdatePriceFieldsSchema = Object.fromEntries(
-    COMMUNITY_ENDPOINT_PRICE_FIELDS.map((field) => [
-        field.key,
-        PriceSchema.optional(),
-    ]),
-) as unknown as Record<
-    CommunityEndpointPriceKey,
-    z.ZodOptional<z.ZodType<number>>
->;
-
-function enforceCommunityEndpointPriceLimits(
-    source: Partial<Record<CommunityEndpointPriceKey, number>>,
-    modality: (typeof COMMUNITY_ENDPOINT_MODALITIES)[number],
-    imagePricing: (typeof COMMUNITY_ENDPOINT_IMAGE_PRICING_MODES)[number],
-): void {
-    for (const field of communityEndpointPriceFieldsForModality(
-        modality,
-        imagePricing,
-    )) {
-        const price = source[field.key];
-        const maxPrice =
-            field.priceUnit === "image"
-                ? MAX_COMMUNITY_PRICE_PER_IMAGE
-                : MAX_COMMUNITY_PRICE_PER_TOKEN;
-        if (price === undefined || price <= maxPrice) continue;
-
-        const limit =
-            field.priceUnit === "image"
-                ? `${MAX_COMMUNITY_PRICE_PER_IMAGE} Pollen per image`
-                : `${MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS} Pollen per 1M tokens`;
-        throw new HTTPException(400, {
-            message: `${field.label} price must not exceed ${limit}`,
-        });
-    }
-}
-
-const VisibilitySchema = z
-    .enum(COMMUNITY_ENDPOINT_VISIBILITIES)
-    .describe(
-        '"private": owner-only, shown only to the owner, with no owner-set price. "public": anyone and listed in the catalog; it may be free or priced. Publishing requires an allowlisted account.',
-    );
-const EndpointFieldsSchema = {
-    // No "/": the public model id is `<owner>/<name>`, so a slash in the name
-    // would inject a second separator and let one model spoof another's id.
-    name: z
-        .string()
-        .trim()
-        .min(1)
-        .max(120)
-        .regex(/^[^/]+$/, "Model name cannot contain '/'"),
-    title: z
-        .string()
-        .trim()
-        .min(1)
-        .max(COMMUNITY_ENDPOINT_TITLE_MAX_LENGTH)
-        .describe("Display name shown in the model catalog."),
-    description: z
-        .string()
-        .trim()
-        .max(COMMUNITY_ENDPOINT_DESCRIPTION_MAX_LENGTH)
-        .optional(),
-    baseUrl: z
-        .string()
-        .url()
-        .describe(
-            "OpenAI-compatible `/v1` base URL or full chat, image generation, or image edit URL.",
-        ),
-    upstreamModel: z.string().trim().min(1).max(253).optional(),
-    bearerToken: z.string().min(1),
-} as const;
-
-const CreateEndpointSchema = z.object({
-    ...EndpointFieldsSchema,
-    modality: ModalitySchema.optional().default("text"),
-    imagePricing: ImagePricingSchema.optional().default("request"),
-    supportsImageEdits: z.boolean().optional().default(false),
-    visibility: VisibilitySchema.optional().default("private"),
-    ...UpdatePriceFieldsSchema,
-});
-const UpdateEndpointSchema = z.object({
-    name: EndpointFieldsSchema.name.optional(),
-    title: EndpointFieldsSchema.title.optional(),
-    description: EndpointFieldsSchema.description,
-    baseUrl: EndpointFieldsSchema.baseUrl.optional(),
-    upstreamModel: EndpointFieldsSchema.upstreamModel,
-    bearerToken: EndpointFieldsSchema.bearerToken.optional(),
-    visibility: VisibilitySchema.optional(),
-    imagePricing: ImagePricingSchema.optional(),
-    supportsImageEdits: z.boolean().optional(),
-    active: z.boolean().optional(),
-    ...UpdatePriceFieldsSchema,
-});
-const ModelListSchema = z.object({
-    baseUrl: z.string().url(),
-    bearerToken: z.string().min(1),
-});
-const TestEndpointSchema = z.object({
-    baseUrl: z.string().url(),
-    bearerToken: z.string().min(1),
-    model: z.string().trim().min(1).max(253),
-    modality: ModalitySchema.optional().default("text"),
-});
-const ResponsePriceFieldsSchema = Object.fromEntries(
-    COMMUNITY_ENDPOINT_PRICE_FIELDS.map((field) => [field.key, z.number()]),
-) as unknown as Record<CommunityEndpointPriceKey, z.ZodType<number>>;
-const CommunityEndpointResponseSchema = z.object({
-    id: z.string(),
-    modelId: z.string(),
-    name: z.string(),
-    title: z.string(),
-    description: z.string().nullable(),
-    modality: ModalitySchema,
-    imagePricing: ImagePricingSchema,
-    supportsImageEdits: z.boolean(),
-    baseUrl: z.string(),
-    upstreamModel: z.string(),
-    visibility: VisibilitySchema,
-    ...ResponsePriceFieldsSchema,
-    disabled: z.boolean(),
-    disabledReason: z.string().nullable(),
-    disabledAt: z.string().nullable(),
-    createdAt: z.string(),
-    updatedAt: z.string(),
-});
-const CommunityEndpointListResponseSchema = z.object({
-    data: z.array(CommunityEndpointResponseSchema),
-});
-const CommunityEndpointModelsResponseSchema = z.object({
-    data: z.array(z.string()),
-});
-const CommunityEndpointTestResponseSchema = z
-    .object({
-        ok: z.boolean(),
-        message: z.string(),
-        usage: z
-            .record(z.string(), z.unknown())
-            .describe(
-                "Raw provider usage, or `{ images: 1 }` when an image provider returns no token usage.",
-            ),
-        billableUsage: z
-            .record(z.string(), z.number())
-            .describe(
-                "Normalized billable usage fields used to reveal applicable prices.",
-            ),
-        imagePricing: ImagePricingSchema.optional().describe(
-            "Image tests only: pricing mode detected from the provider response.",
-        ),
-        supportsImageEdits: z
-            .boolean()
-            .optional()
-            .describe(
-                "Image tests only: true when the derived `/images/edits` endpoint returned a valid image.",
-            ),
-    })
-    .passthrough();
-const CommunityEndpointDeleteResponseSchema = z.object({
-    id: z.string(),
-});
 const ENDPOINT_PROBE_THROTTLE_SECONDS = 30;
 type Db = ReturnType<typeof drizzle<typeof schema>>;
-type CommunityEndpointRow = typeof schema.communityEndpoint.$inferSelect;
-
 function normalizeInputBaseUrl(value: string): string {
     try {
         return normalizeCommunityEndpointBaseUrl(value);
@@ -248,8 +88,19 @@ function normalizeInputBearerToken(value: string): string {
     }
 }
 
-// Anyone may register private endpoints for their own use. Publishing and raw
-// upstream probes require an allowlisted account.
+function normalizeInputProviderUrl(value: string): string {
+    try {
+        return normalizeCommunityProviderUrl(value);
+    } catch (error) {
+        throw new HTTPException(400, {
+            message:
+                error instanceof Error ? error.message : "Invalid provider URL",
+        });
+    }
+}
+
+// Anyone may register private endpoints for their own use and probe their own
+// upstream. Publishing requires an allowlisted account.
 async function requireCommunityEndpointPublishAccess(
     db: Db,
     userId: string,
@@ -262,7 +113,7 @@ async function requireCommunityEndpointPublishAccess(
     if (!isCommunityEndpointOwnerAllowed(user)) {
         throw new HTTPException(403, {
             message:
-                "Community model publishing tools require approval. Models can stay private for your own use.",
+                "Community model publishing requires approval. Models can stay private for your own use.",
         });
     }
 }
@@ -280,33 +131,6 @@ async function requireOwnerGithubUsername(
         message:
             "A GitHub username is required to register community endpoints",
     });
-}
-
-function toResponse(row: CommunityEndpointRow, ownerGithubUsername: string) {
-    const modality = normalizeCommunityEndpointModality(row.modality);
-    return {
-        id: row.id,
-        modelId: communityModelId(ownerGithubUsername, row.name),
-        name: row.name,
-        title: communityEndpointTitle({
-            modelId: communityModelId(ownerGithubUsername, row.name),
-            title: row.title,
-            description: row.description,
-        }),
-        description: row.description,
-        modality,
-        imagePricing: normalizeCommunityEndpointImagePricing(row.imagePricing),
-        supportsImageEdits: row.supportsImageEdits,
-        baseUrl: row.baseUrl,
-        upstreamModel: row.upstreamModel,
-        visibility: row.visibility,
-        ...communityEndpointPrices(row),
-        disabled: row.disabledAt !== null,
-        disabledReason: row.disabledReason,
-        disabledAt: row.disabledAt,
-        createdAt: row.createdAt,
-        updatedAt: row.updatedAt,
-    };
 }
 
 async function requireOwnedEndpoint(db: Db, id: string, ownerUserId: string) {
@@ -351,18 +175,6 @@ function throwEndpointTestError(error: unknown): never {
 }
 
 type EndpointProbeKind = "models" | "test";
-
-function requireCommunityEndpointManagePermission(apiKey?: {
-    permissions?: Record<string, string[]>;
-    metadata?: Record<string, unknown>;
-}): void {
-    if (!apiKey) return;
-    if (!hasDirectAccountPermission(apiKey, "keys")) {
-        throw new HTTPException(403, {
-            message: "API key does not have 'account:keys' permission",
-        });
-    }
-}
 
 // Publishing is allowlist-gated. Pricing is independent: public endpoints may
 // be free or owner-priced.
@@ -409,7 +221,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
     .get(
         "/",
         describeRoute({
-            tags: ["👤 Account"],
+            tags: ["🧩 Community Models"],
             summary: "List My Models",
             description:
                 "List private and public community models owned by the authenticated account. API keys require `account:keys`.",
@@ -431,27 +243,248 @@ export const communityEndpointsRoutes = new Hono<Env>()
         async (c) => {
             const user = c.var.auth.requireUser();
             const db = drizzle(c.env.DB, { schema });
-            requireCommunityEndpointManagePermission(c.var.auth.apiKey);
+            requireAccountPermission(c.var.auth.apiKey, "keys");
             const ownerGithubUsername = await requireOwnerGithubUsername(
                 db,
                 user.id,
             );
-            const rows = await db.query.communityEndpoint.findMany({
-                where: eq(schema.communityEndpoint.ownerUserId, user.id),
-                orderBy: (endpoint, { desc }) => [desc(endpoint.createdAt)],
+            const rows = await db
+                .select()
+                .from(schema.communityEndpoint)
+                .where(eq(schema.communityEndpoint.ownerUserId, user.id))
+                .orderBy(desc(schema.communityEndpoint.createdAt));
+            const owner = await db.query.user.findFirst({
+                columns: {
+                    communityProviderName: true,
+                    communityProviderUrl: true,
+                },
+                where: eq(schema.user.id, user.id),
             });
-            return c.json({
-                data: rows.map((row) => toResponse(row, ownerGithubUsername)),
+            return c.json(
+                CommunityEndpointListResponseSchema.parse({
+                    data: rows.map((endpoint) =>
+                        toCommunityEndpointResponse(
+                            endpoint,
+                            ownerGithubUsername,
+                            c.env.AGENT_RUNTIME_BASE_URL,
+                        ),
+                    ),
+                    provider: {
+                        name: owner?.communityProviderName ?? null,
+                        url: owner?.communityProviderUrl ?? null,
+                    },
+                }),
+            );
+        },
+    )
+    .post(
+        "/provider",
+        describeRoute({
+            tags: ["🧩 Community Models"],
+            summary: "Update Community Provider Profile",
+            description:
+                "Set the public provider name and HTTPS service link shared by all community models owned by the authenticated account. Send both fields empty to clear the profile. Publishing approval and `account:keys` are required.",
+            responses: {
+                200: {
+                    description: "Updated community provider profile",
+                    content: {
+                        "application/json": {
+                            schema: resolver(
+                                CommunityProviderProfileResponseSchema,
+                            ),
+                        },
+                    },
+                },
+                400: { description: "Invalid provider profile" },
+                401: { description: "Unauthorized" },
+                403: { description: "Permission denied" },
+            },
+        }),
+        validator("json", CommunityProviderProfileInputSchema),
+        async (c) => {
+            const user = c.var.auth.requireUser();
+            const input = c.req.valid("json");
+            const db = drizzle(c.env.DB, { schema });
+            requireAccountPermission(c.var.auth.apiKey, "keys");
+            await requireCommunityEndpointPublishAccess(db, user.id);
+
+            const name = input.name.trim();
+            const url = input.url.trim();
+            if (Boolean(name) !== Boolean(url)) {
+                throw new HTTPException(400, {
+                    message: "Provider name and URL must be set together",
+                });
+            }
+
+            const [profile] = await db
+                .update(schema.user)
+                .set({
+                    communityProviderName: name || null,
+                    communityProviderUrl: url
+                        ? normalizeInputProviderUrl(url)
+                        : null,
+                    updatedAt: new Date(),
+                })
+                .where(eq(schema.user.id, user.id))
+                .returning({
+                    name: schema.user.communityProviderName,
+                    url: schema.user.communityProviderUrl,
+                });
+            return c.json(profile);
+        },
+    )
+    .get(
+        "/:id/fallback-candidates",
+        describeRoute({
+            tags: ["🧩 Community Models"],
+            summary: "List Fallback Candidates",
+            description:
+                "Community models this model may declare as fallbacks: listed, public or owned by you, same modality, and priced at or below it on every price field. Computed with the same rule the update endpoint validates against, so every id listed here is accepted. Eligibility is re-checked when a request is routed, so a target repriced above this model afterwards stops serving without changing the stored list.",
+            responses: {
+                200: {
+                    description: "Eligible fallback model ids",
+                    content: {
+                        "application/json": {
+                            schema: resolver(FallbackCandidatesResponseSchema),
+                        },
+                    },
+                },
+                401: { description: "Unauthorized" },
+                403: { description: "Permission denied" },
+                404: { description: "Model not found" },
+            },
+        }),
+        async (c) => {
+            const user = c.var.auth.requireUser();
+            const db = drizzle(c.env.DB, { schema });
+            requireAccountPermission(c.var.auth.apiKey, "keys");
+            const ownerGithubUsername = await requireOwnerGithubUsername(
+                db,
+                user.id,
+            );
+            const endpoint = await db.query.communityEndpoint.findFirst({
+                where: and(
+                    eq(schema.communityEndpoint.id, c.req.param("id")),
+                    eq(schema.communityEndpoint.ownerUserId, user.id),
+                ),
             });
+            if (!endpoint) {
+                throw new HTTPException(404, { message: "Model not found" });
+            }
+            if (endpoint.type !== "proxy") return c.json({ data: [] });
+            const endpointPayload = parseListingPayload(
+                "proxy",
+                endpoint.payload,
+            );
+            if (!endpointPayload) {
+                throw new Error(`Invalid proxy payload for ${endpoint.id}`);
+            }
+            const primary: FallbackPrimary = {
+                modelId: communityModelId(ownerGithubUsername, endpoint.name),
+                ownerUserId: user.id,
+                modality: endpointPayload.modality,
+                imagePricing: endpointPayload.imagePricing,
+                paidOnly: endpointPayload.paidOnly,
+                prices: endpointPayload.prices,
+                inputModalities: endpointPayload.inputModalities,
+            };
+            const candidates = await db
+                .select({
+                    endpoint: schema.communityEndpoint,
+                    ownerGithubUsername: schema.user.githubUsername,
+                })
+                .from(schema.communityEndpoint)
+                .innerJoin(
+                    schema.user,
+                    eq(schema.communityEndpoint.ownerUserId, schema.user.id),
+                )
+                .where(
+                    or(
+                        eq(schema.communityEndpoint.visibility, "public"),
+                        eq(schema.communityEndpoint.ownerUserId, user.id),
+                    ),
+                );
+            const data = candidates
+                .flatMap(({ endpoint: row, ownerGithubUsername: owner }) => {
+                    if (!owner) return [];
+                    const modelId = communityModelId(owner, row.name);
+                    return fallbackTargetRejection(primary, modelId, row)
+                        ? []
+                        : [modelId];
+                })
+                .sort();
+            return c.json({ data });
+        },
+    )
+    .post(
+        "/endpoint-agents",
+        describeRoute({
+            tags: ["🤖 Community Agents"],
+            summary: "Create Endpoint Agent",
+            description:
+                "Register an agent running on an external OpenAI-compatible endpoint. Pollinations sends a short-lived agent run token instead of a stored bearer credential. Private is the default; public agents require an allowlisted account. API keys require `account:keys`.",
+            responses: {
+                200: {
+                    description: "Created endpoint agent",
+                    content: {
+                        "application/json": {
+                            schema: resolver(EndpointAgentResponseSchema),
+                        },
+                    },
+                },
+                400: { description: "Invalid endpoint agent configuration" },
+                401: { description: "Unauthorized" },
+                403: { description: "Permission denied" },
+            },
+        }),
+        validator("json", CreateEndpointAgentSchema),
+        async (c) => {
+            const user = c.var.auth.requireUser();
+            const input = c.req.valid("json");
+            const db = drizzle(c.env.DB, { schema });
+            requireAccountPermission(c.var.auth.apiKey, "keys");
+            const ownerGithubUsername = await requireOwnerGithubUsername(
+                db,
+                user.id,
+            );
+            await ensureModelNameAvailable(db, user.id, input.name);
+            await enforcePublishingAccess(db, user.id, input.visibility);
+            const payload: EndpointAgentListingPayload = {
+                perUserRpm: input.perUserRpm,
+            };
+            const [row] = await db
+                .insert(schema.communityEndpoint)
+                .values({
+                    id: crypto.randomUUID(),
+                    ownerUserId: user.id,
+                    name: input.name,
+                    title: input.title,
+                    description: input.description || null,
+                    visibility: input.visibility,
+                    type: "endpoint_agent",
+                    baseUrl: normalizeInputBaseUrl(input.baseUrl),
+                    upstreamModel: input.upstreamModel ?? input.name,
+                    payload: JSON.stringify(payload),
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                })
+                .returning();
+            return c.json(
+                toCommunityEndpointResponse(
+                    row,
+                    ownerGithubUsername,
+                    c.env.AGENT_RUNTIME_BASE_URL,
+                ),
+            );
         },
     )
     .post(
         "/",
         describeRoute({
-            tags: ["👤 Account"],
+            tags: ["🧩 Community Models"],
             summary: "Create My Model",
             description:
-                "Register a private or public community text or image model. Private is the default. Public models require an allowlisted account and may be free or priced. API keys require `account:keys`. The upstream bearer token is encrypted and never returned.",
+                "Register a private or public community text, image, or transcription model. Private is the default. Public models require an allowlisted account and may be free or priced. API keys require `account:keys`. The upstream bearer token is encrypted and never returned.",
             responses: {
                 200: {
                     description: "Created community model",
@@ -471,63 +504,62 @@ export const communityEndpointsRoutes = new Hono<Env>()
             const user = c.var.auth.requireUser();
             const input = c.req.valid("json");
             const db = drizzle(c.env.DB, { schema });
-            requireCommunityEndpointManagePermission(c.var.auth.apiKey);
+            requireAccountPermission(c.var.auth.apiKey, "keys");
             const ownerGithubUsername = await requireOwnerGithubUsername(
                 db,
                 user.id,
             );
             await ensureModelNameAvailable(db, user.id, input.name);
-            const imagePricing =
-                input.modality === "image" ? input.imagePricing : "request";
-            const prices =
-                input.visibility === "public"
-                    ? communityEndpointPricesForModality(
-                          input,
-                          input.modality,
-                          imagePricing,
-                      )
-                    : communityEndpointPrices({});
-            enforceCommunityEndpointPriceLimits(
-                prices,
-                input.modality,
-                imagePricing,
-            );
+            const policy = deriveCreateProxyPolicy(input);
+            const modelId = communityModelId(ownerGithubUsername, input.name);
+            const payload: ProxyListingPayload = {
+                bearerTokenCiphertext: await encryptSecret(
+                    normalizeInputBearerToken(input.bearerToken),
+                    c.env.BETTER_AUTH_SECRET,
+                ),
+                ...policy,
+                fallbacks: input.fallbacks
+                    ? await resolveFallbacks(db, input.fallbacks, {
+                          modelId,
+                          ownerUserId: user.id,
+                          ...policy,
+                      })
+                    : [],
+            };
             await enforcePublishingAccess(db, user.id, input.visibility);
-            const id = crypto.randomUUID();
             const [row] = await db
                 .insert(schema.communityEndpoint)
                 .values({
-                    id,
+                    id: crypto.randomUUID(),
                     ownerUserId: user.id,
                     name: input.name,
                     title: input.title,
                     description: input.description || null,
-                    modality: input.modality,
-                    imagePricing,
-                    supportsImageEdits:
-                        input.modality === "image" && input.supportsImageEdits,
+                    visibility: input.visibility,
+                    type: "proxy",
                     baseUrl: normalizeInputBaseUrl(input.baseUrl),
                     upstreamModel: input.upstreamModel ?? input.name,
-                    bearerTokenCiphertext: await encryptSecret(
-                        normalizeInputBearerToken(input.bearerToken),
-                        c.env.BETTER_AUTH_SECRET,
-                    ),
-                    visibility: input.visibility,
-                    ...prices,
+                    payload: JSON.stringify(payload),
                     createdAt: new Date(),
                     updatedAt: new Date(),
                 })
                 .returning();
-            return c.json(toResponse(row, ownerGithubUsername));
+            return c.json(
+                toCommunityEndpointResponse(
+                    row,
+                    ownerGithubUsername,
+                    c.env.AGENT_RUNTIME_BASE_URL,
+                ),
+            );
         },
     )
     .post(
         "/models",
         describeRoute({
-            tags: ["👤 Account"],
+            tags: ["🧩 Community Models"],
             summary: "List Upstream Models",
             description:
-                "Fetch OpenAI-compatible upstream model IDs before publishing a My Models endpoint. Requires community model publishing approval; API keys also require `account:keys`.",
+                "Fetch OpenAI-compatible upstream model IDs from a provider before registering a My Models endpoint. Limited to one probe every 30 seconds per account. API keys require `account:keys`.",
             responses: {
                 200: {
                     description: "Upstream model IDs",
@@ -549,9 +581,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
         async (c) => {
             const user = c.var.auth.requireUser();
             const input = c.req.valid("json");
-            const db = drizzle(c.env.DB, { schema });
-            requireCommunityEndpointManagePermission(c.var.auth.apiKey);
-            await requireCommunityEndpointPublishAccess(db, user.id);
+            requireAccountPermission(c.var.auth.apiKey, "keys");
             const throttled = await enforceEndpointProbeThrottle(
                 c,
                 user.id,
@@ -569,10 +599,10 @@ export const communityEndpointsRoutes = new Hono<Env>()
     .post(
         "/test",
         describeRoute({
-            tags: ["👤 Account"],
+            tags: ["🧩 Community Models"],
             summary: "Test My Model Endpoint",
             description:
-                "Test an OpenAI-compatible upstream model before publishing it. Image tests detect token pricing and probe the derived `/images/edits` endpoint. Requires community model publishing approval; API keys also require `account:keys`.",
+                "Test an OpenAI-compatible upstream model before registering it. Image tests detect the image pricing mode and probe the derived `/images/edits` endpoint. Limited to one probe every 30 seconds per account. API keys require `account:keys`.",
             responses: {
                 200: {
                     description: "Endpoint test result",
@@ -594,9 +624,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
         async (c) => {
             const user = c.var.auth.requireUser();
             const input = c.req.valid("json");
-            const db = drizzle(c.env.DB, { schema });
-            requireCommunityEndpointManagePermission(c.var.auth.apiKey);
-            await requireCommunityEndpointPublishAccess(db, user.id);
+            requireAccountPermission(c.var.auth.apiKey, "keys");
             const throttled = await enforceEndpointProbeThrottle(
                 c,
                 user.id,
@@ -607,15 +635,23 @@ export const communityEndpointsRoutes = new Hono<Env>()
                 const result =
                     input.modality === "image"
                         ? await testCommunityImageEndpoint(input)
-                        : await testCommunityEndpoint(input);
+                        : input.modality === "transcription"
+                          ? await testCommunityTranscriptionEndpoint(input)
+                          : input.modality === "video"
+                            ? await testCommunityVideoEndpoint(input)
+                            : await testCommunityEndpoint(input);
                 return c.json({
                     ok: true,
                     message:
                         input.modality === "image"
-                            ? result.supportsImageEdits
+                            ? result.inputModalities?.includes("image")
                                 ? "Generation and editing endpoints responded with image data"
                                 : "Generation endpoint responded; editing is not supported"
-                            : "Endpoint responded with usage",
+                            : input.modality === "transcription"
+                              ? "Endpoint responded with transcription text"
+                              : input.modality === "video"
+                                ? "Endpoint responded with video data"
+                                : "Endpoint responded with usage",
                     ...result,
                 });
             } catch (error) {
@@ -626,7 +662,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
     .post(
         "/:id/update",
         describeRoute({
-            tags: ["👤 Account"],
+            tags: ["🧩 Community Models"],
             summary: "Update My Model",
             description:
                 "Update a community model owned by the authenticated account. Changing visibility to public publishes it and requires an allowlisted account; public models may be free or priced. API keys require `account:keys`.",
@@ -651,15 +687,16 @@ export const communityEndpointsRoutes = new Hono<Env>()
             const input = c.req.valid("json");
             const { id } = c.req.param();
             const db = drizzle(c.env.DB, { schema });
-            requireCommunityEndpointManagePermission(c.var.auth.apiKey);
+            requireAccountPermission(c.var.auth.apiKey, "keys");
             const ownerGithubUsername = await requireOwnerGithubUsername(
                 db,
                 user.id,
             );
             const endpoint = await requireOwnedEndpoint(db, id, user.id);
-            const modality = normalizeCommunityEndpointModality(
-                endpoint.modality,
-            );
+            // The row already owns its immutable type. Validate the external
+            // body against that exact strict Zod schema instead of asking
+            // every client to echo a redundant discriminator.
+            assertValidUpdate(endpoint.type, input);
             await ensureModelNameAvailable(
                 db,
                 user.id,
@@ -672,80 +709,154 @@ export const communityEndpointsRoutes = new Hono<Env>()
             > = {
                 updatedAt: new Date(),
             };
+            const pendingReady = pendingCommunityEndpointChangeIsReady(
+                endpoint.pendingAt,
+            );
+            const currentVisibility =
+                pendingReady && endpoint.pendingVisibility
+                    ? endpoint.pendingVisibility
+                    : endpoint.visibility;
+            let pendingPayload = pendingReady ? null : endpoint.pendingPayload;
+            let pendingVisibility = pendingReady
+                ? null
+                : endpoint.pendingVisibility;
+            let pendingAt = pendingReady ? null : endpoint.pendingAt;
             if (input.name !== undefined) update.name = input.name;
             if (input.title !== undefined) update.title = input.title;
             if (input.description !== undefined) {
                 update.description = input.description || null;
             }
-            if (input.baseUrl !== undefined) {
-                update.baseUrl = normalizeInputBaseUrl(input.baseUrl);
+            if (input.hidden !== undefined) {
+                update.hiddenAt = input.hidden ? new Date() : null;
+                update.hiddenReason = input.hidden ? "Hidden by owner" : null;
+                update.hiddenBy = input.hidden ? "owner" : null;
             }
-            if (input.upstreamModel !== undefined) {
-                update.upstreamModel = input.upstreamModel;
-            }
-            if (input.bearerToken !== undefined) {
-                update.bearerTokenCiphertext = await encryptSecret(
-                    normalizeInputBearerToken(input.bearerToken),
-                    c.env.BETTER_AUTH_SECRET,
-                );
-            }
-            if (input.visibility !== undefined) {
-                update.visibility = input.visibility;
-            }
-            if (input.supportsImageEdits !== undefined) {
-                update.supportsImageEdits =
-                    modality === "image" && input.supportsImageEdits;
-            }
-            if (input.active !== undefined) {
-                update.disabledAt = input.active ? null : new Date();
-                update.disabledReason = input.active
-                    ? null
-                    : "Deactivated by owner";
-                update.disabledBy = input.active ? null : "owner";
-            }
-            const storedImagePricing = normalizeCommunityEndpointImagePricing(
-                endpoint.imagePricing,
+            await enforcePublishingAccess(
+                db,
+                user.id,
+                input.visibility ?? currentVisibility,
             );
-            const effectiveImagePricing =
-                modality === "image" && input.imagePricing !== undefined
-                    ? input.imagePricing
-                    : storedImagePricing;
-            update.imagePricing = effectiveImagePricing;
-            for (const field of communityEndpointPriceFieldsForModality(
-                modality,
-                effectiveImagePricing,
-            )) {
-                if (input[field.key] !== undefined) {
-                    update[field.key] = input[field.key];
-                } else if (effectiveImagePricing !== storedImagePricing) {
-                    // Switching modes changes the unit of the shared price
-                    // columns (per image ↔ per token); stored values must not
-                    // be reinterpreted, so unsent prices reset to free.
-                    update[field.key] = 0;
+            let nextVisibility = currentVisibility;
+            if (input.visibility === "private") {
+                nextVisibility = "private";
+                pendingPayload = null;
+                pendingVisibility = null;
+                pendingAt = null;
+            } else if (
+                input.visibility === "public" &&
+                currentVisibility === "private"
+            ) {
+                pendingVisibility = "public";
+                pendingAt ??= new Date();
+            }
+            update.visibility = nextVisibility;
+            if (endpoint.type === "prompt_agent") {
+                // Prompt configuration is edited through /account/agents.
+                // This route only updates shared listing state such as hidden.
+            } else if (endpoint.type === "endpoint_agent") {
+                if (!parseListingPayload("endpoint_agent", endpoint.payload)) {
+                    throw new Error(
+                        `Invalid endpoint_agent payload for ${endpoint.id}`,
+                    );
+                }
+                if (input.baseUrl !== undefined) {
+                    update.baseUrl = normalizeInputBaseUrl(input.baseUrl);
+                }
+                if (input.upstreamModel !== undefined) {
+                    update.upstreamModel = input.upstreamModel;
+                }
+                if (input.perUserRpm !== undefined) {
+                    update.payload = JSON.stringify({
+                        perUserRpm: input.perUserRpm,
+                    });
+                }
+            } else {
+                const current = parseListingPayload("proxy", endpoint.payload);
+                if (!current) {
+                    throw new Error(`Invalid proxy payload for ${endpoint.id}`);
+                }
+                const maturedPending = pendingReady
+                    ? parseListingPayload("proxy", endpoint.pendingPayload)
+                    : null;
+                const stored = applyPendingProxyPricing(
+                    current,
+                    maturedPending,
+                );
+                const queued = parseListingPayload("proxy", pendingPayload);
+                const targetBase = queued ?? stored;
+                const targetVisibility = pendingVisibility ?? nextVisibility;
+                const targetPolicy = deriveUpdatedProxyPolicy(
+                    targetBase,
+                    input,
+                    targetVisibility,
+                );
+                const delayPricing =
+                    targetVisibility === "public" &&
+                    (currentVisibility === "public" ||
+                        pendingVisibility === "public") &&
+                    hasProxyPricingInput(input);
+                const pricingChanged = proxyPricingChanged(
+                    targetBase,
+                    targetPolicy,
+                );
+                const immediateInput = delayPricing
+                    ? withoutProxyPricingChanges(input)
+                    : input;
+                const policy = deriveUpdatedProxyPolicy(
+                    stored,
+                    immediateInput,
+                    nextVisibility,
+                );
+                const fallbacks =
+                    input.fallbacks === undefined
+                        ? stored.fallbacks
+                        : await resolveFallbacks(db, input.fallbacks, {
+                              modelId: communityModelId(
+                                  ownerGithubUsername,
+                                  input.name ?? endpoint.name,
+                              ),
+                              ownerUserId: user.id,
+                              ...policy,
+                          });
+                const bearerTokenCiphertext =
+                    input.bearerToken === undefined
+                        ? stored.bearerTokenCiphertext
+                        : await encryptSecret(
+                              normalizeInputBearerToken(input.bearerToken),
+                              c.env.BETTER_AUTH_SECRET,
+                          );
+                if (input.baseUrl !== undefined) {
+                    update.baseUrl = normalizeInputBaseUrl(input.baseUrl);
+                }
+                if (input.upstreamModel !== undefined) {
+                    update.upstreamModel = input.upstreamModel;
+                }
+                if (pendingReady || changesProxyPayload(input)) {
+                    const payload: ProxyListingPayload = {
+                        bearerTokenCiphertext,
+                        ...policy,
+                        fallbacks,
+                    };
+                    update.payload = JSON.stringify(payload);
+                }
+                const queuesPublication =
+                    input.visibility === "public" &&
+                    currentVisibility === "private";
+                if ((delayPricing && pricingChanged) || queuesPublication) {
+                    const targetPayload: ProxyListingPayload = {
+                        bearerTokenCiphertext,
+                        ...targetPolicy,
+                        fallbacks,
+                    };
+                    pendingPayload = JSON.stringify(targetPayload);
+                    if (currentVisibility === "public" && pricingChanged) {
+                        pendingAt = new Date();
+                    }
                 }
             }
-            const effectiveVisibility = input.visibility ?? endpoint.visibility;
-            // A private model is owner-only, so owner-declared public pricing
-            // does not apply; making a published model private clears prices.
-            const effectivePrices =
-                effectiveVisibility === "private"
-                    ? communityEndpointPrices({})
-                    : communityEndpointPricesForModality(
-                          { ...endpoint, ...update },
-                          modality,
-                          effectiveImagePricing,
-                      );
-            enforceCommunityEndpointPriceLimits(
-                effectivePrices,
-                modality,
-                effectiveImagePricing,
-            );
-            await enforcePublishingAccess(db, user.id, effectiveVisibility);
-            // Persist visibility together with the complete effective price
-            // set on every update, so concurrent partial updates cannot
-            // interleave into a public row with cleared prices.
-            update.visibility = effectiveVisibility;
-            Object.assign(update, effectivePrices);
+            update.pendingPayload = pendingPayload;
+            update.pendingVisibility = pendingVisibility;
+            update.pendingAt = pendingAt;
             const [row] = await db
                 .update(schema.communityEndpoint)
                 .set(update)
@@ -756,13 +867,19 @@ export const communityEndpointsRoutes = new Hono<Env>()
                     ),
                 )
                 .returning();
-            return c.json(toResponse(row, ownerGithubUsername));
+            return c.json(
+                toCommunityEndpointResponse(
+                    row,
+                    ownerGithubUsername,
+                    c.env.AGENT_RUNTIME_BASE_URL,
+                ),
+            );
         },
     )
     .delete(
         "/:id",
         describeRoute({
-            tags: ["👤 Account"],
+            tags: ["🧩 Community Models"],
             summary: "Delete My Model",
             description:
                 "Delete a community model owned by the authenticated account. API keys require `account:keys`.",
@@ -786,7 +903,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
             const user = c.var.auth.requireUser();
             const { id } = c.req.param();
             const db = drizzle(c.env.DB, { schema });
-            requireCommunityEndpointManagePermission(c.var.auth.apiKey);
+            requireAccountPermission(c.var.auth.apiKey, "keys");
             await requireOwnedEndpoint(db, id, user.id);
             await db
                 .delete(schema.communityEndpoint)

--- a/enter.pollinations.ai/src/routes/community-endpoints/proxy-policy.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints/proxy-policy.ts
@@ -1,0 +1,273 @@
+import {
+    COMMUNITY_ENDPOINT_INPUT_MODALITIES,
+    COMMUNITY_ENDPOINT_PRICE_FIELDS,
+    type CommunityEndpointAdvertised,
+    type CommunityEndpointImagePricing,
+    type CommunityEndpointModality,
+    type CommunityEndpointPriceKey,
+    type CommunityEndpointPrices,
+    type CommunityEndpointVisibility,
+    communityEndpointPriceFieldsForModality,
+    communityEndpointPrices,
+    communityEndpointPricesForModality,
+    MAX_COMMUNITY_PRICE_PER_IMAGE,
+    MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS,
+    MAX_COMMUNITY_PRICE_PER_SECOND,
+    MAX_COMMUNITY_PRICE_PER_TOKEN,
+    MAX_COMMUNITY_PRICE_PER_VIDEO_SECOND,
+    normalizeCommunityEndpointInputModalities,
+    type ProxyListingPayload,
+} from "@shared/community-endpoints.ts";
+import { HTTPException } from "hono/http-exception";
+import type { ProxyCreateInput, ProxyUpdateInput } from "./schemas.ts";
+
+export type ProxyPolicy = Pick<
+    ProxyListingPayload,
+    | "modality"
+    | "imagePricing"
+    | "inputModalities"
+    | "paidOnly"
+    | "perUserRpm"
+    | "advertised"
+    | "prices"
+>;
+
+const PRICE_LIMIT_BY_UNIT = {
+    image: {
+        maximum: MAX_COMMUNITY_PRICE_PER_IMAGE,
+        label: `${MAX_COMMUNITY_PRICE_PER_IMAGE} Pollen per image`,
+    },
+    second: {
+        maximum: MAX_COMMUNITY_PRICE_PER_SECOND,
+        label: `${MAX_COMMUNITY_PRICE_PER_SECOND} Pollen per second`,
+    },
+    video_second: {
+        maximum: MAX_COMMUNITY_PRICE_PER_VIDEO_SECOND,
+        label: `${MAX_COMMUNITY_PRICE_PER_VIDEO_SECOND} Pollen per video second`,
+    },
+    token: {
+        maximum: MAX_COMMUNITY_PRICE_PER_TOKEN,
+        label: `${MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS} Pollen per 1M tokens`,
+    },
+    million: {
+        maximum: MAX_COMMUNITY_PRICE_PER_TOKEN,
+        label: `${MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS} Pollen per 1M tokens`,
+    },
+} as const;
+
+function assertPriceLimits(
+    prices: CommunityEndpointPrices,
+    modality: CommunityEndpointModality,
+    imagePricing: CommunityEndpointImagePricing,
+): void {
+    for (const field of communityEndpointPriceFieldsForModality(
+        modality,
+        imagePricing,
+    )) {
+        const limit = PRICE_LIMIT_BY_UNIT[field.priceUnit];
+        if (prices[field.key] <= limit.maximum) continue;
+        throw new HTTPException(400, {
+            message: `${field.label} price must not exceed ${limit.label}`,
+        });
+    }
+}
+
+function assertInputModalities(
+    modality: CommunityEndpointModality,
+    inputModalities: readonly string[],
+): void {
+    const permitted = COMMUNITY_ENDPOINT_INPUT_MODALITIES[modality];
+    const unsupported = inputModalities.find(
+        (input) => !(permitted as readonly string[]).includes(input),
+    );
+    if (!unsupported) return;
+    throw new HTTPException(400, {
+        message: `${unsupported} input is not supported for ${modality} models`,
+    });
+}
+
+function hasAdvertisedClaim(
+    advertised: CommunityEndpointAdvertised | undefined,
+): boolean {
+    return Object.values(advertised ?? {}).some((value) =>
+        Array.isArray(value) ? value.length > 0 : value != null,
+    );
+}
+
+function normalizeAdvertised(
+    advertised: CommunityEndpointAdvertised | undefined,
+): CommunityEndpointAdvertised | undefined {
+    return hasAdvertisedClaim(advertised) ? advertised : undefined;
+}
+
+function assertAdvertised(
+    modality: CommunityEndpointModality,
+    advertised: CommunityEndpointAdvertised | undefined,
+): void {
+    if (modality !== "text" && hasAdvertisedClaim(advertised)) {
+        throw new HTTPException(400, {
+            message: "advertised metadata is only supported for text models",
+        });
+    }
+}
+
+function visibilityPolicy(
+    visibility: CommunityEndpointVisibility,
+    requestedPaidOnly: boolean,
+    priceSource: Partial<Record<CommunityEndpointPriceKey, number>>,
+    modality: CommunityEndpointModality,
+    imagePricing: CommunityEndpointImagePricing,
+): Pick<ProxyPolicy, "paidOnly" | "prices"> {
+    return visibility === "private"
+        ? { paidOnly: false, prices: communityEndpointPrices({}) }
+        : {
+              paidOnly: requestedPaidOnly,
+              prices: communityEndpointPricesForModality(
+                  priceSource,
+                  modality,
+                  imagePricing,
+              ),
+          };
+}
+
+function validatePolicy(
+    policy: ProxyPolicy,
+    requestedAdvertised: CommunityEndpointAdvertised | undefined,
+): ProxyPolicy {
+    assertInputModalities(policy.modality, policy.inputModalities);
+    // An omitted update preserves stored metadata without revalidating it.
+    assertAdvertised(policy.modality, requestedAdvertised);
+    assertPriceLimits(policy.prices, policy.modality, policy.imagePricing);
+    return policy;
+}
+
+export function deriveCreateProxyPolicy(input: ProxyCreateInput): ProxyPolicy {
+    const modality = input.modality;
+    const imagePricing = modality === "image" ? input.imagePricing : "request";
+    const inputModalities =
+        input.inputModalities ??
+        normalizeCommunityEndpointInputModalities(undefined, modality);
+
+    return validatePolicy(
+        {
+            modality,
+            imagePricing,
+            inputModalities,
+            advertised: normalizeAdvertised(input.advertised),
+            perUserRpm: input.perUserRpm ?? null,
+            ...visibilityPolicy(
+                input.visibility,
+                input.paidOnly,
+                input,
+                modality,
+                imagePricing,
+            ),
+        },
+        input.advertised,
+    );
+}
+
+function updatePriceSource(
+    stored: ProxyListingPayload,
+    input: ProxyUpdateInput,
+    imagePricing: CommunityEndpointImagePricing,
+): Partial<Record<CommunityEndpointPriceKey, number>> {
+    const resetPrices =
+        imagePricing === stored.imagePricing
+            ? {}
+            : Object.fromEntries(
+                  communityEndpointPriceFieldsForModality(
+                      stored.modality,
+                      imagePricing,
+                  )
+                      .filter((field) => input[field.key] === undefined)
+                      .map((field) => [field.key, 0]),
+              );
+    return { ...stored.prices, ...input, ...resetPrices };
+}
+
+export function deriveUpdatedProxyPolicy(
+    stored: ProxyListingPayload,
+    input: ProxyUpdateInput,
+    visibility: CommunityEndpointVisibility,
+): ProxyPolicy {
+    const modality = stored.modality;
+    const imagePricing =
+        modality === "image"
+            ? (input.imagePricing ?? stored.imagePricing)
+            : stored.imagePricing;
+    const inputModalities = input.inputModalities ?? stored.inputModalities;
+
+    return validatePolicy(
+        {
+            modality,
+            imagePricing,
+            inputModalities,
+            advertised:
+                input.advertised === undefined
+                    ? stored.advertised
+                    : normalizeAdvertised(input.advertised),
+            perUserRpm:
+                input.perUserRpm === undefined
+                    ? stored.perUserRpm
+                    : input.perUserRpm,
+            ...visibilityPolicy(
+                visibility,
+                input.paidOnly ?? stored.paidOnly,
+                updatePriceSource(stored, input, imagePricing),
+                modality,
+                imagePricing,
+            ),
+        },
+        input.advertised,
+    );
+}
+
+export function proxyPricingChanged(
+    current: Pick<ProxyListingPayload, "paidOnly" | "imagePricing" | "prices">,
+    target: Pick<ProxyListingPayload, "paidOnly" | "imagePricing" | "prices">,
+): boolean {
+    return (
+        current.paidOnly !== target.paidOnly ||
+        current.imagePricing !== target.imagePricing ||
+        COMMUNITY_ENDPOINT_PRICE_FIELDS.some(
+            ({ key }) => current.prices[key] !== target.prices[key],
+        )
+    );
+}
+
+export function hasProxyPricingInput(input: ProxyUpdateInput): boolean {
+    return (
+        input.paidOnly !== undefined ||
+        input.imagePricing !== undefined ||
+        COMMUNITY_ENDPOINT_PRICE_FIELDS.some(
+            ({ key }) => input[key] !== undefined,
+        )
+    );
+}
+
+export function withoutProxyPricingChanges(
+    input: ProxyUpdateInput,
+): ProxyUpdateInput {
+    const immediate = { ...input };
+    delete immediate.paidOnly;
+    delete immediate.imagePricing;
+    for (const { key } of COMMUNITY_ENDPOINT_PRICE_FIELDS) {
+        delete immediate[key];
+    }
+    return immediate;
+}
+
+export function changesProxyPayload(input: ProxyUpdateInput): boolean {
+    return [
+        input.bearerToken,
+        input.visibility,
+        input.perUserRpm,
+        input.paidOnly,
+        input.imagePricing,
+        input.inputModalities,
+        input.advertised,
+        input.fallbacks,
+        ...COMMUNITY_ENDPOINT_PRICE_FIELDS.map(({ key }) => input[key]),
+    ].some((value) => value !== undefined);
+}

--- a/enter.pollinations.ai/src/services/community-endpoint-openai.ts
+++ b/enter.pollinations.ai/src/services/community-endpoint-openai.ts
@@ -1,19 +1,27 @@
 import {
+    COMMUNITY_ENDPOINT_TIMEOUT_MS,
     type CommunityEndpointImagePricing,
+    communityAudioTranscriptionsUrl,
     communityChatCompletionsUrl,
+    communityEndpointErrorDetail,
     communityImageEditsUrl,
     communityImageGenerationsUrl,
     communityOpenAIBaseUrl,
-    normalizeCommunityAssetUrl,
+    communityTranscriptionSeconds,
+    communityVideoGenerationsUrl,
+    decodeCommunityBase64,
+    firstCommunityImageBytes,
+    firstCommunityVideoData,
     normalizeCommunityEndpointBearerToken,
 } from "@shared/community-endpoints.ts";
 import { detectImageMimeType } from "@shared/image-mime.ts";
-import type { Usage } from "@shared/registry/registry.ts";
+import type { ModelInputModality, Usage } from "@shared/registry/registry.ts";
 import {
     getOpenAIImageUsage,
     openaiImageUsageToUsage,
     openaiUsageToUsage,
 } from "@shared/registry/usage-headers.ts";
+import { SAMPLE_AUDIO_BASE64 } from "./sample-audio.ts";
 
 type EndpointAuth = {
     baseUrl: string;
@@ -29,12 +37,9 @@ export type CommunityEndpointTestResult = {
     billableUsage: Usage;
     /** Image tests only: billing mode detected from the probe response. */
     imagePricing?: CommunityEndpointImagePricing;
-    /** Image tests only: whether a valid /images/edits response was observed. */
-    supportsImageEdits?: boolean;
+    /** Image tests only: input types detected by the generation/edit probes. */
+    inputModalities?: ModelInputModality[];
 };
-
-const REQUEST_TIMEOUT_MS = 90_000;
-const MAX_IMAGE_BYTES = 20 * 1024 * 1024;
 
 function authorizationHeaders(bearerToken: string): HeadersInit {
     return {
@@ -55,7 +60,7 @@ async function fetchJson(url: string, init: RequestInit): Promise<unknown> {
         response = await fetch(url, {
             ...init,
             redirect: "manual",
-            signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+            signal: AbortSignal.timeout(COMMUNITY_ENDPOINT_TIMEOUT_MS),
         });
     } catch {
         throw new Error("Endpoint request timed out or could not connect");
@@ -69,7 +74,7 @@ async function fetchJson(url: string, init: RequestInit): Promise<unknown> {
 }
 
 function endpointErrorMessage(status: number, body: unknown): string {
-    const message = endpointBodyMessage(body);
+    const message = communityEndpointErrorDetail(body);
     const prefix =
         status === 401
             ? "Endpoint responded 401 after we sent Authorization"
@@ -77,24 +82,6 @@ function endpointErrorMessage(status: number, body: unknown): string {
               ? `Endpoint responded ${status} with a redirect, which is not supported`
               : `Endpoint responded ${status}`;
     return message ? `${prefix}: ${message}` : prefix;
-}
-
-function endpointBodyMessage(body: unknown): string | null {
-    if (!body || typeof body !== "object") return null;
-    if (
-        "error" in body &&
-        body.error &&
-        typeof body.error === "object" &&
-        "message" in body.error &&
-        typeof body.error.message === "string"
-    ) {
-        return body.error.message;
-    }
-    if ("error" in body && typeof body.error === "string") return body.error;
-    if ("message" in body && typeof body.message === "string") {
-        return body.message;
-    }
-    return null;
 }
 
 export async function listCommunityEndpointModels({
@@ -194,16 +181,19 @@ export async function testCommunityImageEndpoint({
         }),
     });
 
-    const imageBytes = await firstImageBytes(body, baseUrl);
+    const imageBytes = await firstCommunityImageBytes(body, baseUrl);
     const imageMimeType = imageBytes && detectImageMimeType(imageBytes);
     if (!imageBytes || !imageMimeType) {
         throw new Error("Endpoint did not return a supported image");
     }
-    const supportsImageEdits = await testCommunityImageEdits(
+    const supportsImageInput = await testCommunityImageEdits(
         { baseUrl, bearerToken, model },
         imageBytes,
         imageMimeType,
     );
+    const inputModalities: ModelInputModality[] = supportsImageInput
+        ? ["text", "image"]
+        : ["text"];
 
     // Endpoints that return valid OpenAI image token usage are billed
     // per token ("tokens"); everything else falls back to a fixed price
@@ -214,14 +204,120 @@ export async function testCommunityImageEndpoint({
             usage: { ...openaiUsage },
             billableUsage: openaiImageUsageToUsage(openaiUsage),
             imagePricing: "tokens",
-            supportsImageEdits,
+            inputModalities,
         };
     }
     return {
         usage: { images: 1 },
         billableUsage: { completionImageTokens: 1 },
         imagePricing: "request",
-        supportsImageEdits,
+        inputModalities,
+    };
+}
+
+// Transcription endpoints are billed against prompt audio seconds, mirroring
+// the first-party whisper/scribe models. The probe uploads a real audio file
+// and validates the OpenAI transcription response shape.
+export async function testCommunityTranscriptionEndpoint({
+    baseUrl,
+    bearerToken,
+    model,
+}: EndpointTestInput): Promise<CommunityEndpointTestResult> {
+    const sampleBytes = decodeCommunityBase64(SAMPLE_AUDIO_BASE64);
+    if (!sampleBytes) {
+        throw new Error("Failed to decode sample audio");
+    }
+    const formData = new FormData();
+    formData.append("model", model);
+    // Same format the request path pins, so what the probe proves is what
+    // callers actually get. See callCommunityTranscriptionEndpoint.
+    formData.append("response_format", "verbose_json");
+    formData.append(
+        "file",
+        new Blob([new Uint8Array(sampleBytes)], { type: "audio/wav" }),
+        "sample.wav",
+    );
+
+    let body: unknown;
+    try {
+        body = await fetchJson(communityAudioTranscriptionsUrl(baseUrl), {
+            method: "POST",
+            headers: authorizationHeaders(bearerToken),
+            body: formData,
+        });
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        // A plain-json-only endpoint rejects verbose_json outright. Name the
+        // requirement rather than leaving the owner staring at a bare 400.
+        throw new Error(
+            message.includes("responded 400")
+                ? `${message}. Pollinations requests response_format=verbose_json because that is where the audio duration transcription is billed on is reported; models that only support plain json cannot be registered yet.`
+                : message,
+        );
+    }
+
+    // The sample is real speech, so a working endpoint returns something. We
+    // never check what — the wording varies by model and language.
+    if (
+        !body ||
+        typeof body !== "object" ||
+        !("text" in body) ||
+        typeof body.text !== "string" ||
+        body.text.trim().length === 0
+    ) {
+        throw new Error("Endpoint did not return OpenAI transcription text");
+    }
+
+    // The duration is what the endpoint is billed on, so one that cannot report
+    // it must not register — otherwise every request through it would be
+    // unbillable and the owner would earn nothing.
+    const promptAudioSeconds = communityTranscriptionSeconds(body);
+    if (promptAudioSeconds === null) {
+        throw new Error(
+            "Endpoint did not report the audio duration (expected verbose_json's top-level duration, or usage.seconds), which is required to bill transcription",
+        );
+    }
+
+    return {
+        // The pricing UI marks the prompt-audio row against a usage key named
+        // in that field's rawUsagePaths, and the duration is the only thing
+        // billed here — so report it directly rather than echoing an upstream
+        // usage object that may not carry it.
+        usage: { duration: promptAudioSeconds },
+        billableUsage: { promptAudioSeconds },
+    };
+}
+
+// Video endpoints are billed per second of output. The probe sends a minimal
+// request and validates the response shape plus a usable duration.
+export async function testCommunityVideoEndpoint({
+    baseUrl,
+    bearerToken,
+    model,
+}: EndpointTestInput): Promise<CommunityEndpointTestResult> {
+    const body = await fetchJson(communityVideoGenerationsUrl(baseUrl), {
+        method: "POST",
+        headers: {
+            ...authorizationHeaders(bearerToken),
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+            model,
+            prompt: "A short clip of green leaves moving in the wind.",
+            duration: 3,
+        }),
+    });
+
+    const videoData = await firstCommunityVideoData(body, baseUrl);
+    if (!videoData) {
+        throw new Error(
+            "Endpoint did not return video data with a duration_seconds field",
+        );
+    }
+
+    return {
+        usage: { duration_seconds: videoData.durationSeconds },
+        billableUsage: { completionVideoSeconds: videoData.durationSeconds },
     };
 }
 
@@ -248,88 +344,9 @@ async function testCommunityImageEdits(
             headers: authorizationHeaders(bearerToken),
             body: formData,
         });
-        const editedImage = await firstImageBytes(body, baseUrl);
+        const editedImage = await firstCommunityImageBytes(body, baseUrl);
         return Boolean(editedImage && detectImageMimeType(editedImage));
     } catch {
         return false;
-    }
-}
-
-async function firstImageBytes(
-    body: unknown,
-    endpointBaseUrl: string,
-): Promise<Uint8Array | null> {
-    if (
-        !body ||
-        typeof body !== "object" ||
-        !("data" in body) ||
-        !Array.isArray(body.data)
-    ) {
-        return null;
-    }
-    for (const image of body.data) {
-        if (!image || typeof image !== "object") continue;
-        if (
-            "b64_json" in image &&
-            typeof image.b64_json === "string" &&
-            image.b64_json.length > 0
-        ) {
-            return decodeBase64(image.b64_json);
-        }
-        if (
-            "url" in image &&
-            typeof image.url === "string" &&
-            image.url.length > 0
-        ) {
-            return fetchImageBytes(image.url, endpointBaseUrl);
-        }
-    }
-    return null;
-}
-
-async function fetchImageBytes(
-    value: string,
-    endpointBaseUrl: string,
-): Promise<Uint8Array> {
-    let url: string;
-    try {
-        url = normalizeCommunityAssetUrl(value, endpointBaseUrl);
-    } catch {
-        throw new Error("Endpoint returned an unsafe image URL");
-    }
-    let response: Response;
-    try {
-        response = await fetch(url, {
-            redirect: "manual",
-            signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-        });
-    } catch {
-        throw new Error("Endpoint image URL timed out or could not connect");
-    }
-    if (!response.ok) {
-        throw new Error(`Endpoint image URL responded ${response.status}`);
-    }
-    const contentLength = Number(response.headers.get("content-length"));
-    if (Number.isFinite(contentLength) && contentLength > MAX_IMAGE_BYTES) {
-        throw new Error("Endpoint image is larger than 20 MB");
-    }
-    const bytes = new Uint8Array(await response.arrayBuffer());
-    if (bytes.byteLength > MAX_IMAGE_BYTES) {
-        throw new Error("Endpoint image is larger than 20 MB");
-    }
-    return bytes;
-}
-
-function decodeBase64(value: string): Uint8Array | null {
-    try {
-        const encoded = value
-            .replace(/^data:[^,]+,/, "")
-            .replace(/\s/g, "")
-            .replace(/-/g, "+")
-            .replace(/_/g, "/");
-        const decoded = atob(encoded);
-        return Uint8Array.from(decoded, (character) => character.charCodeAt(0));
-    } catch {
-        return null;
     }
 }

--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -1,8 +1,20 @@
-import { createExecutionContext, env, SELF } from "cloudflare:test";
+import {
+    createExecutionContext,
+    env,
+    SELF,
+    waitOnExecutionContext,
+} from "cloudflare:test";
 import type { Logger } from "@logtape/logtape";
 import { verifyAgentRunToken } from "@shared/auth/agent-run-token.ts";
+import { COMMUNITY_MODEL_ALLOWED_GITHUB_IDS } from "@shared/auth/github-id-list.ts";
 import {
+    COMMUNITY_ENDPOINT_CHANGE_DELAY_MS,
+    COMMUNITY_ENDPOINT_PRICE_FIELDS,
+    type CommunityEndpointImagePricing,
+    type CommunityEndpointModality,
+    type CommunityEndpointPrices,
     type CommunityEndpointRuntime,
+    communityAudioTranscriptionsUrl,
     communityChatCompletionsUrl,
     communityEndpointPriceFieldsForModality,
     communityEndpointPrices,
@@ -13,16 +25,27 @@ import {
     communityModelId,
     communityOpenAIBaseUrl,
     communityPriceDefinition,
+    communityVideoGenerationsUrl,
+    type EndpointAgentCommunityEndpointRuntime,
     isCommunityEndpointOwnerAllowed,
+    isCommunityFallbackPricingAllowed,
     legacyCommunityModelId,
     MAX_COMMUNITY_PRICE_PER_IMAGE,
     MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS,
+    MAX_COMMUNITY_PRICE_PER_SECOND,
     MAX_COMMUNITY_PRICE_PER_TOKEN,
+    MAX_COMMUNITY_PRICE_PER_VIDEO_SECOND,
     MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS,
     MIN_COMMUNITY_PRICE_PER_TOKEN,
     normalizeCommunityAssetUrl,
     normalizeCommunityEndpointBaseUrl,
     normalizeCommunityEndpointBearerToken,
+    normalizeCommunityEndpointImagePricing,
+    normalizeCommunityEndpointInputModalities,
+    normalizeCommunityEndpointModality,
+    normalizeCommunityProviderUrl,
+    PROMPT_AGENT_BASE_URL_PLACEHOLDER,
+    type PromptAgentListingPayload,
     parseCommunityModelId,
 } from "@shared/community-endpoints.ts";
 import {
@@ -31,7 +54,22 @@ import {
 } from "@shared/db/better-auth.ts";
 import { handleError } from "@shared/error.ts";
 import { IMMUTABLE_CACHE_CONTROL } from "@shared/http/cache-control.ts";
-import { calculateUsageBilling } from "@shared/registry/registry.ts";
+import { DEFAULT_AUDIO_MODEL } from "@shared/registry/audio.ts";
+import { DEFAULT_EMBEDDING_MODEL } from "@shared/registry/embeddings.ts";
+import { DEFAULT_IMAGE_MODEL } from "@shared/registry/image.ts";
+import { DEFAULT_3D_MODEL } from "@shared/registry/model3d.ts";
+import { DEFAULT_REALTIME_MODEL } from "@shared/registry/realtime.ts";
+import {
+    calculateUsageBilling,
+    getRegistryModelDefinition,
+    type ModelInputModality,
+} from "@shared/registry/registry.ts";
+import { DEFAULT_TEXT_MODEL } from "@shared/registry/text.ts";
+import {
+    FALLBACK_TARGET_HEADER,
+    MODEL_USED_HEADER,
+    USAGE_TYPE_HEADERS,
+} from "@shared/registry/usage-headers.ts";
 import { encryptSecret } from "@shared/secret-encryption.ts";
 import {
     createTestApiKey,
@@ -43,14 +81,125 @@ import { drizzle } from "drizzle-orm/d1";
 import { Hono } from "hono";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Env } from "@/env.ts";
-import { communityImageSupportedEndpoints } from "./community-models.ts";
-import { callCommunityImageEndpoint } from "./image/communityEndpoint.ts";
-import { resetGenerationModelRegistryCache } from "./model-registry.ts";
+import { withInlineGenerationCoordinator } from "../test/helpers/inline-generation-coordinator.ts";
+import { callCommunityTranscriptionEndpoint } from "./audio/communityEndpoint.ts";
+import {
+    communityImageSupportedEndpoints,
+    communityTranscriptionSupportedEndpoints,
+    communityVideoSupportedEndpoints,
+    getCommunityModelRegistryEntries,
+} from "./community-models.ts";
+import {
+    callCommunityImageEndpoint,
+    callCommunityVideoEndpoint,
+} from "./image/communityEndpoint.ts";
+import worker from "./index.ts";
+import {
+    getGenerationModelRegistry,
+    resetGenerationModelRegistryCache,
+} from "./model-registry.ts";
 import { communityEndpointGatewayContext } from "./text/communityEndpoint.ts";
 
 const db = drizzle(env.DB);
+
+type CommunityEndpointInsert = typeof communityEndpointTable.$inferInsert;
+type CommunityEndpointFixture = CommunityEndpointInsert &
+    Partial<CommunityEndpointPrices> & {
+        modality?: CommunityEndpointModality;
+        imagePricing?: CommunityEndpointImagePricing;
+        inputModalities?: ModelInputModality[] | null;
+        baseUrl?: string | null;
+        upstreamModel?: string;
+        agentConfig?: PromptAgentListingPayload;
+        bearerTokenCiphertext?: string | null;
+        perUserRpm?: number | null;
+        fallbacks?: string[] | null;
+    };
+
+/**
+ * Insert rows the way Enter writes them. Tests can keep their readable flat
+ * fixtures while this helper packs the variant fields into `payload`.
+ */
+function insertCommunityEndpoints(
+    values: CommunityEndpointFixture | CommunityEndpointFixture[],
+) {
+    const rows = (Array.isArray(values) ? values : [values]).map((row) => {
+        const type = row.type ?? "proxy";
+        const {
+            modality: rawModality,
+            imagePricing: rawImagePricing,
+            inputModalities: rawInputModalities,
+            baseUrl,
+            upstreamModel,
+            agentConfig,
+            bearerTokenCiphertext,
+            perUserRpm,
+            fallbacks,
+            promptTextPrice: _promptTextPrice,
+            promptCachedPrice: _promptCachedPrice,
+            promptCacheWritePrice: _promptCacheWritePrice,
+            promptAudioPrice: _promptAudioPrice,
+            promptImagePrice: _promptImagePrice,
+            completionTextPrice: _completionTextPrice,
+            completionReasoningPrice: _completionReasoningPrice,
+            completionAudioPrice: _completionAudioPrice,
+            completionImagePrice: _completionImagePrice,
+            completionVideoPrice: _completionVideoPrice,
+            ...listing
+        } = row;
+        const modality = normalizeCommunityEndpointModality(rawModality);
+        const payload =
+            type === "prompt_agent"
+                ? (agentConfig ?? {
+                      systemPrompt: "Test prompt agent.",
+                      baseModel: "openai",
+                      mcpServers: [],
+                  })
+                : type === "endpoint_agent"
+                  ? { perUserRpm: perUserRpm ?? null }
+                  : {
+                        bearerTokenCiphertext:
+                            bearerTokenCiphertext ?? "test-ciphertext",
+                        modality,
+                        imagePricing:
+                            normalizeCommunityEndpointImagePricing(
+                                rawImagePricing,
+                            ),
+                        inputModalities:
+                            normalizeCommunityEndpointInputModalities(
+                                rawInputModalities ?? undefined,
+                                modality,
+                            ),
+                        perUserRpm: perUserRpm ?? null,
+                        fallbacks: fallbacks ?? [],
+                        prices: communityEndpointPrices(row),
+                    };
+        return {
+            ...listing,
+            type,
+            baseUrl:
+                type === "prompt_agent"
+                    ? PROMPT_AGENT_BASE_URL_PLACEHOLDER
+                    : (baseUrl ?? ""),
+            upstreamModel:
+                type === "prompt_agent" ? row.id : (upstreamModel ?? row.name),
+            payload: JSON.stringify(payload),
+        };
+    });
+    return db.insert(communityEndpointTable).values(rows);
+}
 const testLog = { getChild: () => testLog } as unknown as Logger;
 const COMMUNITY_ENDPOINT_ALLOWED_TEST_GITHUB_ID = 36901823;
+// user.github_id is unique, so every test owner needs its own id. Rotate
+// through the allowlist to keep each one both distinct and allowed.
+let allowedGithubIdCursor = 0;
+function nextAllowedGithubId(): number {
+    const ids = COMMUNITY_MODEL_ALLOWED_GITHUB_IDS;
+    const id = ids[allowedGithubIdCursor % ids.length];
+    allowedGithubIdCursor += 1;
+    if (id === undefined) throw new Error("empty community model allowlist");
+    return id;
+}
 const COMMUNITY_ENDPOINT_DENIED_TEST_GITHUB_ID = 999_999_999;
 const TEST_PNG_BASE64 = "iVBORw0KGgo=";
 const TEST_PNG_BYTES = [137, 80, 78, 71, 13, 10, 26, 10];
@@ -117,9 +266,25 @@ async function createEnterFrontendApi(): Promise<Hono<Env>> {
 async function fetchEnterApi(
     app: Hono<Env>,
     request: Request,
+    envOverride: typeof env = env,
 ): Promise<Response> {
     const ctx = createExecutionContext();
-    return app.fetch(request, env, ctx);
+    return app.fetch(request, envOverride, ctx);
+}
+
+async function fetchGen(
+    input: RequestInfo | URL,
+    init?: RequestInit,
+): Promise<Response> {
+    const ctx = createExecutionContext();
+    const response = await worker.fetch(
+        new Request(input, init),
+        withInlineGenerationCoordinator(env),
+        ctx,
+    );
+    const body = response.body ? await response.arrayBuffer() : null;
+    await waitOnExecutionContext(ctx);
+    return new Response(body, response);
 }
 
 async function signedSessionCookie(token: string): Promise<string> {
@@ -196,6 +361,115 @@ function isBillingFetch(request: Request): boolean {
         request.url.startsWith("https://api.europe-west2.gcp.tinybird.co/") ||
         request.url.startsWith("http://localhost:7181/")
     );
+}
+
+/** Tinybird ingest bodies are newline-delimited JSON, one row per event. */
+function parseIngestedEvents(body: string): Record<string, unknown>[] {
+    return body
+        .split("\n")
+        .filter((line) => line.trim().length > 0)
+        .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+async function createCommunityFallbackPair({
+    prefix,
+    modality = "text",
+    primaryName = "primary",
+    fallbackName = "cheap",
+    primaryPerUserRpm,
+    fallbackPerUserRpm,
+}: {
+    prefix: string;
+    modality?: CommunityEndpointModality;
+    primaryName?: string;
+    fallbackName?: string;
+    primaryPerUserRpm?: number;
+    fallbackPerUserRpm?: number;
+}) {
+    const primaryToken = "sk_primary_token";
+    const fallbackToken = "sk_fallback_token";
+    const suffix = crypto.randomUUID().slice(0, 8);
+    const primaryOwner = `${prefix}-primary-${suffix}`;
+    const fallbackOwner = `${prefix}-fallback-${suffix}`;
+    const primaryUserId = await createTestUser({
+        githubId: nextAllowedGithubId(),
+        githubUsername: primaryOwner,
+    });
+    const fallbackUserId = await createTestUser({
+        githubId: nextAllowedGithubId(),
+        githubUsername: fallbackOwner,
+    });
+    const primaryModelId = communityModelId(primaryOwner, primaryName);
+    const fallbackModelId = communityModelId(fallbackOwner, fallbackName);
+    const primaryHostname = `${prefix}-primary.example.com`;
+    const fallbackHostname = `${prefix}-fallback.example.com`;
+    const primaryHost = `https://${primaryHostname}/v1`;
+    const fallbackHost = `https://${fallbackHostname}/v1`;
+    const primaryUpstreamModel = `${primaryName}-upstream`;
+    const fallbackUpstreamModel = `${fallbackName}-upstream`;
+    const priceFields = (price: number) =>
+        modality === "image"
+            ? {
+                  promptTextPrice: 0,
+                  completionTextPrice: 0,
+                  completionImagePrice: price,
+              }
+            : { promptTextPrice: price, completionTextPrice: price };
+    const [primaryPrice, fallbackPrice] =
+        modality === "image"
+            ? [0.02, 0.01]
+            : [0.2 / 1_000_000, 0.1 / 1_000_000];
+
+    await insertCommunityEndpoints([
+        {
+            id: `endpoint-${crypto.randomUUID()}`,
+            ownerUserId: primaryUserId,
+            visibility: "public",
+            perUserRpm: primaryPerUserRpm,
+            name: primaryName,
+            modality,
+            baseUrl: primaryHost,
+            upstreamModel: primaryUpstreamModel,
+            bearerTokenCiphertext: await encryptSecret(
+                primaryToken,
+                env.BETTER_AUTH_SECRET,
+            ),
+            ...priceFields(primaryPrice),
+            fallbacks: [fallbackModelId],
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        },
+        {
+            id: `endpoint-${crypto.randomUUID()}`,
+            ownerUserId: fallbackUserId,
+            visibility: "public",
+            perUserRpm: fallbackPerUserRpm,
+            name: fallbackName,
+            modality,
+            baseUrl: fallbackHost,
+            upstreamModel: fallbackUpstreamModel,
+            bearerTokenCiphertext: await encryptSecret(
+                fallbackToken,
+                env.BETTER_AUTH_SECRET,
+            ),
+            ...priceFields(fallbackPrice),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        },
+    ]);
+
+    return {
+        primaryModelId,
+        fallbackModelId,
+        primaryHost,
+        fallbackHost,
+        primaryHostname,
+        fallbackHostname,
+        primaryUpstreamModel,
+        fallbackUpstreamModel,
+        primaryToken,
+        fallbackToken,
+    };
 }
 
 describe("community endpoint helpers", () => {
@@ -323,6 +597,35 @@ describe("community endpoint helpers", () => {
         ).toThrow("Endpoint URL cannot target a private host");
     });
 
+    it("derives the OpenAI-compatible audio transcription URL", () => {
+        expect(
+            communityAudioTranscriptionsUrl("https://api.example.com/v1"),
+        ).toBe("https://api.example.com/v1/audio/transcriptions");
+        expect(
+            communityAudioTranscriptionsUrl(
+                "https://api.example.com/v1/audio/transcriptions",
+            ),
+        ).toBe("https://api.example.com/v1/audio/transcriptions");
+    });
+
+    it("restricts community transcription models to the transcription endpoint", () => {
+        expect(communityTranscriptionSupportedEndpoints()).toEqual([
+            "/v1/audio/transcriptions",
+        ]);
+    });
+
+    it("normalizes public community provider URLs", () => {
+        expect(
+            normalizeCommunityProviderUrl(" https://example.com/models#top "),
+        ).toBe("https://example.com/models");
+        expect(() =>
+            normalizeCommunityProviderUrl("http://example.com"),
+        ).toThrow("Provider URL must use https");
+        expect(() =>
+            normalizeCommunityProviderUrl("https://user:pass@example.com"),
+        ).toThrow("Provider URL cannot include credentials");
+    });
+
     it("uses the community endpoint description as the model title", () => {
         const modelDefinition = communityModelDefinition({
             modelId: "voodoohop/openai",
@@ -340,6 +643,27 @@ describe("community endpoint helpers", () => {
         );
     });
 
+    it("carries the owner's paid-only choice onto the model definition", () => {
+        const prices = communityEndpointPrices({ promptTextPrice: 0.1 });
+
+        expect(
+            communityModelDefinition({
+                modelId: "voodoohop/openai",
+                description: null,
+                ...prices,
+            }).paidOnly,
+        ).toBe(false);
+
+        expect(
+            communityModelDefinition({
+                modelId: "voodoohop/openai",
+                description: null,
+                paidOnly: true,
+                ...prices,
+            }).paidOnly,
+        ).toBe(true);
+    });
+
     it("prefers a stored title over the description", () => {
         const modelDefinition = communityModelDefinition({
             modelId: "voodoohop/openai",
@@ -353,6 +677,20 @@ describe("community endpoint helpers", () => {
         expect(modelDefinition.description).toBe(
             "OpenAI via community endpoint",
         );
+    });
+
+    it("projects a provider profile onto the community model brand", () => {
+        const modelDefinition = communityModelDefinition({
+            modelId: "voodoohop/openai",
+            title: "OpenAI Fast",
+            description: null,
+            providerName: "Example AI",
+            providerUrl: "https://example.com/",
+            ...communityEndpointPrices({}),
+        });
+
+        expect(modelDefinition.brand).toBe("Example AI");
+        expect(modelDefinition.brandUrl).toBe("https://example.com/");
     });
 
     it("falls back to the model name when title and description are unset", () => {
@@ -393,19 +731,19 @@ describe("community endpoint helpers", () => {
         });
         expect(definition.cost).not.toHaveProperty("promptTextTokens");
         expect(
-            calculateUsageBilling(
-                modelId,
-                { completionImageTokens: 1 },
-                definition,
-            ).price.totalPrice,
+            calculateUsageBilling({
+                model: modelId,
+                usage: { completionImageTokens: 1 },
+                servedBy: definition,
+            }).price.totalPrice,
         ).toBe(0.03);
     });
 
-    it("advertises image edits only after the edit probe succeeds", () => {
-        expect(communityImageSupportedEndpoints(false)).not.toContain(
+    it("advertises image edits only for models with image input", () => {
+        expect(communityImageSupportedEndpoints(["text"])).not.toContain(
             "/v1/images/edits",
         );
-        expect(communityImageSupportedEndpoints(true)).toContain(
+        expect(communityImageSupportedEndpoints(["text", "image"])).toContain(
             "/v1/images/edits",
         );
     });
@@ -417,7 +755,7 @@ describe("community endpoint helpers", () => {
             description: "Token-priced image model",
             modality: "image",
             imagePricing: "tokens",
-            supportsImageEdits: true,
+            inputModalities: ["text", "image"],
             ...communityEndpointPrices({
                 promptTextPrice: 0.000005,
                 promptImagePrice: 0.00001,
@@ -436,15 +774,15 @@ describe("community endpoint helpers", () => {
             },
         });
         expect(
-            calculateUsageBilling(
-                modelId,
-                {
+            calculateUsageBilling({
+                model: modelId,
+                usage: {
                     promptTextTokens: 100,
                     promptImageTokens: 0,
                     completionImageTokens: 1000,
                 },
-                definition,
-            ).price.totalPrice,
+                servedBy: definition,
+            }).price.totalPrice,
         ).toBeCloseTo(0.000005 * 100 + 0.00004 * 1000, 10);
     });
 
@@ -461,6 +799,175 @@ describe("community endpoint helpers", () => {
         expect(Object.keys(definition)).toHaveLength(
             communityEndpointPriceFieldsForModality("text").length,
         );
+    });
+
+    it('defaults input modalities to ["text"] when not declared', () => {
+        const definition = communityModelDefinition({
+            modelId: "voodoohop/openai",
+            description: "OpenAI via community endpoint",
+            ...communityEndpointPrices({
+                promptTextPrice: 0.1,
+                completionTextPrice: 0.1,
+            }),
+        });
+
+        expect(definition.inputModalities).toEqual(["text"]);
+    });
+
+    it("preserves explicitly declared input modalities", () => {
+        const definition = communityModelDefinition({
+            modelId: "marcosfrgames08/glm-4.6v-flash",
+            description: "Vision model",
+            inputModalities: ["image", "video"],
+            ...communityEndpointPrices({
+                promptTextPrice: 0.1,
+                completionTextPrice: 0.1,
+            }),
+        });
+
+        expect(definition.inputModalities).toEqual(["image", "video"]);
+    });
+
+    it("maps owner-declared catalog metadata onto text models", () => {
+        const definition = communityModelDefinition({
+            modelId: "voodoohop/openai",
+            description: "OpenAI via community endpoint",
+            advertised: {
+                capabilities: ["tool_calling", "reasoning"],
+                contextLength: 128000,
+            },
+            ...communityEndpointPrices({}),
+        });
+
+        expect(definition).toMatchObject({
+            tools: true,
+            reasoning: true,
+            contextLength: 128000,
+        });
+    });
+
+    it("does not advertise text metadata after a model changes modality", () => {
+        const definition = communityModelDefinition({
+            modelId: "voodoohop/gptimage",
+            description: "Image model",
+            modality: "image",
+            advertised: {
+                capabilities: ["tool_calling", "reasoning"],
+                contextLength: 128000,
+            },
+            ...communityEndpointPrices({}),
+        });
+
+        expect(definition.tools).toBeUndefined();
+        expect(definition.reasoning).toBeUndefined();
+        expect(definition.contextLength).toBeUndefined();
+    });
+
+    it("filters inputs that image endpoints cannot accept", () => {
+        const definition = communityModelDefinition({
+            modelId: "voodoohop/gptimage",
+            description: "Image model",
+            modality: "image",
+            inputModalities: ["text", "audio"],
+            ...communityEndpointPrices({
+                promptTextPrice: 0.2,
+                completionImagePrice: 0.03,
+            }),
+        });
+
+        expect(definition.inputModalities).toEqual(["text"]);
+    });
+
+    it("builds community transcription models billed per audio second", () => {
+        const modelId = "voodoohop/whisper";
+        const definition = communityModelDefinition({
+            modelId,
+            description: "Community transcription model",
+            modality: "transcription",
+            ...communityEndpointPrices({ promptAudioPrice: 0.0000445 }),
+        });
+
+        expect(definition).toMatchObject({
+            category: "audio",
+            inputModalities: ["audio"],
+            outputModalities: ["text"],
+            supportedEndpoints: ["/v1/audio/transcriptions"],
+            cost: { promptAudioSeconds: 0.0000445 },
+        });
+        expect(definition).not.toHaveProperty("flatRate");
+        expect(definition.cost).not.toHaveProperty("promptTextTokens");
+        expect(
+            calculateUsageBilling({
+                model: modelId,
+                usage: { promptAudioSeconds: 60 },
+                servedBy: definition,
+            }).price.totalPrice,
+        ).toBeCloseTo(0.0000445 * 60, 10);
+    });
+
+    it("keeps the transcription price as the only billed bucket for its modality", () => {
+        const definition = communityPriceDefinition(
+            communityEndpointPrices({ promptAudioPrice: 0.00002 }),
+            "transcription",
+        );
+        expect(definition).toEqual({ promptAudioSeconds: 0.00002 });
+    });
+
+    it("prices transcription audio in per-second units, not per 1M", () => {
+        const [field] =
+            communityEndpointPriceFieldsForModality("transcription");
+        expect(field).toMatchObject({
+            key: "promptAudioPrice",
+            usageType: "promptAudioSeconds",
+            priceUnit: "second",
+        });
+        expect(MAX_COMMUNITY_PRICE_PER_SECOND).toBeGreaterThan(0);
+        expect(MAX_COMMUNITY_PRICE_PER_SECOND).toBeLessThan(
+            MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS,
+        );
+    });
+
+    describe("fallback target pricing", () => {
+        const uniformPrices = (price: number) =>
+            communityEndpointPrices(
+                Object.fromEntries(
+                    COMMUNITY_ENDPOINT_PRICE_FIELDS.map((field) => [
+                        field.key,
+                        price,
+                    ]),
+                ),
+            );
+
+        it("allows an equally priced target", () => {
+            expect(
+                isCommunityFallbackPricingAllowed(
+                    uniformPrices(0.5),
+                    uniformPrices(0.5),
+                ),
+            ).toBe(true);
+        });
+
+        it("allows a target that is cheaper on every field", () => {
+            expect(
+                isCommunityFallbackPricingAllowed(
+                    uniformPrices(0.5),
+                    uniformPrices(0.25),
+                ),
+            ).toBe(true);
+        });
+
+        it("rejects a target that is more expensive on any single field", () => {
+            // Every price column, so a newly added one cannot silently escape
+            // the same-or-lower rule.
+            for (const field of COMMUNITY_ENDPOINT_PRICE_FIELDS) {
+                expect(
+                    isCommunityFallbackPricingAllowed(uniformPrices(0.5), {
+                        ...uniformPrices(0.5),
+                        [field.key]: 0.51,
+                    }),
+                ).toBe(false);
+            }
+        });
     });
 
     describe("community image endpoint billing", () => {
@@ -482,21 +989,24 @@ describe("community endpoint helpers", () => {
             imagePricing: CommunityEndpointRuntime["imagePricing"],
         ): Promise<CommunityEndpointRuntime> {
             return {
+                type: "proxy",
                 id: "community-endpoint-id",
                 ownerUserId: "owner-id",
                 modelId: "voodoohop/gptimage",
                 name: "gptimage",
                 title: "GPT Image",
                 description: null,
-                delegatesGeneration: false,
                 modality: "image",
                 imagePricing,
-                supportsImageEdits: true,
+                inputModalities: null,
                 baseUrl: "https://api.example.com/v1",
                 upstreamModel: "gpt-image-1",
                 visibility: "public",
-                disabledAt: null,
-                disabledReason: null,
+                paidOnly: false,
+                perUserRpm: null,
+                fallbacks: [],
+                hiddenAt: null,
+                hiddenReason: null,
                 bearerTokenCiphertext: await encryptSecret(
                     "sk_saved_token",
                     secret,
@@ -665,9 +1175,596 @@ describe("community endpoint helpers", () => {
         });
     });
 
+    describe("community transcription endpoint billing", () => {
+        afterEach(() => {
+            vi.unstubAllGlobals();
+        });
+
+        const secret = "test-secret";
+
+        async function transcriptionEndpoint(): Promise<CommunityEndpointRuntime> {
+            return {
+                type: "proxy",
+                id: "community-endpoint-id",
+                ownerUserId: "owner-id",
+                modelId: "voodoohop/whisper",
+                name: "whisper",
+                title: "Whisper",
+                description: null,
+                modality: "transcription",
+                imagePricing: "request",
+                inputModalities: ["audio"],
+                baseUrl: "https://api.example.com/v1",
+                upstreamModel: "whisper-1",
+                visibility: "public",
+                paidOnly: false,
+                perUserRpm: null,
+                fallbacks: [],
+                hiddenAt: null,
+                hiddenReason: null,
+                bearerTokenCiphertext: await encryptSecret(
+                    "sk_saved_token",
+                    secret,
+                ),
+                ...communityEndpointPrices({ promptAudioPrice: 0.0000445 }),
+            };
+        }
+
+        const audioFile = new File([new Uint8Array([1, 2, 3])], "sample.wav", {
+            type: "audio/wav",
+        });
+        const transcriptionOptions = {
+            file: audioFile,
+            language: "en",
+            responseFormat: "json",
+        };
+
+        it("forwards the file and bills the upstream-reported audio seconds", async () => {
+            const fetchMock = vi.fn(async (input, init) => {
+                const request = new Request(input, init);
+                expect(request.url).toBe(
+                    "https://api.example.com/v1/audio/transcriptions",
+                );
+                expect(request.headers.get("authorization")).toBe(
+                    "Bearer sk_saved_token",
+                );
+                expect(request.headers.get("content-type")).toContain(
+                    "multipart/form-data",
+                );
+                const formData = await request.formData();
+                expect(formData.get("model")).toBe("whisper-1");
+                expect(formData.get("file")).toBeInstanceOf(File);
+                expect(formData.get("language")).toBe("en");
+                expect(formData.get("response_format")).toBe("verbose_json");
+
+                return Response.json({
+                    text: "Hello world",
+                    usage: { duration: 12.5 },
+                });
+            });
+            vi.stubGlobal("fetch", fetchMock);
+
+            const response = await callCommunityTranscriptionEndpoint(
+                await transcriptionEndpoint(),
+                transcriptionOptions,
+                secret,
+            );
+
+            expect(response.status).toBe(200);
+            // The shared formatter re-emits the OpenAI json shape: the
+            // upstream's usage block is normalized to usage.seconds.
+            expect(await response.json()).toEqual({
+                text: "Hello world",
+                usage: { type: "duration", seconds: 12.5 },
+            });
+            expect(response.headers.get(MODEL_USED_HEADER)).toBe(
+                "voodoohop/whisper",
+            );
+            expect(
+                response.headers.get(USAGE_TYPE_HEADERS.promptAudioSeconds),
+            ).toBe("12.5");
+        });
+
+        it("accepts whisper-style usage.seconds", async () => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async () =>
+                    Response.json({
+                        text: "Hello",
+                        usage: { seconds: 3 },
+                    }),
+                ),
+            );
+
+            const response = await callCommunityTranscriptionEndpoint(
+                await transcriptionEndpoint(),
+                { file: audioFile },
+                secret,
+            );
+            expect(
+                response.headers.get(USAGE_TYPE_HEADERS.promptAudioSeconds),
+            ).toBe("3");
+        });
+
+        it("accepts a top-level duration, which is where whisper verbose_json puts it", async () => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async () =>
+                    Response.json({ text: "Hello", duration: 8.25 }),
+                ),
+            );
+
+            const response = await callCommunityTranscriptionEndpoint(
+                await transcriptionEndpoint(),
+                { file: audioFile },
+                secret,
+            );
+            expect(
+                response.headers.get(USAGE_TYPE_HEADERS.promptAudioSeconds),
+            ).toBe("8.25");
+        });
+
+        it("explains the verbose_json requirement when the endpoint rejects it", async () => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async () =>
+                    Response.json(
+                        { error: { message: "unsupported response_format" } },
+                        { status: 400 },
+                    ),
+                ),
+            );
+
+            const call = callCommunityTranscriptionEndpoint(
+                await transcriptionEndpoint(),
+                { file: audioFile },
+                secret,
+            );
+            await expect(call).rejects.toThrow("response_format=verbose_json");
+            await expect(call).rejects.toMatchObject({ status: 502 });
+        });
+
+        it("fails rather than billing zero when the upstream reports no duration", async () => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async () => Response.json({ text: "Hello" })),
+            );
+
+            await expect(
+                callCommunityTranscriptionEndpoint(
+                    await transcriptionEndpoint(),
+                    { file: audioFile },
+                    secret,
+                ),
+            ).rejects.toMatchObject({ status: 502 });
+        });
+
+        it("asks upstream for verbose_json even when the caller wants text, then formats down", async () => {
+            const fetchMock = vi.fn(async (input, init) => {
+                const formData = await new Request(input, init).formData();
+                // text carries no usage object, so requesting it upstream would
+                // make the request unbillable. verbose_json is what the probe
+                // verified, and where whisper reports the duration.
+                expect(formData.get("response_format")).toBe("verbose_json");
+                return Response.json({
+                    text: "Hello world",
+                    usage: { seconds: 4 },
+                });
+            });
+            vi.stubGlobal("fetch", fetchMock);
+
+            const response = await callCommunityTranscriptionEndpoint(
+                await transcriptionEndpoint(),
+                { file: audioFile, responseFormat: "text" },
+                secret,
+            );
+
+            expect(response.headers.get("content-type")).toContain(
+                "text/plain",
+            );
+            expect(await response.text()).toBe("Hello world");
+            expect(
+                response.headers.get(USAGE_TYPE_HEADERS.promptAudioSeconds),
+            ).toBe("4");
+        });
+
+        it("serves verbose_json from the metered upstream body", async () => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async () =>
+                    Response.json({
+                        text: "Hello world",
+                        language: "en",
+                        usage: { seconds: 6 },
+                    }),
+                ),
+            );
+
+            const response = await callCommunityTranscriptionEndpoint(
+                await transcriptionEndpoint(),
+                { file: audioFile, responseFormat: "verbose_json" },
+                secret,
+            );
+
+            expect(await response.json()).toMatchObject({
+                text: "Hello world",
+                task: "transcribe",
+                language: "en",
+                duration: 6,
+            });
+        });
+
+        it("serves the endpoint's own segments and words, not an invented one", async () => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async () =>
+                    Response.json({
+                        text: "Hello world. Goodbye.",
+                        language: "en",
+                        duration: 6,
+                        segments: [
+                            { id: 0, start: 0, end: 2.5, text: "Hello world." },
+                            { id: 1, start: 3, end: 5.5, text: "Goodbye." },
+                        ],
+                        words: [
+                            { word: "Hello", start: 0, end: 0.6 },
+                            { word: "world.", start: 0.6, end: 2.5 },
+                        ],
+                    }),
+                ),
+            );
+
+            const response = await callCommunityTranscriptionEndpoint(
+                await transcriptionEndpoint(),
+                { file: audioFile, responseFormat: "verbose_json" },
+                secret,
+            );
+
+            expect(await response.json()).toMatchObject({
+                segments: [
+                    { id: 0, start: 0, end: 2.5, text: "Hello world." },
+                    { id: 1, start: 3, end: 5.5, text: "Goodbye." },
+                ],
+                words: [
+                    { word: "Hello", start: 0, end: 0.6 },
+                    { word: "world.", start: 0.6, end: 2.5 },
+                ],
+            });
+        });
+
+        it("falls back to one file-spanning segment when the endpoint reports none", async () => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async () =>
+                    Response.json({ text: "Hello world", duration: 6 }),
+                ),
+            );
+
+            const response = await callCommunityTranscriptionEndpoint(
+                await transcriptionEndpoint(),
+                { file: audioFile, responseFormat: "verbose_json" },
+                secret,
+            );
+
+            expect(await response.json()).toMatchObject({
+                segments: [{ id: 0, start: 0, end: 6, text: "Hello world" }],
+                words: [],
+            });
+        });
+
+        it("skips upstream segments that are not fully timed", async () => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async () =>
+                    Response.json({
+                        text: "Hello world",
+                        duration: 6,
+                        segments: [
+                            { start: 0, end: 2, text: "Hello" },
+                            { start: 2, text: "world" },
+                            { start: 4, end: 6 },
+                        ],
+                    }),
+                ),
+            );
+
+            const response = await callCommunityTranscriptionEndpoint(
+                await transcriptionEndpoint(),
+                { file: audioFile, responseFormat: "verbose_json" },
+                secret,
+            );
+
+            expect(await response.json()).toMatchObject({
+                segments: [{ id: 0, start: 0, end: 2, text: "Hello" }],
+            });
+        });
+
+        it("rejects diarized_json rather than answering with empty segments", async () => {
+            const fetchMock = vi.fn(async () =>
+                Response.json({ text: "Hello", usage: { seconds: 1 } }),
+            );
+            vi.stubGlobal("fetch", fetchMock);
+
+            await expect(
+                callCommunityTranscriptionEndpoint(
+                    await transcriptionEndpoint(),
+                    { file: audioFile, responseFormat: "diarized_json" },
+                    secret,
+                ),
+            ).rejects.toMatchObject({ status: 400 });
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+
+        it("asks upstream for verbose_json, the shape the probe verified", async () => {
+            const fetchMock = vi.fn(async (input, init) => {
+                const formData = await new Request(input, init).formData();
+                expect(formData.get("response_format")).toBe("verbose_json");
+                return Response.json({ text: "Hello", usage: { seconds: 2 } });
+            });
+            vi.stubGlobal("fetch", fetchMock);
+
+            const response = await callCommunityTranscriptionEndpoint(
+                await transcriptionEndpoint(),
+                { file: audioFile },
+                secret,
+            );
+            expect(
+                response.headers.get(USAGE_TYPE_HEADERS.promptAudioSeconds),
+            ).toBe("2");
+        });
+
+        it("propagates upstream transcription failures", async () => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async () =>
+                    Response.json(
+                        { error: { message: "Audio file too long" } },
+                        { status: 413 },
+                    ),
+                ),
+            );
+
+            await expect(
+                callCommunityTranscriptionEndpoint(
+                    await transcriptionEndpoint(),
+                    transcriptionOptions,
+                    secret,
+                ),
+            ).rejects.toMatchObject({
+                status: 413,
+                message: expect.stringContaining("Audio file too long"),
+            });
+        });
+    });
+
+    it("builds community video models with per-second billing", () => {
+        const modelId = "voodoohop/myvideo";
+        const definition = communityModelDefinition({
+            modelId,
+            description: "Community video model",
+            modality: "video",
+            ...communityEndpointPrices({ completionVideoPrice: 0.1 }),
+        });
+
+        expect(definition).toMatchObject({
+            category: "video",
+            inputModalities: ["text"],
+            outputModalities: ["video"],
+            supportedEndpoints: expect.arrayContaining([
+                "/v1/videos/generations",
+                "/image/{prompt}",
+            ]),
+            cost: { completionVideoSeconds: 0.1 },
+        });
+        expect(definition.cost).not.toHaveProperty("promptTextTokens");
+        expect(definition.cost).not.toHaveProperty("completionImageTokens");
+        expect(
+            calculateUsageBilling({
+                model: modelId,
+                usage: { completionVideoSeconds: 5 },
+                servedBy: definition,
+            }).price.totalPrice,
+        ).toBeCloseTo(0.5, 10);
+    });
+
+    it("prices video in per-second units with its own ceiling", () => {
+        const [field] = communityEndpointPriceFieldsForModality("video");
+        expect(field).toMatchObject({
+            key: "completionVideoPrice",
+            usageType: "completionVideoSeconds",
+            priceUnit: "video_second",
+        });
+        expect(MAX_COMMUNITY_PRICE_PER_VIDEO_SECOND).toBeGreaterThan(
+            MAX_COMMUNITY_PRICE_PER_SECOND,
+        );
+        expect(MAX_COMMUNITY_PRICE_PER_VIDEO_SECOND).toBeLessThanOrEqual(1);
+    });
+
+    it("derives the video generations URL", () => {
+        expect(communityVideoGenerationsUrl("https://api.example.com/v1")).toBe(
+            "https://api.example.com/v1/videos/generations",
+        );
+        expect(
+            communityVideoGenerationsUrl(
+                "https://api.example.com/v1/videos/generations",
+            ),
+        ).toBe("https://api.example.com/v1/videos/generations");
+    });
+
+    it("restricts community video models to the video endpoints", () => {
+        expect(communityVideoSupportedEndpoints()).toEqual(
+            expect.arrayContaining([
+                "/v1/videos/generations",
+                "/image/{prompt}",
+            ]),
+        );
+    });
+
+    it("keeps the video price as the only billed bucket for its modality", () => {
+        const definition = communityPriceDefinition(
+            communityEndpointPrices({ completionVideoPrice: 0.05 }),
+            "video",
+        );
+        expect(definition).toEqual({ completionVideoSeconds: 0.05 });
+    });
+
+    describe("community video endpoint billing", () => {
+        afterEach(() => {
+            vi.unstubAllGlobals();
+        });
+
+        const secret = "test-secret";
+
+        async function videoEndpoint(): Promise<CommunityEndpointRuntime> {
+            return {
+                type: "proxy",
+                id: "community-endpoint-id",
+                ownerUserId: "owner-id",
+                modelId: "voodoohop/myvideo",
+                name: "myvideo",
+                title: "My Video",
+                description: null,
+                modality: "video",
+                imagePricing: "request",
+                inputModalities: null,
+                baseUrl: "https://api.example.com/v1",
+                upstreamModel: "video-gen-1",
+                visibility: "public",
+                paidOnly: false,
+                perUserRpm: null,
+                fallbacks: [],
+                hiddenAt: null,
+                hiddenReason: null,
+                bearerTokenCiphertext: await encryptSecret(
+                    "sk_saved_token",
+                    secret,
+                ),
+                ...communityEndpointPrices({ completionVideoPrice: 0.1 }),
+            };
+        }
+
+        it("bills per second using duration_seconds from the response", async () => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async () =>
+                    Response.json({
+                        data: [
+                            {
+                                url: "https://api.example.com/assets/video.mp4",
+                                duration_seconds: 5.0,
+                            },
+                        ],
+                    }),
+                ),
+            );
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async (input) => {
+                    if (String(input).endsWith("/videos/generations")) {
+                        return Response.json({
+                            data: [
+                                {
+                                    url: "https://api.example.com/video.mp4",
+                                    duration_seconds: 5.0,
+                                },
+                            ],
+                        });
+                    }
+                    // video download
+                    return new Response(new Uint8Array([0, 1, 2, 3]));
+                }),
+            );
+
+            const result = await callCommunityVideoEndpoint(
+                await videoEndpoint(),
+                "a cat walking",
+                { model: "video-gen-1", duration: 5 },
+                secret,
+            );
+
+            expect(result.durationSeconds).toBe(5.0);
+            expect(result.trackingData.usage).toEqual({
+                completionVideoSeconds: 5.0,
+            });
+        });
+
+        it("bills using inline base64 video", async () => {
+            // minimal valid mp4 ftyp box encoded as base64
+            const mp4Base64 = btoa(
+                "\x00\x00\x00\x14ftypisom\x00\x00\x00\x00isom",
+            );
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async () =>
+                    Response.json({
+                        data: [{ b64_json: mp4Base64, duration_seconds: 3.0 }],
+                    }),
+                ),
+            );
+
+            const result = await callCommunityVideoEndpoint(
+                await videoEndpoint(),
+                "a dog running",
+                { model: "video-gen-1" },
+                secret,
+            );
+
+            expect(result.durationSeconds).toBe(3.0);
+            expect(result.trackingData.usage).toEqual({
+                completionVideoSeconds: 3.0,
+            });
+            expect(result.mimeType).toBe("video/mp4");
+        });
+
+        it("fails rather than billing zero when the endpoint omits duration_seconds", async () => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async () =>
+                    Response.json({
+                        data: [{ b64_json: btoa("some-video") }],
+                    }),
+                ),
+            );
+
+            await expect(
+                callCommunityVideoEndpoint(
+                    await videoEndpoint(),
+                    "a dog running",
+                    { model: "video-gen-1" },
+                    secret,
+                ),
+            ).rejects.toMatchObject({ status: 502 });
+        });
+
+        it("propagates upstream video endpoint failures", async () => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async () =>
+                    Response.json(
+                        { error: { message: "Prompt too long" } },
+                        { status: 400 },
+                    ),
+                ),
+            );
+
+            await expect(
+                callCommunityVideoEndpoint(
+                    await videoEndpoint(),
+                    "a very long prompt",
+                    { model: "video-gen-1" },
+                    secret,
+                ),
+            ).rejects.toMatchObject({
+                status: 400,
+                message: expect.stringContaining("Prompt too long"),
+            });
+        });
+    });
+
     it("builds Portkey gateway context with the saved token", async () => {
         const secret = "test-secret";
         const endpoint: CommunityEndpointRuntime = {
+            type: "proxy",
             id: "community-endpoint-id",
             ownerUserId: "owner-id",
             modelId: "voodoohop/openai",
@@ -676,13 +1773,15 @@ describe("community endpoint helpers", () => {
             description: null,
             modality: "text",
             imagePricing: "request",
-            supportsImageEdits: false,
+            inputModalities: null,
             baseUrl: "https://api.example.com/v1",
             upstreamModel: "gpt-4.1-mini",
             visibility: "public",
-            delegatesGeneration: false,
-            disabledAt: null,
-            disabledReason: null,
+            paidOnly: false,
+            perUserRpm: null,
+            fallbacks: [],
+            hiddenAt: null,
+            hiddenReason: null,
             bearerTokenCiphertext: await encryptSecret(
                 "sk_saved_token",
                 secret,
@@ -694,17 +1793,18 @@ describe("community endpoint helpers", () => {
         };
         const modelDefinition = communityModelDefinition(endpoint);
 
-        const context = await communityEndpointGatewayContext(
+        const context = await communityEndpointGatewayContext({
             endpoint,
             modelDefinition,
-            {
+            requestData: {
                 messages: [{ role: "user", content: "hello" }],
                 max_tokens: 5,
             },
             secret,
-            "https://portkey.test",
-            "sk_user_key",
-        );
+            portkeyGatewayUrl: "https://portkey.test",
+            userApiKey: "sk_user_key",
+            parentRequestId: "parent-request-id",
+        });
 
         expect(context).toMatchObject({
             max_tokens: 5,
@@ -722,13 +1822,14 @@ describe("community endpoint helpers", () => {
         expect(context).not.toHaveProperty("messages");
     });
 
-    describe("delegated agent endpoints", () => {
+    describe("endpoint agents", () => {
         const secret = "test-secret";
 
-        async function agentEndpoint(
-            overrides: Partial<CommunityEndpointRuntime> = {},
-        ): Promise<CommunityEndpointRuntime> {
+        function endpointAgent(
+            overrides: Partial<EndpointAgentCommunityEndpointRuntime> = {},
+        ): EndpointAgentCommunityEndpointRuntime {
             return {
+                type: "endpoint_agent",
                 id: "agent-endpoint-id",
                 ownerUserId: "owner-id",
                 modelId: "voodoohop/agent",
@@ -737,17 +1838,15 @@ describe("community endpoint helpers", () => {
                 description: null,
                 modality: "text",
                 imagePricing: "request",
-                supportsImageEdits: false,
+                inputModalities: null,
                 baseUrl: "https://agent.example.com/v1",
                 upstreamModel: "agent",
                 visibility: "public",
-                delegatesGeneration: true,
-                disabledAt: null,
-                disabledReason: null,
-                bearerTokenCiphertext: await encryptSecret(
-                    "sk_saved_token",
-                    secret,
-                ),
+                paidOnly: false,
+                perUserRpm: null,
+                hiddenAt: null,
+                hiddenReason: null,
+                fallbacks: [],
                 ...communityEndpointPrices({}),
                 ...overrides,
             };
@@ -756,50 +1855,108 @@ describe("community endpoint helpers", () => {
         async function contextFor(
             endpoint: CommunityEndpointRuntime,
             parentApiKeyId?: string,
+            parentRequestId = "parent-request-id",
         ) {
-            return communityEndpointGatewayContext(
+            return communityEndpointGatewayContext({
                 endpoint,
-                communityModelDefinition(endpoint),
-                { messages: [{ role: "user", content: "make a video" }] },
+                modelDefinition: communityModelDefinition(endpoint),
+                requestData: {
+                    messages: [{ role: "user", content: "make a video" }],
+                },
                 secret,
-                "https://portkey.test",
-                "sk_user_key",
+                portkeyGatewayUrl: "https://portkey.test",
+                userApiKey: "sk_user_key",
+                parentRequestId,
                 parentApiKeyId,
-            );
+            });
         }
 
-        it("authenticates as a run token, not the caller's or owner's key", async () => {
-            const endpoint = await agentEndpoint();
+        it("authenticates as a run token, not the caller's key", async () => {
+            const endpoint = endpointAgent();
             const context = await contextFor(endpoint, "parent-key-id");
 
             const token = String(context.modelConfig?.authKey);
             expect(token).toMatch(/^ag_/);
             expect(token).not.toContain("sk_user_key");
-            // The owner's saved bearer is replaced, never sent alongside — the
-            // endpoint must not receive a credential it could spend as its own.
-            expect(token).not.toContain("sk_saved_token");
 
             const claims = await verifyAgentRunToken(token, secret);
             expect(claims).toMatchObject({ parentApiKeyId: "parent-key-id" });
         });
 
-        it("sends the saved bearer when the endpoint is not flagged", async () => {
-            const endpoint = await agentEndpoint({
-                delegatesGeneration: false,
-            });
+        it("carries the parent request id so a run's generations can be grouped", async () => {
+            const endpoint = endpointAgent();
+            const context = await contextFor(
+                endpoint,
+                "parent-key-id",
+                "req-abc",
+            );
+
+            const claims = await verifyAgentRunToken(
+                String(context.modelConfig?.authKey),
+                secret,
+            );
+            expect(claims.parentRequestId).toBe("req-abc");
+
+            // Fallback attempts share the parent request but still receive
+            // distinct signed credentials.
+            const second = await contextFor(
+                endpoint,
+                "parent-key-id",
+                "req-abc",
+            );
+            const secondClaims = await verifyAgentRunToken(
+                String(second.modelConfig?.authKey),
+                secret,
+            );
+            expect(secondClaims.parentRequestId).toBe("req-abc");
+            expect(String(second.modelConfig?.authKey)).not.toBe(
+                String(context.modelConfig?.authKey),
+            );
+        });
+
+        // The complement of the test above, and the reason an agent listing
+        // has nowhere to store a credential: only a proxy sends one.
+        it("sends a proxy listing's saved bearer, never a run token", async () => {
+            const { type: _type, ...base } = endpointAgent();
+            const endpoint: CommunityEndpointRuntime = {
+                ...base,
+                type: "proxy",
+                bearerTokenCiphertext: await encryptSecret(
+                    "sk_saved_token",
+                    secret,
+                ),
+            };
             const context = await contextFor(endpoint, "parent-key-id");
             expect(context.modelConfig?.authKey).toBe("sk_saved_token");
         });
 
+        it("always scopes managed agents to their listing id", async () => {
+            const { type: _type, ...base } = endpointAgent();
+            const endpoint: CommunityEndpointRuntime = {
+                ...base,
+                id: "managed-agent-id",
+                type: "prompt_agent",
+                upstreamModel: "managed-agent-id",
+            };
+            const context = await contextFor(endpoint, "parent-key-id");
+            const token = String(context.modelConfig?.authKey);
+            const claims = await verifyAgentRunToken(token, secret);
+            expect(claims).toMatchObject({
+                parentApiKeyId: "parent-key-id",
+                parentRequestId: "parent-request-id",
+                managedAgentId: "managed-agent-id",
+            });
+        });
+
         it("refuses to delegate when there is no key to bill", async () => {
-            const endpoint = await agentEndpoint();
+            const endpoint = endpointAgent();
             await expect(contextFor(endpoint, undefined)).rejects.toThrow(
                 "no API key to bill",
             );
         });
 
         it("refuses to delegate from an endpoint that charges a price", async () => {
-            const endpoint = await agentEndpoint({
+            const endpoint = endpointAgent({
                 ...communityEndpointPrices({ promptTextPrice: 0.1 }),
             });
             await expect(contextFor(endpoint, "parent-key-id")).rejects.toThrow(
@@ -816,10 +1973,10 @@ fixtureTest(
         const modelName = `openai-${crypto.randomUUID().slice(0, 8)}`;
         const modelId = communityModelId(ownerGithubUsername, modelName);
         const ownerUserId = await createTestUser({
-            githubId: COMMUNITY_ENDPOINT_ALLOWED_TEST_GITHUB_ID,
+            githubId: nextAllowedGithubId(),
             githubUsername: ownerGithubUsername,
         });
-        await db.insert(communityEndpointTable).values({
+        await insertCommunityEndpoints({
             id: `endpoint-${crypto.randomUUID()}`,
             ownerUserId,
             visibility: "public",
@@ -855,6 +2012,10 @@ fixtureTest(
                 return Response.json({
                     id: "chatcmpl_test",
                     object: "chat.completion",
+                    // The upstream names itself, as a real provider does. Our
+                    // id has to win over it, or a community model is recorded
+                    // under whatever its owner happens to proxy.
+                    model: "gpt-4.1-mini",
                     choices: [
                         {
                             index: 0,
@@ -878,7 +2039,7 @@ fixtureTest(
         });
         vi.stubGlobal("fetch", fetchMock);
 
-        const response = await SELF.fetch(
+        const response = await fetchGen(
             new Request("https://gen.pollinations.ai/v1/chat/completions", {
                 method: "POST",
                 headers: {
@@ -894,15 +2055,20 @@ fixtureTest(
         );
 
         expect(response.status).toBe(200);
+        // Billing and analytics read the header, and it names OUR model even
+        // though the upstream called itself something else.
         expect(response.headers.get("x-model-used")).toBe(modelId);
         const body = await response.json();
-        expect(body).not.toHaveProperty("model");
+        // The OpenAI-compatible body still echoes the upstream's own name,
+        // which is what a provider's response carries. It disagrees with the
+        // header on purpose today; see the follow-up issue on aligning them.
         expect(body).toMatchObject({
+            model: "gpt-4.1-mini",
             choices: [{ message: { content: "ok" } }],
             usage: { prompt_tokens: 2, completion_tokens: 3, total_tokens: 5 },
         });
 
-        const legacyResponse = await SELF.fetch(
+        const legacyResponse = await fetchGen(
             new Request("https://gen.pollinations.ai/v1/chat/completions", {
                 method: "POST",
                 headers: {
@@ -921,8 +2087,8 @@ fixtureTest(
         );
         expect(legacyResponse.status).toBe(200);
         const legacyBody = await legacyResponse.json();
-        expect(legacyBody).not.toHaveProperty("model");
         expect(legacyBody).toMatchObject({
+            model: "gpt-4.1-mini",
             choices: [{ message: { content: "ok" } }],
         });
 
@@ -941,7 +2107,7 @@ fixtureTest(
         const modelId = communityModelId(ownerGithubUsername, modelName);
         const endpointId = `endpoint-${crypto.randomUUID()}`;
         const ownerUserId = await createTestUser({
-            githubId: COMMUNITY_ENDPOINT_ALLOWED_TEST_GITHUB_ID,
+            githubId: nextAllowedGithubId(),
             githubUsername: ownerGithubUsername,
             // Owner-only private models have no Pollinations charge and remain
             // callable without a Pollinations balance.
@@ -952,7 +2118,7 @@ fixtureTest(
             name: "owner-key",
             userId: ownerUserId,
         });
-        await db.insert(communityEndpointTable).values({
+        await insertCommunityEndpoints({
             id: endpointId,
             ownerUserId,
             visibility: "private",
@@ -999,7 +2165,7 @@ fixtureTest(
 
         // A non-owner caller: the private model resolves to "invalid model",
         // indistinguishable from an unknown name so it isn't discoverable.
-        const otherResponse = await SELF.fetch(
+        const otherResponse = await fetchGen(
             new Request("https://gen.pollinations.ai/v1/chat/completions", {
                 method: "POST",
                 headers: {
@@ -1015,7 +2181,7 @@ fixtureTest(
         expect(otherResponse.status).toBe(400);
 
         // The owner reaches their own private model.
-        const ownerResponse = await SELF.fetch(
+        const ownerResponse = await fetchGen(
             new Request("https://gen.pollinations.ai/v1/chat/completions", {
                 method: "POST",
                 headers: {
@@ -1034,7 +2200,7 @@ fixtureTest(
         });
 
         const catalogIncludesModel = async (authorization?: string) => {
-            const modelsResponse = await SELF.fetch(
+            const modelsResponse = await fetchGen(
                 new Request("https://gen.pollinations.ai/text/models", {
                     headers: authorization
                         ? { Authorization: `Bearer ${authorization}` }
@@ -1062,7 +2228,7 @@ fixtureTest(
         const { key: zeroBalanceCallerKey } = await createTestApiKey({
             user: { tierBalance: 0, packBalance: 0 },
         });
-        const freePublicResponse = await SELF.fetch(
+        const freePublicResponse = await fetchGen(
             new Request("https://gen.pollinations.ai/v1/chat/completions", {
                 method: "POST",
                 headers: {
@@ -1089,10 +2255,10 @@ fixtureTest(
         const modelName = `stream-${crypto.randomUUID().slice(0, 8)}`;
         const modelId = communityModelId(ownerGithubUsername, modelName);
         const ownerUserId = await createTestUser({
-            githubId: COMMUNITY_ENDPOINT_ALLOWED_TEST_GITHUB_ID,
+            githubId: nextAllowedGithubId(),
             githubUsername: ownerGithubUsername,
         });
-        await db.insert(communityEndpointTable).values({
+        await insertCommunityEndpoints({
             id: `endpoint-${crypto.randomUUID()}`,
             ownerUserId,
             visibility: "public",
@@ -1153,7 +2319,7 @@ fixtureTest(
             }),
         );
 
-        const response = await SELF.fetch(
+        const response = await fetchGen(
             new Request("https://gen.pollinations.ai/v1/chat/completions", {
                 method: "POST",
                 headers: {
@@ -1188,10 +2354,10 @@ fixtureTest(
         const modelName = `simple-${crypto.randomUUID().slice(0, 8)}`;
         const modelId = communityModelId(ownerGithubUsername, modelName);
         const ownerUserId = await createTestUser({
-            githubId: COMMUNITY_ENDPOINT_ALLOWED_TEST_GITHUB_ID,
+            githubId: nextAllowedGithubId(),
             githubUsername: ownerGithubUsername,
         });
-        await db.insert(communityEndpointTable).values({
+        await insertCommunityEndpoints({
             id: `endpoint-${crypto.randomUUID()}`,
             ownerUserId,
             visibility: "public",
@@ -1256,7 +2422,7 @@ fixtureTest(
             }),
         );
 
-        const response = await SELF.fetch(
+        const response = await fetchGen(
             new Request(
                 `https://gen.pollinations.ai/text/hello?model=${encodeURIComponent(
                     modelId,
@@ -1273,7 +2439,8 @@ fixtureTest(
         expect(response.headers.get("cache-control")).toBe(
             IMMUTABLE_CACHE_CONTROL,
         );
-        expect(response.headers.get("x-cache")).toBe("MISS");
+        expect(response.headers.get("x-cache")).toBe("HIT");
+        expect(response.headers.get("x-cache-type")).toBeNull();
         expect(response.headers.get("x-cache-key")).toBeTruthy();
         await expect(response.text()).resolves.toBe("simple ok");
     },
@@ -1286,15 +2453,16 @@ fixtureTest(
         const modelName = `catalog-${crypto.randomUUID().slice(0, 8)}`;
         const modelId = communityModelId(ownerGithubUsername, modelName);
         const ownerUserId = await createTestUser({
-            githubId: COMMUNITY_ENDPOINT_ALLOWED_TEST_GITHUB_ID,
+            githubId: nextAllowedGithubId(),
             githubUsername: ownerGithubUsername,
         });
-        await db.insert(communityEndpointTable).values({
+        await insertCommunityEndpoints({
             id: `endpoint-${crypto.randomUUID()}`,
             ownerUserId,
             visibility: "public",
             name: modelName,
             description: "Public community model",
+            perUserRpm: 0.5,
             baseUrl: "https://api.example.com/v1",
             upstreamModel: "gpt-4.1-mini",
             bearerTokenCiphertext: await encryptSecret(
@@ -1307,13 +2475,13 @@ fixtureTest(
             updatedAt: new Date(),
         });
 
-        const textResponse = await SELF.fetch(
+        const textResponse = await fetchGen(
             "https://gen.pollinations.ai/text/models",
         );
-        const allResponse = await SELF.fetch(
+        const allResponse = await fetchGen(
             "https://gen.pollinations.ai/models",
         );
-        const openaiResponse = await SELF.fetch(
+        const openaiResponse = await fetchGen(
             "https://gen.pollinations.ai/v1/models",
         );
 
@@ -1326,6 +2494,7 @@ fixtureTest(
             aliases?: string[];
             category?: string;
             community?: boolean;
+            per_user_rpm?: number | null;
             alpha?: boolean;
             description?: string;
             pricing?: Record<string, string>;
@@ -1337,6 +2506,7 @@ fixtureTest(
             data: {
                 id: string;
                 supported_endpoints?: string[];
+                per_user_rpm?: number | null;
             }[];
         };
 
@@ -1349,6 +2519,7 @@ fixtureTest(
                 ],
                 category: "text",
                 community: true,
+                per_user_rpm: 0.5,
                 alpha: true,
                 title: "Public community model",
                 description: "Public community model",
@@ -1360,12 +2531,14 @@ fixtureTest(
             });
             expect(listed).not.toHaveProperty("baseUrl");
             expect(listed).not.toHaveProperty("bearerTokenCiphertext");
+            expect(listed).not.toHaveProperty("agent");
         }
 
         expect(openaiModels.data).toEqual(
             expect.arrayContaining([
                 expect.objectContaining({
                     id: modelId,
+                    per_user_rpm: 0.5,
                     supported_endpoints: expect.arrayContaining([
                         "/v1/chat/completions",
                     ]),
@@ -1376,21 +2549,173 @@ fixtureTest(
 );
 
 fixtureTest(
-    "excludes a deactivated community model from public model catalogs",
+    "orders every model catalog for practical discovery",
+    async ({ restrictedApiKey }) => {
+        const ownerGithubUsername = `order-${crypto.randomUUID().slice(0, 8)}`;
+        const ownerUserId = await createTestUser({
+            githubId: nextAllowedGithubId(),
+            githubUsername: ownerGithubUsername,
+        });
+        const newestDate = new Date("2100-01-02T00:00:00Z");
+        const tiedDate = new Date("2100-01-01T00:00:00Z");
+        for (const [name, createdAt] of [
+            ["newest", newestDate],
+            ["a-tie", tiedDate],
+            ["b-tie", tiedDate],
+        ] as const) {
+            await insertCommunityEndpoints({
+                id: `endpoint-${crypto.randomUUID()}`,
+                ownerUserId,
+                visibility: "public",
+                name,
+                description: `Ordering test ${name}`,
+                baseUrl: "https://api.example.com/v1",
+                upstreamModel: "gpt-4.1-mini",
+                bearerTokenCiphertext: await encryptSecret(
+                    "sk_saved_token",
+                    env.BETTER_AUTH_SECRET,
+                ),
+                promptTextPrice: 0,
+                completionTextPrice: 0,
+                createdAt,
+                updatedAt: createdAt,
+            });
+        }
+
+        const [allResponse, openaiResponse, textResponse, restrictedResponse] =
+            await Promise.all([
+                fetchGen("https://gen.pollinations.ai/models"),
+                fetchGen("https://gen.pollinations.ai/v1/models"),
+                fetchGen("https://gen.pollinations.ai/text/models"),
+                fetchGen("https://gen.pollinations.ai/models", {
+                    headers: {
+                        Authorization: `Bearer ${restrictedApiKey}`,
+                    },
+                }),
+            ]);
+
+        expect(allResponse.status).toBe(200);
+        expect(openaiResponse.status).toBe(200);
+        expect(textResponse.status).toBe(200);
+        expect(restrictedResponse.status).toBe(200);
+
+        type ListedModel = {
+            name: string;
+            category: string;
+            community?: boolean;
+            alpha?: boolean;
+            added_date?: number;
+        };
+        const allModels = (await allResponse.json()) as ListedModel[];
+        const openaiModels = (await openaiResponse.json()) as {
+            data: { id: string }[];
+        };
+        const textModels = (await textResponse.json()) as ListedModel[];
+        const restrictedModels =
+            (await restrictedResponse.json()) as ListedModel[];
+        const officialModels = allModels.filter((model) => !model.community);
+        const communityModels = allModels.filter((model) => model.community);
+        const allNames = allModels.map((model) => model.name);
+
+        expect(allNames).toEqual(openaiModels.data.map((model) => model.id));
+        expect(textModels.map((model) => model.name)).toEqual(
+            allModels
+                .filter((model) => model.category === "text")
+                .map((model) => model.name),
+        );
+        expect(allNames).toEqual([
+            ...officialModels.map((model) => model.name),
+            ...communityModels.map((model) => model.name),
+        ]);
+
+        const categoryOrder = [
+            "text",
+            "image",
+            "video",
+            "3d",
+            "audio",
+            "realtime",
+            "embedding",
+        ];
+        expect([
+            ...new Set(officialModels.map((model) => model.category)),
+        ]).toEqual(
+            categoryOrder.filter((category) =>
+                officialModels.some((model) => model.category === category),
+            ),
+        );
+
+        const defaults: Record<string, string> = {
+            text: DEFAULT_TEXT_MODEL,
+            image: DEFAULT_IMAGE_MODEL,
+            "3d": DEFAULT_3D_MODEL,
+            audio: DEFAULT_AUDIO_MODEL,
+            realtime: DEFAULT_REALTIME_MODEL,
+            embedding: DEFAULT_EMBEDDING_MODEL,
+        };
+        for (const category of categoryOrder) {
+            const models = officialModels.filter(
+                (model) => model.category === category,
+            );
+            const defaultModel = defaults[category];
+            if (defaultModel !== undefined) {
+                expect(models[0]?.name).toBe(defaultModel);
+            }
+            const remainingModels =
+                defaultModel === undefined ? models : models.slice(1);
+            expect(remainingModels).toEqual(
+                [...remainingModels].sort(
+                    (left, right) =>
+                        Number(left.alpha === true) -
+                            Number(right.alpha === true) ||
+                        (right.added_date ?? 0) - (left.added_date ?? 0) ||
+                        (left.name < right.name
+                            ? -1
+                            : left.name > right.name
+                              ? 1
+                              : 0),
+                ),
+            );
+        }
+
+        expect(communityModels.slice(0, 3)).toMatchObject([
+            {
+                name: communityModelId(ownerGithubUsername, "newest"),
+                added_date: newestDate.getTime(),
+            },
+            {
+                name: communityModelId(ownerGithubUsername, "a-tie"),
+                added_date: tiedDate.getTime(),
+            },
+            {
+                name: communityModelId(ownerGithubUsername, "b-tie"),
+                added_date: tiedDate.getTime(),
+            },
+        ]);
+
+        const restrictedNames = restrictedModels.map((model) => model.name);
+        expect(restrictedNames).toEqual(
+            allNames.filter((name) => restrictedNames.includes(name)),
+        );
+    },
+);
+
+fixtureTest(
+    "excludes a hidden community model from public model catalogs",
     async () => {
         const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;
         const modelName = `disabled-${crypto.randomUUID().slice(0, 8)}`;
         const modelId = communityModelId(ownerGithubUsername, modelName);
         const ownerUserId = await createTestUser({
-            githubId: COMMUNITY_ENDPOINT_ALLOWED_TEST_GITHUB_ID,
+            githubId: nextAllowedGithubId(),
             githubUsername: ownerGithubUsername,
         });
-        await db.insert(communityEndpointTable).values({
+        await insertCommunityEndpoints({
             id: `endpoint-${crypto.randomUUID()}`,
             ownerUserId,
             visibility: "public",
             name: modelName,
-            description: "Deactivated community model",
+            description: "Hidden community model",
             baseUrl: "https://api.example.com/v1",
             upstreamModel: "gpt-4.1-mini",
             bearerTokenCiphertext: await encryptSecret(
@@ -1399,20 +2724,20 @@ fixtureTest(
             ),
             promptTextPrice: 0.1 / 1_000_000,
             completionTextPrice: 0.2 / 1_000_000,
-            disabledAt: new Date(),
-            disabledReason: "repeated upstream 500s",
-            disabledBy: "monitor",
+            hiddenAt: new Date(),
+            hiddenReason: "repeated upstream 500s",
+            hiddenBy: "monitor",
             createdAt: new Date(),
             updatedAt: new Date(),
         });
 
-        const textResponse = await SELF.fetch(
+        const textResponse = await fetchGen(
             "https://gen.pollinations.ai/text/models",
         );
-        const allResponse = await SELF.fetch(
+        const allResponse = await fetchGen(
             "https://gen.pollinations.ai/models",
         );
-        const openaiResponse = await SELF.fetch(
+        const openaiResponse = await fetchGen(
             "https://gen.pollinations.ai/v1/models",
         );
 
@@ -1434,7 +2759,187 @@ fixtureTest(
 );
 
 fixtureTest(
-    "rejects a direct chat completion against a deactivated community model",
+    "filters model catalogs with ?community query parameter",
+    async () => {
+        const suffix = crypto.randomUUID().slice(0, 8);
+        const textOwner = `filter-text-${suffix}`;
+        const imageOwner = `filter-img-${suffix}`;
+        const textName = `qp-text-${suffix}`;
+        const imageName = `qp-img-${suffix}`;
+        const textModelId = communityModelId(textOwner, textName);
+        const imageModelId = communityModelId(imageOwner, imageName);
+
+        const textUserId = await createTestUser({
+            githubId: nextAllowedGithubId(),
+            githubUsername: textOwner,
+        });
+        const imageUserId = await createTestUser({
+            githubId: nextAllowedGithubId(),
+            githubUsername: imageOwner,
+        });
+
+        await insertCommunityEndpoints([
+            {
+                id: `endpoint-${crypto.randomUUID()}`,
+                ownerUserId: textUserId,
+                visibility: "public",
+                name: textName,
+                description: "Community text filter test model",
+                baseUrl: "https://api.example.com/v1",
+                upstreamModel: "gpt-4.1-mini",
+                bearerTokenCiphertext: await encryptSecret(
+                    "sk_saved_token",
+                    env.BETTER_AUTH_SECRET,
+                ),
+                promptTextPrice: 0,
+                completionTextPrice: 0,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            },
+            {
+                id: `endpoint-${crypto.randomUUID()}`,
+                ownerUserId: imageUserId,
+                visibility: "public",
+                name: imageName,
+                description: "Community image filter test model",
+                modality: "image",
+                baseUrl: "https://img.example.com/v1",
+                upstreamModel: "flux-1",
+                bearerTokenCiphertext: await encryptSecret(
+                    "sk_saved_token",
+                    env.BETTER_AUTH_SECRET,
+                ),
+                promptTextPrice: 0,
+                completionTextPrice: 0,
+                completionImagePrice: 0.01,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            },
+        ]);
+
+        type ListedModel = { name: string; community?: boolean };
+
+        const [
+            allDefault,
+            allExclude,
+            allOnly,
+            textExclude,
+            textOnly,
+            openaiExclude,
+            openaiOnly,
+            imageExclude,
+            imageOnly,
+            allExcludeNumeric,
+            allOnlyNumeric,
+        ] = await Promise.all([
+            SELF.fetch("https://gen.pollinations.ai/models"),
+            SELF.fetch("https://gen.pollinations.ai/models?community=false"),
+            SELF.fetch("https://gen.pollinations.ai/models?community=true"),
+            SELF.fetch(
+                "https://gen.pollinations.ai/text/models?community=false",
+            ),
+            SELF.fetch(
+                "https://gen.pollinations.ai/text/models?community=true",
+            ),
+            SELF.fetch("https://gen.pollinations.ai/v1/models?community=false"),
+            SELF.fetch("https://gen.pollinations.ai/v1/models?community=true"),
+            SELF.fetch(
+                "https://gen.pollinations.ai/image/models?community=false",
+            ),
+            SELF.fetch(
+                "https://gen.pollinations.ai/image/models?community=true",
+            ),
+            SELF.fetch("https://gen.pollinations.ai/models?community=0"),
+            SELF.fetch("https://gen.pollinations.ai/models?community=1"),
+        ]);
+
+        for (const r of [
+            allDefault,
+            allExclude,
+            allOnly,
+            textExclude,
+            textOnly,
+            openaiExclude,
+            openaiOnly,
+            imageExclude,
+            imageOnly,
+            allExcludeNumeric,
+            allOnlyNumeric,
+        ]) {
+            expect(r.status).toBe(200);
+        }
+
+        const defaultModels = (await allDefault.json()) as ListedModel[];
+        const excludeModels = (await allExclude.json()) as ListedModel[];
+        const onlyModels = (await allOnly.json()) as ListedModel[];
+        const textExcludeModels = (await textExclude.json()) as ListedModel[];
+        const textOnlyModels = (await textOnly.json()) as ListedModel[];
+        const openaiExcludeData = (await openaiExclude.json()) as {
+            data: { id: string }[];
+        };
+        const openaiOnlyData = (await openaiOnly.json()) as {
+            data: { id: string }[];
+        };
+        const imageExcludeModels = (await imageExclude.json()) as ListedModel[];
+        const imageOnlyModels = (await imageOnly.json()) as ListedModel[];
+        const excludeNumeric =
+            (await allExcludeNumeric.json()) as ListedModel[];
+        const onlyNumeric = (await allOnlyNumeric.json()) as ListedModel[];
+
+        expect(defaultModels.some((m) => m.community)).toBe(true);
+        expect(defaultModels.some((m) => !m.community)).toBe(true);
+
+        expect(excludeModels.every((m) => !m.community)).toBe(true);
+        expect(
+            excludeModels.find((m) => m.name === textModelId),
+        ).toBeUndefined();
+
+        expect(onlyModels.every((m) => m.community === true)).toBe(true);
+        expect(onlyModels.find((m) => m.name === textModelId)).toBeDefined();
+
+        expect(textExcludeModels.every((m) => !m.community)).toBe(true);
+        expect(textOnlyModels.every((m) => m.community === true)).toBe(true);
+
+        expect(
+            openaiExcludeData.data.find((m) => m.id === textModelId),
+        ).toBeUndefined();
+        expect(
+            openaiOnlyData.data.find((m) => m.id === textModelId),
+        ).toBeDefined();
+
+        expect(imageExcludeModels.every((m) => !m.community)).toBe(true);
+        expect(
+            imageExcludeModels.find((m) => m.name === imageModelId),
+        ).toBeUndefined();
+
+        expect(imageOnlyModels.every((m) => m.community === true)).toBe(true);
+        expect(
+            imageOnlyModels.find((m) => m.name === imageModelId),
+        ).toBeDefined();
+
+        expect(excludeNumeric.map((m) => m.name)).toEqual(
+            excludeModels.map((m) => m.name),
+        );
+        expect(onlyNumeric.map((m) => m.name)).toEqual(
+            onlyModels.map((m) => m.name),
+        );
+
+        const invalidResponses = await Promise.all([
+            SELF.fetch("https://gen.pollinations.ai/models?community=tru"),
+            SELF.fetch("https://gen.pollinations.ai/models?community=yes"),
+            SELF.fetch("https://gen.pollinations.ai/v1/models?community=2"),
+            SELF.fetch(
+                "https://gen.pollinations.ai/image/models?community=nope",
+            ),
+        ]);
+        for (const r of invalidResponses) {
+            expect(r.status).toBe(400);
+        }
+    },
+);
+
+fixtureTest(
+    "routes direct calls to a hidden community model",
     async ({ apiKey }) => {
         const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;
         const modelName = `disabled-call-${crypto.randomUUID().slice(0, 8)}`;
@@ -1444,15 +2949,15 @@ fixtureTest(
             modelName,
         );
         const ownerUserId = await createTestUser({
-            githubId: COMMUNITY_ENDPOINT_ALLOWED_TEST_GITHUB_ID,
+            githubId: nextAllowedGithubId(),
             githubUsername: ownerGithubUsername,
         });
-        await db.insert(communityEndpointTable).values({
+        await insertCommunityEndpoints({
             id: `endpoint-${crypto.randomUUID()}`,
             ownerUserId,
             visibility: "public",
             name: modelName,
-            description: "Deactivated community model",
+            description: "Hidden community model",
             baseUrl: "https://api.example.com/v1",
             upstreamModel: "gpt-4.1-mini",
             bearerTokenCiphertext: await encryptSecret(
@@ -1461,15 +2966,46 @@ fixtureTest(
             ),
             promptTextPrice: 0.1 / 1_000_000,
             completionTextPrice: 0.2 / 1_000_000,
-            disabledAt: new Date(),
-            disabledReason: "repeated upstream 500s",
-            disabledBy: "monitor",
+            hiddenAt: new Date(),
+            hiddenReason: "repeated upstream 500s",
+            hiddenBy: "monitor",
             createdAt: new Date(),
             updatedAt: new Date(),
         });
 
+        const fetchMock = vi.fn(async (input, init) => {
+            const request = new Request(input, init);
+
+            if (isPortkeyChatCompletionsRequest(request)) {
+                return Response.json({
+                    id: "chatcmpl_hidden",
+                    object: "chat.completion",
+                    model: "gpt-4.1-mini",
+                    choices: [
+                        {
+                            index: 0,
+                            message: { role: "assistant", content: "ok" },
+                            finish_reason: "stop",
+                        },
+                    ],
+                    usage: {
+                        prompt_tokens: 2,
+                        completion_tokens: 1,
+                        total_tokens: 3,
+                    },
+                });
+            }
+
+            if (isBillingFetch(request)) {
+                return Response.json({ data: [] });
+            }
+
+            throw new Error(`Unexpected fetch: ${request.url}`);
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
         for (const requestedModel of [modelId, legacyModelId]) {
-            const response = await SELF.fetch(
+            const response = await fetchGen(
                 "https://gen.pollinations.ai/v1/chat/completions",
                 {
                     method: "POST",
@@ -1485,18 +3021,21 @@ fixtureTest(
                 },
             );
 
-            expect(response.status).toBe(400);
-            const body = (await response.json()) as {
-                error?: { message?: string };
-            };
-            expect(body.error?.message).toContain("Invalid model or alias");
-            expect(body.error?.message).not.toContain("repeated upstream 500s");
+            expect(response.status).toBe(200);
+            await expect(response.json()).resolves.toMatchObject({
+                choices: [{ message: { content: "ok" } }],
+            });
         }
+
+        const upstreamCalls = fetchMock.mock.calls.filter(([input, init]) =>
+            isPortkeyChatCompletionsRequest(new Request(input, init)),
+        );
+        expect(upstreamCalls).toHaveLength(2);
     },
 );
 
 fixtureTest(
-    "lets a non-allowlisted user register a private model but blocks publishing tools",
+    "lets a non-allowlisted user probe an upstream and register a private model but blocks publishing",
     async ({ apiKey }) => {
         const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;
         const modelName = `denied-${crypto.randomUUID().slice(0, 8)}`;
@@ -1517,6 +3056,40 @@ fixtureTest(
         });
 
         const enterApi = await createEnterCommunityApi();
+        // The probes are open to every account, so they reach the upstream
+        // instead of being refused: stub it and assert on what comes back.
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+                const request = new Request(input, init);
+                if (request.url === "https://api.example.com/v1/models") {
+                    return Response.json({
+                        data: [{ id: "gpt-4.1-mini" }, { id: "gpt-4o" }],
+                    });
+                }
+                if (
+                    request.url ===
+                    "https://api.example.com/v1/chat/completions"
+                ) {
+                    return Response.json({
+                        id: "chatcmpl_probe",
+                        choices: [
+                            {
+                                index: 0,
+                                message: { role: "assistant", content: "OK" },
+                                finish_reason: "stop",
+                            },
+                        ],
+                        usage: {
+                            prompt_tokens: 3,
+                            completion_tokens: 1,
+                            total_tokens: 4,
+                        },
+                    });
+                }
+                throw new Error(`Unexpected fetch: ${request.url}`);
+            }),
+        );
         for (const probe of [
             {
                 path: "models",
@@ -1548,8 +3121,18 @@ fixtureTest(
                     },
                 ),
             );
-            expect(probeResponse.status).toBe(403);
+            expect(probeResponse.status).toBe(200);
+            const probeBody = (await probeResponse.json()) as {
+                data?: string[];
+                ok?: boolean;
+            };
+            if (probe.path === "models") {
+                expect(probeBody.data).toEqual(["gpt-4.1-mini", "gpt-4o"]);
+            } else {
+                expect(probeBody.ok).toBe(true);
+            }
         }
+        vi.unstubAllGlobals();
 
         const directPublishResponse = await fetchEnterApi(
             enterApi,
@@ -1628,7 +3211,7 @@ fixtureTest(
         );
         expect(publishResponse.status).toBe(403);
 
-        await db.insert(communityEndpointTable).values({
+        await insertCommunityEndpoints({
             id: `endpoint-${crypto.randomUUID()}`,
             ownerUserId,
             visibility: "public",
@@ -1686,14 +3269,14 @@ fixtureTest(
         });
         vi.stubGlobal("fetch", fetchMock);
 
-        const modelsResponse = await SELF.fetch(
+        const modelsResponse = await fetchGen(
             "https://gen.pollinations.ai/text/models",
         );
         expect(modelsResponse.status).toBe(200);
         const models = (await modelsResponse.json()) as { name: string }[];
         expect(models.some((model) => model.name === modelId)).toBe(true);
 
-        const generationResponse = await SELF.fetch(
+        const generationResponse = await fetchGen(
             new Request("https://gen.pollinations.ai/v1/chat/completions", {
                 method: "POST",
                 headers: {
@@ -1724,7 +3307,7 @@ fixtureTest(
         const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;
         const modelName = `pollinations-${crypto.randomUUID().slice(0, 8)}`;
         const ownerUserId = await createTestUser({
-            githubId: COMMUNITY_ENDPOINT_ALLOWED_TEST_GITHUB_ID,
+            githubId: nextAllowedGithubId(),
             githubUsername: ownerGithubUsername,
         });
         const sessionToken = `session-${crypto.randomUUID()}`;
@@ -1896,7 +3479,7 @@ fixtureTest(
             error: "rate_limited",
         });
 
-        const response = await SELF.fetch(
+        const response = await fetchGen(
             new Request("https://gen.pollinations.ai/v1/chat/completions", {
                 method: "POST",
                 headers: {
@@ -1930,7 +3513,7 @@ fixtureTest(
         const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;
         const modelName = `image-${crypto.randomUUID().slice(0, 8)}`;
         const ownerUserId = await createTestUser({
-            githubId: COMMUNITY_ENDPOINT_ALLOWED_TEST_GITHUB_ID,
+            githubId: nextAllowedGithubId(),
             githubUsername: ownerGithubUsername,
         });
         const sessionToken = `session-${crypto.randomUUID()}`;
@@ -2052,7 +3635,20 @@ fixtureTest(
         });
         vi.stubGlobal("fetch", fetchMock);
 
-        const registerResponse = await fetchEnterApi(
+        const registrationPayload = {
+            name: modelName,
+            title: "Community Image Endpoint",
+            description: "OpenAI-compatible image endpoint",
+            modality: "image",
+            inputModalities: ["text", "image"],
+            visibility: "public",
+            baseUrl: "https://api.example.com/v1/images/generations",
+            upstreamModel: "gpt-image-1",
+            bearerToken: "Bearer sk_image_upstream",
+            promptTextPrice: 0.000002,
+            completionImagePrice: 0.03,
+        };
+        const unsupportedInputResponse = await fetchEnterApi(
             enterApi,
             new Request("http://localhost:3000/api/community-endpoints", {
                 method: "POST",
@@ -2061,18 +3657,23 @@ fixtureTest(
                     Cookie: await signedSessionCookie(sessionToken),
                 },
                 body: JSON.stringify({
-                    name: modelName,
-                    title: "Community Image Endpoint",
-                    description: "OpenAI-compatible image endpoint",
-                    modality: "image",
-                    supportsImageEdits: true,
-                    visibility: "public",
-                    baseUrl: "https://api.example.com/v1/images/generations",
-                    upstreamModel: "gpt-image-1",
-                    bearerToken: "Bearer sk_image_upstream",
-                    promptTextPrice: 0.000002,
-                    completionImagePrice: 0.03,
+                    ...registrationPayload,
+                    name: `${modelName}-invalid`,
+                    inputModalities: ["text", "audio"],
                 }),
+            }),
+        );
+        expect(unsupportedInputResponse.status).toBe(400);
+
+        const registerResponse = await fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/community-endpoints", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: await signedSessionCookie(sessionToken),
+                },
+                body: JSON.stringify(registrationPayload),
             }),
         );
 
@@ -2081,7 +3682,7 @@ fixtureTest(
             id: string;
             modelId: string;
             modality: string;
-            supportsImageEdits: boolean;
+            inputModalities: string[];
             baseUrl: string;
             upstreamModel: string;
             promptTextPrice: number;
@@ -2090,7 +3691,7 @@ fixtureTest(
         expect(registered).toMatchObject({
             modelId: communityModelId(ownerGithubUsername, modelName),
             modality: "image",
-            supportsImageEdits: true,
+            inputModalities: ["text", "image"],
             baseUrl: "https://api.example.com/v1/images/generations",
             upstreamModel: "gpt-image-1",
             promptTextPrice: 0,
@@ -2119,10 +3720,10 @@ fixtureTest(
                 "Generation and editing endpoints responded with image data",
             usage: { images: 1 },
             billableUsage: { completionImageTokens: 1 },
-            supportsImageEdits: true,
+            inputModalities: ["text", "image"],
         });
 
-        const simpleImageResponse = await SELF.fetch(
+        const simpleImageResponse = await fetchGen(
             new Request(
                 `https://gen.pollinations.ai/image/green%20sprout?model=${encodeURIComponent(
                     registered.modelId,
@@ -2151,7 +3752,7 @@ fixtureTest(
             Array.from(new Uint8Array(await simpleImageResponse.arrayBuffer())),
         ).toEqual(TEST_PNG_BYTES);
 
-        const openaiImageResponse = await SELF.fetch(
+        const openaiImageResponse = await fetchGen(
             new Request("https://gen.pollinations.ai/v1/images/generations", {
                 method: "POST",
                 headers: {
@@ -2191,7 +3792,7 @@ fixtureTest(
             new Blob([new Uint8Array(TEST_PNG_BYTES)], { type: "image/png" }),
             "source.png",
         );
-        const openaiEditResponse = await SELF.fetch(
+        const openaiEditResponse = await fetchGen(
             new Request("https://gen.pollinations.ai/v1/images/edits", {
                 method: "POST",
                 headers: { Authorization: `Bearer ${apiKey}` },
@@ -2208,7 +3809,7 @@ fixtureTest(
             },
         });
 
-        const simpleEditResponse = await SELF.fetch(
+        const simpleEditResponse = await fetchGen(
             new Request(
                 `https://gen.pollinations.ai/image/turn%20it%20red?model=${encodeURIComponent(
                     registered.modelId,
@@ -2227,7 +3828,7 @@ fixtureTest(
             Array.from(new Uint8Array(await simpleEditResponse.arrayBuffer())),
         ).toEqual(TEST_PNG_BYTES);
 
-        const urlImageResponse = await SELF.fetch(
+        const urlImageResponse = await fetchGen(
             new Request("https://gen.pollinations.ai/v1/images/generations", {
                 method: "POST",
                 headers: {
@@ -2237,19 +3838,23 @@ fixtureTest(
                 body: JSON.stringify({
                     model: registered.modelId,
                     prompt: "blue flower",
+                    quality: "hd",
                     response_format: "url",
                 }),
             }),
         );
-        expect(urlImageResponse.status).toBe(400);
+        expect(urlImageResponse.status).toBe(200);
         await expect(urlImageResponse.json()).resolves.toMatchObject({
-            error: {
-                message:
-                    'Community image models support response_format "b64_json" only',
-            },
+            data: [
+                {
+                    url: expect.stringContaining(
+                        `/image/blue%20flower?model=${encodeURIComponent(registered.modelId)}`,
+                    ),
+                },
+            ],
         });
 
-        const invalidMediaResponse = await SELF.fetch(
+        const invalidMediaResponse = await fetchGen(
             new Request("https://gen.pollinations.ai/v1/images/generations", {
                 method: "POST",
                 headers: {
@@ -2264,16 +3869,16 @@ fixtureTest(
         );
         expect(invalidMediaResponse.status).toBe(502);
 
-        const imageModelsResponse = await SELF.fetch(
+        const imageModelsResponse = await fetchGen(
             "https://gen.pollinations.ai/image/models",
         );
-        const textModelsResponse = await SELF.fetch(
+        const textModelsResponse = await fetchGen(
             "https://gen.pollinations.ai/text/models",
         );
-        const allModelsResponse = await SELF.fetch(
+        const allModelsResponse = await fetchGen(
             "https://gen.pollinations.ai/models",
         );
-        const openaiModelsResponse = await SELF.fetch(
+        const openaiModelsResponse = await fetchGen(
             "https://gen.pollinations.ai/v1/models",
         );
 
@@ -2339,7 +3944,7 @@ fixtureTest(
             fetchMock.mock.calls.filter(([input, init]) =>
                 isCommunityImageGenerationsRequest(new Request(input, init)),
             ),
-        ).toHaveLength(4);
+        ).toHaveLength(5);
         expect(
             fetchMock.mock.calls.filter(([input, init]) =>
                 isCommunityImageEditsRequest(new Request(input, init)),
@@ -2350,7 +3955,7 @@ fixtureTest(
                 ([input, init]) =>
                     new Request(input, init).url === TEST_COMMUNITY_IMAGE_URL,
             ),
-        ).toHaveLength(3);
+        ).toHaveLength(4);
 
         const maximumImagePriceResponse = await fetchEnterApi(
             enterApi,
@@ -2392,6 +3997,233 @@ fixtureTest(
 );
 
 fixtureTest(
+    "registers an OpenAI-compatible transcription endpoint and bills it through transcription APIs",
+    async ({ apiKey }) => {
+        const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;
+        const modelName = `stt-${crypto.randomUUID().slice(0, 8)}`;
+        const ownerUserId = await createTestUser({
+            githubId: nextAllowedGithubId(),
+            githubUsername: ownerGithubUsername,
+        });
+        const sessionToken = `session-${crypto.randomUUID()}`;
+        await db.insert(sessionTable).values({
+            id: `session-${crypto.randomUUID()}`,
+            token: sessionToken,
+            userId: ownerUserId,
+            expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+
+        const enterApi = await createEnterCommunityApi();
+        const transcriptionUrl =
+            "https://api.example.com/v1/audio/transcriptions";
+        const fetchMock = vi.fn(async (input, init) => {
+            const request = new Request(input, init);
+            if (request.url === transcriptionUrl) {
+                expect(request.headers.get("authorization")).toBe(
+                    "Bearer sk_transcription_upstream",
+                );
+                const formData = await request.formData();
+                expect(formData.get("model")).toBe("whisper-1");
+                expect(formData.get("file")).toBeInstanceOf(File);
+                return Response.json({
+                    text: "ok",
+                    usage: { duration: 0.5 },
+                });
+            }
+            if (isBillingFetch(request)) {
+                return Response.json({ data: [] });
+            }
+            throw new Error(`Unexpected fetch: ${request.url}`);
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const registrationPayload = {
+            name: modelName,
+            title: "Community Transcription Endpoint",
+            description: "OpenAI-compatible speech-to-text endpoint",
+            modality: "transcription",
+            inputModalities: ["audio"],
+            visibility: "public",
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "whisper-1",
+            bearerToken: "Bearer sk_transcription_upstream",
+            promptAudioPrice: 0.0000445,
+        };
+        const unsupportedInputResponse = await fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/community-endpoints", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: await signedSessionCookie(sessionToken),
+                },
+                body: JSON.stringify({
+                    ...registrationPayload,
+                    name: `${modelName}-invalid`,
+                    inputModalities: ["text"],
+                }),
+            }),
+        );
+        expect(unsupportedInputResponse.status).toBe(400);
+
+        // Omitting inputModalities must follow the modality, not fall back to
+        // text — a text default would make transcription endpoints impossible
+        // to register without naming "audio" explicitly.
+        const defaultedInputResponse = await fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/community-endpoints", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: await signedSessionCookie(sessionToken),
+                },
+                body: JSON.stringify({
+                    ...registrationPayload,
+                    name: `${modelName}-defaulted`,
+                    inputModalities: undefined,
+                }),
+            }),
+        );
+        expect(defaultedInputResponse.status).toBe(200);
+        expect(await defaultedInputResponse.json()).toMatchObject({
+            modality: "transcription",
+            inputModalities: ["audio"],
+        });
+
+        const registerResponse = await fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/community-endpoints", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: await signedSessionCookie(sessionToken),
+                },
+                body: JSON.stringify(registrationPayload),
+            }),
+        );
+        expect(registerResponse.status).toBe(200);
+        const registered = (await registerResponse.json()) as {
+            id: string;
+            modelId: string;
+            modality: string;
+            inputModalities: string[];
+            baseUrl: string;
+            upstreamModel: string;
+            promptAudioPrice: number;
+        };
+        expect(registered).toMatchObject({
+            modelId: communityModelId(ownerGithubUsername, modelName),
+            modality: "transcription",
+            inputModalities: ["audio"],
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "whisper-1",
+            promptAudioPrice: 0.0000445,
+        });
+
+        const testResponse = await fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/community-endpoints/test", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: await signedSessionCookie(sessionToken),
+                },
+                body: JSON.stringify({
+                    baseUrl: registered.baseUrl,
+                    bearerToken: "Bearer sk_transcription_upstream",
+                    model: registered.upstreamModel,
+                    modality: "transcription",
+                }),
+            }),
+        );
+        expect(testResponse.status).toBe(200);
+        await expect(testResponse.json()).resolves.toMatchObject({
+            message: "Endpoint responded with transcription text",
+            usage: { duration: 0.5 },
+            billableUsage: { promptAudioSeconds: 0.5 },
+        });
+
+        const transcriptionFormData = new FormData();
+        transcriptionFormData.append("model", registered.modelId);
+        transcriptionFormData.append("response_format", "json");
+        transcriptionFormData.append(
+            "file",
+            new Blob([new Uint8Array([1, 2, 3])], { type: "audio/wav" }),
+            "sample.wav",
+        );
+        const transcriptionResponse = await fetchGen(
+            new Request("https://gen.pollinations.ai/v1/audio/transcriptions", {
+                method: "POST",
+                headers: { Authorization: `Bearer ${apiKey}` },
+                body: transcriptionFormData,
+            }),
+        );
+        expect(transcriptionResponse.status).toBe(200);
+        await expect(transcriptionResponse.json()).resolves.toMatchObject({
+            text: "ok",
+        });
+        expect(transcriptionResponse.headers.get("x-model-used")).toBe(
+            registered.modelId,
+        );
+        expect(
+            transcriptionResponse.headers.get("x-usage-prompt-audio-seconds"),
+        ).toBe("0.5");
+
+        const openaiModelsResponse = await fetchGen(
+            "https://gen.pollinations.ai/v1/models",
+        );
+        expect(openaiModelsResponse.status).toBe(200);
+        const openaiModels = (await openaiModelsResponse.json()) as {
+            data: {
+                id: string;
+                input_modalities?: string[];
+                supported_endpoints?: string[];
+            }[];
+        };
+        const listedModel = openaiModels.data.find(
+            (model) => model.id === registered.modelId,
+        );
+        expect(listedModel?.input_modalities).toEqual(["audio"]);
+        expect(listedModel?.supported_endpoints).toEqual(
+            expect.arrayContaining(["/v1/audio/transcriptions"]),
+        );
+
+        const audioModelsResponse = await fetchGen(
+            "https://gen.pollinations.ai/audio/models",
+        );
+        expect(audioModelsResponse.status).toBe(200);
+        const audioModels = (await audioModelsResponse.json()) as {
+            name: string;
+            category?: string;
+            community?: boolean;
+            input_modalities?: string[];
+            supported_endpoints?: string[];
+            pricing?: Record<string, string>;
+        }[];
+        const listedAudioModel = audioModels.find(
+            (model) => model.name === registered.modelId,
+        );
+        expect(listedAudioModel).toMatchObject({
+            name: registered.modelId,
+            category: "audio",
+            community: true,
+            input_modalities: ["audio"],
+            pricing: { promptAudioSeconds: "0.0000445" },
+        });
+        expect(listedAudioModel?.supported_endpoints).toEqual(
+            expect.arrayContaining(["/v1/audio/transcriptions"]),
+        );
+        expect(
+            fetchMock.mock.calls.filter(
+                ([input]) => new Request(input).url === transcriptionUrl,
+            ),
+        ).toHaveLength(2);
+    },
+);
+
+fixtureTest(
     "manages my-models through account API with a key that has account keys permission",
     async () => {
         const ownerGithubUsername = `pk-${crypto.randomUUID().slice(0, 8)}`;
@@ -2399,13 +4231,13 @@ fixtureTest(
             type: "publishable",
             accountPermissions: ["keys"],
             user: {
-                githubId: COMMUNITY_ENDPOINT_ALLOWED_TEST_GITHUB_ID,
+                githubId: nextAllowedGithubId(),
                 githubUsername: ownerGithubUsername,
             },
         });
         const denied = await createTestApiKey({
             user: {
-                githubId: COMMUNITY_ENDPOINT_ALLOWED_TEST_GITHUB_ID,
+                githubId: nextAllowedGithubId(),
                 githubUsername: `denied-${crypto.randomUUID().slice(0, 8)}`,
             },
         });
@@ -2440,7 +4272,68 @@ fixtureTest(
             }),
         );
         expect(listResponse.status).toBe(200);
-        await expect(listResponse.json()).resolves.toEqual({ data: [] });
+        await expect(listResponse.json()).resolves.toEqual({
+            data: [],
+            provider: { name: null, url: null },
+        });
+
+        const incompleteProviderResponse = await fetchEnterApi(
+            enterApi,
+            new Request(
+                "http://localhost:3000/api/account/my-models/provider",
+                {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${key}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({ name: "Example AI", url: "" }),
+                },
+            ),
+        );
+        expect(incompleteProviderResponse.status).toBe(400);
+
+        const insecureProviderResponse = await fetchEnterApi(
+            enterApi,
+            new Request(
+                "http://localhost:3000/api/account/my-models/provider",
+                {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${key}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({
+                        name: "Example AI",
+                        url: "http://example.com",
+                    }),
+                },
+            ),
+        );
+        expect(insecureProviderResponse.status).toBe(400);
+
+        const providerResponse = await fetchEnterApi(
+            enterApi,
+            new Request(
+                "http://localhost:3000/api/account/my-models/provider",
+                {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${key}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({
+                        name: "Example AI",
+                        url: "https://example.com",
+                    }),
+                },
+            ),
+        );
+        expect(providerResponse.status).toBe(200);
+        await expect(providerResponse.json()).resolves.toEqual({
+            name: "Example AI",
+            url: "https://example.com/",
+        });
 
         const createResponse = await fetchEnterApi(
             enterApi,
@@ -2457,6 +4350,7 @@ fixtureTest(
                     baseUrl: "https://api.example.com/v1",
                     upstreamModel: "gpt-4.1-mini",
                     bearerToken: "sk_saved_token",
+                    perUserRpm: 0.5,
                 }),
             }),
         );
@@ -2471,11 +4365,13 @@ fixtureTest(
             baseUrl: "https://api.example.com/v1",
             upstreamModel: "gpt-4.1-mini",
             visibility: "private",
+            paidOnly: false,
+            perUserRpm: 0.5,
             promptTextPrice: 0,
             completionTextPrice: 0,
-            disabled: false,
-            disabledReason: null,
-            disabledAt: null,
+            hidden: false,
+            hiddenReason: null,
+            hiddenAt: null,
         });
         expect(created).not.toHaveProperty("bearerToken");
         expect(created).not.toHaveProperty("bearerTokenCiphertext");
@@ -2484,9 +4380,9 @@ fixtureTest(
         await db
             .update(communityEndpointTable)
             .set({
-                disabledAt: new Date(),
-                disabledReason: "was failing",
-                disabledBy: "monitor",
+                hiddenAt: new Date(),
+                hiddenReason: "was failing",
+                hiddenBy: "monitor",
             })
             .where(eq(communityEndpointTable.id, createdId));
 
@@ -2504,6 +4400,7 @@ fixtureTest(
                         title: "Updated Model Title",
                         description: "Updated description",
                         visibility: "public",
+                        paidOnly: true,
                         promptTextPrice: 0.00001,
                         completionTextPrice: 0.00002,
                     }),
@@ -2514,14 +4411,29 @@ fixtureTest(
         await expect(updateResponse.json()).resolves.toMatchObject({
             title: "Updated Model Title",
             description: "Updated description",
-            visibility: "public",
-            promptTextPrice: 0.00001,
-            completionTextPrice: 0.00002,
-            disabled: true,
-            disabledReason: "was failing",
+            visibility: "private",
+            paidOnly: false,
+            promptTextPrice: 0,
+            completionTextPrice: 0,
+            pending: {
+                visibility: "public",
+                paidOnly: true,
+                promptTextPrice: 0.00001,
+                completionTextPrice: 0.00002,
+            },
+            hidden: true,
+            hiddenReason: "was failing",
         });
+        await db
+            .update(communityEndpointTable)
+            .set({
+                pendingAt: new Date(
+                    Date.now() - COMMUNITY_ENDPOINT_CHANGE_DELAY_MS - 1,
+                ),
+            })
+            .where(eq(communityEndpointTable.id, createdId));
 
-        const reactivateResponse = await fetchEnterApi(
+        const relistResponse = await fetchEnterApi(
             enterApi,
             new Request(
                 `http://localhost:3000/api/account/my-models/${createdId}/update`,
@@ -2531,18 +4443,18 @@ fixtureTest(
                         Authorization: `Bearer ${key}`,
                         "Content-Type": "application/json",
                     },
-                    body: JSON.stringify({ active: true }),
+                    body: JSON.stringify({ hidden: false }),
                 },
             ),
         );
-        expect(reactivateResponse.status).toBe(200);
-        await expect(reactivateResponse.json()).resolves.toMatchObject({
-            disabled: false,
-            disabledReason: null,
-            disabledAt: null,
+        expect(relistResponse.status).toBe(200);
+        await expect(relistResponse.json()).resolves.toMatchObject({
+            hidden: false,
+            hiddenReason: null,
+            hiddenAt: null,
         });
 
-        const deactivateResponse = await fetchEnterApi(
+        const hideResponse = await fetchEnterApi(
             enterApi,
             new Request(
                 `http://localhost:3000/api/account/my-models/${createdId}/update`,
@@ -2552,14 +4464,14 @@ fixtureTest(
                         Authorization: `Bearer ${key}`,
                         "Content-Type": "application/json",
                     },
-                    body: JSON.stringify({ active: false }),
+                    body: JSON.stringify({ hidden: true }),
                 },
             ),
         );
-        expect(deactivateResponse.status).toBe(200);
-        await expect(deactivateResponse.json()).resolves.toMatchObject({
-            disabled: true,
-            disabledReason: "Deactivated by owner",
+        expect(hideResponse.status).toBe(200);
+        await expect(hideResponse.json()).resolves.toMatchObject({
+            hidden: true,
+            hiddenReason: "Hidden by owner",
         });
 
         // Minimum-price policy is independent of visibility: any non-negative
@@ -2574,13 +4486,16 @@ fixtureTest(
                         Authorization: `Bearer ${key}`,
                         "Content-Type": "application/json",
                     },
-                    body: JSON.stringify({ promptTextPrice: 1e-12 }),
+                    body: JSON.stringify({
+                        promptTextPrice: 1e-12,
+                    }),
                 },
             ),
         );
         expect(tinyPriceResponse.status).toBe(200);
         await expect(tinyPriceResponse.json()).resolves.toMatchObject({
-            promptTextPrice: 1e-12,
+            promptTextPrice: 0.00001,
+            pending: { promptTextPrice: 1e-12 },
         });
 
         const negativePriceResponse = await fetchEnterApi(
@@ -2593,7 +4508,9 @@ fixtureTest(
                         Authorization: `Bearer ${key}`,
                         "Content-Type": "application/json",
                     },
-                    body: JSON.stringify({ promptTextPrice: -1e-12 }),
+                    body: JSON.stringify({
+                        promptTextPrice: -1e-12,
+                    }),
                 },
             ),
         );
@@ -2611,18 +4528,41 @@ fixtureTest(
                         Authorization: `Bearer ${key}`,
                         "Content-Type": "application/json",
                     },
-                    body: JSON.stringify({ promptTextPrice: 0.00003 }),
+                    body: JSON.stringify({
+                        promptTextPrice: 0.00003,
+                    }),
                 },
             ),
         );
         expect(priceOnlyResponse.status).toBe(200);
         await expect(priceOnlyResponse.json()).resolves.toMatchObject({
             visibility: "public",
-            promptTextPrice: 0.00003,
+            paidOnly: true,
+            promptTextPrice: 0.00001,
             completionTextPrice: 0.00002,
+            pending: {
+                promptTextPrice: 0.00003,
+                completionTextPrice: 0.00002,
+            },
         });
+        const pendingRegistryEntry = (
+            await getCommunityModelRegistryEntries(env)
+        ).find((entry) => entry.id === `${ownerGithubUsername}/my-test-model`);
+        expect(pendingRegistryEntry?.info.pending_change).toMatchObject({
+            paid_only: true,
+            pricing: {
+                currency: "pollen",
+                promptTextTokens: "0.00003",
+                completionTextTokens: "0.00002",
+            },
+        });
+        expect(pendingRegistryEntry?.info.pending_change?.effective_at).toEqual(
+            expect.any(String),
+        );
 
-        // Making the model private clears all owner-set prices.
+        // Making the model private clears all owner-set prices, and with them
+        // the paid-only choice: a free listing that still demanded paid balance
+        // would only gate the owner out of their own model.
         const privatizeResponse = await fetchEnterApi(
             enterApi,
             new Request(
@@ -2633,19 +4573,22 @@ fixtureTest(
                         Authorization: `Bearer ${key}`,
                         "Content-Type": "application/json",
                     },
-                    body: JSON.stringify({ visibility: "private" }),
+                    body: JSON.stringify({
+                        visibility: "private",
+                    }),
                 },
             ),
         );
         expect(privatizeResponse.status).toBe(200);
         await expect(privatizeResponse.json()).resolves.toMatchObject({
             visibility: "private",
+            paidOnly: false,
             promptTextPrice: 0,
             completionTextPrice: 0,
         });
 
-        // Republishing without prices is allowed: zero makes the public model
-        // explicitly free while publishing remains allowlist-gated.
+        // Republishing remains free, but becomes visible after the notice
+        // period rather than immediately.
         const republishResponse = await fetchEnterApi(
             enterApi,
             new Request(
@@ -2656,15 +4599,18 @@ fixtureTest(
                         Authorization: `Bearer ${key}`,
                         "Content-Type": "application/json",
                     },
-                    body: JSON.stringify({ visibility: "public" }),
+                    body: JSON.stringify({
+                        visibility: "public",
+                    }),
                 },
             ),
         );
         expect(republishResponse.status).toBe(200);
         await expect(republishResponse.json()).resolves.toMatchObject({
-            visibility: "public",
+            visibility: "private",
             promptTextPrice: 0,
             completionTextPrice: 0,
+            pending: { visibility: "public" },
         });
 
         const secondListResponse = await fetchEnterApi(
@@ -2678,13 +4624,49 @@ fixtureTest(
         expect(secondListResponse.status).toBe(200);
         const secondList = (await secondListResponse.json()) as {
             data: Record<string, unknown>[];
+            provider: { name: string | null; url: string | null };
         };
         expect(secondList.data).toHaveLength(1);
+        expect(secondList.provider).toEqual({
+            name: "Example AI",
+            url: "https://example.com/",
+        });
         expect(secondList.data[0]).toMatchObject({
             title: "Updated Model Title",
+            perUserRpm: 0.5,
         });
         expect(secondList.data[0]).not.toHaveProperty("bearerToken");
         expect(secondList.data[0]).not.toHaveProperty("bearerTokenCiphertext");
+
+        const registryEntry = (
+            await getCommunityModelRegistryEntries(env)
+        ).find((entry) => entry.id === `${ownerGithubUsername}/my-test-model`);
+        expect(registryEntry?.info).toMatchObject({
+            brand: "Example AI",
+            brand_url: "https://example.com/",
+        });
+        expect(registryEntry?.communityEndpoint.perUserRpm).toBe(0.5);
+
+        const clearLimitResponse = await fetchEnterApi(
+            enterApi,
+            new Request(
+                `http://localhost:3000/api/account/my-models/${createdId}/update`,
+                {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${key}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({
+                        perUserRpm: null,
+                    }),
+                },
+            ),
+        );
+        expect(clearLimitResponse.status).toBe(200);
+        await expect(clearLimitResponse.json()).resolves.toMatchObject({
+            perUserRpm: null,
+        });
     },
 );
 
@@ -2693,7 +4675,7 @@ fixtureTest(
     async () => {
         const ownerGithubUsername = `price-${crypto.randomUUID().slice(0, 8)}`;
         const ownerUserId = await createTestUser({
-            githubId: COMMUNITY_ENDPOINT_ALLOWED_TEST_GITHUB_ID,
+            githubId: nextAllowedGithubId(),
             githubUsername: ownerGithubUsername,
         });
         const sessionToken = `session-${crypto.randomUUID()}`;
@@ -2744,7 +4726,9 @@ fixtureTest(
                             "Content-Type": "application/json",
                             Cookie: cookie,
                         },
-                        body: JSON.stringify({ promptTextPrice: price }),
+                        body: JSON.stringify({
+                            promptTextPrice: price,
+                        }),
                     },
                 ),
             );
@@ -2754,7 +4738,10 @@ fixtureTest(
         );
         expect(minimumResponse.status).toBe(200);
         await expect(minimumResponse.json()).resolves.toMatchObject({
-            promptTextPrice: MIN_COMMUNITY_PRICE_PER_TOKEN,
+            promptTextPrice: 0,
+            pending: {
+                promptTextPrice: MIN_COMMUNITY_PRICE_PER_TOKEN,
+            },
         });
 
         const maximumResponse = await updatePrice(
@@ -2762,7 +4749,10 @@ fixtureTest(
         );
         expect(maximumResponse.status).toBe(200);
         await expect(maximumResponse.json()).resolves.toMatchObject({
-            promptTextPrice: MAX_COMMUNITY_PRICE_PER_TOKEN,
+            promptTextPrice: 0,
+            pending: {
+                promptTextPrice: MAX_COMMUNITY_PRICE_PER_TOKEN,
+            },
         });
 
         const aboveMaximumResponse = await updatePrice(
@@ -2794,7 +4784,7 @@ fixtureTest(
         // Use an approved publisher so the request reaches the outbound probe;
         // non-allowlisted accounts are rejected before any fetch occurs.
         const ownerUserId = await createTestUser({
-            githubId: COMMUNITY_ENDPOINT_ALLOWED_TEST_GITHUB_ID,
+            githubId: nextAllowedGithubId(),
             githubUsername: `redir-${crypto.randomUUID().slice(0, 8)}`,
         });
         const sessionToken = `session-${crypto.randomUUID()}`;
@@ -2848,10 +4838,10 @@ fixtureTest(
     },
 );
 
-fixtureTest("rejects a community model name containing a slash", async () => {
+fixtureTest("rejects unsafe community model names", async () => {
     const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;
     const ownerUserId = await createTestUser({
-        githubId: COMMUNITY_ENDPOINT_ALLOWED_TEST_GITHUB_ID,
+        githubId: nextAllowedGithubId(),
         githubUsername: ownerGithubUsername,
     });
     const sessionToken = `session-${crypto.randomUUID()}`;
@@ -2865,24 +4855,1653 @@ fixtureTest("rejects a community model name containing a slash", async () => {
     });
 
     const enterApi = await createEnterCommunityApi();
-    const response = await fetchEnterApi(
+    for (const name of [
+        "inferenceport.ai/gpt-oss-20b",
+        "bad name",
+        "bad'name",
+        "$(bad)",
+    ]) {
+        const response = await fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/community-endpoints", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: await signedSessionCookie(sessionToken),
+                },
+                body: JSON.stringify({
+                    name,
+                    title: "Unsafe Name",
+                    description: "unsafe model name",
+                    baseUrl: "https://api.example.com/v1",
+                    upstreamModel: "gpt-oss-20b",
+                    bearerToken: "sk_saved_token",
+                }),
+            }),
+        );
+
+        expect(response.status).toBe(400);
+    }
+});
+
+fixtureTest(
+    "rejects proxy registration without a base URL or with agent-only fields",
+    async () => {
+        const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;
+        const ownerUserId = await createTestUser({
+            githubId: nextAllowedGithubId(),
+            githubUsername: ownerGithubUsername,
+        });
+        const sessionToken = `session-${crypto.randomUUID()}`;
+        await db.insert(sessionTable).values({
+            id: `session-${crypto.randomUUID()}`,
+            token: sessionToken,
+            userId: ownerUserId,
+            expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+
+        const enterApi = await createEnterCommunityApi();
+        const cookie = await signedSessionCookie(sessionToken);
+        const register = (body: Record<string, unknown>) =>
+            fetchEnterApi(
+                enterApi,
+                new Request("http://localhost:3000/api/community-endpoints", {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Cookie: cookie,
+                    },
+                    body: JSON.stringify({
+                        name: `bee-${crypto.randomUUID().slice(0, 8)}`,
+                        title: "Registration Test",
+                        bearerToken: "sk_saved_token",
+                        ...body,
+                    }),
+                }),
+            );
+
+        const both = await register({
+            baseUrl: "https://api.example.com/v1",
+            agentId: crypto.randomUUID(),
+        });
+        expect(both.status).toBe(400);
+
+        const neither = await register({});
+        expect(neither.status).toBe(400);
+    },
+);
+
+fixtureTest("creates, edits, routes, and deletes managed agents", async () => {
+    const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;
+    const modelName = `model-${crypto.randomUUID().slice(0, 8)}`;
+    const ownerUserId = await createTestUser({
+        githubId: nextAllowedGithubId(),
+        githubUsername: ownerGithubUsername,
+    });
+    const sessionToken = `session-${crypto.randomUUID()}`;
+    await db.insert(sessionTable).values({
+        id: `session-${crypto.randomUUID()}`,
+        token: sessionToken,
+        userId: ownerUserId,
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+    });
+
+    const enterEnv = {
+        ...env,
+        BETTER_AUTH_URL: "https://enter.test",
+        AGENT_RUNTIME_BASE_URL: env.AGENT_RUNTIME_BASE_URL,
+    };
+    const enterApi = await createEnterFrontendApi();
+    const cookie = (await signedSessionCookie(sessionToken)).replace(
+        "better-auth.session_token",
+        "__Secure-better-auth.session_token",
+    );
+    const promptAgent = {
+        systemPrompt: "You are a terse SQL tutor.",
+        baseModel: "openai-fast",
+        mcpServers: ["pollinations"],
+    };
+    const createAgentResponse = await fetchEnterApi(
         enterApi,
-        new Request("http://localhost:3000/api/community-endpoints", {
+        new Request("https://enter.test/api/account/agents", {
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
-                Cookie: await signedSessionCookie(sessionToken),
+                Cookie: cookie,
             },
             body: JSON.stringify({
-                name: "inferenceport.ai/gpt-oss-20b",
-                title: "Slash Name",
-                description: "name with a slash",
-                baseUrl: "https://api.example.com/v1",
-                upstreamModel: "gpt-oss-20b",
-                bearerToken: "sk_saved_token",
+                ...promptAgent,
+                name: modelName,
+                title: "Managed SQL Tutor",
             }),
         }),
+        enterEnv,
+    );
+    expect(createAgentResponse.status).toBe(200);
+    const agent = (await createAgentResponse.json()) as {
+        id: string;
+        systemPrompt: string;
+        baseModel: string;
+        mcpServers: string[];
+    };
+    expect(agent).toMatchObject({
+        systemPrompt: "You are a terse SQL tutor.",
+        baseModel: "openai-fast",
+        mcpServers: ["pollinations"],
+    });
+    expect(agent).not.toHaveProperty("apiKeyId");
+    expect(agent).not.toHaveProperty("apiKeyCiphertext");
+    expect(agent).not.toHaveProperty("bearerTokenCiphertext");
+    expect(agent).toMatchObject({
+        name: modelName,
+        description: null,
+        visibility: "private",
+        baseUrl: env.AGENT_RUNTIME_BASE_URL,
+        upstreamModel: agent.id,
+    });
+    const [storedAgent] = await db
+        .select()
+        .from(communityEndpointTable)
+        .where(eq(communityEndpointTable.id, agent.id));
+    expect(storedAgent.id).toBe(agent.id);
+    expect(storedAgent.baseUrl).toBe(PROMPT_AGENT_BASE_URL_PLACEHOLDER);
+    expect(storedAgent.upstreamModel).toBe(agent.id);
+    expect(JSON.parse(storedAgent.payload)).toEqual(promptAgent);
+    const partialUpdateResponse = await fetchEnterApi(
+        enterApi,
+        new Request(`https://enter.test/api/account/agents/${agent.id}`, {
+            method: "PATCH",
+            headers: {
+                "Content-Type": "application/json",
+                Cookie: cookie,
+            },
+            body: JSON.stringify({
+                systemPrompt: "You are an editable SQL tutor.",
+            }),
+        }),
+        enterEnv,
+    );
+    expect(partialUpdateResponse.status).toBe(400);
+    const updateAgentResponse = await fetchEnterApi(
+        enterApi,
+        new Request(`https://enter.test/api/account/agents/${agent.id}`, {
+            method: "PATCH",
+            headers: {
+                "Content-Type": "application/json",
+                Cookie: cookie,
+            },
+            body: JSON.stringify({
+                ...promptAgent,
+                systemPrompt: "You are an editable SQL tutor.",
+                name: modelName,
+                title: "Managed SQL Tutor",
+                description: "",
+                visibility: "public",
+            }),
+        }),
+        enterEnv,
+    );
+    expect(updateAgentResponse.status).toBe(200);
+    await expect(updateAgentResponse.json()).resolves.toMatchObject({
+        id: agent.id,
+        systemPrompt: "You are an editable SQL tutor.",
+        mcpServers: ["pollinations"],
+    });
+    const [agentAfterPromptUpdate] = await db
+        .select()
+        .from(communityEndpointTable)
+        .where(eq(communityEndpointTable.id, agent.id));
+    expect(JSON.parse(agentAfterPromptUpdate.payload)).toEqual({
+        ...promptAgent,
+        systemPrompt: "You are an editable SQL tutor.",
+    });
+    const listResponse = await fetchEnterApi(
+        enterApi,
+        new Request("https://enter.test/api/account/my-models", {
+            headers: { Cookie: cookie },
+        }),
+        enterEnv,
+    );
+    expect(listResponse.status).toBe(200);
+    const registration = (
+        (await listResponse.json()) as {
+            data: {
+                id: string;
+                modelId: string;
+                type: "prompt_agent";
+                baseUrl: string;
+                upstreamModel: string;
+            }[];
+        }
+    ).data.find((row) => row.id === agent.id);
+    expect(registration).toBeDefined();
+    if (!registration) throw new Error("Agent listing was not created");
+    expect(registration.id).toBe(agent.id);
+    expect(registration.type).toBe("prompt_agent");
+    expect(registration.baseUrl).toBe(env.AGENT_RUNTIME_BASE_URL);
+    expect(registration.upstreamModel).toBe(agent.id);
+    expect(registration).not.toHaveProperty("modality");
+    const paidUpdateResponse = await fetchEnterApi(
+        enterApi,
+        new Request(
+            `https://enter.test/api/account/my-models/${registration.id}/update`,
+            {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: cookie,
+                },
+                body: JSON.stringify({
+                    promptTextPrice: 0.00001,
+                }),
+            },
+        ),
+        enterEnv,
+    );
+    expect(paidUpdateResponse.status).toBe(400);
+    const fallbackUpdateResponse = await fetchEnterApi(
+        enterApi,
+        new Request(
+            `https://enter.test/api/account/my-models/${registration.id}/update`,
+            {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: cookie,
+                },
+                body: JSON.stringify({
+                    fallbacks: ["owner/backup"],
+                }),
+            },
+        ),
+        enterEnv,
+    );
+    expect(fallbackUpdateResponse.status).toBe(400);
+    expect(await fallbackUpdateResponse.text()).toContain(
+        'Unrecognized key: \\"fallbacks\\"',
+    );
+    const fallbackCandidatesResponse = await fetchEnterApi(
+        enterApi,
+        new Request(
+            `https://enter.test/api/account/my-models/${registration.id}/fallback-candidates`,
+            { headers: { Cookie: cookie } },
+        ),
+        enterEnv,
+    );
+    expect(fallbackCandidatesResponse.status).toBe(200);
+    await expect(fallbackCandidatesResponse.json()).resolves.toEqual({
+        data: [],
+    });
+    const registryEntry = (await getCommunityModelRegistryEntries(env)).find(
+        (entry) => entry.id === registration.modelId,
+    );
+    expect(registryEntry?.communityEndpoint).toMatchObject({
+        type: "prompt_agent",
+        baseUrl: env.AGENT_RUNTIME_BASE_URL,
+        upstreamModel: agent.id,
+    });
+    // An agent listing carries no upstream credential of its own.
+    expect(registryEntry?.communityEndpoint).not.toHaveProperty(
+        "bearerTokenCiphertext",
+    );
+    if (!registryEntry) throw new Error("Agent listing was not registered");
+    expect(registryEntry.agentConfig).toEqual({
+        baseModel: promptAgent.baseModel,
+        mcpServers: ["pollinations"],
+    });
+    expect(registryEntry.definition.cost).toMatchObject({
+        promptTextTokens: 0,
+        completionTextTokens: 0,
+    });
+    const gatewayContext = await communityEndpointGatewayContext({
+        endpoint: registryEntry.communityEndpoint,
+        modelDefinition: registryEntry.definition,
+        requestData: { messages: [{ role: "user", content: "hello" }] },
+        secret: env.BETTER_AUTH_SECRET,
+        portkeyGatewayUrl: env.PORTKEY_GATEWAY_URL,
+        userApiKey: "sk_user_key",
+        parentRequestId: "caller-request-id",
+        parentApiKeyId: "caller-api-key-id",
+    });
+    const runtimeToken = String(gatewayContext.modelConfig?.authKey);
+    expect(runtimeToken).toMatch(/^ag_/);
+    await expect(
+        verifyAgentRunToken(runtimeToken, env.BETTER_AUTH_SECRET),
+    ).resolves.toMatchObject({
+        parentApiKeyId: "caller-api-key-id",
+        parentRequestId: "caller-request-id",
+        managedAgentId: agent.id,
+    });
+    expect(gatewayContext.modelConfig).toMatchObject({
+        "custom-host": env.AGENT_RUNTIME_BASE_URL,
+        model: agent.id,
+    });
+
+    const endpointAgentId = `endpoint-${crypto.randomUUID()}`;
+    await insertCommunityEndpoints({
+        id: endpointAgentId,
+        ownerUserId,
+        type: "endpoint_agent",
+        name: `endpoint-agent-${crypto.randomUUID().slice(0, 8)}`,
+        title: "Endpoint Agent",
+        baseUrl: "https://agent.example.com/v1",
+        upstreamModel: "endpoint-agent",
+        visibility: "private",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+    });
+    const updateEndpointAgentResponse = await fetchEnterApi(
+        enterApi,
+        new Request(
+            `https://enter.test/api/account/my-models/${endpointAgentId}/update`,
+            {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: cookie,
+                },
+                body: JSON.stringify({
+                    baseUrl: "https://updated-agent.example.com/v1",
+                    upstreamModel: "updated-endpoint-agent",
+                    perUserRpm: 7,
+                }),
+            },
+        ),
+        enterEnv,
+    );
+    expect(updateEndpointAgentResponse.status).toBe(200);
+    const endpointAgentResponse = await updateEndpointAgentResponse.json();
+    expect(endpointAgentResponse).toMatchObject({
+        id: endpointAgentId,
+        type: "endpoint_agent",
+        baseUrl: "https://updated-agent.example.com/v1",
+        upstreamModel: "updated-endpoint-agent",
+        perUserRpm: 7,
+    });
+    expect(endpointAgentResponse).not.toHaveProperty("agentId");
+    expect(endpointAgentResponse).not.toHaveProperty("modality");
+    const invalidEndpointAgentUpdateResponse = await fetchEnterApi(
+        enterApi,
+        new Request(
+            `https://enter.test/api/account/my-models/${endpointAgentId}/update`,
+            {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: cookie,
+                },
+                body: JSON.stringify({
+                    bearerToken: "not-supported",
+                }),
+            },
+        ),
+        enterEnv,
+    );
+    expect(invalidEndpointAgentUpdateResponse.status).toBe(400);
+    const endpointAgentRegistryEntry = (
+        await getCommunityModelRegistryEntries(env)
+    ).find((entry) => entry.communityEndpoint.id === endpointAgentId);
+    expect(endpointAgentRegistryEntry?.communityEndpoint).toMatchObject({
+        type: "endpoint_agent",
+        baseUrl: "https://updated-agent.example.com/v1",
+        upstreamModel: "updated-endpoint-agent",
+        perUserRpm: 7,
+    });
+    expect(endpointAgentRegistryEntry?.communityEndpoint).not.toHaveProperty(
+        "bearerTokenCiphertext",
     );
 
-    expect(response.status).toBe(400);
+    const [modelsResponse, openaiModelsResponse] = await Promise.all([
+        fetchGen("https://gen.pollinations.ai/models"),
+        fetchGen("https://gen.pollinations.ai/v1/models"),
+    ]);
+    const models = (await modelsResponse.json()) as {
+        name: string;
+        community?: boolean;
+        agent?: boolean;
+        base_model?: string;
+        pricing?: Record<string, string>;
+        capabilities?: string[];
+        input_modalities?: string[];
+        output_modalities?: string[];
+    }[];
+    const openaiModels = (await openaiModelsResponse.json()) as {
+        data: {
+            id: string;
+            agent?: boolean;
+            base_model?: string;
+            pricing?: Record<string, string>;
+            capabilities?: string[];
+            input_modalities?: string[];
+            output_modalities?: string[];
+            tools?: boolean;
+            reasoning?: boolean;
+            context_length?: number;
+        }[];
+    };
+    const baseModelInfo = models.find(
+        (model) => model.name === promptAgent.baseModel,
+    );
+    const agentModelInfo = models.find(
+        (model) => model.name === registration.modelId,
+    );
+    expect(baseModelInfo).toBeDefined();
+    const agentCapabilities = [
+        ...(baseModelInfo?.capabilities ?? []),
+        "pollinations_models",
+    ];
+    expect(agentModelInfo).toMatchObject({
+        community: true,
+        agent: true,
+        base_model: promptAgent.baseModel,
+        pricing: baseModelInfo?.pricing,
+        capabilities: agentCapabilities,
+        input_modalities: baseModelInfo?.input_modalities,
+        output_modalities: baseModelInfo?.output_modalities,
+    });
+    const openaiBaseModel = openaiModels.data.find(
+        (model) => model.id === promptAgent.baseModel,
+    );
+    const openaiAgentModel = openaiModels.data.find(
+        (model) => model.id === registration.modelId,
+    );
+    expect(openaiBaseModel).toBeDefined();
+    expect(openaiAgentModel).toMatchObject({
+        agent: true,
+        base_model: promptAgent.baseModel,
+        pricing: baseModelInfo?.pricing,
+        capabilities: agentCapabilities,
+        input_modalities: openaiBaseModel?.input_modalities,
+        output_modalities: openaiBaseModel?.output_modalities,
+        tools: openaiBaseModel?.tools,
+        context_length: openaiBaseModel?.context_length,
+    });
+
+    const deleteRegisteredAgentResponse = await fetchEnterApi(
+        enterApi,
+        new Request(`https://enter.test/api/account/agents/${agent.id}`, {
+            method: "DELETE",
+            headers: { Cookie: cookie },
+        }),
+        enterEnv,
+    );
+    expect(deleteRegisteredAgentResponse.status).toBe(200);
+    await expect(
+        db
+            .select()
+            .from(communityEndpointTable)
+            .where(eq(communityEndpointTable.id, agent.id)),
+    ).resolves.toEqual([]);
 });
+
+fixtureTest("validates community fallback targets on write", async () => {
+    const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;
+    const ownerUserId = await createTestUser({
+        githubId: nextAllowedGithubId(),
+        githubUsername: ownerGithubUsername,
+    });
+    const otherOwnerGithubUsername = `other-${crypto.randomUUID().slice(0, 8)}`;
+    const otherOwnerUserId = await createTestUser({
+        githubId: nextAllowedGithubId(),
+        githubUsername: otherOwnerGithubUsername,
+    });
+    const sessionToken = `session-${crypto.randomUUID()}`;
+    await db.insert(sessionTable).values({
+        id: `session-${crypto.randomUUID()}`,
+        token: sessionToken,
+        userId: ownerUserId,
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+    });
+
+    const bearerTokenCiphertext = await encryptSecret(
+        "sk_saved_token",
+        env.BETTER_AUTH_SECRET,
+    );
+    const targetNames = {
+        cheap: `cheap-${crypto.randomUUID().slice(0, 8)}`,
+        priv: `private-${crypto.randomUUID().slice(0, 8)}`,
+        otherPrivate: `other-private-${crypto.randomUUID().slice(0, 8)}`,
+        otherDisabled: `other-disabled-${crypto.randomUUID().slice(0, 8)}`,
+        disabled: `disabled-${crypto.randomUUID().slice(0, 8)}`,
+        delegating: `delegating-${crypto.randomUUID().slice(0, 8)}`,
+        image: `image-${crypto.randomUUID().slice(0, 8)}`,
+        pricey: `pricey-${crypto.randomUUID().slice(0, 8)}`,
+    };
+    for (const target of [
+        {
+            id: `endpoint-${crypto.randomUUID()}`,
+            ownerUserId,
+            visibility: "public",
+            name: targetNames.cheap,
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "cheap-upstream",
+            bearerTokenCiphertext,
+            promptTextPrice: 0.1 / 1_000_000,
+            completionTextPrice: 0.1 / 1_000_000,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        },
+        {
+            id: `endpoint-${crypto.randomUUID()}`,
+            ownerUserId: otherOwnerUserId,
+            visibility: "private",
+            name: targetNames.otherPrivate,
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "other-private-upstream",
+            bearerTokenCiphertext,
+            promptTextPrice: 0,
+            completionTextPrice: 0,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        },
+        {
+            id: `endpoint-${crypto.randomUUID()}`,
+            ownerUserId: otherOwnerUserId,
+            visibility: "public",
+            name: targetNames.otherDisabled,
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "other-disabled-upstream",
+            bearerTokenCiphertext,
+            promptTextPrice: 0,
+            completionTextPrice: 0,
+            hiddenAt: new Date(),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        },
+        {
+            id: `endpoint-${crypto.randomUUID()}`,
+            ownerUserId,
+            visibility: "public",
+            name: targetNames.disabled,
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "disabled-upstream",
+            bearerTokenCiphertext,
+            promptTextPrice: 0,
+            completionTextPrice: 0,
+            hiddenAt: new Date(),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        },
+        {
+            id: `endpoint-${crypto.randomUUID()}`,
+            ownerUserId,
+            visibility: "private",
+            name: targetNames.priv,
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "private-upstream",
+            bearerTokenCiphertext,
+            promptTextPrice: 0,
+            completionTextPrice: 0,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        },
+        {
+            id: `endpoint-${crypto.randomUUID()}`,
+            ownerUserId,
+            visibility: "public",
+            name: targetNames.delegating,
+            type: "endpoint_agent",
+            baseUrl: "https://agent.example.com/v1",
+            upstreamModel: "delegating-upstream",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        },
+        {
+            id: `endpoint-${crypto.randomUUID()}`,
+            ownerUserId,
+            visibility: "public",
+            name: targetNames.image,
+            modality: "image",
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "image-upstream",
+            bearerTokenCiphertext,
+            promptTextPrice: 0,
+            completionTextPrice: 0,
+            completionImagePrice: 0.01,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        },
+        {
+            id: `endpoint-${crypto.randomUUID()}`,
+            ownerUserId,
+            visibility: "public",
+            name: targetNames.pricey,
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "pricey-upstream",
+            bearerTokenCiphertext,
+            promptTextPrice: 0.1 / 1_000_000,
+            completionTextPrice: 0.5 / 1_000_000,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        },
+    ] satisfies CommunityEndpointFixture[]) {
+        await insertCommunityEndpoints(target);
+    }
+
+    const enterApi = await createEnterCommunityApi();
+    const primaryName = `primary-${crypto.randomUUID().slice(0, 8)}`;
+    const createWithFallback = async (name: string, ...fallbacks: string[]) =>
+        fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/community-endpoints", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: await signedSessionCookie(sessionToken),
+                },
+                body: JSON.stringify({
+                    name,
+                    title: "Primary",
+                    baseUrl: "https://api.example.com/v1",
+                    upstreamModel: "primary-upstream",
+                    bearerToken: "sk_saved_token",
+                    visibility: "public",
+                    promptTextPrice: 0.2 / 1_000_000,
+                    completionTextPrice: 0.2 / 1_000_000,
+                    fallbacks,
+                }),
+            }),
+        );
+
+    const selfReference = await createWithFallback(
+        primaryName,
+        communityModelId(ownerGithubUsername, primaryName),
+    );
+    expect(selfReference.status).toBe(400);
+    expect(await selfReference.text()).toContain(
+        "Fallback target cannot be the model itself",
+    );
+
+    const missing = await createWithFallback(
+        primaryName,
+        communityModelId(ownerGithubUsername, "does-not-exist"),
+    );
+    expect(missing.status).toBe(400);
+    expect(await missing.text()).toContain("does not exist");
+
+    const privateTarget = await createWithFallback(
+        `${primaryName}-private`,
+        communityModelId(ownerGithubUsername, targetNames.priv),
+    );
+    expect(privateTarget.status).toBe(200);
+    await expect(privateTarget.json()).resolves.toMatchObject({
+        fallbacks: [communityModelId(ownerGithubUsername, targetNames.priv)],
+    });
+
+    const otherPrivateTarget = await createWithFallback(
+        `${primaryName}-other-private`,
+        communityModelId(otherOwnerGithubUsername, targetNames.otherPrivate),
+    );
+    expect(otherPrivateTarget.status).toBe(400);
+    expect(await otherPrivateTarget.text()).toContain("does not exist");
+
+    const otherDisabledTarget = await createWithFallback(
+        `${primaryName}-other-disabled`,
+        communityModelId(otherOwnerGithubUsername, targetNames.otherDisabled),
+    );
+    expect(otherDisabledTarget.status).toBe(400);
+    expect(await otherDisabledTarget.text()).toContain("does not exist");
+
+    const disabledTarget = await createWithFallback(
+        `${primaryName}-disabled`,
+        communityModelId(ownerGithubUsername, targetNames.disabled),
+    );
+    expect(disabledTarget.status).toBe(400);
+    expect(await disabledTarget.text()).toContain("must be listed");
+
+    const delegatingTarget = await createWithFallback(
+        `${primaryName}-delegating`,
+        communityModelId(ownerGithubUsername, targetNames.delegating),
+    );
+    expect(delegatingTarget.status).toBe(400);
+    expect(await delegatingTarget.text()).toContain(
+        "cannot delegate generation",
+    );
+
+    const wrongModality = await createWithFallback(
+        `${primaryName}-modality`,
+        communityModelId(ownerGithubUsername, targetNames.image),
+    );
+    expect(wrongModality.status).toBe(400);
+    expect(await wrongModality.text()).toContain("is a image model, not text");
+
+    const overPriced = await createWithFallback(
+        `${primaryName}-price`,
+        communityModelId(ownerGithubUsername, targetNames.pricey),
+    );
+    expect(overPriced.status).toBe(400);
+    const overPricedMessage = await overPriced.text();
+    expect(overPricedMessage).toContain("completionTextPrice");
+    expect(overPricedMessage).toContain("exceeds this model's");
+    // Only the offending field is named — promptTextPrice is within budget.
+    expect(overPricedMessage).not.toContain("promptTextPrice");
+
+    const cheapModelId = communityModelId(
+        ownerGithubUsername,
+        targetNames.cheap,
+    );
+    const accepted = await createWithFallback(primaryName, cheapModelId);
+    expect(accepted.status).toBe(200);
+    const created = (await accepted.json()) as {
+        id: string;
+        modelId: string;
+        fallbacks: string[];
+    };
+    expect(created.fallbacks).toEqual([cheapModelId]);
+
+    // One bad id fails the whole list, so a partial order is never stored.
+    const partiallyBad = await createWithFallback(
+        `${primaryName}-partial`,
+        cheapModelId,
+        communityModelId(ownerGithubUsername, "does-not-exist"),
+    );
+    expect(partiallyBad.status).toBe(400);
+    expect(await partiallyBad.text()).toContain("does not exist");
+
+    const duplicated = await createWithFallback(
+        `${primaryName}-dup`,
+        cheapModelId,
+        cheapModelId,
+    );
+    expect(duplicated.status).toBe(400);
+    expect(await duplicated.text()).toContain("listed more than once");
+
+    // The dashboard's dropdown is built from this list, so anything it offers
+    // must be acceptable to the update endpoint above — same rule, one function.
+    const candidates = await fetchEnterApi(
+        enterApi,
+        new Request(
+            `http://localhost:3000/api/community-endpoints/${created.id}/fallback-candidates`,
+            { headers: { Cookie: await signedSessionCookie(sessionToken) } },
+        ),
+    );
+    expect(candidates.status).toBe(200);
+    const { data: eligible } = (await candidates.json()) as { data: string[] };
+    expect(eligible).toContain(cheapModelId);
+    expect(eligible).toContain(
+        communityModelId(ownerGithubUsername, targetNames.priv),
+    );
+    // Never itself, and never a target the write path would reject.
+    expect(eligible).not.toContain(created.modelId);
+    for (const rejected of [
+        targetNames.image,
+        targetNames.pricey,
+        targetNames.disabled,
+        targetNames.delegating,
+    ]) {
+        expect(eligible).not.toContain(
+            communityModelId(ownerGithubUsername, rejected),
+        );
+    }
+
+    // An empty array clears the stored targets.
+    const cleared = await fetchEnterApi(
+        enterApi,
+        new Request(
+            `http://localhost:3000/api/community-endpoints/${created.id}/update`,
+            {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: await signedSessionCookie(sessionToken),
+                },
+                body: JSON.stringify({
+                    fallbacks: [],
+                }),
+            },
+        ),
+    );
+    expect(cleared.status).toBe(200);
+    await expect(cleared.json()).resolves.toMatchObject({
+        fallbacks: [],
+    });
+});
+
+fixtureTest(
+    "links community fallback targets in the generation registry",
+    async () => {
+        const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;
+        const ownerUserId = await createTestUser({
+            githubId: nextAllowedGithubId(),
+            githubUsername: ownerGithubUsername,
+        });
+        const bearerTokenCiphertext = await encryptSecret(
+            "sk_saved_token",
+            env.BETTER_AUTH_SECRET,
+        );
+        const suffix = crypto.randomUUID().slice(0, 8);
+        const name = (label: string) => `${label}-${suffix}`;
+        const id = (label: string) =>
+            communityModelId(ownerGithubUsername, name(label));
+        const endpoint = (
+            label: string,
+            values: Partial<CommunityEndpointFixture>,
+        ): CommunityEndpointFixture => ({
+            id: `endpoint-${crypto.randomUUID()}`,
+            ownerUserId,
+            visibility: "public" as const,
+            name: name(label),
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: `${label}-upstream`,
+            bearerTokenCiphertext,
+            promptTextPrice: 0.2 / 1_000_000,
+            completionTextPrice: 0.2 / 1_000_000,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            ...values,
+        });
+
+        // Inserted one at a time: D1 caps the bound variables per statement.
+        for (const row of [
+            endpoint("valid-primary", {
+                fallbacks: [id("valid-target")],
+            }),
+            endpoint("valid-target", {
+                promptTextPrice: 0.1 / 1_000_000,
+                completionTextPrice: 0.1 / 1_000_000,
+            }),
+            endpoint("disabled-primary", {
+                fallbacks: [id("disabled-target")],
+            }),
+            endpoint("disabled-target", {
+                hiddenAt: new Date(),
+                hiddenReason: "repeated upstream 500s",
+            }),
+            endpoint("deleted-primary", {
+                fallbacks: [
+                    communityModelId(ownerGithubUsername, "never-existed"),
+                ],
+            }),
+            endpoint("repriced-primary", {
+                fallbacks: [id("repriced-target")],
+            }),
+            // Priced above its primary since the fallback was configured.
+            endpoint("repriced-target", {
+                completionTextPrice: 0.5 / 1_000_000,
+            }),
+            endpoint("delegating-primary", {
+                fallbacks: [id("delegating-target")],
+            }),
+            endpoint("delegating-target", {
+                type: "endpoint_agent",
+            }),
+            endpoint("second-target", {
+                promptTextPrice: 0.1 / 1_000_000,
+                completionTextPrice: 0.1 / 1_000_000,
+            }),
+            endpoint("third-target", {
+                promptTextPrice: 0.1 / 1_000_000,
+                completionTextPrice: 0.1 / 1_000_000,
+            }),
+            endpoint("fourth-target", {
+                promptTextPrice: 0.1 / 1_000_000,
+                completionTextPrice: 0.1 / 1_000_000,
+            }),
+            endpoint("multi-primary", {
+                fallbacks: [id("valid-target"), id("second-target")],
+                // Its own targets declare fallbacks too; none of them may leak
+                // into this model's routing.
+            }),
+            endpoint("greedy-primary", {
+                fallbacks: [
+                    id("valid-target"),
+                    id("second-target"),
+                    id("third-target"),
+                    id("fourth-target"),
+                ],
+            }),
+            endpoint("gappy-primary", {
+                fallbacks: [
+                    id("valid-target"),
+                    communityModelId(ownerGithubUsername, "never-existed"),
+                    id("second-target"),
+                ],
+            }),
+            endpoint("image-primary", {
+                modality: "image",
+                imagePricing: "request",
+                promptTextPrice: 0,
+                completionTextPrice: 0,
+                completionImagePrice: 0.02,
+                fallbacks: [id("image-target")],
+            }),
+            endpoint("image-target", {
+                modality: "image",
+                imagePricing: "request",
+                promptTextPrice: 0,
+                completionTextPrice: 0,
+                completionImagePrice: 0.01,
+            }),
+            endpoint("image-request-primary", {
+                modality: "image",
+                imagePricing: "request",
+                promptTextPrice: 0,
+                completionTextPrice: 0,
+                // 0.02 Pollen per generated image.
+                completionImagePrice: 0.02,
+                fallbacks: [id("image-tokens-target")],
+            }),
+            // Switched itself to token pricing after being picked as a target:
+            // the same column now means Pollen per token (0.00005 = the 50
+            // Pollen/1M cap), so the raw numbers are no longer comparable and
+            // a 1568-token image would bill 0.0784 against a 0.02 quote.
+            endpoint("image-tokens-target", {
+                modality: "image",
+                imagePricing: "tokens",
+                promptTextPrice: 0,
+                completionTextPrice: 0,
+                completionImagePrice: 0.00005,
+            }),
+        ]) {
+            await insertCommunityEndpoints(row);
+        }
+
+        resetGenerationModelRegistryCache();
+        const registry = await getGenerationModelRegistry(env);
+
+        const fallbackIds = (model: string) =>
+            registry.resolve(model)?.fallbackEntries?.map((e) => e.id);
+
+        expect(fallbackIds(id("valid-primary"))).toEqual([id("valid-target")]);
+        expect(fallbackIds(id("disabled-primary"))).toBeUndefined();
+        expect(fallbackIds(id("deleted-primary"))).toBeUndefined();
+        expect(fallbackIds(id("repriced-primary"))).toBeUndefined();
+        expect(fallbackIds(id("delegating-primary"))).toBeUndefined();
+
+        // Same image pricing mode on both sides: the price columns mean the
+        // same thing, so the link stands.
+        expect(fallbackIds(id("image-primary"))).toEqual([id("image-target")]);
+        // Different modes: comparing per-image against per-token prices is
+        // meaningless, so the link is dropped rather than billed across units.
+        expect(fallbackIds(id("image-request-primary"))).toBeUndefined();
+
+        // The declared list is kept in order, and only what this owner
+        // declared: a target's own list is never appended.
+        expect(fallbackIds(id("multi-primary"))).toEqual([
+            id("valid-target"),
+            id("second-target"),
+        ]);
+        // Over the cap: the extras are dropped rather than the request
+        // spending an unbounded number of upstream timeouts.
+        expect(fallbackIds(id("greedy-primary"))).toEqual([
+            id("valid-target"),
+            id("second-target"),
+            id("third-target"),
+        ]);
+        // A dead id in the middle is skipped, keeping the survivors' order.
+        expect(fallbackIds(id("gappy-primary"))).toEqual([
+            id("valid-target"),
+            id("second-target"),
+        ]);
+    },
+);
+
+fixtureTest(
+    "uses the served model's transform for a registry fallback",
+    async ({ apiKey }) => {
+        const suffix = crypto.randomUUID().slice(0, 8);
+        const ownerGithubUsername = `transform-owner-${suffix}`;
+        const ownerUserId = await createTestUser({
+            githubId: nextAllowedGithubId(),
+            githubUsername: ownerGithubUsername,
+        });
+        const fallbackModelId = communityModelId(
+            ownerGithubUsername,
+            `plain-${suffix}`,
+        );
+
+        await insertCommunityEndpoints({
+            id: `endpoint-${crypto.randomUUID()}`,
+            ownerUserId,
+            visibility: "public",
+            name: `plain-${suffix}`,
+            baseUrl: "https://plain.example.com/v1",
+            upstreamModel: "plain-upstream",
+            bearerTokenCiphertext: await encryptSecret(
+                "sk_plain_token",
+                env.BETTER_AUTH_SECRET,
+            ),
+            promptTextPrice: 0.1 / 1_000_000,
+            completionTextPrice: 0.1 / 1_000_000,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+
+        const source = getRegistryModelDefinition("qwen-coder");
+        const previousFallbacks = source.fallbacks;
+        try {
+            source.fallbacks = [fallbackModelId];
+            resetGenerationModelRegistryCache();
+
+            const messageRoles: string[][] = [];
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async (input, init) => {
+                    const request = new Request(input, init);
+                    if (isPortkeyChatCompletionsRequest(request)) {
+                        const body = (await request.json()) as {
+                            messages: { role: string }[];
+                        };
+                        messageRoles.push(
+                            body.messages.map((message) => message.role),
+                        );
+                        if (
+                            request.headers.get("x-portkey-custom-host") !==
+                            "https://plain.example.com/v1"
+                        ) {
+                            return Response.json(
+                                { error: { message: "rate limited" } },
+                                { status: 429 },
+                            );
+                        }
+                        return Response.json({
+                            id: "chatcmpl_fallback_transform",
+                            object: "chat.completion",
+                            choices: [
+                                {
+                                    index: 0,
+                                    message: {
+                                        role: "assistant",
+                                        content: "ok",
+                                    },
+                                    finish_reason: "stop",
+                                },
+                            ],
+                            usage: {
+                                prompt_tokens: 1,
+                                completion_tokens: 1,
+                                total_tokens: 2,
+                            },
+                        });
+                    }
+                    if (isBillingFetch(request)) {
+                        return Response.json({ data: [] });
+                    }
+                    throw new Error(`Unexpected fetch: ${request.url}`);
+                }),
+            );
+
+            const response = await fetchGen(
+                new Request("https://gen.pollinations.ai/v1/chat/completions", {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${apiKey}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({
+                        model: "qwen-coder",
+                        messages: [{ role: "user", content: "hello" }],
+                    }),
+                }),
+            );
+
+            expect(response.status).toBe(200);
+            expect(response.headers.get("x-model-used")).toBe(fallbackModelId);
+            expect(messageRoles).toEqual([["system", "user"], ["user"]]);
+        } finally {
+            source.fallbacks = previousFallbacks;
+            resetGenerationModelRegistryCache();
+        }
+    },
+);
+
+fixtureTest(
+    "serves a failed community model from its fallback and bills the fallback",
+    async ({ apiKey }) => {
+        const {
+            primaryModelId,
+            fallbackModelId,
+            primaryHost,
+            fallbackHost,
+            primaryUpstreamModel,
+            fallbackUpstreamModel,
+            primaryToken,
+            fallbackToken,
+        } = await createCommunityFallbackPair({
+            prefix: "text-success",
+            fallbackPerUserRpm: 1,
+        });
+
+        // Read inside the mock: request bodies cannot cross isolates.
+        const gatewayCalls: {
+            customHost: string | null;
+            bearerToken: string | null;
+            upstreamModel: string | null;
+        }[] = [];
+        const ingestedEvents: Record<string, unknown>[] = [];
+        const fetchMock = vi.fn(async (input, init) => {
+            const request = new Request(input, init);
+            if (isPortkeyChatCompletionsRequest(request)) {
+                const customHost = request.headers.get("x-portkey-custom-host");
+                gatewayCalls.push({
+                    customHost,
+                    bearerToken: request.headers.get("authorization"),
+                    upstreamModel: request.headers.get("x-portkey-model"),
+                });
+                // The primary is rate limited — the failure the fallback exists
+                // for.
+                if (customHost === primaryHost) {
+                    return Response.json(
+                        { error: { message: "rate limited" } },
+                        { status: 429 },
+                    );
+                }
+                return Response.json({
+                    id: "chatcmpl_fallback",
+                    object: "chat.completion",
+                    choices: [
+                        {
+                            index: 0,
+                            message: { role: "assistant", content: "ok" },
+                            finish_reason: "stop",
+                        },
+                    ],
+                    usage: {
+                        prompt_tokens: 2,
+                        completion_tokens: 3,
+                        total_tokens: 5,
+                    },
+                });
+            }
+            if (isBillingFetch(request)) {
+                if (new URL(request.url).pathname === "/v0/events") {
+                    ingestedEvents.push(
+                        ...parseIngestedEvents(await request.text()),
+                    );
+                }
+                return Response.json({ data: [] });
+            }
+            throw new Error(`Unexpected fetch: ${request.url}`);
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const request = (content: string) =>
+            fetchGen(
+                new Request("https://gen.pollinations.ai/v1/chat/completions", {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${apiKey}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({
+                        model: primaryModelId,
+                        messages: [{ role: "user", content }],
+                    }),
+                }),
+            );
+
+        const response = await request("hello-first");
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get(FALLBACK_TARGET_HEADER)).toBe(
+            "config.targets[1]",
+        );
+        // The served model, not the requested one, is reported as used.
+        expect(response.headers.get("x-model-used")).toBe(fallbackModelId);
+
+        // Each endpoint is called once, in the order the owner declared, and
+        // each attempt carries only its own endpoint's credential.
+        expect(gatewayCalls).toEqual([
+            {
+                customHost: primaryHost,
+                bearerToken: `Bearer ${primaryToken}`,
+                upstreamModel: primaryUpstreamModel,
+            },
+            {
+                customHost: fallbackHost,
+                bearerToken: `Bearer ${fallbackToken}`,
+                upstreamModel: fallbackUpstreamModel,
+            },
+        ]);
+
+        // Two rows for the one request: the primary's failure, unbilled, and the
+        // model that served. Without the first, a model rescued on every request
+        // reads as healthy. The 429 is recorded as the 502 the caller would have
+        // seen, so it counts as a server error rather than the caller's fault.
+        await vi.waitFor(() => expect(ingestedEvents).toHaveLength(2));
+        expect(
+            ingestedEvents.map((event) => [
+                event.modelUsed,
+                event.responseStatus,
+                event.isBilledUsage,
+            ]),
+        ).toContainEqual([primaryModelId, 502, false]);
+        expect(
+            ingestedEvents.map((event) => [
+                event.modelUsed,
+                event.responseStatus,
+                event.isBilledUsage,
+            ]),
+        ).toContainEqual([fallbackModelId, 200, true]);
+        // Both rows belong to the same request, so the pair can be joined.
+        expect(
+            new Set(ingestedEvents.map((event) => event.requestId)).size,
+        ).toBe(1);
+
+        const limitedResponse = await request("hello-second");
+        expect(limitedResponse.status).toBe(429);
+        expect(limitedResponse.headers.get("Retry-After")).toBeTruthy();
+        await expect(limitedResponse.json()).resolves.toMatchObject({
+            error: { code: "community_model_rate_limit" },
+        });
+        // The primary was attempted again, but its limited fallback was not.
+        expect(gatewayCalls).toHaveLength(3);
+        expect(gatewayCalls[2]?.customHost).toBe(primaryHost);
+    },
+);
+
+fixtureTest(
+    "names the model that failed last when every candidate fails",
+    async ({ apiKey }) => {
+        const { primaryModelId, fallbackModelId } =
+            await createCommunityFallbackPair({
+                prefix: "text-all-fail",
+            });
+
+        const ingestedEvents: Record<string, unknown>[] = [];
+        const fetchMock = vi.fn(async (input, init) => {
+            const request = new Request(input, init);
+            if (isPortkeyChatCompletionsRequest(request)) {
+                // Nothing rescues this request: every endpoint is rate limited.
+                return Response.json(
+                    { error: { message: "rate limited" } },
+                    { status: 429 },
+                );
+            }
+            if (isBillingFetch(request)) {
+                if (new URL(request.url).pathname === "/v0/events") {
+                    ingestedEvents.push(
+                        ...parseIngestedEvents(await request.text()),
+                    );
+                }
+                return Response.json({ data: [] });
+            }
+            throw new Error(`Unexpected fetch: ${request.url}`);
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const response = await fetchGen(
+            new Request("https://gen.pollinations.ai/v1/chat/completions", {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${apiKey}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    model: primaryModelId,
+                    messages: [{ role: "user", content: "hello" }],
+                }),
+            }),
+        );
+
+        expect(response.status).toBe(502);
+
+        // Two upstream calls, two rows, and each names the model it reached.
+        // The row that records how the request ended must name the fallback:
+        // naming the primary would count it twice and leave a permanently
+        // broken fallback invisible in every per-model view.
+        // A 5xx also emits an unrelated server-error event to Tinybird, so
+        // narrow to the generation rows.
+        const generationRows = () =>
+            ingestedEvents.filter((event) => "requestId" in event);
+        await vi.waitFor(() => expect(generationRows()).toHaveLength(2));
+        expect(
+            generationRows().map((event) => [
+                event.modelUsed,
+                event.isFinal,
+                event.isBilledUsage,
+            ]),
+        ).toEqual(
+            expect.arrayContaining([
+                [primaryModelId, false, false],
+                [fallbackModelId, true, false],
+            ]),
+        );
+        // Both rows belong to the same request, so the pair can be joined.
+        expect(
+            new Set(generationRows().map((event) => event.requestId)).size,
+        ).toBe(1);
+    },
+);
+
+fixtureTest(
+    "retries a failed community image endpoint against its fallback",
+    async ({ apiKey }) => {
+        const {
+            primaryModelId,
+            fallbackModelId,
+            primaryHostname,
+            fallbackHostname,
+        } = await createCommunityFallbackPair({
+            prefix: "image-retry",
+            modality: "image",
+            primaryName: "primary-image",
+            fallbackName: "cheap-image",
+        });
+
+        const upstreamHosts: string[] = [];
+        const fetchMock = vi.fn(async (input, init) => {
+            const request = new Request(input, init);
+            if (isCommunityImageGenerationsRequest(request)) {
+                const host = new URL(request.url).host;
+                upstreamHosts.push(host);
+                if (host === primaryHostname) {
+                    return Response.json(
+                        { error: "upstream down" },
+                        {
+                            status: 500,
+                        },
+                    );
+                }
+                return Response.json({
+                    created: 1,
+                    data: [{ b64_json: TEST_PNG_BASE64 }],
+                });
+            }
+            if (isBillingFetch(request)) return Response.json({ data: [] });
+            throw new Error(`Unexpected fetch: ${request.url}`);
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const response = await fetchGen(
+            new Request(
+                `https://gen.pollinations.ai/image/green%20sprout?model=${encodeURIComponent(primaryModelId)}`,
+                { headers: { Authorization: `Bearer ${apiKey}` } },
+            ),
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("content-type")).toBe("image/png");
+        expect(upstreamHosts).toEqual([primaryHostname, fallbackHostname]);
+        expect(response.headers.get("x-model-used")).toBe(fallbackModelId);
+        expect(response.headers.get(FALLBACK_TARGET_HEADER)).toBe(
+            "config.targets[1]",
+        );
+        expect(
+            Array.from(new Uint8Array(await response.arrayBuffer())),
+        ).toEqual(TEST_PNG_BYTES);
+    },
+);
+
+fixtureTest(
+    "tries every declared image fallback and bills the model that served",
+    async ({ apiKey }) => {
+        const suffix = crypto.randomUUID().slice(0, 8);
+        const owners = ["one", "two", "three"].map(
+            (label) => `chain-${label}-${suffix}`,
+        );
+        const userIds: string[] = [];
+        for (const owner of owners) {
+            userIds.push(
+                await createTestUser({
+                    githubId: nextAllowedGithubId(),
+                    githubUsername: owner,
+                }),
+            );
+        }
+        const bearerTokenCiphertext = await encryptSecret(
+            "sk_image_upstream",
+            env.BETTER_AUTH_SECRET,
+        );
+        // Descending prices, as the same-or-lower rule requires of every target.
+        const prices = [0.03, 0.02, 0.01];
+        const modelIds = owners.map((owner, index) =>
+            communityModelId(owner, `chain-image-${index}`),
+        );
+
+        for (const [index, owner] of owners.entries()) {
+            await insertCommunityEndpoints({
+                id: `endpoint-${crypto.randomUUID()}`,
+                ownerUserId: userIds[index],
+                visibility: "public" as const,
+                name: `chain-image-${index}`,
+                modality: "image",
+                baseUrl: `https://${owner}.example.com/v1`,
+                upstreamModel: `${owner}-upstream`,
+                bearerTokenCiphertext,
+                promptTextPrice: 0,
+                completionTextPrice: 0,
+                completionImagePrice: prices[index],
+                // The primary declares BOTH fallbacks itself; neither target
+                // declares anything, so nothing but this list is followed.
+                ...(index === 0
+                    ? { fallbacks: [modelIds[1], modelIds[2]] }
+                    : {}),
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            });
+        }
+
+        const upstreamHosts: string[] = [];
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async (input, init) => {
+                const request = new Request(input, init);
+                if (isCommunityImageGenerationsRequest(request)) {
+                    const host = new URL(request.url).host;
+                    upstreamHosts.push(host);
+                    // Only the last link works, so a 200 proves both hops ran.
+                    if (host !== `${owners[2]}.example.com`) {
+                        return Response.json(
+                            { error: "upstream down" },
+                            { status: 500 },
+                        );
+                    }
+                    return Response.json({
+                        created: 1,
+                        data: [{ b64_json: TEST_PNG_BASE64 }],
+                    });
+                }
+                if (isBillingFetch(request)) return Response.json({ data: [] });
+                throw new Error(`Unexpected fetch: ${request.url}`);
+            }),
+        );
+
+        const response = await fetchGen(
+            new Request(
+                `https://gen.pollinations.ai/image/green%20sprout?model=${encodeURIComponent(modelIds[0])}`,
+                { headers: { Authorization: `Bearer ${apiKey}` } },
+            ),
+        );
+
+        expect(response.status).toBe(200);
+        // In declared order, each endpoint contacted exactly once — no model
+        // is ever retried against itself.
+        expect(upstreamHosts).toEqual(
+            owners.map((owner) => `${owner}.example.com`),
+        );
+        expect(response.headers.get("x-model-used")).toBe(modelIds[2]);
+        expect(response.headers.get(FALLBACK_TARGET_HEADER)).toBe(
+            "config.targets[2]",
+        );
+        expect(
+            Array.from(new Uint8Array(await response.arrayBuffer())),
+        ).toEqual(TEST_PNG_BYTES);
+
+        // The OpenAI-compatible route replaces the generated response with
+        // JSON, so it has to carry the fallback marker across itself —
+        // otherwise tracking reads the rescue as a plain first-try success.
+        const openaiResponse = await fetchGen(
+            new Request("https://gen.pollinations.ai/v1/images/generations", {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${apiKey}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    model: modelIds[0],
+                    prompt: "green sprout",
+                }),
+            }),
+        );
+
+        expect(openaiResponse.status).toBe(200);
+        expect(openaiResponse.headers.get("x-model-used")).toBe(modelIds[2]);
+        expect(openaiResponse.headers.get(FALLBACK_TARGET_HEADER)).toBe(
+            "config.targets[2]",
+        );
+    },
+);
+
+fixtureTest(
+    "does not replay image caller errors or moderation refusals on the fallback",
+    async ({ apiKey }) => {
+        const { primaryModelId, primaryHostname } =
+            await createCommunityFallbackPair({
+                prefix: "image-strict",
+                modality: "image",
+                primaryName: "strict-image",
+                fallbackName: "loose-image",
+            });
+        let upstreamHosts: string[] = [];
+        let primaryFailure = {
+            status: 400,
+            body: { error: { message: "size must be at most 1536x1536" } },
+        };
+        const fetchMock = vi.fn(async (input, init) => {
+            const request = new Request(input, init);
+            if (isCommunityImageGenerationsRequest(request)) {
+                const host = new URL(request.url).host;
+                upstreamHosts.push(host);
+                if (host === primaryHostname) {
+                    return Response.json(primaryFailure.body, {
+                        status: primaryFailure.status,
+                    });
+                }
+                return Response.json({
+                    created: 1,
+                    data: [{ b64_json: TEST_PNG_BASE64 }],
+                });
+            }
+            if (isBillingFetch(request)) return Response.json({ data: [] });
+            throw new Error(`Unexpected fetch: ${request.url}`);
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const generate = async () => {
+            const response = await fetchGen(
+                new Request(
+                    `https://gen.pollinations.ai/image/green%20sprout?model=${encodeURIComponent(primaryModelId)}`,
+                    { headers: { Authorization: `Bearer ${apiKey}` } },
+                ),
+            );
+            // Drain before asserting: an unread body keeps the isolate alive.
+            await response.arrayBuffer();
+            return response;
+        };
+
+        // A caller error cannot succeed on a replay: the fallback is never
+        // called and the primary's own 400 reaches the client.
+        const callerError = await generate();
+        expect(callerError.status).toBe(400);
+        expect(upstreamHosts).toEqual([primaryHostname]);
+
+        // A moderation refusal must not be routed around, whatever status the
+        // provider wrapped it in — it stays a 422 content-policy rejection.
+        upstreamHosts = [];
+        primaryFailure = {
+            status: 500,
+            body: {
+                error: { message: "Prompt flagged by our content filter" },
+            },
+        };
+        const moderationRefusal = await generate();
+        expect(moderationRefusal.status).toBe(422);
+        expect(upstreamHosts).toEqual([primaryHostname]);
+    },
+);
+
+fixtureTest(
+    "does not serve a fallback the API key is not allowed to use",
+    async () => {
+        const { primaryModelId, fallbackModelId, primaryHost } =
+            await createCommunityFallbackPair({
+                prefix: "scoped",
+            });
+
+        // Scoped to the primary only — calling the fallback directly is a 403.
+        const { key } = await createTestApiKey({
+            allowedModels: [primaryModelId],
+            user: { tierBalance: 100 },
+        });
+
+        const gatewayCalls: {
+            config: string | null;
+            provider: string | null;
+            customHost: string | null;
+        }[] = [];
+        const fetchMock = vi.fn(async (input, init) => {
+            const request = new Request(input, init);
+            if (isPortkeyChatCompletionsRequest(request)) {
+                gatewayCalls.push({
+                    config: request.headers.get("x-portkey-config"),
+                    provider: request.headers.get("x-portkey-provider"),
+                    customHost: request.headers.get("x-portkey-custom-host"),
+                });
+                return Response.json({
+                    id: "chatcmpl_primary",
+                    object: "chat.completion",
+                    choices: [
+                        {
+                            index: 0,
+                            message: { role: "assistant", content: "ok" },
+                            finish_reason: "stop",
+                        },
+                    ],
+                    usage: {
+                        prompt_tokens: 2,
+                        completion_tokens: 3,
+                        total_tokens: 5,
+                    },
+                });
+            }
+            if (isBillingFetch(request)) return Response.json({ data: [] });
+            throw new Error(`Unexpected fetch: ${request.url}`);
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const response = await fetchGen(
+            new Request("https://gen.pollinations.ai/v1/chat/completions", {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${key}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    model: primaryModelId,
+                    messages: [{ role: "user", content: "hello" }],
+                }),
+            }),
+        );
+
+        expect(response.status).toBe(200);
+        expect(gatewayCalls).toHaveLength(1);
+        // No strategy/targets config: the request runs against the primary
+        // alone, so the key can never be served the model it cannot call.
+        expect(gatewayCalls[0].config).toBeNull();
+        expect(gatewayCalls[0].provider).toBe("openai");
+        expect(gatewayCalls[0].customHost).toBe(primaryHost);
+
+        // The same key calling the fallback directly is refused.
+        const direct = await fetchGen(
+            new Request("https://gen.pollinations.ai/v1/chat/completions", {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${key}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    model: fallbackModelId,
+                    messages: [{ role: "user", content: "hello" }],
+                }),
+            }),
+        );
+        expect(direct.status).toBe(403);
+    },
+);

--- a/gen.pollinations.ai/src/community-models.ts
+++ b/gen.pollinations.ai/src/community-models.ts
@@ -1,19 +1,26 @@
 import {
+    applyPendingProxyPricing,
+    COMMUNITY_ENDPOINT_CHANGE_DELAY_MS,
     type CommunityEndpointRuntime,
     communityEndpointPrices,
     communityModelDefinition,
     communityModelId,
-    normalizeCommunityEndpointImagePricing,
-    normalizeCommunityEndpointModality,
+    parseListingPayload,
+    pendingCommunityEndpointChangeIsReady,
+    usesAgentRunToken,
 } from "@shared/community-endpoints.ts";
 import * as schema from "@shared/db/better-auth.ts";
 import {
     type ModelInfo,
     modelInfoFromDefinition,
 } from "@shared/registry/model-info.ts";
-import type { ModelDefinition } from "@shared/registry/registry.ts";
+import type {
+    ModelDefinition,
+    ModelInputModality,
+} from "@shared/registry/registry.ts";
 import { eq, isNotNull } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
+import type { AgentCatalogConfig } from "./agent-catalog.ts";
 
 const COMMUNITY_TEXT_ENDPOINTS = [
     "/v1/chat/completions",
@@ -24,14 +31,22 @@ export function communityTextSupportedEndpoints(): string[] {
     return COMMUNITY_TEXT_ENDPOINTS;
 }
 
+export function communityTranscriptionSupportedEndpoints(): string[] {
+    return ["/v1/audio/transcriptions"];
+}
+
 export function communityImageSupportedEndpoints(
-    supportsImageEdits = false,
+    inputModalities: readonly ModelInputModality[] = ["text"],
 ): string[] {
     return [
         "/v1/images/generations",
-        ...(supportsImageEdits ? ["/v1/images/edits"] : []),
+        ...(inputModalities.includes("image") ? ["/v1/images/edits"] : []),
         "/image/{prompt}",
     ];
+}
+
+export function communityVideoSupportedEndpoints(): string[] {
+    return ["/v1/videos/generations", "/image/{prompt}"];
 }
 
 export type CommunityModelRegistryEntry = {
@@ -40,11 +55,18 @@ export type CommunityModelRegistryEntry = {
     info: ModelInfo;
     definition: ModelDefinition;
     communityEndpoint: CommunityEndpointRuntime;
+    agentConfig?: AgentCatalogConfig;
 };
 
+export type CommunityModelEnv = Pick<
+    CloudflareBindings,
+    "DB" | "AGENT_RUNTIME_BASE_URL"
+>;
+
 export async function getCommunityModelRegistryEntries(
-    dbBinding: CloudflareBindings["DB"] | undefined,
+    env: CommunityModelEnv,
 ): Promise<CommunityModelRegistryEntry[]> {
+    const dbBinding = env.DB;
     if (!dbBinding) return [];
     const db = drizzle(dbBinding, { schema });
     const rows = await db
@@ -52,31 +74,22 @@ export async function getCommunityModelRegistryEntries(
             id: schema.communityEndpoint.id,
             ownerUserId: schema.communityEndpoint.ownerUserId,
             ownerGithubUsername: schema.user.githubUsername,
+            providerName: schema.user.communityProviderName,
+            providerUrl: schema.user.communityProviderUrl,
             name: schema.communityEndpoint.name,
             title: schema.communityEndpoint.title,
             description: schema.communityEndpoint.description,
-            modality: schema.communityEndpoint.modality,
-            imagePricing: schema.communityEndpoint.imagePricing,
-            supportsImageEdits: schema.communityEndpoint.supportsImageEdits,
+            type: schema.communityEndpoint.type,
             baseUrl: schema.communityEndpoint.baseUrl,
             upstreamModel: schema.communityEndpoint.upstreamModel,
-            bearerTokenCiphertext:
-                schema.communityEndpoint.bearerTokenCiphertext,
+            payload: schema.communityEndpoint.payload,
+            pendingPayload: schema.communityEndpoint.pendingPayload,
+            pendingVisibility: schema.communityEndpoint.pendingVisibility,
+            pendingAt: schema.communityEndpoint.pendingAt,
             visibility: schema.communityEndpoint.visibility,
-            delegatesGeneration: schema.communityEndpoint.delegatesGeneration,
-            promptTextPrice: schema.communityEndpoint.promptTextPrice,
-            promptCachedPrice: schema.communityEndpoint.promptCachedPrice,
-            promptCacheWritePrice:
-                schema.communityEndpoint.promptCacheWritePrice,
-            promptAudioPrice: schema.communityEndpoint.promptAudioPrice,
-            promptImagePrice: schema.communityEndpoint.promptImagePrice,
-            completionTextPrice: schema.communityEndpoint.completionTextPrice,
-            completionReasoningPrice:
-                schema.communityEndpoint.completionReasoningPrice,
-            completionAudioPrice: schema.communityEndpoint.completionAudioPrice,
-            completionImagePrice: schema.communityEndpoint.completionImagePrice,
-            disabledAt: schema.communityEndpoint.disabledAt,
-            disabledReason: schema.communityEndpoint.disabledReason,
+            hiddenAt: schema.communityEndpoint.hiddenAt,
+            hiddenReason: schema.communityEndpoint.hiddenReason,
+            createdAt: schema.communityEndpoint.createdAt,
         })
         .from(schema.communityEndpoint)
         .innerJoin(
@@ -87,38 +100,153 @@ export async function getCommunityModelRegistryEntries(
 
     return rows.flatMap((row): CommunityModelRegistryEntry[] => {
         if (!row.ownerGithubUsername) return [];
+        const pendingReady = pendingCommunityEndpointChangeIsReady(
+            row.pendingAt,
+        );
+        const effectiveVisibility =
+            pendingReady && row.pendingVisibility
+                ? row.pendingVisibility
+                : row.visibility;
+        const baseUrl =
+            row.type === "prompt_agent"
+                ? env.AGENT_RUNTIME_BASE_URL
+                : row.baseUrl;
+        if (!baseUrl || !row.upstreamModel) return [];
         const modelId = communityModelId(row.ownerGithubUsername, row.name);
-        const communityEndpoint: CommunityEndpointRuntime = {
+        const identity = {
             id: row.id,
             ownerUserId: row.ownerUserId,
             modelId,
             name: row.name,
             title: row.title,
             description: row.description,
-            modality: normalizeCommunityEndpointModality(row.modality),
-            imagePricing: normalizeCommunityEndpointImagePricing(
-                row.imagePricing,
-            ),
-            supportsImageEdits: row.supportsImageEdits,
-            baseUrl: row.baseUrl,
+            providerName: row.providerName,
+            providerUrl: row.providerUrl,
+            baseUrl,
             upstreamModel: row.upstreamModel,
-            bearerTokenCiphertext: row.bearerTokenCiphertext,
-            visibility: row.visibility,
-            delegatesGeneration: row.delegatesGeneration,
-            disabledAt: row.disabledAt ? row.disabledAt.getTime() : null,
-            disabledReason: row.disabledReason,
-            ...communityEndpointPrices(row),
+            visibility: effectiveVisibility,
+            hiddenAt: row.hiddenAt ? row.hiddenAt.getTime() : null,
+            hiddenReason: row.hiddenReason,
         };
-        const definition = communityModelDefinition(communityEndpoint);
+        // An agent charges nothing of its own and fans out to nothing: the
+        // caller pays for whatever it consumes downstream. Both agent kinds
+        // share empty purchase fields; endpoint agents may override only the
+        // gateway's per-user rate limit from their payload.
+        const agentDefaults = {
+            modality: "text" as const,
+            imagePricing: "request" as const,
+            inputModalities: null,
+            paidOnly: false,
+            perUserRpm: null,
+            fallbacks: [],
+            ...communityEndpointPrices({}),
+        };
+        // Each arm parses its own payload, so the shape is narrowed to the one
+        // its type declares. A payload that cannot be read leaves the listing
+        // out of the catalog rather than in it half-populated: an entry
+        // missing its target would fail at call time, not registration time.
+        let communityEndpoint: CommunityEndpointRuntime;
+        let agentConfig: AgentCatalogConfig | undefined;
+        switch (row.type) {
+            case "prompt_agent": {
+                const payload = parseListingPayload(
+                    "prompt_agent",
+                    row.payload,
+                );
+                if (!payload) return [];
+                agentConfig = {
+                    baseModel: payload.baseModel,
+                    mcpServers: payload.mcpServers,
+                };
+                communityEndpoint = {
+                    ...identity,
+                    ...agentDefaults,
+                    type: "prompt_agent",
+                };
+                break;
+            }
+            case "endpoint_agent": {
+                const payload = parseListingPayload(
+                    "endpoint_agent",
+                    row.payload,
+                );
+                if (!payload) return [];
+                communityEndpoint = {
+                    ...identity,
+                    ...agentDefaults,
+                    perUserRpm: payload.perUserRpm,
+                    type: "endpoint_agent",
+                };
+                break;
+            }
+            case "proxy": {
+                const currentPayload = parseListingPayload(
+                    "proxy",
+                    row.payload,
+                );
+                if (!currentPayload) return [];
+                const pendingPayload = parseListingPayload(
+                    "proxy",
+                    row.pendingPayload,
+                );
+                const payload = pendingReady
+                    ? applyPendingProxyPricing(currentPayload, pendingPayload)
+                    : currentPayload;
+                communityEndpoint = {
+                    ...identity,
+                    type: "proxy",
+                    bearerTokenCiphertext: payload.bearerTokenCiphertext,
+                    paidOnly: payload.paidOnly,
+                    modality: payload.modality,
+                    imagePricing: payload.imagePricing,
+                    inputModalities: payload.inputModalities,
+                    perUserRpm: payload.perUserRpm,
+                    fallbacks: payload.fallbacks,
+                    advertised: payload.advertised,
+                    ...payload.prices,
+                };
+            }
+        }
+        const definition = communityModelDefinition({
+            ...communityEndpoint,
+            addedDate: row.createdAt.getTime(),
+            hidden: communityEndpoint.hiddenAt !== null,
+        });
+        const info = modelInfoFromDefinition(modelId, definition, {
+            community: true,
+            agent: usesAgentRunToken(communityEndpoint),
+        });
+        const pendingPayload = parseListingPayload("proxy", row.pendingPayload);
+        if (
+            !pendingReady &&
+            row.pendingAt &&
+            row.visibility === "public" &&
+            pendingPayload
+        ) {
+            const pendingDefinition = communityModelDefinition({
+                ...communityEndpoint,
+                paidOnly: pendingPayload.paidOnly,
+                imagePricing: pendingPayload.imagePricing,
+                ...pendingPayload.prices,
+            });
+            info.pending_change = {
+                effective_at: new Date(
+                    row.pendingAt.getTime() +
+                        COMMUNITY_ENDPOINT_CHANGE_DELAY_MS,
+                ).toISOString(),
+                paid_only: pendingPayload.paidOnly,
+                pricing: modelInfoFromDefinition(modelId, pendingDefinition)
+                    .pricing,
+            };
+        }
         return [
             {
                 id: modelId,
                 aliases: definition.aliases,
-                info: modelInfoFromDefinition(modelId, definition, {
-                    community: true,
-                }),
+                info,
                 definition,
                 communityEndpoint,
+                agentConfig,
             },
         ];
     });

--- a/gen.pollinations.ai/src/image/communityEndpoint.ts
+++ b/gen.pollinations.ai/src/image/communityEndpoint.ts
@@ -1,11 +1,16 @@
 import { Buffer } from "node:buffer";
 import {
+    COMMUNITY_ENDPOINT_TIMEOUT_MS,
     type CommunityEndpointRuntime,
+    communityEndpointErrorDetail,
     communityImageEditsUrl,
     communityImageGenerationsUrl,
-    normalizeCommunityAssetUrl,
+    communityVideoGenerationsUrl,
+    firstCommunityImageBytes,
+    firstCommunityVideoData,
     normalizeCommunityEndpointBearerToken,
 } from "@shared/community-endpoints.ts";
+import { HttpError } from "@shared/http-error.ts";
 import { detectImageMimeType } from "@shared/image-mime.ts";
 import type { Usage } from "@shared/registry/registry.ts";
 import {
@@ -14,18 +19,14 @@ import {
 } from "@shared/registry/usage-headers.ts";
 import { decryptSecret } from "@shared/secret-encryption.ts";
 import type { ImageGenerationResult } from "./createAndReturnImages.ts";
-import { HttpError } from "./httpError.ts";
+import type { VideoGenerationResult } from "./createAndReturnVideos.ts";
 import type { ImageParams } from "./params.ts";
 import {
-    base64ToBuffer,
     bufferToUint8Array,
     downloadUserImage,
 } from "./utils/imageDownload.ts";
 
 type CommunityImageParams = Omit<ImageParams, "model"> & { model: string };
-
-const REQUEST_TIMEOUT_MS = 120_000;
-const MAX_IMAGE_BYTES = 20 * 1024 * 1024;
 
 export async function callCommunityImageEndpoint(
     endpoint: CommunityEndpointRuntime,
@@ -33,6 +34,12 @@ export async function callCommunityImageEndpoint(
     safeParams: CommunityImageParams,
     secret: string,
 ): Promise<ImageGenerationResult> {
+    // Managed agents are text-only, so an image endpoint is always external.
+    if (endpoint.type !== "proxy") {
+        throw new Error(
+            `Community image endpoint '${endpoint.modelId}' is a managed agent`,
+        );
+    }
     const bearerToken = await decryptSecret(
         endpoint.bearerTokenCiphertext,
         secret,
@@ -59,15 +66,15 @@ export async function callCommunityImageEndpoint(
               }),
     );
 
-    const buffer = await firstImageBuffer(body, endpoint.baseUrl);
-    if (!detectImageMimeType(buffer)) {
+    const bytes = await firstCommunityImageBytes(body, endpoint.baseUrl);
+    if (!bytes || !detectImageMimeType(bytes)) {
         throw new HttpError(
             "Community image endpoint did not return a supported image",
             502,
         );
     }
     return {
-        buffer,
+        buffer: Buffer.from(bytes),
         isMature: false,
         isChild: false,
         trackingData: {
@@ -99,7 +106,7 @@ async function imageEditFormData(
     for (const [index, imageUrl] of safeParams.image.entries()) {
         const { buffer, mimeType } = await downloadUserImage(
             imageUrl,
-            AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+            AbortSignal.timeout(COMMUNITY_ENDPOINT_TIMEOUT_MS),
         );
         const extension = mimeType.split("/")[1];
         formData.append(
@@ -179,7 +186,7 @@ async function fetchWithTimeout(
         return await fetch(input, {
             ...init,
             redirect: "manual",
-            signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+            signal: AbortSignal.timeout(COMMUNITY_ENDPOINT_TIMEOUT_MS),
         });
     } catch (error) {
         throw new HttpError(
@@ -191,108 +198,6 @@ async function fetchWithTimeout(
     }
 }
 
-async function firstImageBuffer(
-    body: unknown,
-    endpointBaseUrl: string,
-): Promise<Buffer> {
-    if (
-        !body ||
-        typeof body !== "object" ||
-        !("data" in body) ||
-        !Array.isArray(body.data)
-    ) {
-        throw new HttpError(
-            "Community image endpoint did not return OpenAI image data",
-            502,
-        );
-    }
-    for (const image of body.data) {
-        if (!image || typeof image !== "object") continue;
-        if (
-            "b64_json" in image &&
-            typeof image.b64_json === "string" &&
-            image.b64_json.length > 0
-        ) {
-            return base64ToBuffer(image.b64_json);
-        }
-        if (
-            "url" in image &&
-            typeof image.url === "string" &&
-            image.url.length > 0
-        ) {
-            return fetchImageBuffer(image.url, endpointBaseUrl);
-        }
-    }
-    throw new HttpError(
-        "Community image endpoint did not return base64 or URL image data",
-        502,
-    );
-}
-
-async function fetchImageBuffer(
-    value: string,
-    endpointBaseUrl: string,
-): Promise<Buffer> {
-    let url: string;
-    try {
-        url = normalizeCommunityAssetUrl(value, endpointBaseUrl);
-    } catch {
-        throw new HttpError(
-            "Community image endpoint returned an unsafe image URL",
-            502,
-        );
-    }
-    const response = await fetchWithTimeout(url);
-    if (!response.ok) {
-        throw new HttpError(
-            `Community image URL responded ${response.status}`,
-            502,
-            undefined,
-            url,
-        );
-    }
-    const contentLength = Number(response.headers.get("content-length"));
-    if (Number.isFinite(contentLength) && contentLength > MAX_IMAGE_BYTES) {
-        throw new HttpError("Community image is larger than 20 MB", 502);
-    }
-    return readImageBuffer(response);
-}
-
-async function readImageBuffer(response: Response): Promise<Buffer> {
-    const reader = response.body?.getReader();
-    if (!reader) {
-        const buffer = Buffer.from(await response.arrayBuffer());
-        if (buffer.byteLength > MAX_IMAGE_BYTES) {
-            throw new HttpError("Community image is larger than 20 MB", 502);
-        }
-        return buffer;
-    }
-
-    const chunks: Uint8Array[] = [];
-    let total = 0;
-    try {
-        while (true) {
-            const { done, value } = await reader.read();
-            if (done) break;
-            total += value.byteLength;
-            if (total > MAX_IMAGE_BYTES) {
-                await reader.cancel();
-                throw new HttpError(
-                    "Community image is larger than 20 MB",
-                    502,
-                );
-            }
-            chunks.push(value);
-        }
-    } finally {
-        reader.releaseLock();
-    }
-    return Buffer.concat(
-        chunks.map((chunk) => Buffer.from(chunk)),
-        total,
-    );
-}
-
 function parseJson(text: string): unknown {
     try {
         return JSON.parse(text);
@@ -302,26 +207,73 @@ function parseJson(text: string): unknown {
 }
 
 function endpointErrorMessage(status: number, body: unknown): string {
-    const message = endpointBodyMessage(body);
+    const message = communityEndpointErrorDetail(body);
     return message
         ? `Community image endpoint responded ${status}: ${message}`
         : `Community image endpoint responded ${status}`;
 }
 
-function endpointBodyMessage(body: unknown): string | null {
-    if (!body || typeof body !== "object") return null;
-    if (
-        "error" in body &&
-        body.error &&
-        typeof body.error === "object" &&
-        "message" in body.error &&
-        typeof body.error.message === "string"
-    ) {
-        return body.error.message;
+type CommunityVideoParams = { model: string; duration?: number };
+
+export async function callCommunityVideoEndpoint(
+    endpoint: CommunityEndpointRuntime,
+    prompt: string,
+    safeParams: CommunityVideoParams,
+    secret: string,
+): Promise<VideoGenerationResult> {
+    if (endpoint.type !== "proxy") {
+        throw new Error(
+            `Community video endpoint '${endpoint.modelId}' is a managed agent`,
+        );
     }
-    if ("error" in body && typeof body.error === "string") return body.error;
-    if ("message" in body && typeof body.message === "string") {
-        return body.message;
+    const bearerToken = await decryptSecret(
+        endpoint.bearerTokenCiphertext,
+        secret,
+    );
+    const upstreamUrl = communityVideoGenerationsUrl(endpoint.baseUrl);
+    const requestBody: Record<string, unknown> = {
+        model: endpoint.upstreamModel,
+        prompt,
+    };
+    if (safeParams.duration !== undefined) {
+        requestBody.duration = safeParams.duration;
     }
-    return null;
+
+    const response = await fetchWithTimeout(upstreamUrl, {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${normalizeCommunityEndpointBearerToken(bearerToken)}`,
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify(requestBody),
+    });
+    const text = await response.text();
+    const parsed = parseJson(text);
+
+    if (!response.ok) {
+        throw new HttpError(
+            endpointErrorMessage(response.status, parsed),
+            response.status,
+            { body: text },
+            upstreamUrl,
+        );
+    }
+
+    const videoData = await firstCommunityVideoData(parsed, endpoint.baseUrl);
+    if (!videoData) {
+        throw new HttpError(
+            "Community video endpoint did not return video data with a duration",
+            502,
+        );
+    }
+
+    return {
+        buffer: Buffer.from(videoData.bytes),
+        mimeType: "video/mp4",
+        durationSeconds: videoData.durationSeconds,
+        trackingData: {
+            actualModel: endpoint.upstreamModel,
+            usage: { completionVideoSeconds: videoData.durationSeconds },
+        },
+    };
 }

--- a/gen.pollinations.ai/src/image/handler.ts
+++ b/gen.pollinations.ai/src/image/handler.ts
@@ -1,9 +1,17 @@
 import { remapUpstreamStatus, UpstreamError } from "@shared/error.ts";
 import { IMMUTABLE_CACHE_CONTROL } from "@shared/http/cache-control.ts";
+import { HttpError } from "@shared/http-error.ts";
 import { DEFAULT_IMAGE_MODEL } from "@shared/registry/image.ts";
+import { FALLBACK_TARGET_HEADER } from "@shared/registry/usage-headers.ts";
 import type { Context } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { Env } from "@/env.ts";
+import {
+    fallbackCandidates,
+    formatFallbackTarget,
+    withModelFallback,
+} from "../fallback.ts";
+import { enforceModelRateLimit } from "../utils/model-rate-limit.ts";
 import {
     getRegisteredServers,
     isValidType,
@@ -12,7 +20,10 @@ import {
     setServerRegistryBinding,
     VALID_TYPES,
 } from "./availableServers.ts";
-import { callCommunityImageEndpoint } from "./communityEndpoint.ts";
+import {
+    callCommunityImageEndpoint,
+    callCommunityVideoEndpoint,
+} from "./communityEndpoint.ts";
 import {
     type AuthResult,
     createAndReturnImageCached,
@@ -24,8 +35,8 @@ import {
     type VideoGenerationResult,
 } from "./createAndReturnVideos.ts";
 import { getImageEnv, syncImageEnv } from "./env.ts";
-import { HttpError } from "./httpError.ts";
 import { setKleinVpcBinding } from "./models/fluxKleinModel.ts";
+import { clampNovaCanvasDimensions } from "./models/novaCanvasModel.ts";
 import { type ImageParams, ImageParamsSchema } from "./params.ts";
 import { sanitizeString, sleep } from "./util.ts";
 import {
@@ -34,12 +45,21 @@ import {
     contentPolicyMessage,
     firstContentPolicyMessage,
 } from "./utils/contentModeration.ts";
-import { bufferToUint8Array, detectMimeType } from "./utils/imageDownload.ts";
+import {
+    bufferToUint8Array,
+    detectMimeType,
+    downloadUserImage,
+    readImageDimensions,
+} from "./utils/imageDownload.ts";
 import { setImagesBinding } from "./utils/imageTransform.ts";
 import { buildTrackingHeaders } from "./utils/trackingHeaders.ts";
 
 type ImageContext = Context<Env>;
 type RuntimeImageParams = Omit<ImageParams, "model"> & { model: string };
+
+const EDIT_IMAGE_PROBE_TIMEOUT_MS = 10_000;
+const EDIT_DIMENSION_STEP = 16;
+const MIN_EDIT_DIMENSION = 256;
 
 const IMAGE_ENV_KEYS = [
     "AWS_ACCESS_KEY_ID",
@@ -55,10 +75,12 @@ const IMAGE_ENV_KEYS = [
     "AZURE_MYCELI_PROD_IMG_MINI_WESTUS3_API_KEY",
     "AZURE_MYCELI_PROD_SWEDEN_API_KEY",
     "DASHSCOPE_API_KEY",
+    "DEEPINFRA_API_KEY",
     "GOOGLE_CLIENT_EMAIL",
     "GOOGLE_PRIVATE_KEY",
     "GOOGLE_PRIVATE_KEY_ID",
     "GOOGLE_PROJECT_ID",
+    "FAL_KEY",
     "KLEIN_URL",
     "NOVA_REEL_S3_BUCKET",
     "OPENROUTER_API_KEY",
@@ -220,6 +242,8 @@ function throwImageError(error: unknown): never {
         const { status, message } = classifyImageHttpError(error);
         throw new UpstreamError(status, {
             message,
+            // Propagate only — the code is decided at the throw site.
+            errorCode: error.errorCode,
             requestUrl: safeUpstreamUrl(error.upstreamUrl),
             upstreamStatus: error.status,
             responseBody: imageResponseBody(error),
@@ -390,6 +414,64 @@ async function generateImageResult(
     return result;
 }
 
+/** Tries the requested model and its fallbacks through one modality-neutral loop. */
+async function generateMediaWithFallback(
+    c: ImageContext,
+    prompt: string,
+    safeParams: RuntimeImageParams,
+): Promise<{
+    result: ImageGenerationResult | VideoGenerationResult;
+    params: RuntimeImageParams;
+    servedIndex: number;
+}> {
+    const { result, index } = await withModelFallback(
+        fallbackCandidates(c.var.model),
+        async (attempt) => {
+            const params = { ...safeParams, model: attempt.id };
+            if (attempt.communityEndpoint) {
+                if (attempt.communityEndpoint.modality === "video") {
+                    const generated = await callCommunityVideoEndpoint(
+                        attempt.communityEndpoint,
+                        prompt,
+                        params,
+                        c.env.BETTER_AUTH_SECRET,
+                    );
+                    assertNonEmptyMedia(
+                        generated.buffer,
+                        "Community video endpoint",
+                    );
+                    return { result: generated, params };
+                }
+                const generated = await callCommunityImageEndpoint(
+                    attempt.communityEndpoint,
+                    prompt,
+                    params,
+                    c.env.BETTER_AUTH_SECRET,
+                );
+                assertNonEmptyMedia(
+                    generated.buffer,
+                    "Community image endpoint",
+                );
+                return { result: generated, params };
+            }
+            if (isVideoModel(params.model)) {
+                const generated = await generateVideoResult(c, prompt, params);
+                assertNonEmptyMedia(generated.buffer, "Video provider");
+                return { result: generated, params };
+            }
+            const generated = await generateImageResult(c, prompt, params);
+            assertNonEmptyMedia(generated.buffer, "Image provider");
+            return { result: generated, params };
+        },
+        c.var.track?.attempts,
+        (attempt) => enforceModelRateLimit(c, attempt),
+    );
+    return {
+        ...result,
+        servedIndex: index,
+    };
+}
+
 async function generateVideoResult(
     c: ImageContext,
     originalPrompt: string,
@@ -402,6 +484,45 @@ async function generateVideoResult(
     );
 }
 
+/**
+ * Edit requests that omit `size` should preserve the source image's aspect
+ * ratio instead of silently defaulting to the model's square default (e.g.
+ * 1024x1024). Downloads the first reference image, reads its actual
+ * dimensions, and overrides the params. Explicit size requests and video
+ * models are untouched; any failure falls back to the model default.
+ */
+export async function resolveEditDimensionsForImage(
+    safeParams: RuntimeImageParams,
+): Promise<RuntimeImageParams> {
+    if (safeParams.dimensionsExplicit) return safeParams;
+    const imageUrls = safeParams.image;
+    if (!imageUrls?.length) return safeParams;
+    try {
+        const { buffer, mimeType } = await downloadUserImage(
+            imageUrls[0],
+            AbortSignal.timeout(EDIT_IMAGE_PROBE_TIMEOUT_MS),
+        );
+        const source = readImageDimensions(buffer, mimeType);
+        if (!source) return safeParams;
+
+        const targetLongEdge = Math.max(safeParams.width, safeParams.height);
+        const scale = targetLongEdge / Math.max(source.width, source.height);
+        const normalizeSide = (side: number) =>
+            Math.max(
+                MIN_EDIT_DIMENSION,
+                Math.round((side * scale) / EDIT_DIMENSION_STEP) *
+                    EDIT_DIMENSION_STEP,
+            );
+        return {
+            ...safeParams,
+            width: normalizeSide(source.width),
+            height: normalizeSide(source.height),
+        };
+    } catch {
+        // Keep the model default if the source image cannot be read.
+        return safeParams;
+    }
+}
 export async function generateImageOrVideoResponse(
     c: ImageContext,
     prompt: string,
@@ -409,55 +530,48 @@ export async function generateImageOrVideoResponse(
 ): Promise<Response> {
     syncImageEnvironment(c.env);
     const originalPrompt = decodePrompt(prompt || "random_prompt");
-    const safeParams = parseImageParams(c, body);
+    const parsedParams = parseImageParams(c, body);
+    const definition = c.var.model.definition;
+    const safeParams =
+        definition.category === "image" &&
+        definition.inputModalities?.includes("image")
+            ? await resolveEditDimensionsForImage(parsedParams)
+            : parsedParams;
+    const pricingDimensions =
+        c.var.model.resolved === "nova-canvas"
+            ? clampNovaCanvasDimensions(safeParams.width, safeParams.height)
+            : safeParams;
+    c.var.track.setPricingInput({
+        resolution: safeParams.resolution,
+        quality: safeParams.quality,
+        hasImage: (safeParams.image?.length ?? 0) > 0,
+        maxImageDimension: Math.max(
+            pricingDimensions.width,
+            pricingDimensions.height,
+        ),
+        megapixels: (safeParams.width * safeParams.height) / 1_000_000,
+    });
 
     try {
-        const communityEndpoint = c.var.model.communityEndpoint;
-        if (communityEndpoint) {
-            const result = await callCommunityImageEndpoint(
-                communityEndpoint,
-                originalPrompt,
-                safeParams,
-                c.env.BETTER_AUTH_SECRET,
+        const { result, params, servedIndex } = await generateMediaWithFallback(
+            c,
+            originalPrompt,
+            safeParams,
+        );
+        const headers = mediaHeaders(
+            originalPrompt,
+            params,
+            result,
+            result.mimeType || detectMimeType(result.buffer),
+        );
+        if (servedIndex > 0) {
+            // Same shape text emits, so tracking has one fallback marker.
+            headers.set(
+                FALLBACK_TARGET_HEADER,
+                formatFallbackTarget(servedIndex),
             );
-            assertNonEmptyMedia(result.buffer, "Community image endpoint");
-            return new Response(bufferToUint8Array(result.buffer), {
-                headers: mediaHeaders(
-                    originalPrompt,
-                    safeParams,
-                    result,
-                    detectMimeType(result.buffer),
-                ),
-            });
         }
-
-        if (isVideoModel(safeParams.model)) {
-            const result = await generateVideoResult(
-                c,
-                originalPrompt,
-                safeParams,
-            );
-            assertNonEmptyMedia(result.buffer, "Video provider");
-            return new Response(bufferToUint8Array(result.buffer), {
-                headers: mediaHeaders(
-                    originalPrompt,
-                    safeParams,
-                    result,
-                    result.mimeType || "video/mp4",
-                ),
-            });
-        }
-
-        const result = await generateImageResult(c, originalPrompt, safeParams);
-        assertNonEmptyMedia(result.buffer, "Image provider");
-        return new Response(bufferToUint8Array(result.buffer), {
-            headers: mediaHeaders(
-                originalPrompt,
-                safeParams,
-                result,
-                result.mimeType || detectMimeType(result.buffer),
-            ),
-        });
+        return new Response(bufferToUint8Array(result.buffer), { headers });
     } catch (error) {
         throwImageError(error);
     }

--- a/shared/community-endpoints.ts
+++ b/shared/community-endpoints.ts
@@ -1,14 +1,30 @@
+import { z } from "zod";
 import { isCommunityModelAllowedGithubId } from "./auth/github-id-list.ts";
-import type { ModelDefinition, PriceDefinition } from "./registry/registry.ts";
+import { HttpError } from "./http-error.ts";
+import { MCP_SERVER_IDS } from "./registry/mcp.ts";
+import type { ModelCapability } from "./registry/model-info.ts";
+import {
+    MODEL_INPUT_MODALITIES,
+    type ModelDefinition,
+    type ModelInputModality,
+    type PriceDefinition,
+} from "./registry/registry.ts";
 import {
     OPENAI_CHAT_USAGE_PATHS,
     OPENAI_CHAT_USAGE_TYPES,
     type OpenAIChatUsageType,
 } from "./registry/usage-headers.ts";
+import { readResponseBytes } from "./response-bytes.ts";
 
 export const LEGACY_COMMUNITY_MODEL_PREFIX = "community/";
 export const COMMUNITY_MODEL_REWARD_RATE = 0.75;
-export const COMMUNITY_ENDPOINT_MODALITIES = ["text", "image"] as const;
+export const COMMUNITY_ENDPOINT_CHANGE_DELAY_MS = 12 * 60 * 60 * 1000;
+export const COMMUNITY_ENDPOINT_MODALITIES = [
+    "text",
+    "image",
+    "transcription",
+    "video",
+] as const;
 // How a community image endpoint is billed. "request" charges the fixed
 // per-image price once per generation; "tokens" charges the provider-returned
 // OpenAI image token usage against per-1M prices. The mode is detected by the
@@ -22,6 +38,8 @@ export const COMMUNITY_ENDPOINT_IMAGE_PRICING_MODES = [
 // slug (`name`) and the optional longer `description`.
 export const COMMUNITY_ENDPOINT_TITLE_MAX_LENGTH = 42;
 export const COMMUNITY_ENDPOINT_DESCRIPTION_MAX_LENGTH = 160;
+export const COMMUNITY_PROVIDER_NAME_MAX_LENGTH = 42;
+export const COMMUNITY_PROVIDER_URL_MAX_LENGTH = 2048;
 // Zero is free; positive owner-declared prices start at this floor.
 export const MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS = 0.000001;
 export const MIN_COMMUNITY_PRICE_PER_TOKEN =
@@ -32,10 +50,81 @@ export const MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS = 50;
 export const MAX_COMMUNITY_PRICE_PER_TOKEN =
     MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS / 1_000_000;
 export const MAX_COMMUNITY_PRICE_PER_IMAGE = 0.25;
+// Per-second audio (STT/TTS) prices are tiny compared to per-token rates, so
+// this ceiling is written per minute and divided down: $0.012/min is ~2x
+// OpenAI whisper ($0.006/min) and ~3x the priciest first-party STT model
+// (scribe, $0.00367/min). Keep the division visible — a bare 0.006 here reads
+// like OpenAI's per-minute rate but would bill 60x that per second.
+export const MAX_COMMUNITY_PRICE_PER_SECOND = 0.012 / 60;
+// Per-second video ceiling. First-party video models run up to ~$0.25/s;
+// allow the same headroom community providers may need for GPU cost + margin.
+export const MAX_COMMUNITY_PRICE_PER_VIDEO_SECOND = 0.5;
+export const MAX_COMMUNITY_IMAGE_BYTES = 20 * 1024 * 1024;
+// How long we wait on a community endpoint before giving up. Generous because
+// these are self-hosted hobby GPUs that cold-start, and in line with the text
+// providers (Portkey and Azure both use 290s). Workers impose no wall-clock
+// limit of their own, so without this a hung endpoint would hold the request
+// open until the caller disconnects.
+export const COMMUNITY_ENDPOINT_TIMEOUT_MS = 300_000;
 const BEARER_PREFIX = /^Bearer(?:\s+|$)/i;
 
 export type CommunityEndpointModality =
     (typeof COMMUNITY_ENDPOINT_MODALITIES)[number];
+
+export const COMMUNITY_ENDPOINT_INPUT_MODALITIES = {
+    text: MODEL_INPUT_MODALITIES,
+    image: ["text", "image"],
+    transcription: ["audio"],
+    video: ["text", "image"],
+} as const satisfies Record<
+    CommunityEndpointModality,
+    readonly ModelInputModality[]
+>;
+
+export const MAX_COMMUNITY_CONTEXT_LENGTH = 10_000_000;
+
+export const COMMUNITY_ENDPOINT_CAPABILITIES = [
+    "tool_calling",
+    "reasoning",
+] as const satisfies readonly ModelCapability[];
+
+export type CommunityEndpointCapability =
+    (typeof COMMUNITY_ENDPOINT_CAPABILITIES)[number];
+
+export const CommunityEndpointAdvertisedSchema = z
+    .object({
+        capabilities: z
+            .array(z.enum(COMMUNITY_ENDPOINT_CAPABILITIES))
+            .optional(),
+        contextLength: z
+            .number()
+            .int()
+            .positive()
+            .max(MAX_COMMUNITY_CONTEXT_LENGTH)
+            .optional(),
+    })
+    .strict();
+
+export type CommunityEndpointAdvertised = z.infer<
+    typeof CommunityEndpointAdvertisedSchema
+>;
+
+export function normalizeCommunityEndpointAdvertised(
+    value: CommunityEndpointAdvertised | null | undefined,
+    modality: CommunityEndpointModality,
+): CommunityEndpointAdvertised {
+    if (!value || modality !== "text") return {};
+    const advertised: CommunityEndpointAdvertised = {};
+    if (value.capabilities?.length) {
+        const declared = new Set<string>(value.capabilities);
+        const capabilities = COMMUNITY_ENDPOINT_CAPABILITIES.filter(
+            (capability) => declared.has(capability),
+        );
+        if (capabilities.length) advertised.capabilities = capabilities;
+    }
+    if (value.contextLength) advertised.contextLength = value.contextLength;
+    return advertised;
+}
 
 export type CommunityEndpointImagePricing =
     (typeof COMMUNITY_ENDPOINT_IMAGE_PRICING_MODES)[number];
@@ -135,24 +224,67 @@ const COMMUNITY_IMAGE_TOKEN_PRICE_FIELDS = [
     },
 ] as const;
 
+// Transcription endpoints bill audio input duration in seconds against the
+// same prompt audio price column, mirroring the first-party whisper/scribe
+// models (cost keyed on promptAudioSeconds at a per-second rate).
+const COMMUNITY_TRANSCRIPTION_PRICE_FIELD = {
+    key: "promptAudioPrice",
+    usageType: "promptAudioSeconds",
+    label: "Prompt audio",
+    priceUnit: "second",
+    // Paths are relative to the stored usage object, same as the chat fields
+    // ("prompt_tokens", not "usage.prompt_tokens"). The probe normalizes every
+    // upstream duration shape to `duration`, so that is the only key here.
+    rawUsagePaths: ["duration"],
+} as const;
+
+// Video endpoints bill output duration in seconds. The probe normalises the
+// upstream response to `duration_seconds` (in the data[0] item), so that is
+// the only path declared here.
+const COMMUNITY_VIDEO_PRICE_FIELD = {
+    key: "completionVideoPrice",
+    usageType: "completionVideoSeconds",
+    label: "Generated video",
+    priceUnit: "video_second",
+    rawUsagePaths: ["duration_seconds"],
+} as const;
+
 export const COMMUNITY_ENDPOINT_PRICE_FIELDS = [
     ...COMMUNITY_TEXT_PRICE_FIELDS,
     COMMUNITY_IMAGE_PRICE_FIELD,
+    COMMUNITY_TRANSCRIPTION_PRICE_FIELD,
+    COMMUNITY_VIDEO_PRICE_FIELD,
 ] as const;
 
 const COMMUNITY_TEXT_ENDPOINT_PRICE_FIELDS =
     COMMUNITY_ENDPOINT_PRICE_FIELDS.filter(
-        (field) => field.usageType !== "completionImageTokens",
+        (field) =>
+            field.usageType !== "completionImageTokens" &&
+            field.usageType !== "promptAudioSeconds",
     );
 
 const COMMUNITY_IMAGE_ENDPOINT_PRICE_FIELDS = [
     COMMUNITY_IMAGE_PRICE_FIELD,
 ] as const;
 
+const COMMUNITY_TRANSCRIPTION_ENDPOINT_PRICE_FIELDS = [
+    COMMUNITY_TRANSCRIPTION_PRICE_FIELD,
+] as const;
+
+const COMMUNITY_VIDEO_ENDPOINT_PRICE_FIELDS = [
+    COMMUNITY_VIDEO_PRICE_FIELD,
+] as const;
+
 export function communityEndpointPriceFieldsForModality(
     modality: CommunityEndpointModality,
     imagePricing: CommunityEndpointImagePricing = "request",
 ) {
+    if (modality === "transcription") {
+        return COMMUNITY_TRANSCRIPTION_ENDPOINT_PRICE_FIELDS;
+    }
+    if (modality === "video") {
+        return COMMUNITY_VIDEO_ENDPOINT_PRICE_FIELDS;
+    }
     if (modality !== "image") return COMMUNITY_TEXT_ENDPOINT_PRICE_FIELDS;
     return imagePricing === "tokens"
         ? COMMUNITY_IMAGE_TOKEN_PRICE_FIELDS
@@ -209,9 +341,47 @@ export function communityEndpointPricesForModality(
     ) as CommunityEndpointPrices;
 }
 
+/**
+ * Bounds how much latency one request can spend failing before it gives up:
+ * every extra target is another upstream timeout the caller waits through.
+ * Enforced on write and re-applied when the generation registry links entries.
+ */
+export const MAX_FALLBACK_TARGETS = 3;
+
+/**
+ * True when `target` costs no more than `primary` on every price field.
+ *
+ * The caller is charged the primary's price whichever endpoint serves, so this
+ * bounds the PAYOUT rather than the invoice: a rescuer is paid on their own
+ * listing, and this rule is what guarantees that stays at or below what was
+ * charged. It also stops an owner routing traffic to a pricier model whose
+ * owner would then earn more than the caller was quoted.
+ */
+export function isCommunityFallbackPricingAllowed(
+    primary: CommunityEndpointPrices,
+    target: CommunityEndpointPrices,
+): boolean {
+    return COMMUNITY_ENDPOINT_PRICE_FIELDS.every(
+        (field) => target[field.key] <= primary[field.key],
+    );
+}
+
+/**
+ * A fallback cannot require a balance bucket the caller was never required to
+ * have for the primary model. A paid-only primary may fall back to either kind.
+ */
+export function isCommunityFallbackBalanceAllowed(
+    primary: { paidOnly: boolean },
+    target: { paidOnly: boolean },
+): boolean {
+    return !target.paidOnly || primary.paidOnly;
+}
+
 export function normalizeCommunityEndpointModality(
     value: string | null | undefined,
 ): CommunityEndpointModality {
+    if (value === "transcription") return "transcription";
+    if (value === "video") return "video";
     return value === "image" ? "image" : "text";
 }
 
@@ -219,6 +389,22 @@ export function normalizeCommunityEndpointImagePricing(
     value: string | null | undefined,
 ): CommunityEndpointImagePricing {
     return value === "tokens" ? "tokens" : "request";
+}
+
+export function normalizeCommunityEndpointInputModalities(
+    value: readonly ModelInputModality[] | null | undefined,
+    endpointModality: CommunityEndpointModality,
+): ModelInputModality[] {
+    // Both empty cases — nothing declared, and a declared set that shares
+    // nothing with this modality — fall back to the modality's own first
+    // input: text for text and image endpoints, audio for transcription.
+    // Falling back to a bare "text" would hand a transcription endpoint the
+    // one input it cannot accept, which the write path then rejects with a
+    // 400 naming an input the owner never chose.
+    const permitted = COMMUNITY_ENDPOINT_INPUT_MODALITIES[endpointModality];
+    const declared = new Set(value ?? []);
+    const normalized = permitted.filter((modality) => declared.has(modality));
+    return normalized.length ? [...normalized] : [permitted[0]];
 }
 
 // Access/visibility of a registered endpoint. Private is the default; choosing
@@ -230,7 +416,191 @@ export const COMMUNITY_ENDPOINT_VISIBILITIES = ["private", "public"] as const;
 export type CommunityEndpointVisibility =
     (typeof COMMUNITY_ENDPOINT_VISIBILITIES)[number];
 
-export type CommunityEndpointRuntime = {
+/* -------------------------------------------------------------------------
+ * Listing storage
+ *
+ * A row carries what every listing has — who owns it, what it is called,
+ * whether it is published — plus one `payload` whose shape `type` selects.
+ * A field that belongs to one kind of listing exists only in that kind's
+ * payload, so a listing cannot store a price it never charges or a credential
+ * it never sends. The invariants that used to be checked field by field on
+ * write are now the absence of somewhere to put the value.
+ * ---------------------------------------------------------------------- */
+
+export const LISTING_TYPES = [
+    "proxy",
+    "prompt_agent",
+    "endpoint_agent",
+] as const;
+
+// Prompt agents all share one deployment-specific worker. Store this safe,
+// environment-neutral URL in the common target column, then replace it with
+// AGENT_RUNTIME_BASE_URL when a row crosses the API/runtime boundary. The
+// reserved .invalid host guarantees a missed replacement cannot call another
+// environment by accident.
+export const PROMPT_AGENT_BASE_URL_PLACEHOLDER =
+    "https://agent-runtime.invalid/api/agent-runtime/v1";
+
+export type ListingType = (typeof LISTING_TYPES)[number];
+
+/**
+ * The owner's own OpenAI-compatible server, reached with the upstream bearer
+ * secret registered for that server. This is never the owner's or caller's
+ * Pollinations credential. The only kind that names a price, because it is the
+ * only kind whose caller is buying something from the owner.
+ */
+export type ProxyListingPayload = {
+    bearerTokenCiphertext: string;
+    // Owner-set: callers may only spend Paid Pollen on this model.
+    paidOnly: boolean;
+    modality: CommunityEndpointModality;
+    imagePricing: CommunityEndpointImagePricing;
+    inputModalities: ModelInputModality[];
+    perUserRpm: number | null;
+    fallbacks: string[];
+    advertised?: CommunityEndpointAdvertised;
+    prices: CommunityEndpointPrices;
+};
+
+/**
+ * An agent Enter runs itself. Its row id is also the model sent to the shared
+ * runtime, which loads this configuration from the same row.
+ */
+export const BuiltinMcpServerIdSchema = z.enum(MCP_SERVER_IDS);
+export const PromptAgentConfigSchema = z.object({
+    systemPrompt: z.string().trim().min(1).max(8000),
+    baseModel: z.string().trim().min(1).max(253),
+    mcpServers: z
+        .array(BuiltinMcpServerIdSchema)
+        .max(MCP_SERVER_IDS.length)
+        .refine((servers) => new Set(servers).size === servers.length, {
+            message: "Duplicate MCP servers are not allowed",
+        })
+        .optional()
+        .default([]),
+});
+export const PromptAgentInputSchema = PromptAgentConfigSchema.strict();
+
+export type PromptAgentListingPayload = z.infer<typeof PromptAgentConfigSchema>;
+
+/**
+ * An agent on the owner's own server. It is sent a run token rather than a
+ * credential. The rate limit remains gateway policy, not an upstream secret.
+ */
+export const EndpointAgentListingPayloadSchema = z
+    .object({
+        perUserRpm: z.number().finite().positive().nullable().default(null),
+    })
+    .strict();
+
+export type EndpointAgentListingPayload = z.infer<
+    typeof EndpointAgentListingPayloadSchema
+>;
+
+export type ListingPayloadByType = {
+    proxy: ProxyListingPayload;
+    prompt_agent: PromptAgentListingPayload;
+    endpoint_agent: EndpointAgentListingPayload;
+};
+
+/**
+ * Read a stored payload back into its typed shape.
+ *
+ * Storage is the only place a payload arrives untyped, so it is normalized
+ * once here and every reader downstream gets a complete value. A payload
+ * missing what its type requires returns null, which leaves the listing out of
+ * the catalog rather than in it half-populated.
+ */
+export function parseListingPayload<K extends ListingType>(
+    type: K,
+    raw: string | null,
+): ListingPayloadByType[K] | null {
+    let parsed: unknown;
+    try {
+        parsed = raw === null ? null : JSON.parse(raw);
+    } catch {
+        return null;
+    }
+    if (parsed === null || typeof parsed !== "object") return null;
+    const source = parsed as Record<string, unknown>;
+
+    if (type === "endpoint_agent") {
+        const result = EndpointAgentListingPayloadSchema.safeParse(source);
+        return result.success ? (result.data as ListingPayloadByType[K]) : null;
+    }
+    if (type === "prompt_agent") {
+        const result = PromptAgentConfigSchema.safeParse(source);
+        return result.success ? (result.data as ListingPayloadByType[K]) : null;
+    }
+
+    const bearerTokenCiphertext =
+        typeof source.bearerTokenCiphertext === "string"
+            ? source.bearerTokenCiphertext
+            : "";
+    if (!bearerTokenCiphertext) return null;
+    const modality = normalizeCommunityEndpointModality(
+        typeof source.modality === "string" ? source.modality : null,
+    );
+    return {
+        bearerTokenCiphertext,
+        paidOnly: source.paidOnly === true,
+        modality,
+        imagePricing: normalizeCommunityEndpointImagePricing(
+            typeof source.imagePricing === "string"
+                ? source.imagePricing
+                : null,
+        ),
+        inputModalities: normalizeCommunityEndpointInputModalities(
+            Array.isArray(source.inputModalities)
+                ? (source.inputModalities as ModelInputModality[])
+                : undefined,
+            modality,
+        ),
+        perUserRpm:
+            typeof source.perUserRpm === "number" ? source.perUserRpm : null,
+        fallbacks: Array.isArray(source.fallbacks)
+            ? source.fallbacks.filter(
+                  (id): id is string => typeof id === "string",
+              )
+            : [],
+        advertised: normalizeCommunityEndpointAdvertised(
+            CommunityEndpointAdvertisedSchema.safeParse(source.advertised).data,
+            modality,
+        ),
+        prices: communityEndpointPrices(
+            (typeof source.prices === "object" && source.prices !== null
+                ? source.prices
+                : {}) as Partial<CommunityEndpointPrices>,
+        ),
+    } as ListingPayloadByType[K];
+}
+
+export function pendingCommunityEndpointChangeIsReady(
+    pendingAt: Date | null,
+    now = Date.now(),
+): boolean {
+    return (
+        pendingAt !== null &&
+        now >= pendingAt.getTime() + COMMUNITY_ENDPOINT_CHANGE_DELAY_MS
+    );
+}
+
+/** Apply only the delayed price policy, preserving newer credentials/settings. */
+export function applyPendingProxyPricing(
+    current: ProxyListingPayload,
+    pending: ProxyListingPayload | null,
+): ProxyListingPayload {
+    return pending
+        ? {
+              ...current,
+              paidOnly: pending.paidOnly,
+              imagePricing: pending.imagePricing,
+              prices: pending.prices,
+          }
+        : current;
+}
+
+type CommunityEndpointRuntimeBase = {
     id: string;
     ownerUserId: string;
     modelId: string;
@@ -239,27 +609,85 @@ export type CommunityEndpointRuntime = {
     // communityEndpointTitle() rather than using this directly.
     title: string | null;
     description: string | null;
+    providerName?: string | null;
+    providerUrl?: string | null;
     modality: CommunityEndpointModality;
     imagePricing: CommunityEndpointImagePricing;
-    supportsImageEdits: boolean;
+    inputModalities: ModelInputModality[] | null;
+    // Where the gateway sends the request, and the model name it asks for.
+    // All variants resolve these when the row is read, so routing never has
+    // to know which kind it is holding.
     baseUrl: string;
     upstreamModel: string;
-    bearerTokenCiphertext: string;
     visibility: CommunityEndpointVisibility;
-    /** Admin-granted: may spend an agent run token on the caller's behalf. */
-    delegatesGeneration: boolean;
-    disabledAt: number | null;
-    disabledReason: string | null;
+    paidOnly: boolean;
+    // Exact gateway-side cap per Pollinations user. Null delegates capacity
+    // limits to the upstream, whose 429 then remains a model failure.
+    perUserRpm: number | null;
+    // Community model ids tried in order when this endpoint's upstream fails.
+    // A target's own list is never followed: the owner declares the full order.
+    fallbacks: string[];
+    hiddenAt: number | null;
+    hiddenReason: string | null;
 } & CommunityEndpointPrices;
+
+/** A third-party server, reached with its registered upstream bearer secret. */
+export type ProxyCommunityEndpointRuntime = CommunityEndpointRuntimeBase & {
+    type: "proxy";
+    bearerTokenCiphertext: string;
+    advertised?: CommunityEndpointAdvertised;
+};
+
+/** An agent Enter runs on its own runtime, named by its listing id. */
+export type PromptAgentCommunityEndpointRuntime =
+    CommunityEndpointRuntimeBase & {
+        type: "prompt_agent";
+    };
+
+/** An agent on the owner's own server, sent a run token instead of a key. */
+export type EndpointAgentCommunityEndpointRuntime =
+    CommunityEndpointRuntimeBase & {
+        type: "endpoint_agent";
+    };
+
+export type CommunityEndpointRuntime =
+    | ProxyCommunityEndpointRuntime
+    | PromptAgentCommunityEndpointRuntime
+    | EndpointAgentCommunityEndpointRuntime;
+
+/**
+ * Whether calls to this endpoint spend the caller's balance downstream.
+ *
+ * Both agent kinds do — one runs here, one on the owner's server, and either
+ * way the work is charged to whoever called. A proxy never does: its owner
+ * pays their own upstream and charges the caller a declared price. This is the
+ * fact that decides which credential goes on the wire, so it has one name.
+ */
+export function usesAgentRunToken(endpoint: CommunityEndpointRuntime): boolean {
+    return endpoint.type !== "proxy";
+}
 
 export type CommunityModelDefinitionInput = {
     modelId: string;
+    addedDate?: number;
+    perUserRpm?: number | null;
     title?: string | null;
     description: string | null;
+    providerName?: string | null;
+    providerUrl?: string | null;
     modality?: CommunityEndpointModality;
     imagePricing?: CommunityEndpointImagePricing;
-    supportsImageEdits?: boolean;
+    inputModalities?: ModelInputModality[] | null;
+    fallbacks?: string[];
+    advertised?: CommunityEndpointAdvertised | null;
+    hidden?: boolean;
+    paidOnly?: boolean;
 } & CommunityEndpointPrices;
+
+export type CommunityProviderProfile = {
+    name: string | null;
+    url: string | null;
+};
 
 export type CommunityModelParts = {
     ownerGithubUsername: string;
@@ -291,6 +719,24 @@ export function normalizeCommunityEndpointBearerToken(value: string): string {
     const token = value.trim().replace(BEARER_PREFIX, "").trim();
     if (!token) throw new Error("API bearer token is required");
     return token;
+}
+
+export function communityEndpointErrorDetail(body: unknown): string | null {
+    if (!body || typeof body !== "object") return null;
+    if (
+        "error" in body &&
+        body.error &&
+        typeof body.error === "object" &&
+        "message" in body.error &&
+        typeof body.error.message === "string"
+    ) {
+        return body.error.message;
+    }
+    if ("error" in body && typeof body.error === "string") return body.error;
+    if ("message" in body && typeof body.message === "string") {
+        return body.message;
+    }
+    return null;
 }
 
 export function isCommunityEndpointOwnerAllowed(
@@ -327,6 +773,18 @@ export function normalizeCommunityEndpointBaseUrl(value: string): string {
     return url.toString().replace(/\/+$/, "");
 }
 
+export function normalizeCommunityProviderUrl(value: string): string {
+    const url = new URL(value.trim());
+    if (url.protocol !== "https:") {
+        throw new Error("Provider URL must use https");
+    }
+    if (url.username || url.password) {
+        throw new Error("Provider URL cannot include credentials");
+    }
+    url.hash = "";
+    return url.toString();
+}
+
 export function normalizeCommunityAssetUrl(
     value: string,
     endpointBaseUrl: string,
@@ -348,6 +806,198 @@ export function normalizeCommunityAssetUrl(
     return url.toString();
 }
 
+/**
+ * Pull the first usable image out of an OpenAI images response: inline base64
+ * when present, otherwise the URL it points at, fetched under the shared
+ * timeout and size cap.
+ *
+ * Returns null when the body carries no usable image, so each caller can
+ * phrase that in its own words. A URL that is unsafe, unreachable, or oversized
+ * throws HttpError(502) — the gen funnel renders that status directly, and the
+ * enter probe flattens it to a 400 with the same message.
+ */
+export async function firstCommunityImageBytes(
+    body: unknown,
+    endpointBaseUrl: string,
+): Promise<Uint8Array | null> {
+    if (
+        !body ||
+        typeof body !== "object" ||
+        !("data" in body) ||
+        !Array.isArray(body.data)
+    ) {
+        return null;
+    }
+    for (const image of body.data) {
+        if (!image || typeof image !== "object") continue;
+        if (
+            "b64_json" in image &&
+            typeof image.b64_json === "string" &&
+            image.b64_json.length > 0
+        ) {
+            return decodeCommunityBase64(image.b64_json);
+        }
+        if (
+            "url" in image &&
+            typeof image.url === "string" &&
+            image.url.length > 0
+        ) {
+            return fetchCommunityImageBytes(image.url, endpointBaseUrl);
+        }
+    }
+    return null;
+}
+
+async function fetchCommunityImageBytes(
+    value: string,
+    endpointBaseUrl: string,
+): Promise<Uint8Array> {
+    let url: string;
+    try {
+        url = normalizeCommunityAssetUrl(value, endpointBaseUrl);
+    } catch {
+        throw new HttpError("Endpoint returned an unsafe image URL", 502);
+    }
+    let response: Response;
+    try {
+        // The URL is validated against https + the private-host blocklist
+        // above; following redirects would let the endpoint bounce us to an
+        // unvalidated destination.
+        response = await fetch(url, {
+            redirect: "manual",
+            signal: AbortSignal.timeout(COMMUNITY_ENDPOINT_TIMEOUT_MS),
+        });
+    } catch (error) {
+        throw new HttpError(
+            "Endpoint image URL timed out or could not connect",
+            502,
+            { error: error instanceof Error ? error.message : String(error) },
+            url,
+        );
+    }
+    if (!response.ok) {
+        throw new HttpError(
+            `Endpoint image URL responded ${response.status}`,
+            502,
+            undefined,
+            url,
+        );
+    }
+    return readResponseBytes(
+        response,
+        MAX_COMMUNITY_IMAGE_BYTES,
+        () => new HttpError("Endpoint image is larger than 20 MB", 502),
+    );
+}
+
+export function decodeCommunityBase64(value: string): Uint8Array | null {
+    try {
+        const encoded = value
+            .replace(/^data:[^,]+,/, "")
+            .replace(/\s/g, "")
+            .replace(/-/g, "+")
+            .replace(/_/g, "/");
+        const decoded = atob(encoded);
+        return Uint8Array.from(decoded, (character) => character.charCodeAt(0));
+    } catch {
+        return null;
+    }
+}
+
+export type CommunityVideoData = {
+    bytes: Uint8Array;
+    durationSeconds: number;
+};
+
+/**
+ * Pull the first usable video out of a community video-generations response.
+ * Expects the same `data[0].url` / `data[0].b64_json` envelope as the image
+ * endpoint, plus a `duration_seconds` number for billing. Returns null when
+ * the body carries no usable video; throws HttpError(502) for unsafe or
+ * oversized URLs so the gen funnel surfaces the status directly.
+ */
+export async function firstCommunityVideoData(
+    body: unknown,
+    endpointBaseUrl: string,
+): Promise<CommunityVideoData | null> {
+    if (
+        !body ||
+        typeof body !== "object" ||
+        !("data" in body) ||
+        !Array.isArray(body.data)
+    ) {
+        return null;
+    }
+    for (const item of body.data) {
+        if (!item || typeof item !== "object") continue;
+        const durationSeconds =
+            typeof item.duration_seconds === "number" &&
+            Number.isFinite(item.duration_seconds) &&
+            item.duration_seconds > 0
+                ? item.duration_seconds
+                : null;
+        if (durationSeconds === null) continue;
+
+        let bytes: Uint8Array | null = null;
+        if (
+            "b64_json" in item &&
+            typeof item.b64_json === "string" &&
+            item.b64_json.length > 0
+        ) {
+            bytes = decodeCommunityBase64(item.b64_json);
+        } else if (
+            "url" in item &&
+            typeof item.url === "string" &&
+            item.url.length > 0
+        ) {
+            bytes = await fetchCommunityVideoBytes(item.url, endpointBaseUrl);
+        }
+        if (bytes && bytes.length > 0) {
+            return { bytes, durationSeconds };
+        }
+    }
+    return null;
+}
+
+async function fetchCommunityVideoBytes(
+    value: string,
+    endpointBaseUrl: string,
+): Promise<Uint8Array> {
+    let url: string;
+    try {
+        url = normalizeCommunityAssetUrl(value, endpointBaseUrl);
+    } catch {
+        throw new HttpError("Endpoint returned an unsafe video URL", 502);
+    }
+    let response: Response;
+    try {
+        response = await fetch(url, {
+            redirect: "manual",
+            signal: AbortSignal.timeout(COMMUNITY_ENDPOINT_TIMEOUT_MS),
+        });
+    } catch (error) {
+        throw new HttpError(
+            "Endpoint video URL timed out or could not connect",
+            502,
+            { error: error instanceof Error ? error.message : String(error) },
+            url,
+        );
+    }
+    if (!response.ok) {
+        throw new HttpError(
+            `Endpoint video URL responded ${response.status}`,
+            502,
+            undefined,
+            url,
+        );
+    }
+    return readResponseBytes(
+        response,
+        MAX_COMMUNITY_IMAGE_BYTES,
+        () => new HttpError("Endpoint video is larger than 20 MB", 502),
+    );
+}
+
 export function communityChatCompletionsUrl(baseUrl: string): string {
     return `${communityOpenAIBaseUrl(baseUrl)}/chat/completions`;
 }
@@ -360,12 +1010,47 @@ export function communityImageEditsUrl(baseUrl: string): string {
     return `${communityOpenAIBaseUrl(baseUrl)}/images/edits`;
 }
 
+export function communityAudioTranscriptionsUrl(baseUrl: string): string {
+    return `${communityOpenAIBaseUrl(baseUrl)}/audio/transcriptions`;
+}
+
+export function communityVideoGenerationsUrl(baseUrl: string): string {
+    return `${communityOpenAIBaseUrl(baseUrl)}/videos/generations`;
+}
+
+/**
+ * Audio duration reported by an OpenAI-compatible transcription response.
+ *
+ * The three shapes in the wild: gpt-4o-transcribe reports `usage.seconds`,
+ * whisper-style servers report `usage.duration`, and stock whisper
+ * `verbose_json` puts `duration` at the top level. Returns null when none of
+ * them carry a usable number — callers decide what that means, and both the
+ * registration probe and the request path treat it as a failure so an endpoint
+ * that cannot be metered is never billed at zero.
+ */
+export function communityTranscriptionSeconds(body: unknown): number | null {
+    if (!body || typeof body !== "object") return null;
+    const record = body as Record<string, unknown>;
+    const usage =
+        record.usage && typeof record.usage === "object"
+            ? (record.usage as Record<string, unknown>)
+            : undefined;
+    for (const value of [usage?.duration, usage?.seconds, record.duration]) {
+        if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+            return value;
+        }
+    }
+    return null;
+}
+
 export function communityOpenAIBaseUrl(baseUrl: string): string {
     const normalized = normalizeCommunityEndpointBaseUrl(baseUrl);
     for (const suffix of [
         "/chat/completions",
         "/images/generations",
         "/images/edits",
+        "/audio/transcriptions",
+        "/videos/generations",
     ]) {
         if (normalized.endsWith(suffix)) {
             return normalized.slice(0, -suffix.length);
@@ -428,30 +1113,62 @@ export function communityModelDefinition(
         endpoint.imagePricing,
     );
     const isImage = modality === "image";
+    const isTranscription = modality === "transcription";
+    const isVideo = modality === "video";
     // Token-priced image endpoints bill like text models (usage × per-token
     // rates), so only fixed per-request image endpoints are flat-rate.
     const isFlatRateImage = isImage && imagePricing === "request";
+    const inputModalities = normalizeCommunityEndpointInputModalities(
+        endpoint.inputModalities,
+        modality,
+    );
+    const providerName = endpoint.providerName?.trim();
+    const providerUrl = endpoint.providerUrl?.trim();
+    const { capabilities = [], ...advertised } =
+        normalizeCommunityEndpointAdvertised(endpoint.advertised, modality);
     return {
         aliases,
         provider: "community",
-        brand: "Community",
-        category: isImage ? "image" : "text",
+        perUserRpm: endpoint.perUserRpm,
+        brand: providerName || "Community",
+        brandUrl: providerName && providerUrl ? providerUrl : undefined,
+        category: isImage
+            ? "image"
+            : isTranscription
+              ? "audio"
+              : isVideo
+                ? "video"
+                : "text",
         cost: communityPriceDefinition(endpoint, modality, imagePricing),
         priceMultiplier: 1,
-        addedDate: 0,
+        addedDate: endpoint.addedDate ?? 0,
         title: communityEndpointTitle(endpoint),
         description: description || undefined,
-        inputModalities:
-            isImage && endpoint.supportsImageEdits
-                ? ["text", "image"]
-                : ["text"],
-        outputModalities: isImage ? ["image"] : ["text"],
-        paidOnly: false,
+        inputModalities,
+        outputModalities: isImage ? ["image"] : isVideo ? ["video"] : ["text"],
+        hidden: endpoint.hidden,
+        ...(endpoint.fallbacks?.length
+            ? { fallbacks: endpoint.fallbacks }
+            : {}),
+        ...(isTranscription
+            ? { supportedEndpoints: ["/v1/audio/transcriptions"] }
+            : isVideo
+              ? {
+                    supportedEndpoints: [
+                        "/v1/videos/generations",
+                        "/image/{prompt}",
+                    ],
+                }
+              : {}),
+        paidOnly: endpoint.paidOnly ?? false,
         alpha: true,
         // Explicit false (not omitted) for token-priced image endpoints: the
         // catalog only renders per-1M prices when flat_rate === false or a
         // prompt token price is set.
         ...(isImage ? { flatRate: isFlatRateImage } : {}),
+        ...(capabilities.includes("tool_calling") ? { tools: true } : {}),
+        ...(capabilities.includes("reasoning") ? { reasoning: true } : {}),
+        ...advertised,
     };
 }
 


### PR DESCRIPTION
## Summary

- Adds `"video"` to `COMMUNITY_ENDPOINT_MODALITIES` so publishers can register video-generation models
- Adds `COMMUNITY_VIDEO_PRICE_FIELD` (`completionVideoPrice` → `completionVideoSeconds`, unit `"video_second"`) with `MAX_COMMUNITY_PRICE_PER_VIDEO_SECOND = 0.5` Pollen ceiling
- Adds `communityVideoGenerationsUrl()` helper (maps to `/v1/videos/generations`) and `firstCommunityVideoData()` extractor (reads `data[].url|b64_json` + `data[].duration_seconds`)
- Routes community video endpoints through `callCommunityVideoEndpoint` in the gen handler; registration probe via `testCommunityVideoEndpoint` in the enter service
- Community video models appear in the public catalog with category `"video"`, outputModalities `["video"]`, and supported endpoints `["/v1/videos/generations", "/image/{prompt}"]`
- Billing is per-second (`completionVideoSeconds`) extracted from `duration_seconds` in the endpoint response; registration is rejected if the field is missing
- Tests cover model definition, price ceiling, URL construction, billing for URL and base64 responses, zero-duration rejection, and upstream error propagation

## Test plan

- [ ] Unit tests pass: `npm test --workspace pollinations-gen` and `npm run typecheck --workspace pollinations-gen`
- [ ] Register a community video endpoint via `POST /community-endpoints` with `modality: "video"` — verify probe succeeds and model appears in catalog
- [ ] Generate via the video route — verify response is a playable video and Pollen deducted reflects `completionVideoSeconds`
- [ ] Confirm price ceiling is enforced: setting `completionVideoPrice > 0.5` returns 400

Fixes #13906

🤖 Generated with [Claude Code](https://claude.com/claude-code)