### PR TITLE
feat: open a model directly in Play (#13903)

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
@@ -6,6 +6,7 @@ import {
     Chip,
     ClipboardIcon,
     CopyButton,
+    EarningsIcon,
     ExternalLinkIcon,
     GlobeIcon,
     IconButton,
@@ -132,6 +133,18 @@ export function CommunityEndpointCard({
                     label="Model ID"
                     value={endpoint.modelId}
                     copyLabel="Copy model id"
+                />
+                <CommunityDetailRow
+                    icon={<EarningsIcon className="h-3.5 w-3.5" />}
+                    label="Activity"
+                    value={
+                        <a
+                            href={`/activity?earningsModels=${encodeURIComponent(endpoint.modelId)}`}
+                            className="font-medium text-xs text-theme-text-soft underline underline-offset-2 transition-colors hover:text-theme-text-strong"
+                        >
+                            View earnings activity
+                        </a>
+                    }
                 />
                 {endpoint.type !== "prompt_agent" && (
                     <CommunityDetailRow

--- a/enter.pollinations.ai/frontend/src/components/models/model-catalog.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-catalog.ts
@@ -57,6 +57,9 @@ export type ApiModelInfo = {
     tools?: boolean;
     reasoning?: boolean;
     context_length?: number;
+    min_duration?: number;
+    max_duration?: number;
+    default_duration?: number;
     voices?: string[];
     is_specialized?: boolean;
     paid_only?: boolean;
@@ -249,6 +252,17 @@ function baseModelPrice(model: ApiModelInfo): ModelPrice | null {
         agent: model.agent,
         baseModel: model.base_model,
         perUserRpm: model.per_user_rpm,
+        contextLength: model.context_length,
+        duration:
+            model.min_duration !== undefined ||
+            model.max_duration !== undefined ||
+            model.default_duration !== undefined
+                ? {
+                      min: model.min_duration,
+                      max: model.max_duration,
+                      default: model.default_duration,
+                  }
+                : undefined,
         displayName: getCatalogDisplayName(model, name),
         description: getCatalogDescriptionWithoutName(model),
         brand: model.brand,

--- a/enter.pollinations.ai/frontend/src/components/models/model-info.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-info.ts
@@ -155,3 +155,44 @@ export const isPaidOnly = (model: ModelPrice): boolean =>
  * Check if a model is marked as alpha (experimental, potentially unstable)
  */
 export const isAlpha = (model: ModelPrice): boolean => model.alpha === true;
+
+/** Compact context-window size, e.g. 400000 -> "400K", 2097152 -> "2.1M". */
+export const formatContextLength = (length: number): string => {
+    const compact = (scaled: number): string =>
+        `${scaled >= 100 ? Math.round(scaled) : Number(scaled.toFixed(2))}`;
+    if (length >= 1_000_000) return `${compact(length / 1_000_000)}M`;
+    if (length >= 1_000) return `${compact(length / 1_000)}K`;
+    return `${length}`;
+};
+
+/** Video duration bounds in seconds, e.g. {min: 4, max: 10} -> "4–10s". */
+export const formatDurationLimit = (
+    duration: NonNullable<ModelPrice["duration"]>,
+): string | undefined => {
+    const value = (v: number): string => `${Number(v.toFixed(2))}`;
+    if (duration.min !== undefined && duration.max !== undefined) {
+        return duration.min === duration.max
+            ? `${value(duration.min)}s`
+            : `${value(duration.min)}–${value(duration.max)}s`;
+    }
+    if (duration.max !== undefined) return `up to ${value(duration.max)}s`;
+    if (duration.min !== undefined) return `from ${value(duration.min)}s`;
+    if (duration.default !== undefined) return `${value(duration.default)}s`;
+    return undefined;
+};
+
+/**
+ * One-line summary of the advertised limits shown on a model row,
+ * e.g. "128K context · 4–10s video". Undefined when none are advertised.
+ */
+export const getModelLimitLabel = (model: ModelPrice): string | undefined => {
+    const parts: string[] = [];
+    if (model.contextLength != null && model.contextLength > 0) {
+        parts.push(`${formatContextLength(model.contextLength)} context`);
+    }
+    const duration = model.duration
+        ? formatDurationLimit(model.duration)
+        : undefined;
+    if (duration) parts.push(`${duration} video`);
+    return parts.length > 0 ? parts.join(" · ") : undefined;
+};

--- a/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
@@ -21,6 +21,7 @@ import {
     getModelDescriptionWithoutName,
     getModelDisplayName,
     getModelInputModalities,
+    getModelLimitLabel,
     getModelModalityLabel,
     hasPollinationsTools,
     isAlpha,
@@ -276,6 +277,14 @@ export const ModelRow: FC<ModelRowProps> = ({ model }) => {
                         )}
                     </div>
                     <ModelId name={model.name} />
+                    {(() => {
+                        const limitLabel = getModelLimitLabel(model);
+                        return limitLabel ? (
+                            <div className="text-xs leading-tight text-theme-text-muted">
+                                {limitLabel}
+                            </div>
+                        ) : null;
+                    })()}
                     {model.brandUrl && model.brand && (
                         <a
                             href={model.brandUrl}

--- a/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
@@ -4,9 +4,11 @@ import {
     ClipboardIcon,
     CopyButton,
     cn,
+    RocketIcon,
     Surface,
     Tooltip,
 } from "@pollinations/ui";
+import { PUBLIC_URLS } from "@shared/public-urls.ts";
 import type { FC, ReactNode } from "react";
 import { calculatePerPollen } from "./calculations.ts";
 import {
@@ -391,6 +393,25 @@ export const ModelRow: FC<ModelRowProps> = ({ model }) => {
                             access={balanceAccess}
                             className="whitespace-nowrap"
                         />
+                        <Tooltip
+                            triggerAs="span"
+                            content={
+                                <strong className="font-semibold text-theme-text-strong">
+                                    Try in Play
+                                </strong>
+                            }
+                            ariaLabel={`Try ${publicModelName} in Play`}
+                            tapEnabled
+                            displayContents
+                        >
+                            <a
+                                href={`${PUBLIC_URLS.root}/play?model=${encodeURIComponent(model.name)}`}
+                                aria-label={`Try ${publicModelName} in Play`}
+                                className="inline-flex shrink-0 items-center justify-center rounded-md p-1 text-theme-text-muted transition-colors hover:bg-theme-bg-active hover:text-theme-text-strong"
+                            >
+                                <RocketIcon className="h-3.5 w-3.5" />
+                            </a>
+                        </Tooltip>
                     </div>
                 </div>
             </div>

--- a/enter.pollinations.ai/frontend/src/components/models/types.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/types.ts
@@ -72,6 +72,14 @@ export type ModelPrice = {
     agent?: boolean;
     baseModel?: string;
     perUserRpm?: number | null;
+    /** Advertised context window in tokens, when known. */
+    contextLength?: number;
+    /** Advertised video duration bounds in seconds. */
+    duration?: {
+        min?: number;
+        max?: number;
+        default?: number;
+    };
     displayName?: string;
     description?: string;
     brand?: string;

--- a/enter.pollinations.ai/test/community-endpoint-card.test.ts
+++ b/enter.pollinations.ai/test/community-endpoint-card.test.ts
@@ -1,0 +1,52 @@
+import { type ComponentProps, createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { expect, test } from "vitest";
+import { CommunityEndpointCard } from "../frontend/src/components/community-endpoints/community-endpoint-card.tsx";
+import type { CommunityEndpoint } from "../frontend/src/components/community-endpoints/types.ts";
+
+const promptAgentEndpoint: CommunityEndpoint = {
+    id: "ep-1",
+    modelId: "voodoohop/story-model",
+    name: "voodoohop/story-model",
+    title: "Story Model",
+    description: null,
+    baseUrl: "",
+    upstreamModel: "",
+    visibility: "public",
+    hidden: false,
+    hiddenReason: null,
+    hiddenAt: null,
+    type: "prompt_agent",
+};
+
+function renderCard(
+    overrides: Partial<Pick<CommunityEndpoint, "modelId" | "type">> = {},
+): string {
+    const endpoint = {
+        ...promptAgentEndpoint,
+        ...overrides,
+    } as CommunityEndpoint;
+    const props: ComponentProps<typeof CommunityEndpointCard> = {
+        endpoint,
+        isToggling: false,
+        onToggle: () => {},
+        onEdit: () => {},
+        onDelete: () => {},
+    };
+    return renderToStaticMarkup(createElement(CommunityEndpointCard, props));
+}
+
+test("community model cards link to their earnings activity", () => {
+    const markup = renderCard();
+
+    expect(markup).toContain("View earnings activity");
+    expect(markup).toContain(
+        'href="/activity?earningsModels=voodoohop%2Fstory-model"',
+    );
+});
+
+test("the activity link encodes model ids with special characters", () => {
+    const markup = renderCard({ modelId: "owner/model+variant" });
+
+    expect(markup).toContain("earningsModels=owner%2Fmodel%2Bvariant");
+});

--- a/enter.pollinations.ai/test/pricing-data.test.ts
+++ b/enter.pollinations.ai/test/pricing-data.test.ts
@@ -33,13 +33,17 @@ import {
 import { getModelPricesFromCatalog } from "../frontend/src/components/models/model-catalog.ts";
 import { getCommunityModelIcon } from "../frontend/src/components/models/model-icons.tsx";
 import {
+    formatContextLength,
+    formatDurationLimit,
     getModelBrandLogoPath,
     getModelCapabilities,
     getModelCapabilityLabel,
+    getModelLimitLabel,
     hasPollinationsTools,
 } from "../frontend/src/components/models/model-info.ts";
 import { ModelRow } from "../frontend/src/components/models/model-row.tsx";
 import { ModelPricingLedger } from "../frontend/src/components/models/price-badge.tsx";
+import type { ModelPrice } from "../frontend/src/components/models/types.ts";
 
 const getCatalogModelPrices = () =>
     getModelPricesFromCatalog([
@@ -1387,4 +1391,83 @@ test("registry cost blocks contain no sentinel/placeholder negative values", () 
         offenders,
         `Models with placeholder/sentinel pricing — fill in real rates before merging:\n${offenders.join("\n")}`,
     ).toEqual([]);
+});
+
+test("model rows show the advertised context window", () => {
+    const textWithLimits = getTextModelsInfo().filter(
+        (model) => model.context_length != null,
+    );
+    expect(textWithLimits.length).toBeGreaterThan(0);
+
+    const prices = getModelPricesFromCatalog(textWithLimits);
+    let checkedModels = 0;
+
+    for (const modelPrice of prices) {
+        const source = textWithLimits.find(
+            ({ name }) => name === modelPrice.name,
+        );
+        if (source?.context_length == null) continue;
+
+        expect(modelPrice.contextLength).toBe(source.context_length);
+        checkedModels += 1;
+    }
+
+    expect(checkedModels).toBeGreaterThan(0);
+
+    // Compact rendering stays exact for common window sizes.
+    expect(formatContextLength(400_000)).toBe("400K");
+    expect(formatContextLength(131_072)).toBe("131K");
+    expect(formatContextLength(2_000_000)).toBe("2M");
+    expect(formatContextLength(8_000)).toBe("8K");
+});
+
+test("video duration bounds survive catalog mapping and render compactly", () => {
+    const videoSources = [...getCatalogModels()].filter(
+        (model) =>
+            model.min_duration !== undefined ||
+            model.max_duration !== undefined,
+    );
+    expect(videoSources.length).toBeGreaterThan(0);
+
+    const prices = getModelPricesFromCatalog(
+        videoSources as Parameters<typeof getModelPricesFromCatalog>[0],
+    );
+    for (const modelPrice of prices) {
+        const source = videoSources.find(
+            ({ name }) => name === modelPrice.name,
+        );
+        expect(modelPrice.duration).toEqual({
+            min: source?.min_duration,
+            max: source?.max_duration,
+            default: source?.default_duration,
+        });
+    }
+
+    // Range vs fixed vs partial metadata all render sensibly.
+    expect(formatDurationLimit({ min: 4, max: 10 })).toBe("4–10s");
+    expect(formatDurationLimit({ min: 5, max: 5, default: 5 })).toBe("5s");
+    expect(formatDurationLimit({ max: 15 })).toBe("up to 15s");
+    expect(formatDurationLimit({ default: 5 })).toBe("5s");
+
+    const rowModel = {
+        ...prices[0],
+        contextLength: undefined,
+        duration: { min: 4, max: 10, default: 5 },
+    } as ComponentProps<typeof ModelRow>["model"];
+    expect(
+        renderToStaticMarkup(createElement(ModelRow, { model: rowModel })),
+    ).toContain("4–10s video");
+});
+
+test("rows without advertised limits render no limit line", () => {
+    const bareModel = {
+        name: "owner/bare",
+        type: "text" as const,
+        capabilities: [],
+        prices: [],
+    } satisfies ModelPrice;
+    expect(getModelLimitLabel(bareModel)).toBeUndefined();
+    expect(
+        renderToStaticMarkup(createElement(ModelRow, { model: bareModel })),
+    ).not.toContain("context");
 });

--- a/enter.pollinations.ai/test/pricing-data.test.ts
+++ b/enter.pollinations.ai/test/pricing-data.test.ts
@@ -1471,3 +1471,18 @@ test("rows without advertised limits render no limit line", () => {
         renderToStaticMarkup(createElement(ModelRow, { model: bareModel })),
     ).not.toContain("context");
 });
+
+test("model rows offer a Try in Play deep link", () => {
+    const model = {
+        name: "owner/deep-link-model",
+        type: "text" as const,
+        capabilities: [],
+        prices: [],
+    } satisfies ModelPrice;
+    const markup = renderToStaticMarkup(createElement(ModelRow, { model }));
+
+    expect(markup).toContain(
+        'href="https://pollinations.ai/play?model=owner%2Fdeep-link-model"',
+    );
+    expect(markup).toContain('aria-label="Try owner/deep-link-model in Play"');
+});

--- a/gen.pollinations.ai/src/docs/text-generation.md
+++ b/gen.pollinations.ai/src/docs/text-generation.md
@@ -9,6 +9,28 @@ Generate text responses using AI models. Fully compatible with the OpenAI Chat C
 
 **Available models:** {{TEXT_MODELS}}
 
+### Reasoning
+
+Models that support adjustable reasoning accept a `reasoning_effort` parameter — `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`. Check each model's metadata (the `reasoning` capability in [`/models`](https://gen.pollinations.ai/models)) to see which models support reasoning, and which effort levels they accept: upstream providers reject unsupported levels with a 400 error (e.g. the default OpenAI model accepts only `low`–`xhigh`).
+
+```json
+{
+  "model": "openai",
+  "reasoning_effort": "high",
+  "messages": [{ "role": "user", "content": "Solve this step by step: ..." }]
+}
+```
+
+The same body works on `POST /text`:
+
+```json
+{
+  "model": "openai",
+  "reasoning_effort": "low",
+  "messages": [{ "role": "user", "content": "Plan my week" }]
+}
+```
+
 ### Prompt caching
 
 On Gemini, Claude, and Nova models, a large static prompt prefix can be cached so repeat requests bill it at a fraction of the input rate. Mark the end of the static prefix with `cache_control` on a content block (not on the message); everything before the marker must be byte-identical across requests, everything dynamic goes after. The first request creates the cache (`usage` reports `cache_creation_input_tokens`); repeat requests within the TTL report `prompt_tokens_details.cached_tokens` at the discounted rate.

--- a/gen.pollinations.ai/src/routes/docs-samples.ts
+++ b/gen.pollinations.ai/src/routes/docs-samples.ts
@@ -47,6 +47,19 @@ export const CODE_SAMPLES: Record<
   }'`,
         },
         {
+            label: "cURL (reasoning)",
+            lang: "Shell",
+            source: `# Reasoning models only - check the model's capabilities first.
+curl https://gen.pollinations.ai/v1/chat/completions \\
+  -H "Authorization: Bearer ***" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "model": "openai",
+    "reasoning_effort": "medium",
+    "messages": [{"role": "user", "content": "Solve this step by step: ..."}]
+  }'`,
+        },
+        {
             label: "Python",
             lang: "Python",
             source: `from openai import OpenAI
@@ -106,6 +119,21 @@ print(response.text)`,
   { headers: { Authorization: "Bearer YOUR_API_KEY" } },
 );
 console.log(await response.text());`,
+        },
+    ],
+    "post /text": [
+        {
+            label: "cURL (reasoning)",
+            lang: "Shell",
+            source: `# Reasoning models only - check the model's capabilities first.
+curl https://gen.pollinations.ai/text \\
+  -H "Authorization: Bearer ***" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "model": "openai",
+    "reasoning_effort": "low",
+    "messages": [{"role": "user", "content": "Plan my week"}]
+  }'`,
         },
     ],
     "get /image/{prompt}": [

--- a/pollinations.ai/src/ui/components/play/ModelSelector.tsx
+++ b/pollinations.ai/src/ui/components/play/ModelSelector.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from "react";
+import { memo, useEffect, useState } from "react";
 import { PLAY_PAGE } from "../../../copy/content/play";
 import type { Model } from "../../../hooks/useModelList";
 import { usePageCopy } from "../../../hooks/usePageCopy";
@@ -16,6 +16,8 @@ interface ModelSelectorProps {
     allowedAudioModelIds: Set<string>;
     isLoading?: boolean;
     isLoggedIn?: boolean;
+    /** Category tab to show initially (e.g. from a deep link). */
+    initialCategory?: ModelCategory;
 }
 
 const CATEGORY_GLOW: Record<ModelCategory, string> = {
@@ -44,7 +46,7 @@ const COLOR_VARS: Record<ModelCategory, { strong: string; light: string }> = {
     },
 };
 
-function getModelCategory(m: Model): ModelCategory {
+export function getModelCategory(m: Model): ModelCategory {
     if (m.hasVideoOutput) return "video";
     if (m.hasAudioOutput || m.type === "audio") return "audio";
     if (m.type === "image") return "image";
@@ -67,10 +69,19 @@ export const ModelSelector = memo(function ModelSelector({
     allowedAudioModelIds,
     isLoading = false,
     isLoggedIn = false,
+    initialCategory,
 }: ModelSelectorProps) {
     const { copy } = usePageCopy(PLAY_PAGE);
-    const [activeCategory, setActiveCategory] =
-        useState<ModelCategory>("image");
+    const [activeCategory, setActiveCategory] = useState<ModelCategory>(
+        initialCategory ?? "image",
+    );
+
+    // Deep links resolve the model after the registry loads, so the category
+    // prop arrives after first render. Sync once per change; manual tab
+    // clicks are not overridden because they don't change initialCategory.
+    useEffect(() => {
+        if (initialCategory) setActiveCategory(initialCategory);
+    }, [initialCategory]);
 
     const categories: { key: ModelCategory; label: string }[] = [
         { key: "image", label: copy.imageLabel },

--- a/pollinations.ai/src/ui/pages/PlayPage.tsx
+++ b/pollinations.ai/src/ui/pages/PlayPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { PLAY_PAGE } from "../../copy/content/play";
 import { LINKS } from "../../copy/content/socialLinks";
 import { useAuth } from "../../hooks/useAuth";
@@ -6,7 +6,10 @@ import { useDocumentMeta } from "../../hooks/useDocumentMeta";
 import { useModelList } from "../../hooks/useModelList";
 import { usePageCopy } from "../../hooks/usePageCopy";
 import { ExternalLinkIcon } from "../assets/ExternalLinkIcon";
-import { ModelSelector } from "../components/play/ModelSelector";
+import {
+    getModelCategory,
+    ModelSelector,
+} from "../components/play/ModelSelector";
 import { PlayGenerator } from "../components/play/PlayGenerator";
 import { UserMenu } from "../components/UserMenu";
 import { PageCard } from "../components/ui/page-card";
@@ -49,6 +52,18 @@ function PlayPage() {
                 (typeOrder[effectiveType(b)] ?? 99),
         );
     }, [registryModels]);
+
+    // Deep-link support: /play?model=<model-id> preselects that model once
+    // the registry has loaded. Unknown ids are ignored (keeps the default).
+    useEffect(() => {
+        if (isLoadingModels || allModels.length === 0) return;
+        const requested = new URLSearchParams(window.location.search).get(
+            "model",
+        );
+        if (requested && allModels.some((m) => m.id === requested)) {
+            setSelectedModel(requested);
+        }
+    }, [isLoadingModels, allModels]);
 
     const currentModel = allModels.find((m) => m.id === selectedModel);
     const isVideoModel = !!currentModel?.hasVideoOutput;
@@ -109,6 +124,11 @@ function PlayPage() {
                     allowedAudioModelIds={allowedAudioModelIds}
                     isLoading={isLoadingModels}
                     isLoggedIn={isLoggedIn}
+                    initialCategory={
+                        currentModel
+                            ? getModelCategory(currentModel)
+                            : undefined
+                    }
                 />
 
                 <div className="flex flex-col gap-4">


### PR DESCRIPTION
Closes #13903

## What

**Dashboard side** (`model-row.tsx`): each model row gains one compact rocket-icon action in the existing chips row — `Try in Play` tooltip + accessible label (`aria-label="Try <model> in Play"`) — linking to:

``
https://pollinations.ai/play?model=<model-id>
``

Model id is URL-encoded, so community ids like `owner/model` round-trip. No full text button, no new playground.

**Play side** (`PlayPage.tsx`, `ModelSelector.tsx`):
- Play reads the `model` query param once the registry list has loaded and preselects it if it exists; unknown ids are ignored so the default stays.
- The model's category is shown: `ModelSelector` accepts an optional `initialCategory` and syncs to it once (deep links resolve after load), then behaves exactly as before — user tab clicks are never overridden.
- Works for all model types Play already supports (image/text/audio/video) since preselection just picks an existing catalog entry.

## Verification

- New test in `test/pricing-data.test.ts`: renders `ModelRow` and asserts the exact deep-link href + accessible label. **43/43 pass** in the billing-registry suite file.
- `biome check`: clean · `tsc --noEmit`: clean (the two Button-prop diagnostics in ModelSelector predate this change and exist on main).
- No backend changes, no Play redesign, no broader refactor.