### PR TITLE
chore: sync main into production

### DIFF
--- a/.github/workflows/deploy-cloudflare-production.yml
+++ b/.github/workflows/deploy-cloudflare-production.yml
@@ -27,6 +27,10 @@ on:
           - gen
           - media
         default: all
+      sync_discord_secrets:
+        description: 'Sync the approved Discord secrets to Enter'
+        type: boolean
+        default: false
 
 concurrency:
   group: pollinations-cloudflare-production
@@ -189,10 +193,25 @@ jobs:
       - name: Install root dependencies
         run: npm ci
 
+      - name: Setup SOPS
+        if: github.event_name == 'workflow_dispatch' && inputs.sync_discord_secrets
+        uses: nhedger/setup-sops@v2
+
       - name: Build and deploy to Cloudflare
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_MYCELI }}
         run: npm run deploy:production --workspace pollinations-enter
+
+      - name: Push Discord secrets
+        if: github.event_name == 'workflow_dispatch' && inputs.sync_discord_secrets
+        env:
+          SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_MYCELI }}
+        run: >-
+          sops exec-file --no-fifo enter.pollinations.ai/secrets/prod.vars.json
+          'jq "{DISCORD_CLIENT_ID, DISCORD_CLIENT_SECRET, DISCORD_BOT_TOKEN}" {}
+          | npx wrangler secret bulk - --env production
+          --config enter.pollinations.ai/wrangler.toml'
 
   deploy-gen:
     needs: [changes, migrate, deploy-mcp-apps]

--- a/enter.pollinations.ai/frontend/src/routes/_dashboard.account.tsx
+++ b/enter.pollinations.ai/frontend/src/routes/_dashboard.account.tsx
@@ -3,6 +3,7 @@ import {
     Button,
     CopyButton,
     Dialog,
+    DiscordIcon,
     FieldStack,
     GitHubIcon,
     Heading,
@@ -13,11 +14,20 @@ import {
     Text,
 } from "@pollinations/ui";
 import { createFileRoute, redirect } from "@tanstack/react-router";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { apiClient } from "../api.ts";
 import { authClient } from "../auth.ts";
 import { Route as DashboardRoute } from "./_dashboard.tsx";
 
 const DELETE_CONFIRMATION = "DELETE";
+
+type DiscordConnection = {
+    id: string;
+    username: string | null;
+    displayName: string | null;
+    avatarUrl: string | null;
+    isPollinationsMember: boolean | null;
+};
 
 export const Route = createFileRoute("/_dashboard/account")({
     beforeLoad: ({ context, location }) => {
@@ -32,12 +42,100 @@ export const Route = createFileRoute("/_dashboard/account")({
 });
 
 function AccountPage() {
-    const { user, githubUsername } = DashboardRoute.useLoaderData();
+    const { user, githubUsername, discordAvailable } =
+        DashboardRoute.useLoaderData();
     const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+    const [discordConnection, setDiscordConnection] = useState<
+        DiscordConnection | null | undefined
+    >();
+    const [connectionPending, setConnectionPending] = useState(false);
+    const [connectionError, setConnectionError] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (!discordAvailable) return;
+        void (async () => {
+            try {
+                const { data, error } = await authClient.listAccounts();
+                if (error) throw error;
+
+                const account = data?.find(
+                    (account) => account.providerId === "discord",
+                );
+                if (!account) {
+                    setDiscordConnection(null);
+                    return;
+                }
+
+                const [infoResponse, membershipResponse] = await Promise.all([
+                    authClient
+                        .accountInfo({
+                            query: { accountId: account.accountId },
+                        })
+                        .catch(() => null),
+                    apiClient.account["discord-membership"]
+                        .$get()
+                        .catch(() => null),
+                ]);
+                const info = infoResponse?.data;
+                const membership = membershipResponse?.ok
+                    ? await membershipResponse.json().catch(() => null)
+                    : null;
+                const profile = info?.data as
+                    | { username?: unknown }
+                    | undefined;
+                setDiscordConnection({
+                    id: account.accountId,
+                    username:
+                        typeof profile?.username === "string"
+                            ? profile.username
+                            : null,
+                    displayName: info?.user.name || null,
+                    avatarUrl: info?.user.image || null,
+                    isPollinationsMember: membership?.member ?? null,
+                });
+            } catch {
+                setConnectionError("Could not load connected accounts.");
+                setDiscordConnection(null);
+            }
+        })();
+    }, [discordAvailable]);
 
     if (!user) return null;
 
     const displayName = user.name || githubUsername || "Pollinations user";
+
+    async function handleDiscordConnection(): Promise<void> {
+        setConnectionPending(true);
+        setConnectionError(null);
+
+        try {
+            if (discordConnection) {
+                const { error } = await authClient.unlinkAccount({
+                    providerId: "discord",
+                });
+                if (error) {
+                    setConnectionError("Could not disconnect Discord.");
+                } else {
+                    setDiscordConnection(null);
+                }
+                return;
+            }
+
+            const { error } = await authClient.linkSocial({
+                provider: "discord",
+                callbackURL: "/account",
+            });
+            if (error) setConnectionError("Could not connect Discord.");
+        } catch {
+            setConnectionError(
+                discordConnection
+                    ? "Could not disconnect Discord."
+                    : "Could not connect Discord.",
+            );
+        } finally {
+            setConnectionPending(false);
+        }
+    }
 
     return (
         <div className="flex flex-col gap-6">
@@ -105,6 +203,82 @@ function AccountPage() {
                     </CopyButton>
                 </Surface>
             </Section>
+
+            {discordAvailable && (
+                <Section title="Connected accounts" framed>
+                    <Surface
+                        variant="card"
+                        className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+                    >
+                        <div className="flex items-center gap-3">
+                            {discordConnection?.avatarUrl ? (
+                                <img
+                                    src={discordConnection.avatarUrl}
+                                    alt="Discord avatar"
+                                    className="h-10 w-10 shrink-0 rounded-full"
+                                />
+                            ) : (
+                                <DiscordIcon className="h-6 w-6 shrink-0" />
+                            )}
+                            <div>
+                                <Text tone="strong" weight="semibold">
+                                    Discord
+                                </Text>
+                                <Text size="sm" tone="muted">
+                                    {discordConnection
+                                        ? [
+                                              discordConnection.displayName,
+                                              discordConnection.username &&
+                                                  `@${discordConnection.username}`,
+                                          ]
+                                              .filter(Boolean)
+                                              .join(" · ")
+                                        : discordConnection === undefined
+                                          ? "Checking connection..."
+                                          : "Connect your Discord identity for community features."}
+                                </Text>
+                                {discordConnection && (
+                                    <>
+                                        <Text size="sm" tone="muted">
+                                            Discord ID: {discordConnection.id}
+                                        </Text>
+                                        {discordConnection.isPollinationsMember !==
+                                            null && (
+                                            <Text size="sm" tone="muted">
+                                                {discordConnection.isPollinationsMember
+                                                    ? "Member of the Pollinations Discord"
+                                                    : "Not a member of the Pollinations Discord"}
+                                            </Text>
+                                        )}
+                                    </>
+                                )}
+                            </div>
+                        </div>
+                        <Button
+                            type="button"
+                            className="shrink-0 self-start sm:self-center"
+                            disabled={
+                                discordConnection === undefined ||
+                                connectionPending
+                            }
+                            onClick={() => void handleDiscordConnection()}
+                        >
+                            {connectionPending
+                                ? "Working..."
+                                : discordConnection
+                                  ? "Disconnect Discord"
+                                  : discordConnection === undefined
+                                    ? "Checking..."
+                                    : "Connect Discord"}
+                        </Button>
+                    </Surface>
+                    {connectionError && (
+                        <Text size="sm" tone="muted">
+                            {connectionError}
+                        </Text>
+                    )}
+                </Section>
+            )}
 
             <Section title="Danger zone" framed>
                 <div className="flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">

--- a/enter.pollinations.ai/frontend/src/routes/_dashboard.tsx
+++ b/enter.pollinations.ai/frontend/src/routes/_dashboard.tsx
@@ -45,6 +45,7 @@ export const Route = createFileRoute("/_dashboard")({
                 tierBalance: 0,
                 packBalance: 0,
                 communityEndpointsAllowed: false,
+                discordAvailable: false,
                 billingState: null,
                 paidWeek: 0,
                 tierWeek: 0,
@@ -89,6 +90,7 @@ export const Route = createFileRoute("/_dashboard")({
             packBalance: d1BalanceResult?.packBalance ?? 0,
             communityEndpointsAllowed:
                 profileResult?.communityEndpointsAllowed ?? false,
+            discordAvailable: profileResult?.discordAvailable ?? false,
             billingState,
             paidWeek: earningsTodayResult?.paidWeek ?? 0,
             tierWeek: earningsTodayResult?.tierWeek ?? 0,

--- a/enter.pollinations.ai/src/auth.ts
+++ b/enter.pollinations.ai/src/auth.ts
@@ -5,7 +5,10 @@ import {
     StagingAccessDeniedError,
 } from "@shared/auth/api-key.ts";
 import * as betterAuthSchema from "@shared/db/better-auth.ts";
-import { user as userTable } from "@shared/db/better-auth.ts";
+import {
+    account as accountTable,
+    user as userTable,
+} from "@shared/db/better-auth.ts";
 import {
     getInstallationToken,
     githubAppCredentialsFromEnv,
@@ -25,14 +28,36 @@ import {
     getSessionFromCtx,
 } from "better-auth/api";
 import { admin, openAPI } from "better-auth/plugins";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
+import { discordConfigFromEnv } from "./services/discord.ts";
 
 const DELETE_ACCOUNT_FRESH_SESSION_MS = 10 * 60 * 1000;
 
 export function createAuth(env: Cloudflare.Env, ctx?: ExecutionContext) {
     const db = drizzle(env.DB);
     const apiKeyPlugin = createApiKeyPlugin();
+    const discordConfig = discordConfigFromEnv(env);
+
+    const hasDiscordAccount = async (userId: string) => {
+        const [account] = await db
+            .select({ id: accountTable.id })
+            .from(accountTable)
+            .where(
+                and(
+                    eq(accountTable.userId, userId),
+                    eq(accountTable.providerId, "discord"),
+                ),
+            )
+            .limit(1);
+        return Boolean(account);
+    };
+
+    const discordAccountAlreadyConnected = () =>
+        new APIError("BAD_REQUEST", {
+            code: "DISCORD_ACCOUNT_ALREADY_CONNECTED",
+            message: "Only one Discord account can be connected.",
+        });
 
     const adminPlugin = admin({
         adminUserIds: ["Py5RZYN9c10OsC1fjUYiqMYjttf0PLGv"],
@@ -57,6 +82,24 @@ export function createAuth(env: Cloudflare.Env, ctx?: ExecutionContext) {
             // scales freshAge by 1e3 twice (update-user.mjs), so the threshold
             // lands ~1000x too high and never fires. Enforce it here instead.
             before: createAuthMiddleware(async (authContext) => {
+                if (
+                    authContext.path === "/sign-in/social" &&
+                    authContext.body.provider === "discord"
+                ) {
+                    throw new APIError("BAD_REQUEST", {
+                        message:
+                            "Discord can only be connected to an existing Pollinations account.",
+                    });
+                }
+                if (
+                    authContext.path === "/link-social" &&
+                    authContext.body.provider === "discord"
+                ) {
+                    const session = await getSessionFromCtx(authContext);
+                    if (session && (await hasDiscordAccount(session.user.id))) {
+                        throw discordAccountAlreadyConnected();
+                    }
+                }
                 if (authContext.path !== "/delete-user") return;
 
                 const session = await getSessionFromCtx(authContext);
@@ -81,6 +124,20 @@ export function createAuth(env: Cloudflare.Env, ctx?: ExecutionContext) {
             schema: betterAuthSchema,
             provider: "sqlite",
         }),
+        databaseHooks: {
+            account: {
+                create: {
+                    before: async (account) => {
+                        if (
+                            account.providerId === "discord" &&
+                            (await hasDiscordAccount(account.userId))
+                        ) {
+                            throw discordAccountAlreadyConnected();
+                        }
+                    },
+                },
+            },
+        },
         advanced: {
             // Configure background tasks for Cloudflare Workers
             // Required for deferUpdates to work properly
@@ -110,6 +167,15 @@ export function createAuth(env: Cloudflare.Env, ctx?: ExecutionContext) {
                 enabled: true,
             },
         },
+        account: {
+            accountLinking: {
+                allowDifferentEmails: true,
+                // Better Auth 1.4 requires this for Discord accounts without a
+                // verified email. The sign-in hook above still limits Discord
+                // to explicit, authenticated linkSocial flows.
+                trustedProviders: discordConfig ? ["discord"] : [],
+            },
+        },
         socialProviders: {
             github: {
                 clientId: env.GITHUB_CLIENT_ID,
@@ -119,6 +185,18 @@ export function createAuth(env: Cloudflare.Env, ctx?: ExecutionContext) {
                     githubUsername: profile.login,
                 }),
             },
+            ...(discordConfig && {
+                discord: {
+                    clientId: discordConfig.clientId,
+                    clientSecret: discordConfig.clientSecret,
+                    disableSignUp: true,
+                    mapProfileToUser: (profile) => ({
+                        // Better Auth requires an email even when explicitly
+                        // linking a phone-only Discord account.
+                        email: profile.email ?? `${profile.id}@discord.invalid`,
+                    }),
+                },
+            }),
         },
         plugins: [
             adminPlugin,

--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -29,6 +29,12 @@ import { describeRoute, resolver } from "hono-openapi";
 import { z } from "zod";
 import type { Env } from "../env.ts";
 import { auth } from "../middleware/auth.ts";
+import {
+    type DiscordMembership,
+    DiscordRateLimitError,
+    discordConfigFromEnv,
+    getPollinationsDiscordMembership,
+} from "../services/discord.ts";
 import { QUEST_CATEGORIES } from "../services/quests/definitions.ts";
 import { listQuestCards } from "../services/quests/index.ts";
 import {
@@ -648,6 +654,9 @@ const profileResponseSchema = z.object({
         .describe(
             "Whether the account is allowed to manage community endpoints.",
         ),
+    discordAvailable: z
+        .boolean()
+        .describe("Whether Discord account connections are available."),
     name: z
         .string()
         .nullable()
@@ -662,6 +671,11 @@ const profileResponseSchema = z.object({
         .describe(
             "User's email address (only returned when the key has `account:profile` or `account:keys`)",
         ),
+});
+
+const discordMembershipResponseSchema = z.object({
+    member: z.boolean(),
+    joinedAt: z.string().nullable(),
 });
 
 const accountBalanceSchema = z.object({
@@ -802,6 +816,70 @@ export const accountRoutes = new Hono<Env>()
     .route("/agents", agentsRoutes)
     .route("/my-models", communityEndpointsRoutes)
     .get(
+        "/discord-membership",
+        describeRoute({
+            tags: ["👤 Account"],
+            summary: "Check Discord Membership",
+            description:
+                "Checks whether the linked Discord account belongs to the Pollinations Discord server.",
+            responses: {
+                200: {
+                    description: "Discord membership status",
+                    content: {
+                        "application/json": {
+                            schema: resolver(discordMembershipResponseSchema),
+                        },
+                    },
+                },
+                401: { description: "Unauthorized" },
+                403: { description: "Dashboard session required" },
+                404: { description: "Discord account not connected" },
+                429: { description: "Discord membership check rate limited" },
+                502: { description: "Discord membership check failed" },
+            },
+        }),
+        async (c) => {
+            await c.var.auth.requireAuthorization();
+            if (!c.var.auth.session) {
+                throw new HTTPException(403, {
+                    message:
+                        "Discord membership checks require a dashboard session",
+                });
+            }
+            const user = c.var.auth.requireUser();
+            let membership: DiscordMembership | null;
+            try {
+                membership = await getPollinationsDiscordMembership(
+                    c.env,
+                    user.id,
+                );
+            } catch (error) {
+                if (error instanceof DiscordRateLimitError) {
+                    return c.json(
+                        {
+                            error: "rate_limited",
+                            message: "Discord membership check rate limited",
+                        },
+                        429,
+                        {
+                            "Retry-After": String(error.retryAfterSeconds),
+                        },
+                    );
+                }
+                throw new HTTPException(502, {
+                    message: "Discord membership check failed",
+                });
+            }
+
+            if (!membership) {
+                throw new HTTPException(404, {
+                    message: "Discord account not connected",
+                });
+            }
+            return c.json(membership);
+        },
+    )
+    .get(
         "/profile",
         describeRoute({
             tags: ["👤 Account"],
@@ -849,6 +927,7 @@ export const accountRoutes = new Hono<Env>()
                 image: profile.image ?? null,
                 communityEndpointsAllowed:
                     isCommunityEndpointOwnerAllowed(profile),
+                discordAvailable: Boolean(discordConfigFromEnv(c.env)),
                 ...(includeProfilePII && {
                     name: profile.name ?? null,
                     email: profile.email ?? null,

--- a/enter.pollinations.ai/src/routes/quests.ts
+++ b/enter.pollinations.ai/src/routes/quests.ts
@@ -18,9 +18,8 @@ import type {
 } from "../services/quests/types.ts";
 import { requireAccountPermission } from "./account-permissions.ts";
 
-// Bumped to v26: established GitHub, app_paid_request, and app_users_10 are
-// available; Early Adopter and app_pollen_10 are visible as coming soon.
-const CACHE_KEY = "quests:catalog:v26";
+// Bumped to v29: the Discord quest links to account connection and the server.
+const CACHE_KEY = "quests:catalog:v29";
 const CACHE_TTL = 60;
 const QUEST_CHECK_THROTTLE_SECONDS = 60;
 

--- a/enter.pollinations.ai/src/services/discord.ts
+++ b/enter.pollinations.ai/src/services/discord.ts
@@ -1,0 +1,118 @@
+const POLLINATIONS_DISCORD_GUILD_ID = "885844321461485618";
+const DISCORD_MEMBERSHIP_CACHE_TTL_SECONDS = 60;
+
+type DiscordBindings = CloudflareBindings & {
+    DISCORD_CLIENT_ID?: string;
+    DISCORD_CLIENT_SECRET?: string;
+    DISCORD_BOT_TOKEN?: string;
+};
+
+type DiscordConfig = {
+    clientId: string;
+    clientSecret: string;
+    botToken: string;
+};
+
+export type DiscordMembership = {
+    member: boolean;
+    joinedAt: string | null;
+};
+
+export class DiscordRateLimitError extends Error {
+    constructor(readonly retryAfterSeconds: number) {
+        super("Discord membership lookup is rate limited");
+        this.name = "DiscordRateLimitError";
+    }
+}
+
+export function discordConfigFromEnv(env: object): DiscordConfig | null {
+    const bindings = env as DiscordBindings;
+    const clientId = bindings.DISCORD_CLIENT_ID?.trim();
+    const clientSecret = bindings.DISCORD_CLIENT_SECRET?.trim();
+    const botToken = bindings.DISCORD_BOT_TOKEN?.trim();
+    return clientId && clientSecret && botToken
+        ? { clientId, clientSecret, botToken }
+        : null;
+}
+
+export async function getPollinationsDiscordMembership(
+    env: CloudflareBindings,
+    userId: string,
+): Promise<DiscordMembership | null> {
+    const config = discordConfigFromEnv(env);
+    if (!config) return null;
+
+    const account = await env.DB.prepare(
+        `SELECT account_id AS accountId
+         FROM account
+         WHERE user_id = ? AND provider_id = 'discord'
+         LIMIT 1`,
+    )
+        .bind(userId)
+        .first<{ accountId: string }>();
+
+    if (!account) return null;
+
+    const cacheKey = `discord:membership:${account.accountId}`;
+    const cached = await env.KV.get<DiscordMembership>(cacheKey, "json").catch(
+        () => null,
+    );
+    if (cached) return cached;
+
+    const response = await fetch(
+        `https://discord.com/api/v10/guilds/${POLLINATIONS_DISCORD_GUILD_ID}/members/${account.accountId}`,
+        {
+            headers: {
+                Authorization: `Bot ${config.botToken}`,
+            },
+        },
+    );
+
+    if (response.status === 429) {
+        const body = (await response.json().catch(() => null)) as {
+            retry_after?: unknown;
+        } | null;
+        const headerSeconds = Number(response.headers.get("Retry-After"));
+        const bodySeconds = Number(body?.retry_after);
+        const retryAfterSeconds = Math.max(
+            1,
+            Math.ceil(
+                Number.isFinite(headerSeconds) && headerSeconds > 0
+                    ? headerSeconds
+                    : Number.isFinite(bodySeconds) && bodySeconds > 0
+                      ? bodySeconds
+                      : 1,
+            ),
+        );
+        throw new DiscordRateLimitError(retryAfterSeconds);
+    }
+
+    if (response.status === 404) {
+        const body = (await response.json().catch(() => null)) as {
+            code?: unknown;
+        } | null;
+        if (body?.code !== 10007) {
+            throw new Error(
+                `Discord membership check failed: 404 code=${String(body?.code ?? "unknown")}`,
+            );
+        }
+        const membership = { member: false, joinedAt: null };
+        await env.KV.put(cacheKey, JSON.stringify(membership), {
+            expirationTtl: DISCORD_MEMBERSHIP_CACHE_TTL_SECONDS,
+        }).catch(() => undefined);
+        return membership;
+    }
+    if (!response.ok) {
+        throw new Error(`Discord membership check failed: ${response.status}`);
+    }
+
+    const member = (await response.json()) as { joined_at?: string };
+    const membership = {
+        member: true,
+        joinedAt: member.joined_at ?? null,
+    };
+    await env.KV.put(cacheKey, JSON.stringify(membership), {
+        expirationTtl: DISCORD_MEMBERSHIP_CACHE_TTL_SECONDS,
+    }).catch(() => undefined);
+    return membership;
+}

--- a/enter.pollinations.ai/src/services/quests/groups/discord-community.ts
+++ b/enter.pollinations.ai/src/services/quests/groups/discord-community.ts
@@ -1,0 +1,43 @@
+import {
+    discordConfigFromEnv,
+    getPollinationsDiscordMembership,
+} from "../../discord.ts";
+import type { QuestDefinition } from "../definitions.ts";
+import {
+    type QuestCard,
+    type QuestEvaluation,
+    type QuestEvaluationContext,
+    type QuestUser,
+    questToCard,
+} from "../types.ts";
+
+const joinDiscordQuest: QuestDefinition = {
+    id: "join_discord",
+    title: "Join the Pollinations Discord",
+    description:
+        "[Connect Discord](/account), then [join the Pollinations community server](https://discord.gg/pollinations-ai-885844321461485618).",
+    category: "community",
+    scope: "perUser",
+    rewardAmount: 1,
+    balanceBucket: "tier",
+    url: "https://discord.gg/pollinations-ai-885844321461485618",
+};
+
+export async function listQuestCards({
+    env,
+}: QuestEvaluationContext): Promise<QuestCard[]> {
+    return discordConfigFromEnv(env) ? [questToCard(joinDiscordQuest)] : [];
+}
+
+export async function evaluateUser(
+    { env }: QuestEvaluationContext,
+    user: QuestUser,
+): Promise<QuestEvaluation> {
+    if (!discordConfigFromEnv(env)) return { proposals: [] };
+    const membership = await getPollinationsDiscordMembership(env, user.id);
+    return {
+        proposals: membership?.member
+            ? [{ quest: joinDiscordQuest, userId: user.id }]
+            : [],
+    };
+}

--- a/enter.pollinations.ai/src/services/quests/index.ts
+++ b/enter.pollinations.ai/src/services/quests/index.ts
@@ -1,5 +1,6 @@
 import * as accountSetup from "./groups/account-setup.ts";
 import * as appGrowth from "./groups/app-growth.ts";
+import * as discordCommunity from "./groups/discord-community.ts";
 import * as githubContributions from "./groups/github-contributions.ts";
 import * as githubProfile from "./groups/github-profile.ts";
 import * as identity from "./groups/identity.ts";
@@ -9,6 +10,7 @@ import type { QuestCard, QuestEvaluationContext, QuestGroup } from "./types.ts";
 export const QUEST_GROUPS: QuestGroup[] = [
     { id: "account-setup", ...accountSetup },
     { id: "app-growth", ...appGrowth },
+    { id: "discord-community", ...discordCommunity },
     { id: "model-usage", ...modelUsage },
     { id: "github-profile", ...githubProfile },
     { id: "github-contributions", ...githubContributions },

--- a/enter.pollinations.ai/test/fixtures.ts
+++ b/enter.pollinations.ai/test/fixtures.ts
@@ -12,6 +12,7 @@ import { createAuthClient } from "better-auth/client";
 import { adminClient, apiKeyClient } from "better-auth/client/plugins";
 import { drizzle } from "drizzle-orm/d1";
 import { test as base, expect } from "vitest";
+import { createMockDiscord } from "./mocks/discord.ts";
 import { createMockGithub } from "./mocks/github.ts";
 import { createMockStripe } from "./mocks/stripe.ts";
 
@@ -27,6 +28,7 @@ const createAuthClientInstance = () =>
 
 const createMocks = () => ({
     tinybird: createMockTinybird(),
+    discord: createMockDiscord(),
     github: createMockGithub(),
     stripe: createMockStripe(),
 });

--- a/enter.pollinations.ai/test/integration/account-linking.test.ts
+++ b/enter.pollinations.ai/test/integration/account-linking.test.ts
@@ -1,0 +1,293 @@
+import { env, SELF } from "cloudflare:test";
+import {
+    account as accountTable,
+    rewards as rewardsTable,
+    user as userTable,
+} from "@shared/db/better-auth.ts";
+import { and, eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import { expect } from "vitest";
+import { createAuth } from "../../src/auth.ts";
+import { discordConfigFromEnv } from "../../src/services/discord.ts";
+import { checkQuestsForUser } from "../../src/services/quest-checker.ts";
+import { test } from "../fixtures.ts";
+
+async function seedDiscordAccount(accountId: string): Promise<string> {
+    const db = drizzle(env.DB);
+    const [user] = await db.select({ id: userTable.id }).from(userTable);
+    if (!user) throw new Error("Expected fixture user");
+    await db.insert(accountTable).values({
+        id: crypto.randomUUID(),
+        accountId,
+        providerId: "discord",
+        userId: user.id,
+    });
+    return user.id;
+}
+
+test("requires complete Discord configuration", () => {
+    expect(
+        discordConfigFromEnv({
+            DISCORD_CLIENT_ID: "client-id",
+            DISCORD_CLIENT_SECRET: "client-secret",
+        }),
+    ).toBeNull();
+    expect(
+        discordConfigFromEnv({
+            DISCORD_CLIENT_ID: "client-id",
+            DISCORD_CLIENT_SECRET: "client-secret",
+            DISCORD_BOT_TOKEN: "bot-token",
+        }),
+    ).not.toBeNull();
+
+    const auth = createAuth({
+        ...env,
+        DISCORD_BOT_TOKEN: "",
+    } as unknown as Cloudflare.Env);
+    expect(auth.options.socialProviders).not.toHaveProperty("discord");
+});
+
+test("links a Discord identity to the signed-in GitHub account", async ({
+    apiKey,
+    mocks,
+    sessionToken,
+}) => {
+    await mocks.enable("discord");
+
+    const linkResponse = await SELF.fetch(
+        "http://localhost:3000/api/auth/link-social",
+        {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Cookie: `better-auth.session_token=${sessionToken}`,
+            },
+            body: JSON.stringify({
+                provider: "discord",
+                callbackURL: "/account",
+            }),
+        },
+    );
+    expect(linkResponse.status).toBe(200);
+
+    const { url } = (await linkResponse.json()) as { url: string };
+    const authorizationUrl = new URL(url);
+    const state = authorizationUrl.searchParams.get("state");
+    expect(
+        authorizationUrl.searchParams.get("scope")?.split(" "),
+    ).not.toContain("guilds.members.read");
+    const stateCookie = linkResponse.headers.get("Set-Cookie");
+    if (!state || !stateCookie) throw new Error("Expected Discord OAuth state");
+
+    const callbackUrl = new URL(
+        "http://localhost:3000/api/auth/callback/discord",
+    );
+    callbackUrl.searchParams.set("code", "discord-test-code");
+    callbackUrl.searchParams.set("state", state);
+
+    const callbackResponse = await SELF.fetch(callbackUrl.toString(), {
+        headers: {
+            Accept: "text/html,application/xhtml+xml",
+            Cookie: `better-auth.session_token=${sessionToken}; ${stateCookie}`,
+            "User-Agent": "Mozilla/5.0 (compatible; test-browser)",
+        },
+        redirect: "manual",
+    });
+
+    expect(callbackResponse.status).toBe(302);
+    expect(callbackResponse.headers.get("Location")).toBe("/account");
+
+    const db = drizzle(env.DB);
+    const [user] = await db.select({ id: userTable.id }).from(userTable);
+    if (!user) throw new Error("Expected fixture user");
+    const discordAccount = (await db.select().from(accountTable)).find(
+        (account) => account.providerId === "discord",
+    );
+
+    expect(discordAccount).toMatchObject({
+        accountId: mocks.discord.state.userId,
+        userId: user?.id,
+    });
+    expect(discordAccount?.accessToken).toBe("mock_discord_access_token");
+    expect(discordAccount?.refreshToken).toBe("mock_discord_refresh_token");
+
+    const secondLinkResponse = await SELF.fetch(
+        "http://localhost:3000/api/auth/link-social",
+        {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Cookie: `better-auth.session_token=${sessionToken}`,
+            },
+            body: JSON.stringify({
+                provider: "discord",
+                callbackURL: "/account",
+            }),
+        },
+    );
+    expect(secondLinkResponse.status).toBe(400);
+    await expect(secondLinkResponse.json()).resolves.toMatchObject({
+        code: "DISCORD_ACCOUNT_ALREADY_CONNECTED",
+    });
+    const discordAccounts = await db
+        .select()
+        .from(accountTable)
+        .where(
+            and(
+                eq(accountTable.userId, user.id),
+                eq(accountTable.providerId, "discord"),
+            ),
+        );
+    expect(discordAccounts).toHaveLength(1);
+
+    const accountInfoResponse = await SELF.fetch(
+        `http://localhost:3000/api/auth/account-info?accountId=${discordAccount?.accountId}`,
+        {
+            headers: {
+                Cookie: `better-auth.session_token=${sessionToken}`,
+            },
+        },
+    );
+    expect(accountInfoResponse.status).toBe(200);
+    await expect(accountInfoResponse.json()).resolves.toMatchObject({
+        data: { username: "discord-test-user" },
+        user: {
+            id: mocks.discord.state.userId,
+            name: "Discord Test User",
+        },
+    });
+
+    const membershipResponse = await SELF.fetch(
+        "http://localhost:3000/api/account/discord-membership",
+        {
+            headers: {
+                Cookie: `better-auth.session_token=${sessionToken}`,
+            },
+        },
+    );
+    expect(membershipResponse.status).toBe(200);
+    await expect(membershipResponse.json()).resolves.toEqual({
+        member: true,
+        joinedAt: "2021-09-10T11:09:04.586000+00:00",
+    });
+    expect(mocks.discord.state.membershipRequestCount).toBe(1);
+
+    const cachedMembershipResponse = await SELF.fetch(
+        "http://localhost:3000/api/account/discord-membership",
+        {
+            headers: {
+                Cookie: `better-auth.session_token=${sessionToken}`,
+            },
+        },
+    );
+    expect(cachedMembershipResponse.status).toBe(200);
+    expect(mocks.discord.state.membershipRequestCount).toBe(1);
+
+    const apiKeyResponse = await SELF.fetch(
+        "http://localhost:3000/api/account/discord-membership",
+        { headers: { Authorization: `Bearer ${apiKey}` } },
+    );
+    expect(apiKeyResponse.status).toBe(403);
+    expect(mocks.discord.state.membershipRequestCount).toBe(1);
+
+    await checkQuestsForUser(env, user.id);
+    expect(mocks.discord.state.membershipRequestCount).toBe(1);
+    const [reward] = await db
+        .select({
+            questId: rewardsTable.questId,
+            pollenAmount: rewardsTable.pollenAmount,
+        })
+        .from(rewardsTable)
+        .where(
+            and(
+                eq(rewardsTable.userId, user.id),
+                eq(rewardsTable.questId, "join_discord"),
+            ),
+        );
+    expect(reward).toEqual({ questId: "join_discord", pollenAmount: 1 });
+});
+
+test("treats Discord error 10007 as a missing member", async ({
+    mocks,
+    sessionToken,
+}) => {
+    await mocks.enable("discord");
+    await seedDiscordAccount(mocks.discord.state.userId);
+    mocks.discord.state.membershipStatus = 404;
+    mocks.discord.state.membershipErrorCode = 10007;
+
+    const response = await SELF.fetch(
+        "http://localhost:3000/api/account/discord-membership",
+        {
+            headers: {
+                Cookie: `better-auth.session_token=${sessionToken}`,
+            },
+        },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+        member: false,
+        joinedAt: null,
+    });
+});
+
+test("surfaces Discord 404 errors other than unknown member", async ({
+    mocks,
+    sessionToken,
+}) => {
+    await mocks.enable("discord");
+    await seedDiscordAccount(mocks.discord.state.userId);
+    mocks.discord.state.membershipStatus = 404;
+    mocks.discord.state.membershipErrorCode = 10004;
+
+    const response = await SELF.fetch(
+        "http://localhost:3000/api/account/discord-membership",
+        {
+            headers: {
+                Cookie: `better-auth.session_token=${sessionToken}`,
+            },
+        },
+    );
+
+    expect(response.status).toBe(502);
+});
+
+test("forwards Discord membership rate limits", async ({
+    mocks,
+    sessionToken,
+}) => {
+    await mocks.enable("discord");
+    await seedDiscordAccount(mocks.discord.state.userId);
+    mocks.discord.state.membershipStatus = 429;
+    mocks.discord.state.retryAfterSeconds = 12;
+
+    const firstResponse = await SELF.fetch(
+        "http://localhost:3000/api/account/discord-membership",
+        {
+            headers: {
+                Cookie: `better-auth.session_token=${sessionToken}`,
+            },
+        },
+    );
+    expect(firstResponse.status).toBe(429);
+    expect(firstResponse.headers.get("Retry-After")).toBe("12");
+    expect(mocks.discord.state.membershipRequestCount).toBe(1);
+});
+
+test("rejects Discord as a standalone sign-in provider", async () => {
+    const response = await SELF.fetch(
+        "http://localhost:3000/api/auth/sign-in/social",
+        {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ provider: "discord" }),
+        },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+        message:
+            "Discord can only be connected to an existing Pollinations account.",
+    });
+});

--- a/enter.pollinations.ai/test/integration/account-profile.test.ts
+++ b/enter.pollinations.ai/test/integration/account-profile.test.ts
@@ -22,6 +22,7 @@ describe("GET /api/account/profile", () => {
         expect(data).not.toHaveProperty("tier");
         expect(data).not.toHaveProperty("nextResetAt");
         expect(data.communityEndpointsAllowed).toBe(false);
+        expect(data.discordAvailable).toBe(true);
         expect(data).toHaveProperty("name");
         expect(data).toHaveProperty("email");
     });
@@ -41,6 +42,7 @@ describe("GET /api/account/profile", () => {
         expect(data).not.toHaveProperty("tier");
         expect(data).not.toHaveProperty("nextResetAt");
         expect(data.communityEndpointsAllowed).toBe(false);
+        expect(data.discordAvailable).toBe(true);
         expect(data).not.toHaveProperty("name");
         expect(data).not.toHaveProperty("email");
     });

--- a/enter.pollinations.ai/test/mocks/discord.ts
+++ b/enter.pollinations.ai/test/mocks/discord.ts
@@ -1,0 +1,89 @@
+import {
+    createHonoMockHandler,
+    type MockAPI,
+} from "@shared/test/mocks/fetch.ts";
+import { Hono } from "hono";
+
+type MockDiscordState = {
+    userId: string;
+    membershipRequestCount: number;
+    membershipStatus: number;
+    membershipErrorCode: number;
+    retryAfterSeconds: number;
+};
+
+export function createMockDiscord(): MockAPI<MockDiscordState> {
+    const state = {
+        userId: "987654321",
+        membershipRequestCount: 0,
+        membershipStatus: 200,
+        membershipErrorCode: 10007,
+        retryAfterSeconds: 12,
+    };
+    const userProfile = {
+        id: state.userId,
+        username: "discord-test-user",
+        discriminator: "0",
+        global_name: "Discord Test User",
+        avatar: null,
+        email: null,
+        verified: false,
+    };
+    const discord = new Hono()
+        .post("/api/oauth2/token", (c) =>
+            c.json({
+                access_token: "mock_discord_access_token",
+                expires_in: 604800,
+                refresh_token: "mock_discord_refresh_token",
+                scope: "identify email",
+                token_type: "Bearer",
+            }),
+        )
+        .get("/api/users/@me", (c) => c.json(userProfile))
+        .get("/api/users/%40me", (c) => c.json(userProfile))
+        .get("/api/v10/guilds/885844321461485618/members/:userId", (c) => {
+            state.membershipRequestCount += 1;
+            if (
+                c.req.header("Authorization") !== "Bot test_discord_bot_token"
+            ) {
+                return c.json({ message: "Unauthorized" }, 401);
+            }
+            if (state.membershipStatus === 404) {
+                return c.json(
+                    {
+                        code: state.membershipErrorCode,
+                        message: "Not Found",
+                    },
+                    404,
+                );
+            }
+            if (state.membershipStatus === 429) {
+                return c.json(
+                    {
+                        message: "You are being rate limited.",
+                        retry_after: state.retryAfterSeconds,
+                    },
+                    429,
+                    { "Retry-After": String(state.retryAfterSeconds) },
+                );
+            }
+            return c.json({
+                user: userProfile,
+                joined_at: "2021-09-10T11:09:04.586000+00:00",
+                roles: [],
+            });
+        });
+
+    return {
+        state,
+        reset: () => {
+            state.membershipRequestCount = 0;
+            state.membershipStatus = 200;
+            state.membershipErrorCode = 10007;
+            state.retryAfterSeconds = 12;
+        },
+        handlerMap: {
+            "discord.com": createHonoMockHandler(discord),
+        },
+    };
+}

--- a/enter.pollinations.ai/test/quests.test.ts
+++ b/enter.pollinations.ai/test/quests.test.ts
@@ -5,6 +5,7 @@ import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { expect } from "vitest";
 import { checkQuestsForUser } from "../src/services/quest-checker.ts";
+import * as discordCommunity from "../src/services/quests/groups/discord-community.ts";
 import * as questIndex from "../src/services/quests/index.ts";
 import type { QuestGroup } from "../src/services/quests/types.ts";
 import { test } from "./fixtures.ts";
@@ -21,6 +22,25 @@ const QUEST_REWARDS_LAUNCH_CUTOFF_MILLIS = Date.parse(
 const BEFORE_QUEST_REWARDS_LAUNCH_MILLIS =
     QUEST_REWARDS_LAUNCH_CUTOFF_MILLIS - 1;
 const AFTER_QUEST_REWARDS_LAUNCH_DATE = new Date("2026-06-22T00:00:00.000Z");
+
+test("omits the Discord quest when its configuration is incomplete", async () => {
+    const ctx = {
+        db: drizzle(env.DB, { schema }),
+        env: {
+            ...env,
+            DISCORD_BOT_TOKEN: "",
+        } as unknown as CloudflareBindings,
+    };
+
+    await expect(discordCommunity.listQuestCards(ctx)).resolves.toEqual([]);
+    await expect(
+        discordCommunity.evaluateUser(ctx, {
+            id: "unused",
+            githubId: null,
+            githubUsername: null,
+        }),
+    ).resolves.toEqual({ proposals: [] });
+});
 
 // Build an issue body the deriver can parse: a "### Reward" heading (when a
 // reward is given) plus a short Goal section for the description.
@@ -273,7 +293,7 @@ test("catalog returns quest definitions without ledger stats", async ({
     sessionToken: _sessionToken,
 }) => {
     await mocks.enable("github");
-    await env.KV.delete("quests:catalog:v26");
+    await env.KV.delete("quests:catalog:v29");
 
     const response = await SELF.fetch(
         "http://localhost:3000/api/quests/catalog",
@@ -346,6 +366,11 @@ test("catalog returns quest definitions without ledger stats", async ({
         rewardAmount: 0.25,
         balanceBucket: "tier",
     });
+    expectStableCatalogFields("join_discord", {
+        state: "available",
+        rewardAmount: 1,
+        balanceBucket: "tier",
+    });
     expectStableCatalogFields("app_active", {
         state: "available",
         rewardAmount: 7,
@@ -392,7 +417,7 @@ test("catalog includes coming-soon GitHub issue placeholder", async ({
     sessionToken: _sessionToken,
 }) => {
     await mocks.enable("github");
-    await env.KV.delete("quests:catalog:v26");
+    await env.KV.delete("quests:catalog:v29");
 
     const response = await SELF.fetch(
         "http://localhost:3000/api/quests/catalog",
@@ -430,7 +455,7 @@ test("catalog excludes closed GitHub quest issues without merged PRs", async ({
     sessionToken: _sessionToken,
 }) => {
     await mocks.enable("github");
-    await env.KV.delete("quests:catalog:v26");
+    await env.KV.delete("quests:catalog:v29");
 
     seedQuestIssue(mocks.github.state, {
         issueNumber: 801,
@@ -476,7 +501,7 @@ test("account quests merge earned rewards into completed status", async ({
 }) => {
     const db = drizzle(env.DB, { schema });
     await mocks.enable("github", "tinybird");
-    await env.KV.delete("quests:catalog:v26");
+    await env.KV.delete("quests:catalog:v29");
     const user = await getOnlyUser();
 
     const createKeyResponse = await SELF.fetch(

--- a/enter.pollinations.ai/wrangler.toml
+++ b/enter.pollinations.ai/wrangler.toml
@@ -234,6 +234,9 @@ LOG_FORMAT = "text"
 D1_EXPORT_TOKEN_SHA256 = "93b05a64761af544d325ac158513bef41959e8777a7375981ec7ae41f84cb05d"
 GITHUB_CLIENT_ID = "test_github_client_id"
 GITHUB_CLIENT_SECRET = "test_github_client_secret"
+DISCORD_CLIENT_ID = "test_discord_client_id"
+DISCORD_CLIENT_SECRET = "test_discord_client_secret"
+DISCORD_BOT_TOKEN = "test_discord_bot_token"
 BETTER_AUTH_SECRET = "not-a-secret-workers-test-only"
 # isInternalRequest() rejects tokens shorter than 32 characters, so a shorter
 # placeholder 401s every internal route instead of exercising it.


### PR DESCRIPTION
- Deploys Discord account linking and the 1-Pollen membership quest
- Includes session-only cached membership checks and corrected Discord error handling
- Adds the gated production sync for the three approved Discord secrets