### PR TITLE
fix: run targeted Enter production deploys

### DIFF
--- a/.github/workflows/deploy-cloudflare-production.yml
+++ b/.github/workflows/deploy-cloudflare-production.yml
@@ -177,7 +177,10 @@ jobs:
 
   deploy-enter:
     needs: [changes, migrate]
-    if: needs.changes.outputs.enter == 'true'
+    if: >-
+      !cancelled() &&
+      needs.changes.outputs.enter == 'true' &&
+      needs.migrate.result == 'success'
     runs-on: ubuntu-latest
     env:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID_MYCELI }}


### PR DESCRIPTION
- Fixes Enter-only production dispatches after the optional gen test is skipped
- Requires the shared migration job to succeed before deploying Enter
- Unblocks the approved Discord production secret sync