### PR TITLE
fix: block requests from overdrawn wallets

### DIFF
--- a/gen.pollinations.ai/src/byop-markup.test.ts
+++ b/gen.pollinations.ai/src/byop-markup.test.ts
@@ -321,7 +321,7 @@ describe("BYOP markup", () => {
         });
     });
 
-    it("allows a zero-cost model when every balance is zero", async () => {
+    it("requires a positive balance even when the model estimate is zero", async () => {
         const vars = {
             auth: {
                 user: { id: "preflight-payer" },
@@ -337,12 +337,53 @@ describe("BYOP markup", () => {
             log: fakeLog(),
         } as unknown as Parameters<typeof checkBalance>[0];
 
-        await checkBalance(vars, fakeStatsEnv(0));
+        await expect(checkBalance(vars, fakeStatsEnv(0))).rejects.toMatchObject(
+            {
+                status: 402,
+            },
+        );
+    });
 
-        expect(vars.balance.balanceCheckResult?.balances).toEqual({
-            "v1:meter:tier": 0,
-            "v1:meter:pack": 0,
-        });
+    it("rejects every model when the wallet is in debt with no positive balance", async () => {
+        const vars = {
+            auth: {
+                user: { id: "preflight-payer" },
+                apiKey: { id: "sk-test", pollenBalance: 0 },
+            },
+            balance: {
+                getBalance: async () => ({
+                    tierBalance: -1,
+                    packBalance: 0,
+                }),
+            },
+            model: testModel(),
+            log: fakeLog(),
+        } as unknown as Parameters<typeof checkBalance>[0];
+
+        await expect(checkBalance(vars, fakeStatsEnv(0))).rejects.toMatchObject(
+            {
+                status: 402,
+            },
+        );
+    });
+
+    it("allows a positive bucket to cover a debt in the other bucket", async () => {
+        const vars = {
+            auth: {
+                user: { id: "preflight-payer" },
+                apiKey: { id: "sk-test", pollenBalance: 2 },
+            },
+            balance: {
+                getBalance: async () => ({
+                    tierBalance: -1,
+                    packBalance: 2,
+                }),
+            },
+            model: testModel(),
+            log: fakeLog(),
+        } as unknown as Parameters<typeof checkBalance>[0];
+
+        await checkBalance(vars, fakeStatsEnv(1));
     });
 
     it("requires paid-only preflight to have pack balance above the model estimate", async () => {

--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -1869,7 +1869,7 @@ fixtureTest(
 );
 
 fixtureTest(
-    "a private model is owner-only and a zero-priced public model is free",
+    "a private model is owner-only and a zero-priced public model is free for funded callers",
     async ({ apiKey }) => {
         const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;
         const modelName = `private-${crypto.randomUUID().slice(0, 8)}`;
@@ -1878,9 +1878,9 @@ fixtureTest(
         const ownerUserId = await createTestUser({
             githubId: nextAllowedGithubId(),
             githubUsername: ownerGithubUsername,
-            // Owner-only private models have no Pollinations charge and remain
-            // callable without a Pollinations balance.
-            tierBalance: 0,
+            // Owner-only private models have no Pollinations charge, but every
+            // request still needs a positive balance in some bucket.
+            tierBalance: 1,
         });
         // A key belonging to the endpoint owner — its calls are owner calls.
         const { key: ownerApiKey } = await createTestApiKey({
@@ -1987,29 +1987,38 @@ fixtureTest(
         await expect(catalogIncludesModel(apiKey)).resolves.toBe(false);
         await expect(catalogIncludesModel()).resolves.toBe(false);
 
-        // Publishing the same zero-priced endpoint makes it globally callable
-        // without requiring a Pollinations balance.
+        // Publishing the same zero-priced endpoint makes it globally callable.
+        // It is never charged, but preflight still requires a positive balance
+        // in some bucket, so an empty wallet is rejected before the call.
         await db
             .update(communityEndpointTable)
             .set({ visibility: "public" })
             .where(eq(communityEndpointTable.id, endpointId));
         resetGenerationModelRegistryCache();
+        const callFreePublicModel = async (callerKey: string) =>
+            fetchGen(
+                new Request("https://gen.pollinations.ai/v1/chat/completions", {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${callerKey}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({
+                        model: modelId,
+                        messages: [{ role: "user", content: "free public" }],
+                    }),
+                }),
+            );
         const { key: zeroBalanceCallerKey } = await createTestApiKey({
             user: { tierBalance: 0, packBalance: 0 },
         });
-        const freePublicResponse = await fetchGen(
-            new Request("https://gen.pollinations.ai/v1/chat/completions", {
-                method: "POST",
-                headers: {
-                    Authorization: `Bearer ${zeroBalanceCallerKey}`,
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    model: modelId,
-                    messages: [{ role: "user", content: "free public" }],
-                }),
-            }),
+        expect((await callFreePublicModel(zeroBalanceCallerKey)).status).toBe(
+            402,
         );
+        const { key: fundedCallerKey } = await createTestApiKey({
+            user: { tierBalance: 1, packBalance: 0 },
+        });
+        const freePublicResponse = await callFreePublicModel(fundedCallerKey);
         expect(freePublicResponse.status).toBe(200);
         await expect(freePublicResponse.json()).resolves.toMatchObject({
             choices: [{ message: { content: "ok" } }],

--- a/shared/billing/bucket-selection.ts
+++ b/shared/billing/bucket-selection.ts
@@ -13,8 +13,9 @@ export type BalanceBucket = "tier" | "pack";
  * the request proceed before any mutation.
  *
  * The two therefore need not use identical thresholds. This preflight clamps
- * negative estimates to zero and accepts zero-cost coverage. The write path
- * skips non-positive charges entirely; for a positive actual charge, it uses
+ * negative estimates to zero, but every request still requires a positive
+ * balance in at least one bucket. The write path skips non-positive charges
+ * entirely; for a positive actual charge, it uses
  * Quest Pollen when that bucket covers the charge, otherwise any positive paid
  * balance, and finally Quest Pollen debt when the paid balance is non-positive.
  */
@@ -23,12 +24,16 @@ export function canCoverEstimatedCharge(
     estimatedCost: number,
     isPaidOnly = false,
 ): boolean {
+    const hasPositiveBalance =
+        balances.tierBalance > 0 || balances.packBalance > 0;
+    if (!hasPositiveBalance) return false;
+
     const threshold = Math.max(0, estimatedCost);
     // Paid-only stays strict: the flag means "must hold paid balance", a
     // positive-balance requirement rather than a cost-coverage one. A paid-only
     // model is never free, so no zero-balance caller needs to get through.
     if (isPaidOnly) return balances.packBalance > threshold;
-    // Cost coverage, so a zero-priced model is covered by a zero balance.
+    // Once the wallet has a positive bucket, compare each bucket to the cost.
     return (
         balances.tierBalance >= threshold || balances.packBalance >= threshold
     );


### PR DESCRIPTION
- Preflight now requires a positive balance in at least one bucket (Quest > 0 or Paid > 0) before the estimate check; a wallet in debt with no positive bucket gets 402 on every model, including free ones
- A positive Paid balance still covers a negative Quest balance, so users recover by purchasing
- Root cause: #13512 changed the coverage check from `>` to `>=`, so a 0 paid balance "covered" a 0 estimate. Estimates read as 0 whenever the Tinybird `public_model_stats` fetch failed (empty result cached in KV for 1h), which became frequent after #13467 made the pipe heavier on Aug 22. Aug 22–25: 12,718 overdrawn calls, 210 users, ~226 Pollen of Quest debt, one wallet to −134
- Behaviour change: accounts at exactly 0/0 can no longer call zero-priced community endpoints (including owners calling their own private model) until they hold some Pollen
- Not addressed: truly concurrent requests can still each incur one debt charge before any settles; the empty stats result is still cached for the TTL (no longer a billing hole)
- Tests: full gen suite 606 passed; the two `elevenlabs-*` failures reproduce on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHuPnX3Kamv8h2onjppz8Z