### PR TITLE
feat: show context window and video duration in Models dashboard

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/model-catalog.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-catalog.ts
@@ -57,6 +57,9 @@ export type ApiModelInfo = {
     tools?: boolean;
     reasoning?: boolean;
     context_length?: number;
+    min_duration?: number;
+    max_duration?: number;
+    default_duration?: number;
     voices?: string[];
     is_specialized?: boolean;
     paid_only?: boolean;
@@ -249,6 +252,17 @@ function baseModelPrice(model: ApiModelInfo): ModelPrice | null {
         agent: model.agent,
         baseModel: model.base_model,
         perUserRpm: model.per_user_rpm,
+        contextLength: model.context_length,
+        duration:
+            model.min_duration !== undefined ||
+            model.max_duration !== undefined ||
+            model.default_duration !== undefined
+                ? {
+                      min: model.min_duration,
+                      max: model.max_duration,
+                      default: model.default_duration,
+                  }
+                : undefined,
         displayName: getCatalogDisplayName(model, name),
         description: getCatalogDescriptionWithoutName(model),
         brand: model.brand,

--- a/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
@@ -41,6 +41,35 @@ import {
 } from "./price-badge.tsx";
 import type { ModelPrice } from "./types.ts";
 
+function stripTrailingZeros(value: number): string {
+    return String(Number(value.toFixed(2)));
+}
+
+function formatContextLimit(contextLength: number): string {
+    if (contextLength >= 1_000_000)
+        return `${stripTrailingZeros(contextLength / 1_000_000)}M`;
+    if (contextLength >= 1_000)
+        return `${stripTrailingZeros(contextLength / 1_000)}K`;
+    return String(contextLength);
+}
+
+function formatDurationLimit(seconds: number): string {
+    return `${stripTrailingZeros(seconds)}s`;
+}
+
+function getVideoDurationLabel(
+    duration: NonNullable<ModelPrice["duration"]>,
+): string | null {
+    const hasRange =
+        duration.min != null &&
+        duration.max != null &&
+        duration.min !== duration.max;
+    if (hasRange)
+        return `${formatDurationLimit(duration.min as number)}–${formatDurationLimit(duration.max as number)}`;
+    const fixed = duration.min ?? duration.max ?? duration.default;
+    return fixed != null ? formatDurationLimit(fixed) : null;
+}
+
 type ModelRowProps = {
     model: ModelPrice;
 };
@@ -276,6 +305,24 @@ export const ModelRow: FC<ModelRowProps> = ({ model }) => {
                         )}
                     </div>
                     <ModelId name={model.name} />
+                    {(model.contextLength != null || model.duration) && (
+                        <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-theme-text-muted">
+                            {model.contextLength != null && (
+                                <span>
+                                    {formatContextLimit(model.contextLength)}{" "}
+                                    context
+                                </span>
+                            )}
+                            {(() => {
+                                const durationLabel = model.duration
+                                    ? getVideoDurationLabel(model.duration)
+                                    : null;
+                                return durationLabel ? (
+                                    <span>{durationLabel}</span>
+                                ) : null;
+                            })()}
+                        </div>
+                    )}
                     {model.brandUrl && model.brand && (
                         <a
                             href={model.brandUrl}

--- a/enter.pollinations.ai/frontend/src/components/models/types.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/types.ts
@@ -68,6 +68,14 @@ export type ModelPriceAdjustment = {
 export type ModelPrice = {
     name: string;
     type: ModelCategory;
+    /** Maximum prompt + completion window in tokens, when advertised. */
+    contextLength?: number;
+    /** Advertised video duration limits in seconds. */
+    duration?: {
+        min?: number;
+        max?: number;
+        default?: number;
+    };
     community?: boolean;
     agent?: boolean;
     baseModel?: string;


### PR DESCRIPTION
Closes #13905

## Changes
- Preserves `context_length`, `min_duration`, `max_duration`, and `default_duration` through the existing catalog-to-dashboard mapping (`ApiModelInfo` → `ModelPrice`).
- Renders a compact, muted limit line under each model id: context window (e.g. `128K context`) and the advertised video duration range or fixed value (e.g. `5–10s`), only when the metadata exists.
- No API, registry, pricing, sorting, or filtering changes.

## Test plan
- `/models` dashboard: text models with `context_length` show e.g. `128K context`; video models with duration metadata show their range/fixed duration; models without metadata render unchanged.