### PR TITLE
chore: sync main into production

### DIFF
--- a/.github/workflows/deploy-cloudflare-production.yml
+++ b/.github/workflows/deploy-cloudflare-production.yml
@@ -177,7 +177,10 @@ jobs:
 
   deploy-enter:
     needs: [changes, migrate]
-    if: needs.changes.outputs.enter == 'true'
+    if: >-
+      !cancelled() &&
+      needs.changes.outputs.enter == 'true' &&
+      needs.migrate.result == 'success'
     runs-on: ubuntu-latest
     env:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID_MYCELI }}


### PR DESCRIPTION
- Promotes the targeted Enter deployment fix
- Allows Enter-only dispatches when the optional gen test is skipped
- Unblocks the approved Discord secret sync