### PR TITLE
feat: add metadata and key:value filters to Models search

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/model-query.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-query.ts
@@ -1,0 +1,126 @@
+import { isPaidOnly } from "./model-info.ts";
+import type { ModelPrice } from "./types.ts";
+
+/** Supported `key:value` filter keys, inspired by GitHub search. */
+const FILTER_KEYS = ["access", "owner", "id", "type", "capability"] as const;
+
+export type ModelQueryFilterKey = (typeof FILTER_KEYS)[number];
+
+export type ModelQueryFilter =
+    | { key: "access"; value: "paid" | "quest" | "free" }
+    | { key: "owner"; value: string }
+    | { key: "id"; value: string }
+    | { key: "type"; value: string }
+    | { key: "capability"; value: string };
+
+export type ParsedModelQuery = {
+    terms: string[];
+    filters: ModelQueryFilter[];
+};
+
+const ACCESS_VALUES = ["paid", "quest", "free"] as const;
+
+type AccessValue = (typeof ACCESS_VALUES)[number];
+
+const isAccessValue = (value: string): value is AccessValue =>
+    (ACCESS_VALUES as readonly string[]).includes(value);
+
+const isFilterKey = (key: string): key is ModelQueryFilterKey =>
+    (FILTER_KEYS as readonly string[]).includes(key);
+
+/**
+ * Splits a raw query into free-text terms and `key:value` filters.
+ * Tokens that look like filters but use an unsupported key or an
+ * unknown access value stay free-text terms.
+ */
+export function parseModelQuery(query: string): ParsedModelQuery {
+    const terms: string[] = [];
+    const filters: ModelQueryFilter[] = [];
+
+    for (const token of query.split(/\s+/)) {
+        if (!token) continue;
+        const match = /^([a-zA-Z]+):(\S+)$/.exec(token);
+        const key = match?.[1]?.toLowerCase();
+        if (!match || !key || !isFilterKey(key)) {
+            terms.push(token.toLowerCase());
+            continue;
+        }
+        const value = match[2];
+        if (key === "access") {
+            const access = value.toLowerCase();
+            if (isAccessValue(access)) {
+                filters.push({ key, value: access });
+            } else {
+                terms.push(token.toLowerCase());
+            }
+            continue;
+        }
+        filters.push({ key, value } as ModelQueryFilter);
+    }
+
+    return { terms, filters };
+}
+
+function matchesAccess(
+    model: ModelPrice,
+    access: "paid" | "quest" | "free",
+): boolean {
+    if (access === "free") return model.free === true;
+    if (access === "paid") return isPaidOnly(model);
+    // "quest" is everything callable without paying up front.
+    return model.free !== true && !isPaidOnly(model);
+}
+
+function matchesFilter(model: ModelPrice, filter: ModelQueryFilter): boolean {
+    switch (filter.key) {
+        case "access":
+            return matchesAccess(model, filter.value);
+        case "owner": {
+            // Community ids are "<github-login>/<model>", so the public
+            // owner login is a prefix of the canonical id.
+            if (!model.community) return false;
+            return model.name
+                .toLowerCase()
+                .startsWith(`${filter.value.toLowerCase()}/`);
+        }
+        case "id":
+            return model.name.toLowerCase() === filter.value.toLowerCase();
+        case "type": {
+            const category = model.agent ? "agent" : model.type;
+            return category === filter.value.toLowerCase();
+        }
+        case "capability":
+            return model.capabilities.some(
+                (capability) => capability === filter.value.toLowerCase(),
+            );
+    }
+}
+
+function queryHaystack(model: ModelPrice): string {
+    return [
+        model.name,
+        model.displayName,
+        model.description,
+        model.brand,
+        model.baseModel,
+        ...(model.inputModalities ?? []),
+        ...(model.outputModalities ?? []),
+        ...model.capabilities,
+    ]
+        .filter((field) => typeof field === "string" && field.length > 0)
+        .join(" ")
+        .toLowerCase();
+}
+
+/** True when every term and every filter matches the model. */
+export function matchesModelQuery(
+    model: ModelPrice,
+    parsed: ParsedModelQuery,
+): boolean {
+    if (parsed.terms.length === 0 && parsed.filters.length === 0) return true;
+    const haystack = parsed.terms.length > 0 ? queryHaystack(model) : "";
+    return (
+        parsed.terms.every((term) => haystack.includes(term)) &&
+        parsed.filters.every((filter) => matchesFilter(model, filter))
+    );
+}

--- a/enter.pollinations.ai/frontend/src/components/models/models.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/models.tsx
@@ -34,7 +34,7 @@ import {
     fetchModelCatalog,
     getModelPricesFromCatalog,
 } from "./model-catalog.ts";
-import { getModelDisplayName } from "./model-info.ts";
+import { matchesModelQuery, parseModelQuery } from "./model-query.ts";
 import type { ModelScope, ModelSort } from "./model-search.ts";
 import { sortModels } from "./model-sort.ts";
 import {
@@ -116,13 +116,6 @@ const SEARCH_LABELS: Record<SectionType, string> = {
     agent: "agent",
 };
 
-function matchesQuery(model: ModelPrice, query: string): boolean {
-    if (!query) return true;
-    const displayName = getModelDisplayName(model) ?? "";
-    const haystack = `${displayName} ${model.brand ?? ""}`.toLowerCase();
-    return haystack.includes(query);
-}
-
 function categorizeModels(
     models: ModelPrice[],
 ): Record<SectionType, ModelPrice[]> {
@@ -192,6 +185,7 @@ export const Models: FC = () => {
         [catalogModels, stats],
     );
     const query = search.trim().toLowerCase();
+    const parsedQuery = useMemo(() => parseModelQuery(query), [query]);
     const scopedModels = useMemo(
         () =>
             allModels.filter(
@@ -202,10 +196,10 @@ export const Models: FC = () => {
     );
     const filteredModels = useMemo(
         () =>
-            query
-                ? scopedModels.filter((model) => matchesQuery(model, query))
-                : scopedModels,
-        [query, scopedModels],
+            scopedModels.filter((model) =>
+                matchesModelQuery(model, parsedQuery),
+            ),
+        [parsedQuery, scopedModels],
     );
 
     const loadModelCatalog = useCallback(
@@ -422,6 +416,12 @@ export const Models: FC = () => {
                                 aria-label={`Search ${searchTarget}`}
                                 className="w-full pl-9"
                             />
+                            <p className="mt-1 truncate text-xs text-theme-text-muted">
+                                Filters: access:paid · access:quest ·
+                                access:free · owner:&lt;github-login&gt; ·
+                                id:&lt;model-id&gt; · type:&lt;category&gt; ·
+                                capability:&lt;capability&gt;
+                            </p>
                         </div>
                         <Dropdown
                             align="end"

--- a/enter.pollinations.ai/test/model-query.test.ts
+++ b/enter.pollinations.ai/test/model-query.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vitest";
+import {
+    matchesModelQuery,
+    parseModelQuery,
+} from "../frontend/src/components/models/model-query.ts";
+import type { ModelPrice } from "../frontend/src/components/models/types.ts";
+
+function model(name: string, overrides: Partial<ModelPrice> = {}): ModelPrice {
+    return {
+        name,
+        type: "text",
+        capabilities: [],
+        prices: [],
+        ...overrides,
+    };
+}
+
+const paidModel = () =>
+    model("openai/gpt-5", {
+        displayName: "GPT-5",
+        description: "Flagship reasoning model",
+        brand: "OpenAI",
+        baseModel: "gpt-5-base",
+        capabilities: ["reasoning", "tool_calling"],
+        inputModalities: ["text", "image"],
+        outputModalities: ["text"],
+        paidOnly: true,
+    });
+
+describe("parseModelQuery", () => {
+    it("returns empty parse for blank queries", () => {
+        expect(parseModelQuery("")).toEqual({ terms: [], filters: [] });
+        expect(parseModelQuery("   ")).toEqual({ terms: [], filters: [] });
+    });
+
+    it("splits free text from key:value filters", () => {
+        const parsed = parseModelQuery(
+            "fast type:image access:free owner:alice id:x/y capability:reasoning",
+        );
+        expect(parsed.terms).toEqual(["fast"]);
+        expect(parsed.filters).toEqual([
+            { key: "type", value: "image" },
+            { key: "access", value: "free" },
+            { key: "owner", value: "alice" },
+            { key: "id", value: "x/y" },
+            { key: "capability", value: "reasoning" },
+        ]);
+    });
+
+    it("keeps unknown keys and invalid access values as terms", () => {
+        const parsed = parseModelQuery("foo:bar access:everything openai");
+        expect(parsed.terms).toEqual([
+            "foo:bar",
+            "access:everything",
+            "openai",
+        ]);
+        expect(parsed.filters).toEqual([]);
+    });
+
+    it("is case-insensitive on filter keys and access values", () => {
+        const parsed = parseModelQuery("TYPE:Image ACCESS:Paid");
+        expect(parsed.filters).toEqual([
+            { key: "type", value: "Image" },
+            { key: "access", value: "paid" },
+        ]);
+    });
+});
+
+describe("matchesModelQuery", () => {
+    it("matches every model for an empty query", () => {
+        const parsed = parseModelQuery("");
+        expect(matchesModelQuery(paidModel(), parsed)).toBe(true);
+    });
+
+    it("matches free text across loaded metadata", () => {
+        const parsed = parseModelQuery("flagship");
+        expect(matchesModelQuery(paidModel(), parsed)).toBe(true);
+        expect(matchesModelQuery(paidModel(), parseModelQuery("flux"))).toBe(
+            false,
+        );
+    });
+
+    it("searches canonical id, brand, base model, modalities, capabilities", () => {
+        for (const term of [
+            "openai/gpt-5",
+            "openai",
+            "gpt-5-base",
+            "image",
+            "tool_calling",
+        ]) {
+            expect(matchesModelQuery(paidModel(), parseModelQuery(term))).toBe(
+                true,
+            );
+        }
+        expect(
+            matchesModelQuery(paidModel(), parseModelQuery("nosuchword")),
+        ).toBe(false);
+    });
+
+    it("filters by each access value", () => {
+        const paid = paidModel();
+        const free = model("flux", { free: true, type: "image" });
+        const quest = model("openai-large", {});
+
+        expect(matchesModelQuery(paid, parseModelQuery("access:paid"))).toBe(
+            true,
+        );
+        expect(matchesModelQuery(free, parseModelQuery("access:paid"))).toBe(
+            false,
+        );
+        expect(matchesModelQuery(free, parseModelQuery("access:free"))).toBe(
+            true,
+        );
+        expect(matchesModelQuery(quest, parseModelQuery("access:quest"))).toBe(
+            true,
+        );
+        expect(matchesModelQuery(paid, parseModelQuery("access:quest"))).toBe(
+            false,
+        );
+    });
+
+    it("matches owner only for community models with that login prefix", () => {
+        const community = model("alice/tiny-agent", {
+            community: true,
+            agent: true,
+        });
+        const official = model("alice/impersonator");
+
+        expect(
+            matchesModelQuery(community, parseModelQuery("owner:alice")),
+        ).toBe(true);
+        // Case-insensitive owner match.
+        expect(
+            matchesModelQuery(community, parseModelQuery("owner:ALICE")),
+        ).toBe(true);
+        expect(
+            matchesModelQuery(official, parseModelQuery("owner:alice")),
+        ).toBe(false);
+        expect(matchesModelQuery(community, parseModelQuery("owner:bob"))).toBe(
+            false,
+        );
+    });
+
+    it("matches exact canonical id case-insensitively", () => {
+        expect(
+            matchesModelQuery(paidModel(), parseModelQuery("id:OPENAI/GPT-5")),
+        ).toBe(true);
+        expect(
+            matchesModelQuery(paidModel(), parseModelQuery("id:gpt-4")),
+        ).toBe(false);
+    });
+
+    it("matches dashboard category including agents", () => {
+        const agent = model("alice/tiny-agent", {
+            community: true,
+            agent: true,
+        });
+        expect(matchesModelQuery(agent, parseModelQuery("type:agent"))).toBe(
+            true,
+        );
+        expect(matchesModelQuery(agent, parseModelQuery("type:text"))).toBe(
+            false,
+        );
+        expect(
+            matchesModelQuery(paidModel(), parseModelQuery("type:text")),
+        ).toBe(true);
+    });
+
+    it("matches raw capability values", () => {
+        expect(
+            matchesModelQuery(
+                paidModel(),
+                parseModelQuery("capability:reasoning"),
+            ),
+        ).toBe(true);
+        expect(
+            matchesModelQuery(
+                paidModel(),
+                parseModelQuery("capability:code_execution"),
+            ),
+        ).toBe(false);
+    });
+
+    it("combines terms and filters with AND semantics", () => {
+        const community = model("bob/painter", {
+            community: true,
+            type: "image",
+            description: "Fast image generator",
+        });
+        expect(
+            matchesModelQuery(
+                community,
+                parseModelQuery("fast owner:bob type:image"),
+            ),
+        ).toBe(true);
+        expect(
+            matchesModelQuery(
+                community,
+                parseModelQuery("fast owner:alice type:image"),
+            ),
+        ).toBe(false);
+        expect(
+            matchesModelQuery(community, parseModelQuery("slow owner:bob")),
+        ).toBe(false);
+    });
+});


### PR DESCRIPTION
Closes #13907

## Changes
- Free-text search now covers all loaded metadata: canonical model ID, title, description, publisher/brand, base model, input/output modalities, and capabilities.
- New documented `key:value` filter syntax (GitHub-search inspired):
  - `access:paid`, `access:quest`, `access:free`
  - `owner:<github-login>` — matches the public login prefix of community ids (`<login>/<model>`), never an internal user ID
  - `id:<model-id>` (exact, case-insensitive)
  - `type:<category>` (agents included)
  - `capability:<capability>`
- Terms and filters combine freely with AND semantics; tokens with unknown keys or invalid access values degrade to free text.
- Existing scope/category/sort/URL `q` state untouched — filters ride in the same param, so direct links and reloads work.
- Discoverability: one compact muted hint line under the search box.
- Frontend-only. Parsing + matching covered by focused tests (`test/model-query.test.ts`, 13 cases).