### PR TITLE
feat: show context window length in model cards

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/model-catalog.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-catalog.ts
@@ -263,6 +263,7 @@ function baseModelPrice(model: ApiModelInfo): ModelPrice | null {
             outputSortPrice === undefined,
         alpha: model.alpha,
         addedDate: model.added_date,
+        contextLength: model.context_length,
         inputSortPrice,
         outputSortPrice,
         prices: [],

--- a/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
@@ -309,6 +309,17 @@ export const ModelRow: FC<ModelRowProps> = ({ model }) => {
                             {model.brand}
                         </a>
                     )}
+                    {model.contextLength && (
+                        <span className="text-[11px] text-theme-text-muted">
+                            {model.contextLength >= 1000000
+                                ? `${(model.contextLength / 1000000).toFixed(1)}M`
+                                : model.contextLength >= 1000
+                                  ? `${Math.round(model.contextLength / 1000)}K`
+                                  : model.contextLength}{" "}
+                            context
+                        </span>
+                    )}
+
                     <div className="flex min-w-0 flex-col gap-0.5">
                         {(inputModalities.length > 0 ||
                             capabilities.length > 0 ||

--- a/enter.pollinations.ai/frontend/src/components/models/types.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/types.ts
@@ -83,6 +83,7 @@ export type ModelPrice = {
     free?: boolean;
     alpha?: boolean;
     addedDate?: number;
+    contextLength?: number;
     inputSortPrice?: number;
     outputSortPrice?: number;
     prices: ModelPriceLine[];


### PR DESCRIPTION
## Summary

Show the context window length in model catalog cards when available.

## Changes

- Added `contextLength` to `ModelPrice` type
- Mapped `context_length` from API response through catalog-to-dashboard pipeline
- Display context length as human-readable text (e.g. "128K context", "1.0M context") below the brand link

## How it works

1. API response includes `context_length` field for supported models
2. `model-catalog.ts` maps it to `contextLength` on ModelPrice
3. `model-row.tsx` renders it as a compact text label

Context length is only shown when the API provides it — no empty states or fallbacks.

Closes #13905