### PR TITLE
feat: add metadata and filters to Models search

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/model-query.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-query.ts
@@ -1,0 +1,126 @@
+import { isPaidOnly } from "./model-info.ts";
+import type { ModelPrice } from "./types.ts";
+
+/** Supported `key:value` filter keys, inspired by GitHub search. */
+const FILTER_KEYS = ["access", "owner", "id", "type", "capability"] as const;
+
+export type ModelQueryFilterKey = (typeof FILTER_KEYS)[number];
+
+export type ModelQueryFilter =
+    | { key: "access"; value: "paid" | "quest" | "free" }
+    | { key: "owner"; value: string }
+    | { key: "id"; value: string }
+    | { key: "type"; value: string }
+    | { key: "capability"; value: string };
+
+export type ParsedModelQuery = {
+    terms: string[];
+    filters: ModelQueryFilter[];
+};
+
+const ACCESS_VALUES = ["paid", "quest", "free"] as const;
+
+type AccessValue = (typeof ACCESS_VALUES)[number];
+
+const isAccessValue = (value: string): value is AccessValue =>
+    (ACCESS_VALUES as readonly string[]).includes(value);
+
+const isFilterKey = (key: string): key is ModelQueryFilterKey =>
+    (FILTER_KEYS as readonly string[]).includes(key);
+
+/**
+ * Splits a raw query into free-text terms and `key:value` filters.
+ * Tokens that look like filters but use an unsupported key or an
+ * unknown access value stay free-text terms.
+ */
+export function parseModelQuery(query: string): ParsedModelQuery {
+    const terms: string[] = [];
+    const filters: ModelQueryFilter[] = [];
+
+    for (const token of query.split(/\s+/)) {
+        if (!token) continue;
+        const match = /^([a-zA-Z]+):(\S+)$/.exec(token);
+        const key = match?.[1]?.toLowerCase();
+        if (!match || !key || !isFilterKey(key)) {
+            terms.push(token.toLowerCase());
+            continue;
+        }
+        const value = match[2];
+        if (key === "access") {
+            const access = value.toLowerCase();
+            if (isAccessValue(access)) {
+                filters.push({ key, value: access });
+            } else {
+                terms.push(token.toLowerCase());
+            }
+            continue;
+        }
+        filters.push({ key, value } as ModelQueryFilter);
+    }
+
+    return { terms, filters };
+}
+
+function matchesAccess(
+    model: ModelPrice,
+    access: "paid" | "quest" | "free",
+): boolean {
+    if (access === "free") return model.free === true;
+    if (access === "paid") return isPaidOnly(model);
+    // "quest" is everything callable without paying up front.
+    return model.free !== true && !isPaidOnly(model);
+}
+
+function matchesFilter(model: ModelPrice, filter: ModelQueryFilter): boolean {
+    switch (filter.key) {
+        case "access":
+            return matchesAccess(model, filter.value);
+        case "owner": {
+            // Community ids are "<github-login>/<model>", so the public
+            // owner login is a prefix of the canonical id.
+            if (!model.community) return false;
+            return model.name
+                .toLowerCase()
+                .startsWith(`${filter.value.toLowerCase()}/`);
+        }
+        case "id":
+            return model.name.toLowerCase() === filter.value.toLowerCase();
+        case "type": {
+            const category = model.agent ? "agent" : model.type;
+            return category === filter.value.toLowerCase();
+        }
+        case "capability":
+            return model.capabilities.some(
+                (capability) => capability === filter.value.toLowerCase(),
+            );
+    }
+}
+
+function queryHaystack(model: ModelPrice): string {
+    return [
+        model.name,
+        model.displayName,
+        model.description,
+        model.brand,
+        model.baseModel,
+        ...(model.inputModalities ?? []),
+        ...(model.outputModalities ?? []),
+        ...model.capabilities,
+    ]
+        .filter((field) => typeof field === "string" && field.length > 0)
+        .join(" ")
+        .toLowerCase();
+}
+
+/** True when every term and every filter matches the model. */
+export function matchesModelQuery(
+    model: ModelPrice,
+    parsed: ParsedModelQuery,
+): boolean {
+    if (parsed.terms.length === 0 && parsed.filters.length === 0) return true;
+    const haystack = parsed.terms.length > 0 ? queryHaystack(model) : "";
+    return (
+        parsed.terms.every((term) => haystack.includes(term)) &&
+        parsed.filters.every((filter) => matchesFilter(model, filter))
+    );
+}

--- a/enter.pollinations.ai/frontend/src/components/models/models.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/models.tsx
@@ -34,7 +34,7 @@ import {
     fetchModelCatalog,
     getModelPricesFromCatalog,
 } from "./model-catalog.ts";
-import { getModelDisplayName } from "./model-info.ts";
+import { matchesModelQuery, parseModelQuery } from "./model-query.ts";
 import type { ModelScope, ModelSort } from "./model-search.ts";
 import { sortModels } from "./model-sort.ts";
 import {
@@ -116,13 +116,6 @@ const SEARCH_LABELS: Record<SectionType, string> = {
     agent: "agent",
 };
 
-function matchesQuery(model: ModelPrice, query: string): boolean {
-    if (!query) return true;
-    const displayName = getModelDisplayName(model) ?? "";
-    const haystack = `${displayName} ${model.brand ?? ""}`.toLowerCase();
-    return haystack.includes(query);
-}
-
 function categorizeModels(
     models: ModelPrice[],
 ): Record<SectionType, ModelPrice[]> {
@@ -191,7 +184,8 @@ export const Models: FC = () => {
         () => getModelPricesFromCatalog(catalogModels, stats),
         [catalogModels, stats],
     );
-    const query = search.trim().toLowerCase();
+    const query = search.trim();
+    const parsedQuery = useMemo(() => parseModelQuery(query), [query]);
     const scopedModels = useMemo(
         () =>
             allModels.filter(
@@ -202,10 +196,10 @@ export const Models: FC = () => {
     );
     const filteredModels = useMemo(
         () =>
-            query
-                ? scopedModels.filter((model) => matchesQuery(model, query))
+            parsedQuery
+                ? scopedModels.filter((model) => matchesModelQuery(model, parsedQuery))
                 : scopedModels,
-        [query, scopedModels],
+        [parsedQuery, scopedModels],
     );
 
     const loadModelCatalog = useCallback(
@@ -422,6 +416,9 @@ export const Models: FC = () => {
                                 aria-label={`Search ${searchTarget}`}
                                 className="w-full pl-9"
                             />
+                            <p className="mt-1 truncate text-xs text-theme-text-muted">
+                                Filters: access:paid · access:quest · access:free · owner:&lt;github-login&gt; · id:&lt;model-id&gt; · type:&lt;category&gt; · capability:&lt;capability&gt;
+                            </p>
                         </div>
                         <Dropdown
                             align="end"

--- a/enter.pollinations.ai/test/model-query.test.ts
+++ b/enter.pollinations.ai/test/model-query.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, test } from "vitest";
+import { matchesModelQuery, parseModelQuery } from "./model-query.ts";
+import type { ModelCategory, ModelPrice } from "./types.ts";
+
+function makeModel(overrides: Partial<ModelPrice> = {}): ModelPrice {
+    return {
+        name: "test-model",
+        type: "text" as ModelCategory,
+        capabilities: [],
+        prices: [],
+        ...overrides,
+    };
+}
+
+describe("parseModelQuery", () => {
+    test("empty string returns no filters and no terms", () => {
+        const result = parseModelQuery("");
+        expect(result.filters).toEqual([]);
+        expect(result.terms).toEqual([]);
+    });
+
+    test("whitespace-only string returns no filters and no terms", () => {
+        const result = parseModelQuery("   ");
+        expect(result.filters).toEqual([]);
+        expect(result.terms).toEqual([]);
+    });
+
+    test("splits free-text terms", () => {
+        const result = parseModelQuery("hello world");
+        expect(result.terms).toEqual(["hello", "world"]);
+        expect(result.filters).toEqual([]);
+    });
+
+    test("parses key:value filters", () => {
+        const result = parseModelQuery("access:paid type:video");
+        expect(result.filters).toEqual([
+            { key: "access", value: "paid" },
+            { key: "type", value: "video" },
+        ]);
+        expect(result.terms).toEqual([]);
+    });
+
+    test("combines free-text terms and filters", () => {
+        const result = parseModelQuery("flux access:paid video");
+        expect(result.filters).toEqual([{ key: "access", value: "paid" }]);
+        expect(result.terms).toEqual(["flux", "video"]);
+    });
+
+    test("unknown filter keys are kept as terms", () => {
+        const result = parseModelQuery("unknown:value hello");
+        expect(result.filters).toEqual([]);
+        expect(result.terms).toEqual(["unknown:value", "hello"]);
+    });
+
+    test("filter with empty value is treated as a term", () => {
+        const result = parseModelQuery("access: hello");
+        expect(result.filters).toEqual([]);
+        expect(result.terms).toEqual(["access:", "hello"]);
+    });
+
+    test("invalid access value degrades to term", () => {
+        const result = parseModelQuery("access:maybe hello");
+        expect(result.filters).toEqual([]);
+        expect(result.terms).toEqual(["access:maybe", "hello"]);
+    });
+
+    test("preserves owner value case for matching", () => {
+        const result = parseModelQuery("owner:SomeUser id:MODEL-ID");
+        expect(result.filters).toEqual([
+            { key: "owner", value: "SomeUser" },
+            { key: "id", value: "MODEL-ID" },
+        ]);
+    });
+});
+
+describe("matchesModelQuery", () => {
+    test("empty query matches everything", () => {
+        const model = makeModel({ name: "test", type: "text" });
+        expect(matchesModelQuery(model, parseModelQuery(""))).toBe(true);
+        expect(matchesModelQuery(model, parseModelQuery("   "))).toBe(true);
+    });
+
+    test("free-text matches by name", () => {
+        const model = makeModel({
+            name: "gpt-5-pro",
+            type: "text",
+        });
+        expect(matchesModelQuery(model, parseModelQuery("gpt"))).toBe(true);
+        expect(matchesModelQuery(model, parseModelQuery("gpt-5"))).toBe(true);
+        expect(matchesModelQuery(model, parseModelQuery("nonexistent"))).toBe(
+            false,
+        );
+    });
+
+    test("free-text matches by displayName", () => {
+        const model = makeModel({
+            name: "model-x",
+            displayName: "GPT-5.5 Luna",
+            type: "text",
+        });
+        expect(matchesModelQuery(model, parseModelQuery("luna"))).toBe(true);
+        expect(matchesModelQuery(model, parseModelQuery("gpt-5.5"))).toBe(true);
+    });
+
+    test("free-text matches by brand", () => {
+        const model = makeModel({
+            name: "model-x",
+            brand: "Google",
+            type: "text",
+        });
+        expect(matchesModelQuery(model, parseModelQuery("google"))).toBe(true);
+    });
+
+    test("free-text matches by description", () => {
+        const model = makeModel({
+            name: "model-x",
+            description: "Fast text generation with strong reasoning",
+            type: "text",
+        });
+        expect(matchesModelQuery(model, parseModelQuery("reasoning"))).toBe(
+            true,
+        );
+        expect(matchesModelQuery(model, parseModelQuery("fast generation"))).toBe(
+            true,
+        );
+    });
+
+    test("free-text matches by modalities", () => {
+        const model = makeModel({
+            name: "model-x",
+            type: "image",
+            inputModalities: ["text", "image"],
+            outputModalities: ["image"],
+        });
+        expect(matchesModelQuery(model, parseModelQuery("video"))).toBe(false);
+        expect(matchesModelQuery(model, parseModelQuery("audio"))).toBe(false);
+        expect(matchesModelQuery(model, parseModelQuery("text image"))).toBe(true);
+    });
+
+    test("free-text matches by capabilities", () => {
+        const model = makeModel({
+            name: "model-x",
+            type: "text",
+            capabilities: ["reasoning", "tool_calling"],
+        });
+        expect(matchesModelQuery(model, parseModelQuery("reasoning"))).toBe(true);
+        expect(matchesModelQuery(model, parseModelQuery("web_search"))).toBe(
+            false,
+        );
+    });
+
+    test("free-text requires all terms to match (AND logic)", () => {
+        const model = makeModel({
+            name: "gpt-5",
+            brand: "OpenAI",
+            type: "text",
+        });
+        expect(matchesModelQuery(model, parseModelQuery("gpt openai"))).toBe(true);
+        expect(
+            matchesModelQuery(model, parseModelQuery("gpt anthropic")),
+        ).toBe(false);
+    });
+
+    test("access:paid filter matches paidOnly models", () => {
+        const model = makeModel({
+            name: "paid-model",
+            type: "text",
+            paidOnly: true,
+            free: false,
+        });
+        expect(matchesModelQuery(model, parseModelQuery("access:paid"))).toBe(
+            true,
+        );
+        expect(matchesModelQuery(model, parseModelQuery("access:free"))).toBe(
+            false,
+        );
+        expect(matchesModelQuery(model, parseModelQuery("access:quest"))).toBe(
+            false,
+        );
+    });
+
+    test("access:free filter matches free models", () => {
+        const model = makeModel({
+            name: "free-model",
+            type: "text",
+            free: true,
+            paidOnly: false,
+        });
+        expect(matchesModelQuery(model, parseModelQuery("access:free"))).toBe(
+            true,
+        );
+        expect(matchesModelQuery(model, parseModelQuery("access:paid"))).toBe(
+            false,
+        );
+        expect(matchesModelQuery(model, parseModelQuery("access:quest"))).toBe(
+            false,
+        );
+    });
+
+    test("access:quest filter matches models that are not free and not paidOnly", () => {
+        const model = makeModel({
+            name: "quest-model",
+            type: "text",
+            free: false,
+            paidOnly: false,
+        });
+        expect(matchesModelQuery(model, parseModelQuery("access:quest"))).toBe(
+            true,
+        );
+        expect(matchesModelQuery(model, parseModelQuery("access:free"))).toBe(
+            false,
+        );
+        expect(matchesModelQuery(model, parseModelQuery("access:paid"))).toBe(
+            false,
+        );
+    });
+
+    test("owner: filter matches community model owner from name prefix", () => {
+        const model = makeModel({
+            name: "someuser/my-model",
+            type: "text",
+            community: true,
+        });
+        expect(matchesModelQuery(model, parseModelQuery("owner:someuser"))).toBe(
+            true,
+        );
+        expect(matchesModelQuery(model, parseModelQuery("owner:otheruser"))).toBe(
+            false,
+        );
+    });
+
+    test("owner: filter does not match non-community models", () => {
+        const model = makeModel({
+            name: "official-model",
+            type: "text",
+            community: false,
+        });
+        expect(matchesModelQuery(model, parseModelQuery("owner:anyone"))).toBe(
+            false,
+        );
+    });
+
+    test("id: filter matches exact model id case-insensitively", () => {
+        const model = makeModel({
+            name: "Flux-Schnell",
+            type: "image",
+        });
+        expect(matchesModelQuery(model, parseModelQuery("id:flux-schnell"))).toBe(
+            true,
+        );
+        expect(matchesModelQuery(model, parseModelQuery("id:FLUX-SCHNELL"))).toBe(
+            true,
+        );
+        expect(matchesModelQuery(model, parseModelQuery("id:other"))).toBe(false);
+    });
+
+    test("type: filter matches canonical category", () => {
+        const model = makeModel({
+            name: "my-video-model",
+            type: "video",
+            community: true,
+        });
+        expect(matchesModelQuery(model, parseModelQuery("type:video"))).toBe(true);
+        expect(matchesModelQuery(model, parseModelQuery("type:image"))).toBe(
+            false,
+        );
+    });
+
+    test("type: agent models match agent category", () => {
+        const model = makeModel({
+            name: "agent-model",
+            type: "text",
+            agent: true,
+            community: true,
+        });
+        expect(matchesModelQuery(model, parseModelQuery("type:agent"))).toBe(true);
+        expect(matchesModelQuery(model, parseModelQuery("type:text"))).toBe(false);
+    });
+
+    test("capability: filter matches model capabilities", () => {
+        const model = makeModel({
+            name: "smart-model",
+            type: "text",
+            capabilities: ["reasoning", "tool_calling"],
+        });
+        expect(
+            matchesModelQuery(model, parseModelQuery("capability:reasoning")),
+        ).toBe(true);
+        expect(
+            matchesModelQuery(model, parseModelQuery("capability:web_search")),
+        ).toBe(false);
+    });
+
+    test("combined terms and filters use AND logic", () => {
+        const model = makeModel({
+            name: "flux-schnell",
+            type: "image",
+            community: true,
+            free: false,
+            paidOnly: true,
+        });
+        const parsed = parseModelQuery("flux access:paid");
+        expect(matchesModelQuery(model, parsed)).toBe(true);
+    });
+
+    test("unrelated terms with matching filter still match", () => {
+        const model = makeModel({
+            name: "dall-e-3",
+            type: "image",
+            free: true,
+        });
+        // "xyz" won't match anything in haystack but access:free will
+        const parsed = parseModelQuery("xyz access:free");
+        expect(matchesModelQuery(model, parsed)).toBe(false); // term fails
+    });
+
+    test("query with only filter terms no free-text matching", () => {
+        const model = makeModel({
+            name: "test-model",
+            type: "text",
+            free: true,
+        });
+        expect(matchesModelQuery(model, parseModelQuery("access:free"))).toBe(
+            true,
+        );
+    });
+});


### PR DESCRIPTION
Closes #13907

Adds key:value filter syntax to the Models search, enabling precise filtering alongside free-text discovery.

**Changes:**
- Added `model-query.ts` with `parseModelQuery()` and `matchesModelQuery()` functions
- Extended `models.tsx` to use the new query parser with filter support
- Added discoverable filter hint text below the search box

**Supported filters:**
- `access:paid`, `access:quest`, `access:free`
- `owner:<github-login>`
- `id:<model-id>`
- `type:<category>`
- `capability:<capability>`

**Test coverage:**
- Comprehensive unit tests in `test/model-query.test.ts`

Frontend-only change; no backend or API modifications required.