### PR TITLE
Add Quest leaderboard to the Community page

### DIFF
--- a/enter.pollinations.ai/src/routes/quests.ts
+++ b/enter.pollinations.ai/src/routes/quests.ts
@@ -1,7 +1,10 @@
 import { claimReward } from "@shared/billing/rewards.ts";
 import * as schema from "@shared/db/better-auth.ts";
-import { rewards as rewardsTable } from "@shared/db/better-auth.ts";
-import { desc, eq } from "drizzle-orm";
+import {
+    rewards as rewardsTable,
+    user as usersTable,
+} from "@shared/db/better-auth.ts";
+import { and, desc, eq, isNotNull, like, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
@@ -21,6 +24,7 @@ import { requireAccountPermission } from "./account-permissions.ts";
 // Bumped to v29: the Discord quest links to account connection and the server.
 const CACHE_KEY = "quests:catalog:v29";
 const CACHE_TTL = 60;
+const LEADERBOARD_CACHE_KEY = "quests:leaderboard:v1";
 const QUEST_CHECK_THROTTLE_SECONDS = 60;
 
 export type QuestCatalogResponse = {
@@ -62,6 +66,26 @@ const rewardSchema = z.object({
 const questRewardsResponseSchema = z.object({
     rewards: z.array(rewardSchema),
 });
+
+const leaderboardEntrySchema = z.object({
+    // Public GitHub identity only - never internal user ids.
+    githubLogin: z.string(),
+    completedQuests: z.number().int(),
+    totalPollen: z.number(),
+});
+
+const questLeaderboardResponseSchema = z.object({
+    leaderboard: z.array(leaderboardEntrySchema),
+    totals: z.object({
+        contributors: z.number().int(),
+        completedQuests: z.number().int(),
+        totalPollen: z.number(),
+    }),
+});
+
+export type QuestLeaderboardResponse = z.infer<
+    typeof questLeaderboardResponseSchema
+>;
 
 const questCheckResponseSchema = z.object({
     success: z.boolean(),
@@ -118,6 +142,89 @@ export const questsRoutes = new Hono<Env>()
                 expirationTtl: CACHE_TTL,
             });
             return c.json(catalog);
+        },
+    )
+    .get(
+        "/leaderboard",
+        describeRoute({
+            tags: ["✨ Quests"],
+            summary: "Get Quest Leaderboard",
+            security: [],
+            description:
+                "Aggregates public Pollen earned from completed public GitHub POLLEN-QUEST issues, grouped by contributor GitHub login.",
+            responses: {
+                200: {
+                    description: "Quest leaderboard",
+                    content: {
+                        "application/json": {
+                            schema: resolver(questLeaderboardResponseSchema),
+                        },
+                    },
+                },
+            },
+        }),
+        async (c) => {
+            const cached = await c.env.KV.get<QuestLeaderboardResponse>(
+                LEADERBOARD_CACHE_KEY,
+                "json",
+            );
+            if (cached) return c.json(cached);
+
+            const db = drizzle(c.env.DB);
+            const rows = await db
+                .select({
+                    githubLogin: usersTable.githubUsername,
+                    completedQuests: sql<number>`count(*)`.mapWith(Number),
+                    totalPollen:
+                        sql<number>`sum(${rewardsTable.pollenAmount})`.mapWith(
+                            Number,
+                        ),
+                })
+                .from(rewardsTable)
+                .innerJoin(usersTable, eq(rewardsTable.userId, usersTable.id))
+                .where(
+                    and(
+                        like(rewardsTable.questId, "github:issue:%"),
+                        isNotNull(usersTable.githubUsername),
+                    ),
+                )
+                .groupBy(usersTable.githubUsername)
+                .orderBy(desc(sql`sum(${rewardsTable.pollenAmount})`))
+                .limit(50);
+
+            const leaderboard = rows.flatMap((row) =>
+                row.githubLogin
+                    ? [
+                          {
+                              githubLogin: row.githubLogin,
+                              completedQuests: row.completedQuests,
+                              totalPollen: row.totalPollen,
+                          },
+                      ]
+                    : [],
+            );
+
+            const response: QuestLeaderboardResponse = {
+                leaderboard,
+                totals: {
+                    contributors: leaderboard.length,
+                    completedQuests: leaderboard.reduce(
+                        (sum, entry) => sum + entry.completedQuests,
+                        0,
+                    ),
+                    totalPollen: leaderboard.reduce(
+                        (sum, entry) => sum + entry.totalPollen,
+                        0,
+                    ),
+                },
+            };
+
+            await c.env.KV.put(
+                LEADERBOARD_CACHE_KEY,
+                JSON.stringify(response),
+                { expirationTtl: CACHE_TTL },
+            );
+            return c.json(response);
         },
     )
     .post(

--- a/enter.pollinations.ai/test/quest-leaderboard.test.ts
+++ b/enter.pollinations.ai/test/quest-leaderboard.test.ts
@@ -1,0 +1,127 @@
+import { env, SELF } from "cloudflare:test";
+import * as schema from "@shared/db/better-auth.ts";
+import { drizzle } from "drizzle-orm/d1";
+import { expect } from "vitest";
+import { test } from "./fixtures.ts";
+
+type LeaderboardResponse = {
+    leaderboard: {
+        githubLogin: string;
+        completedQuests: number;
+        totalPollen: number;
+    }[];
+    totals: {
+        contributors: number;
+        completedQuests: number;
+        totalPollen: number;
+    };
+};
+
+// Seed a dashboard user carrying a public GitHub identity.
+async function seedGithubUser(
+    db: ReturnType<typeof drizzle>,
+    id: string,
+    githubUsername: string,
+): Promise<void> {
+    await db.insert(schema.user).values({
+        id,
+        name: id,
+        email: `${id}@test.local`,
+        githubUsername,
+    });
+}
+
+function issueReward(
+    issueNumber: number,
+    userId: string,
+    pollenAmount: number,
+) {
+    return {
+        id: `reward-github-issue-${issueNumber}-${userId}`,
+        idempotencyKey: `quest:github:issue:${issueNumber}:${userId}`,
+        userId,
+        questId: `github:issue:${issueNumber}`,
+        title: "POLLEN-QUEST",
+        url: `https://github.com/pollinations/pollinations/issues/${issueNumber}`,
+        pollenAmount,
+        balanceBucket: "tier",
+    };
+}
+
+test("quest leaderboard ranks GitHub contributors by earned Pollen", async () => {
+    const db = drizzle(env.DB, { schema });
+
+    await seedGithubUser(db, "lb-alice", "alice");
+    await seedGithubUser(db, "lb-bob", "bob");
+
+    // alice completes two quests (5 + 3 pollen), bob one (7 pollen).
+    await db
+        .insert(schema.rewards)
+        .values([
+            issueReward(900, "lb-alice", 5),
+            issueReward(901, "lb-alice", 3),
+            issueReward(902, "lb-bob", 7),
+        ]);
+
+    const response = await SELF.fetch(
+        "http://localhost:3000/api/quests/leaderboard",
+    );
+    expect(response.status).toBe(200);
+
+    const payload = (await response.json()) as LeaderboardResponse;
+
+    expect(payload.leaderboard).toEqual([
+        { githubLogin: "alice", completedQuests: 2, totalPollen: 8 },
+        { githubLogin: "bob", completedQuests: 1, totalPollen: 7 },
+    ]);
+    expect(payload.totals).toEqual({
+        contributors: 2,
+        completedQuests: 3,
+        totalPollen: 15,
+    });
+});
+
+test("quest leaderboard ignores non-GitHub quests and users without a public GitHub identity", async () => {
+    const db = drizzle(env.DB, { schema });
+
+    await seedGithubUser(db, "lb-carol", "carol");
+    // A dashboard user without a linked GitHub account can earn rewards,
+    // but only public GitHub identities may appear on the board.
+    await db.insert(schema.user).values({
+        id: "lb-dave",
+        name: "dave",
+        email: "lb-dave@test.local",
+        githubUsername: null,
+    });
+
+    await db.insert(schema.rewards).values([
+        issueReward(910, "lb-carol", 2),
+        // Product quest reward - not a public GitHub POLLEN-QUEST.
+        {
+            id: "reward-product-top-up-lb-dave",
+            idempotencyKey: "first_top_up:lb-dave",
+            userId: "lb-dave",
+            questId: "first_top_up",
+            title: "First top-up",
+            pollenAmount: 50,
+            balanceBucket: "tier",
+        },
+        issueReward(911, "lb-dave", 9),
+    ]);
+
+    const response = await SELF.fetch(
+        "http://localhost:3000/api/quests/leaderboard",
+    );
+    expect(response.status).toBe(200);
+
+    const payload = (await response.json()) as LeaderboardResponse;
+
+    expect(payload.leaderboard).toEqual([
+        { githubLogin: "carol", completedQuests: 1, totalPollen: 2 },
+    ]);
+    expect(payload.totals).toEqual({
+        contributors: 1,
+        completedQuests: 1,
+        totalPollen: 2,
+    });
+});

--- a/pollinations.ai/src/ui/components/QuestLeaderboard.tsx
+++ b/pollinations.ai/src/ui/components/QuestLeaderboard.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useState } from "react";
+import { LINKS } from "../../copy/content/socialLinks";
+import { ExternalLinkIcon } from "../assets/ExternalLinkIcon";
+import { Divider } from "./ui/divider";
+import { Body, Heading } from "./ui/typography";
+
+type LeaderboardEntry = {
+    githubLogin: string;
+    completedQuests: number;
+    totalPollen: number;
+};
+
+type QuestLeaderboardData = {
+    leaderboard: LeaderboardEntry[];
+    totals: {
+        contributors: number;
+        completedQuests: number;
+        totalPollen: number;
+    };
+};
+
+const LEADERBOARD_API = `${LINKS.enter}/api/quests/leaderboard`;
+const QUESTS_PAGE_URL = `${LINKS.enter}/quests`;
+
+/** Compact leaderboard of Pollen earned from public GitHub POLLEN-QUEST issues. */
+export function QuestLeaderboard() {
+    const [data, setData] = useState<QuestLeaderboardData | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        fetch(LEADERBOARD_API)
+            .then((res) => (res.ok ? res.json() : null))
+            .then((body: QuestLeaderboardData | null) => {
+                if (!cancelled && body && body.leaderboard.length > 0) {
+                    setData(body);
+                }
+            })
+            .catch(() => {
+                // The section simply stays hidden without data.
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    if (!data) return null;
+
+    return (
+        <>
+            <div className="mb-12">
+                <Heading variant="section">Quest leaderboard</Heading>
+                <Body size="sm" spacing="comfortable">
+                    Community members who completed public GitHub{" "}
+                    <strong>POLLEN-QUEST</strong> issues, ranked by quest Pollen
+                    earned — {data.totals.completedQuests} quests solved for{" "}
+                    {Math.round(data.totals.totalPollen)} Pollen across{" "}
+                    {data.totals.contributors} contributors.
+                </Body>
+                <div className="overflow-hidden rounded-sub-card border border-border-subtle bg-white/60">
+                    <table className="w-full text-left font-body text-sm">
+                        <thead>
+                            <tr className="border-b border-border-subtle">
+                                <th className="px-4 py-2 font-headline text-[10px] font-black uppercase text-muted">
+                                    #
+                                </th>
+                                <th className="px-4 py-2 font-headline text-[10px] font-black uppercase text-muted">
+                                    Contributor
+                                </th>
+                                <th className="px-4 py-2 text-right font-headline text-[10px] font-black uppercase text-muted">
+                                    Quests
+                                </th>
+                                <th className="px-4 py-2 text-right font-headline text-[10px] font-black uppercase text-muted">
+                                    Pollen
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {data.leaderboard.map((entry, index) => (
+                                <tr
+                                    key={entry.githubLogin}
+                                    className="border-b border-border-subtle last:border-b-0"
+                                >
+                                    <td className="px-4 py-2 font-mono text-xs text-subtle">
+                                        {index + 1}
+                                    </td>
+                                    <td className="px-4 py-2">
+                                        <a
+                                            href={`https://github.com/${entry.githubLogin}`}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="font-bold text-dark hover:underline"
+                                        >
+                                            {entry.githubLogin}
+                                        </a>
+                                    </td>
+                                    <td className="px-4 py-2 text-right tabular-nums">
+                                        {entry.completedQuests}
+                                    </td>
+                                    <td className="px-4 py-2 text-right font-bold tabular-nums">
+                                        {entry.totalPollen % 1 === 0
+                                            ? entry.totalPollen
+                                            : entry.totalPollen.toFixed(2)}
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+                <Body size="sm" spacing="comfortable" className="mt-3">
+                    Want on the board?{" "}
+                    <a
+                        href={QUESTS_PAGE_URL}
+                        className="font-headline text-xs font-black hover:underline inline-flex items-center gap-1 text-dark bg-accent-strong px-2 py-0.5"
+                    >
+                        Pick a Quest
+                        <ExternalLinkIcon className="w-3 h-3" strokeWidth="4" />
+                    </a>{" "}
+                    and ship a merged PR.
+                </Body>
+            </div>
+            <Divider />
+        </>
+    );
+}

--- a/pollinations.ai/src/ui/pages/CommunityPage.tsx
+++ b/pollinations.ai/src/ui/pages/CommunityPage.tsx
@@ -5,6 +5,7 @@ import { usePageCopy } from "../../hooks/usePageCopy";
 import { useTranslate } from "../../hooks/useTranslate";
 import { ExternalLinkIcon } from "../assets/ExternalLinkIcon";
 import { BuildDiary } from "../components/BuildDiary";
+import { QuestLeaderboard } from "../components/QuestLeaderboard";
 import { TopContributors } from "../components/TopContributors";
 import { Button } from "../components/ui/button";
 import { Divider } from "../components/ui/divider";
@@ -319,6 +320,10 @@ export default function CommunityPage() {
                         })}
                     </div>
                 </div>
+
+                <Divider />
+
+                <QuestLeaderboard />
 
                 <Divider />
 


### PR DESCRIPTION
Closes #13909

## What

- **Public aggregate** — `GET /api/quests/leaderboard` on enter: aggregates Pollen from completed public GitHub POLLEN-QUEST rewards (`questId` = `github:issue:*`) out of the existing reward ledger, grouped by each earner's public GitHub username, ranked by total Pollen, plus small totals (`contributors` / `completedQuests` / `totalPollen`). Cached in KV for 60s like the catalog.
- **Community page section** — compact `QuestLeaderboard` between Voting and Top Contributors: rank, GitHub login (links to profile), completed quests, total Pollen; clear link to the Quests page (`https://enter.pollinations.ai/quests`). Renders nothing while loading or empty.
- **Focused tests** — route-level tests seed real reward rows: ranking/totals aggregate correctly, while non-GitHub quests and users without a public GitHub identity stay off the board.

## Constraints honored

Only public GitHub identity and aggregate counts are exposed (no internal user ids). No Tinybird, no new tables, no GitHub commit scraping, no seasons/badges/leaderboard framework — just the existing quest reward ledger.
