### PR TITLE
feat: add Try in Play action on model cards

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
@@ -286,6 +286,29 @@ export const ModelRow: FC<ModelRowProps> = ({ model }) => {
                             {model.brand}
                         </a>
                     )}
+                    {model.contextLength && (
+                        <span className="text-[11px] text-theme-text-muted">
+                            {model.contextLength >= 1000000
+                                ? `${(model.contextLength / 1000000).toFixed(1)}M`
+                                : model.contextLength >= 1000
+                                  ? `${Math.round(model.contextLength / 1000)}K`
+                                  : model.contextLength}{" "}
+                            context
+                        </span>
+                    )}
+
+                    {model.type !== "embedding" && model.type !== "agent" && (
+                        <a
+                            href={`https://pollinations.ai/play?model=${encodeURIComponent(model.name)}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center gap-1 text-[11px] text-theme-text-muted hover:text-theme-text-soft transition-colors"
+                            title="Try in Play"
+                            aria-label={`Try ${model.displayName ?? model.name} in Play`}
+                        >
+                            ▶ Play
+                        </a>
+                    )}
                     <div className="flex min-w-0 flex-col gap-0.5">
                         {(inputModalities.length > 0 ||
                             capabilities.length > 0 ||

--- a/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
@@ -297,7 +297,7 @@ export const ModelRow: FC<ModelRowProps> = ({ model }) => {
                         </span>
                     )}
 
-                    {model.type !== "embedding" && model.type !== "agent" && (
+                    {model.type !== "embedding" && !model.agent && (
                         <a
                             href={`https://pollinations.ai/play?model=${encodeURIComponent(model.name)}`}
                             target="_blank"

--- a/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
@@ -286,17 +286,6 @@ export const ModelRow: FC<ModelRowProps> = ({ model }) => {
                             {model.brand}
                         </a>
                     )}
-                    {model.contextLength && (
-                        <span className="text-[11px] text-theme-text-muted">
-                            {model.contextLength >= 1000000
-                                ? `${(model.contextLength / 1000000).toFixed(1)}M`
-                                : model.contextLength >= 1000
-                                  ? `${Math.round(model.contextLength / 1000)}K`
-                                  : model.contextLength}{" "}
-                            context
-                        </span>
-                    )}
-
                     {model.type !== "embedding" && !model.agent && (
                         <a
                             href={`https://pollinations.ai/play?model=${encodeURIComponent(model.name)}`}

--- a/pollinations.ai/src/ui/pages/PlayPage.tsx
+++ b/pollinations.ai/src/ui/pages/PlayPage.tsx
@@ -14,7 +14,8 @@ import { PageContainer } from "../components/ui/page-container";
 import { Body, Title } from "../components/ui/typography";
 
 function PlayPage() {
-    const [selectedModel, setSelectedModel] = useState("flux");
+    const urlModel = new URLSearchParams(window.location.search).get("model");
+    const [selectedModel, setSelectedModel] = useState(urlModel || "flux");
     const [prompt, setPrompt] = useState("");
     const { apiKey, isLoggedIn, login } = useAuth();
     const {


### PR DESCRIPTION
## Summary

Add a compact "Try in Play" link on each model card that opens the Play page with the model preselected.

## Changes

### Model cards (`model-row.tsx`)
- Added `▶ Play` link on each model card (except embedding/agent types)
- Opens `https://pollinations.ai/play?model=<model-id>` in new tab
- Compact text link with tooltip and accessible label

### Play page (`PlayPage.tsx`)
- Reads `?model=` query parameter from URL
- Preselects the model in the model selector

## How it works

1. User clicks `▶ Play` on any model card
2. New tab opens with `/play?model=<model-id>`
3. PlayPage reads the URL param and sets initial model selection

Closes #13903