### PR TITLE
refactor: simplify Discord quest membership

### DIFF
--- a/enter.pollinations.ai/frontend/src/routes/_dashboard.account.tsx
+++ b/enter.pollinations.ai/frontend/src/routes/_dashboard.account.tsx
@@ -15,7 +15,6 @@ import {
 } from "@pollinations/ui";
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
-import { apiClient } from "../api.ts";
 import { authClient } from "../auth.ts";
 import { Route as DashboardRoute } from "./_dashboard.tsx";
 
@@ -26,7 +25,6 @@ type DiscordConnection = {
     username: string | null;
     displayName: string | null;
     avatarUrl: string | null;
-    isPollinationsMember: boolean | null;
 };
 
 export const Route = createFileRoute("/_dashboard/account")({
@@ -66,20 +64,12 @@ function AccountPage() {
                     return;
                 }
 
-                const [infoResponse, membershipResponse] = await Promise.all([
-                    authClient
-                        .accountInfo({
-                            query: { accountId: account.accountId },
-                        })
-                        .catch(() => null),
-                    apiClient.account["discord-membership"]
-                        .$get()
-                        .catch(() => null),
-                ]);
+                const infoResponse = await authClient
+                    .accountInfo({
+                        query: { accountId: account.accountId },
+                    })
+                    .catch(() => null);
                 const info = infoResponse?.data;
-                const membership = membershipResponse?.ok
-                    ? await membershipResponse.json().catch(() => null)
-                    : null;
                 const profile = info?.data as
                     | { username?: unknown }
                     | undefined;
@@ -91,7 +81,6 @@ function AccountPage() {
                             : null,
                     displayName: info?.user.name || null,
                     avatarUrl: info?.user.image || null,
-                    isPollinationsMember: membership?.member ?? null,
                 });
             } catch {
                 setConnectionError("Could not load connected accounts.");
@@ -238,19 +227,9 @@ function AccountPage() {
                                           : "Connect your Discord identity for community features."}
                                 </Text>
                                 {discordConnection && (
-                                    <>
-                                        <Text size="sm" tone="muted">
-                                            Discord ID: {discordConnection.id}
-                                        </Text>
-                                        {discordConnection.isPollinationsMember !==
-                                            null && (
-                                            <Text size="sm" tone="muted">
-                                                {discordConnection.isPollinationsMember
-                                                    ? "Member of the Pollinations Discord"
-                                                    : "Not a member of the Pollinations Discord"}
-                                            </Text>
-                                        )}
-                                    </>
+                                    <Text size="sm" tone="muted">
+                                        Discord ID: {discordConnection.id}
+                                    </Text>
                                 )}
                             </div>
                         </div>

--- a/enter.pollinations.ai/src/routes/account.ts
+++ b/enter.pollinations.ai/src/routes/account.ts
@@ -29,12 +29,7 @@ import { describeRoute, resolver } from "hono-openapi";
 import { z } from "zod";
 import type { Env } from "../env.ts";
 import { auth } from "../middleware/auth.ts";
-import {
-    type DiscordMembership,
-    DiscordRateLimitError,
-    discordConfigFromEnv,
-    getPollinationsDiscordMembership,
-} from "../services/discord.ts";
+import { discordConfigFromEnv } from "../services/discord.ts";
 import { QUEST_CATEGORIES } from "../services/quests/definitions.ts";
 import { listQuestCards } from "../services/quests/index.ts";
 import {
@@ -673,11 +668,6 @@ const profileResponseSchema = z.object({
         ),
 });
 
-const discordMembershipResponseSchema = z.object({
-    member: z.boolean(),
-    joinedAt: z.string().nullable(),
-});
-
 const accountBalanceSchema = z.object({
     total: z
         .number()
@@ -815,70 +805,6 @@ export const accountRoutes = new Hono<Env>()
     })
     .route("/agents", agentsRoutes)
     .route("/my-models", communityEndpointsRoutes)
-    .get(
-        "/discord-membership",
-        describeRoute({
-            tags: ["👤 Account"],
-            summary: "Check Discord Membership",
-            description:
-                "Checks whether the linked Discord account belongs to the Pollinations Discord server.",
-            responses: {
-                200: {
-                    description: "Discord membership status",
-                    content: {
-                        "application/json": {
-                            schema: resolver(discordMembershipResponseSchema),
-                        },
-                    },
-                },
-                401: { description: "Unauthorized" },
-                403: { description: "Dashboard session required" },
-                404: { description: "Discord account not connected" },
-                429: { description: "Discord membership check rate limited" },
-                502: { description: "Discord membership check failed" },
-            },
-        }),
-        async (c) => {
-            await c.var.auth.requireAuthorization();
-            if (!c.var.auth.session) {
-                throw new HTTPException(403, {
-                    message:
-                        "Discord membership checks require a dashboard session",
-                });
-            }
-            const user = c.var.auth.requireUser();
-            let membership: DiscordMembership | null;
-            try {
-                membership = await getPollinationsDiscordMembership(
-                    c.env,
-                    user.id,
-                );
-            } catch (error) {
-                if (error instanceof DiscordRateLimitError) {
-                    return c.json(
-                        {
-                            error: "rate_limited",
-                            message: "Discord membership check rate limited",
-                        },
-                        429,
-                        {
-                            "Retry-After": String(error.retryAfterSeconds),
-                        },
-                    );
-                }
-                throw new HTTPException(502, {
-                    message: "Discord membership check failed",
-                });
-            }
-
-            if (!membership) {
-                throw new HTTPException(404, {
-                    message: "Discord account not connected",
-                });
-            }
-            return c.json(membership);
-        },
-    )
     .get(
         "/profile",
         describeRoute({

--- a/enter.pollinations.ai/src/services/discord.ts
+++ b/enter.pollinations.ai/src/services/discord.ts
@@ -13,17 +13,9 @@ type DiscordConfig = {
     botToken: string;
 };
 
-export type DiscordMembership = {
+type CachedDiscordMembership = {
     member: boolean;
-    joinedAt: string | null;
 };
-
-export class DiscordRateLimitError extends Error {
-    constructor(readonly retryAfterSeconds: number) {
-        super("Discord membership lookup is rate limited");
-        this.name = "DiscordRateLimitError";
-    }
-}
 
 export function discordConfigFromEnv(env: object): DiscordConfig | null {
     const bindings = env as DiscordBindings;
@@ -35,12 +27,12 @@ export function discordConfigFromEnv(env: object): DiscordConfig | null {
         : null;
 }
 
-export async function getPollinationsDiscordMembership(
+export async function isPollinationsDiscordMember(
     env: CloudflareBindings,
     userId: string,
-): Promise<DiscordMembership | null> {
+): Promise<boolean> {
     const config = discordConfigFromEnv(env);
-    if (!config) return null;
+    if (!config) return false;
 
     const account = await env.DB.prepare(
         `SELECT account_id AS accountId
@@ -51,13 +43,14 @@ export async function getPollinationsDiscordMembership(
         .bind(userId)
         .first<{ accountId: string }>();
 
-    if (!account) return null;
+    if (!account) return false;
 
     const cacheKey = `discord:membership:${account.accountId}`;
-    const cached = await env.KV.get<DiscordMembership>(cacheKey, "json").catch(
-        () => null,
-    );
-    if (cached) return cached;
+    const cached = await env.KV.get<CachedDiscordMembership>(
+        cacheKey,
+        "json",
+    ).catch(() => null);
+    if (cached) return cached.member;
 
     const response = await fetch(
         `https://discord.com/api/v10/guilds/${POLLINATIONS_DISCORD_GUILD_ID}/members/${account.accountId}`,
@@ -69,22 +62,7 @@ export async function getPollinationsDiscordMembership(
     );
 
     if (response.status === 429) {
-        const body = (await response.json().catch(() => null)) as {
-            retry_after?: unknown;
-        } | null;
-        const headerSeconds = Number(response.headers.get("Retry-After"));
-        const bodySeconds = Number(body?.retry_after);
-        const retryAfterSeconds = Math.max(
-            1,
-            Math.ceil(
-                Number.isFinite(headerSeconds) && headerSeconds > 0
-                    ? headerSeconds
-                    : Number.isFinite(bodySeconds) && bodySeconds > 0
-                      ? bodySeconds
-                      : 1,
-            ),
-        );
-        throw new DiscordRateLimitError(retryAfterSeconds);
+        throw new Error("Discord membership lookup is rate limited");
     }
 
     if (response.status === 404) {
@@ -96,23 +74,19 @@ export async function getPollinationsDiscordMembership(
                 `Discord membership check failed: 404 code=${String(body?.code ?? "unknown")}`,
             );
         }
-        const membership = { member: false, joinedAt: null };
+        const membership = { member: false };
         await env.KV.put(cacheKey, JSON.stringify(membership), {
             expirationTtl: DISCORD_MEMBERSHIP_CACHE_TTL_SECONDS,
         }).catch(() => undefined);
-        return membership;
+        return false;
     }
     if (!response.ok) {
         throw new Error(`Discord membership check failed: ${response.status}`);
     }
 
-    const member = (await response.json()) as { joined_at?: string };
-    const membership = {
-        member: true,
-        joinedAt: member.joined_at ?? null,
-    };
+    const membership = { member: true };
     await env.KV.put(cacheKey, JSON.stringify(membership), {
         expirationTtl: DISCORD_MEMBERSHIP_CACHE_TTL_SECONDS,
     }).catch(() => undefined);
-    return membership;
+    return true;
 }

--- a/enter.pollinations.ai/src/services/quests/groups/discord-community.ts
+++ b/enter.pollinations.ai/src/services/quests/groups/discord-community.ts
@@ -1,6 +1,6 @@
 import {
     discordConfigFromEnv,
-    getPollinationsDiscordMembership,
+    isPollinationsDiscordMember,
 } from "../../discord.ts";
 import type { QuestDefinition } from "../definitions.ts";
 import {
@@ -34,10 +34,8 @@ export async function evaluateUser(
     user: QuestUser,
 ): Promise<QuestEvaluation> {
     if (!discordConfigFromEnv(env)) return { proposals: [] };
-    const membership = await getPollinationsDiscordMembership(env, user.id);
+    const member = await isPollinationsDiscordMember(env, user.id);
     return {
-        proposals: membership?.member
-            ? [{ quest: joinDiscordQuest, userId: user.id }]
-            : [],
+        proposals: member ? [{ quest: joinDiscordQuest, userId: user.id }] : [],
     };
 }

--- a/enter.pollinations.ai/test/integration/account-linking.test.ts
+++ b/enter.pollinations.ai/test/integration/account-linking.test.ts
@@ -8,7 +8,10 @@ import { and, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { expect } from "vitest";
 import { createAuth } from "../../src/auth.ts";
-import { discordConfigFromEnv } from "../../src/services/discord.ts";
+import {
+    discordConfigFromEnv,
+    isPollinationsDiscordMember,
+} from "../../src/services/discord.ts";
 import { checkQuestsForUser } from "../../src/services/quest-checker.ts";
 import { test } from "../fixtures.ts";
 
@@ -23,6 +26,23 @@ async function seedDiscordAccount(accountId: string): Promise<string> {
         userId: user.id,
     });
     return user.id;
+}
+
+async function getDiscordReward(userId: string) {
+    const db = drizzle(env.DB);
+    const [reward] = await db
+        .select({
+            questId: rewardsTable.questId,
+            pollenAmount: rewardsTable.pollenAmount,
+        })
+        .from(rewardsTable)
+        .where(
+            and(
+                eq(rewardsTable.userId, userId),
+                eq(rewardsTable.questId, "join_discord"),
+            ),
+        );
+    return reward ?? null;
 }
 
 test("requires complete Discord configuration", () => {
@@ -48,7 +68,6 @@ test("requires complete Discord configuration", () => {
 });
 
 test("links a Discord identity to the signed-in GitHub account", async ({
-    apiKey,
     mocks,
     sessionToken,
 }) => {
@@ -157,121 +176,55 @@ test("links a Discord identity to the signed-in GitHub account", async ({
         },
     });
 
-    const membershipResponse = await SELF.fetch(
-        "http://localhost:3000/api/account/discord-membership",
-        {
-            headers: {
-                Cookie: `better-auth.session_token=${sessionToken}`,
-            },
-        },
-    );
-    expect(membershipResponse.status).toBe(200);
-    await expect(membershipResponse.json()).resolves.toEqual({
-        member: true,
-        joinedAt: "2021-09-10T11:09:04.586000+00:00",
-    });
-    expect(mocks.discord.state.membershipRequestCount).toBe(1);
-
-    const cachedMembershipResponse = await SELF.fetch(
-        "http://localhost:3000/api/account/discord-membership",
-        {
-            headers: {
-                Cookie: `better-auth.session_token=${sessionToken}`,
-            },
-        },
-    );
-    expect(cachedMembershipResponse.status).toBe(200);
-    expect(mocks.discord.state.membershipRequestCount).toBe(1);
-
-    const apiKeyResponse = await SELF.fetch(
-        "http://localhost:3000/api/account/discord-membership",
-        { headers: { Authorization: `Bearer ${apiKey}` } },
-    );
-    expect(apiKeyResponse.status).toBe(403);
-    expect(mocks.discord.state.membershipRequestCount).toBe(1);
-
     await checkQuestsForUser(env, user.id);
     expect(mocks.discord.state.membershipRequestCount).toBe(1);
-    const [reward] = await db
-        .select({
-            questId: rewardsTable.questId,
-            pollenAmount: rewardsTable.pollenAmount,
-        })
-        .from(rewardsTable)
-        .where(
-            and(
-                eq(rewardsTable.userId, user.id),
-                eq(rewardsTable.questId, "join_discord"),
-            ),
-        );
-    expect(reward).toEqual({ questId: "join_discord", pollenAmount: 1 });
+    await checkQuestsForUser(env, user.id);
+    expect(mocks.discord.state.membershipRequestCount).toBe(1);
+    await expect(getDiscordReward(user.id)).resolves.toEqual({
+        questId: "join_discord",
+        pollenAmount: 1,
+    });
 });
 
 test("treats Discord error 10007 as a missing member", async ({
     mocks,
-    sessionToken,
+    sessionToken: _sessionToken,
 }) => {
     await mocks.enable("discord");
-    await seedDiscordAccount(mocks.discord.state.userId);
+    const userId = await seedDiscordAccount(mocks.discord.state.userId);
     mocks.discord.state.membershipStatus = 404;
     mocks.discord.state.membershipErrorCode = 10007;
 
-    const response = await SELF.fetch(
-        "http://localhost:3000/api/account/discord-membership",
-        {
-            headers: {
-                Cookie: `better-auth.session_token=${sessionToken}`,
-            },
-        },
-    );
-
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({
-        member: false,
-        joinedAt: null,
-    });
+    await expect(isPollinationsDiscordMember(env, userId)).resolves.toBe(false);
+    expect(mocks.discord.state.membershipRequestCount).toBe(1);
 });
 
 test("surfaces Discord 404 errors other than unknown member", async ({
     mocks,
-    sessionToken,
+    sessionToken: _sessionToken,
 }) => {
     await mocks.enable("discord");
-    await seedDiscordAccount(mocks.discord.state.userId);
+    const userId = await seedDiscordAccount(mocks.discord.state.userId);
     mocks.discord.state.membershipStatus = 404;
     mocks.discord.state.membershipErrorCode = 10004;
 
-    const response = await SELF.fetch(
-        "http://localhost:3000/api/account/discord-membership",
-        {
-            headers: {
-                Cookie: `better-auth.session_token=${sessionToken}`,
-            },
-        },
+    await expect(isPollinationsDiscordMember(env, userId)).rejects.toThrow(
+        "404 code=10004",
     );
-
-    expect(response.status).toBe(502);
+    expect(mocks.discord.state.membershipRequestCount).toBe(1);
 });
 
-test("forwards Discord membership rate limits", async ({
+test("surfaces Discord membership rate limits", async ({
     mocks,
-    sessionToken,
+    sessionToken: _sessionToken,
 }) => {
     await mocks.enable("discord");
-    await seedDiscordAccount(mocks.discord.state.userId);
+    const userId = await seedDiscordAccount(mocks.discord.state.userId);
     mocks.discord.state.membershipStatus = 429;
-    mocks.discord.state.retryAfterSeconds = 12;
 
-    const firstResponse = await SELF.fetch(
-        "http://localhost:3000/api/account/discord-membership",
-        {
-            headers: {
-                Cookie: `better-auth.session_token=${sessionToken}`,
-            },
-        },
+    await expect(isPollinationsDiscordMember(env, userId)).rejects.toThrow(
+        "Discord membership lookup is rate limited",
     );
-    expect(firstResponse.status).toBe(429);
-    expect(firstResponse.headers.get("Retry-After")).toBe("12");
     expect(mocks.discord.state.membershipRequestCount).toBe(1);
 });
 

--- a/enter.pollinations.ai/test/mocks/discord.ts
+++ b/enter.pollinations.ai/test/mocks/discord.ts
@@ -9,7 +9,6 @@ type MockDiscordState = {
     membershipRequestCount: number;
     membershipStatus: number;
     membershipErrorCode: number;
-    retryAfterSeconds: number;
 };
 
 export function createMockDiscord(): MockAPI<MockDiscordState> {
@@ -18,7 +17,6 @@ export function createMockDiscord(): MockAPI<MockDiscordState> {
         membershipRequestCount: 0,
         membershipStatus: 200,
         membershipErrorCode: 10007,
-        retryAfterSeconds: 12,
     };
     const userProfile = {
         id: state.userId,
@@ -61,10 +59,10 @@ export function createMockDiscord(): MockAPI<MockDiscordState> {
                 return c.json(
                     {
                         message: "You are being rate limited.",
-                        retry_after: state.retryAfterSeconds,
+                        retry_after: 12,
                     },
                     429,
-                    { "Retry-After": String(state.retryAfterSeconds) },
+                    { "Retry-After": "12" },
                 );
             }
             return c.json({
@@ -80,7 +78,6 @@ export function createMockDiscord(): MockAPI<MockDiscordState> {
             state.membershipRequestCount = 0;
             state.membershipStatus = 200;
             state.membershipErrorCode = 10007;
-            state.retryAfterSeconds = 12;
         },
         handlerMap: {
             "discord.com": createHonoMockHandler(discord),


### PR DESCRIPTION
- Removes the UI-only Discord membership endpoint and account-page status lookup
- Keeps membership verification inside the server-side Discord quest evaluator
- Simplifies cached membership results to a boolean while preserving Discord error handling
- Verifies linked members still earn the 1-Pollen `join_discord` reward

Tests:
- `npm run typecheck`
- `npx vitest run test/integration/account-linking.test.ts`
- `npx vitest run test/quests.test.ts`