### PR TITLE
feat: metadata search and key:value filters for Models search (#13907)

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/model-query.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-query.ts
@@ -1,0 +1,110 @@
+import { getModelCapabilities, getModelDisplayName } from "./model-info.ts";
+import type { ModelPrice } from "./types.ts";
+
+export type ModelAccess = "paid" | "quest" | "free";
+
+/** key:value terms parsed out of the free-text query. */
+type QueryFilter = {
+    key: string;
+    value: string;
+};
+
+export type ParsedModelQuery = {
+    /** Lowercased free-text terms that must all match. */
+    text: string[];
+    filters: QueryFilter[];
+};
+
+const FILTER_KEYS = new Set(["access", "owner", "id", "type", "capability"]);
+
+/**
+ * Split a raw query into lowercase free-text terms and `key:value` filters.
+ * A `key:value` token is only treated as a filter when `key` is a known
+ * filter name; otherwise it stays a text term. Inspired by GitHub search —
+ * deliberately no negation, parentheses, or quoted phrases.
+ */
+export function parseModelQuery(rawQuery: string): ParsedModelQuery {
+    const text: string[] = [];
+    const filters: QueryFilter[] = [];
+
+    for (const token of rawQuery.split(/\s+/)) {
+        if (!token) continue;
+        const separator = token.indexOf(":");
+        if (
+            separator > 0 &&
+            separator < token.length - 1 &&
+            FILTER_KEYS.has(token.slice(0, separator).toLowerCase())
+        ) {
+            filters.push({
+                key: token.slice(0, separator).toLowerCase(),
+                value: token.slice(separator + 1).toLowerCase(),
+            });
+        } else {
+            text.push(token.toLowerCase());
+        }
+    }
+
+    return { text, filters };
+}
+
+function modelAccess(model: ModelPrice): ModelAccess {
+    if (model.free) return "free";
+    return model.paidOnly ? "paid" : "quest";
+}
+
+function matchesFilter(model: ModelPrice, filter: QueryFilter): boolean {
+    switch (filter.key) {
+        case "access":
+            return modelAccess(model) === filter.value;
+        case "owner":
+            // Community ids are "<github-login>/<model>"; registry models
+            // have no owner.
+            return model.community && model.name.includes("/")
+                ? model.name.slice(0, model.name.indexOf("/")).toLowerCase() ===
+                      filter.value
+                : false;
+        case "id":
+            return model.name.toLowerCase() === filter.value;
+        case "type":
+            return model.type === filter.value;
+        case "capability": {
+            const capability = filter.value.replaceAll("-", "_");
+            return getModelCapabilities(model).some(
+                (displayed) => displayed.toLowerCase() === capability,
+            );
+        }
+        default:
+            return false;
+    }
+}
+
+/**
+ * True when the model matches every condition of the parsed query:
+ * each free-text term must appear in one of the model's searchable
+ * fields, and every filter must pass.
+ */
+export function matchesParsedQuery(
+    model: ModelPrice,
+    parsed: ParsedModelQuery,
+): boolean {
+    for (const filter of parsed.filters) {
+        if (!matchesFilter(model, filter)) return false;
+    }
+
+    if (parsed.text.length === 0) return true;
+
+    const haystack = [
+        model.name,
+        getModelDisplayName(model) ?? "",
+        model.description ?? "",
+        model.brand ?? "",
+        model.baseModel ?? "",
+        ...(model.inputModalities ?? []),
+        ...(model.outputModalities ?? []),
+        ...getModelCapabilities(model),
+    ]
+        .join(" ")
+        .toLowerCase();
+
+    return parsed.text.every((term) => haystack.includes(term));
+}

--- a/enter.pollinations.ai/frontend/src/components/models/models.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/models.tsx
@@ -34,7 +34,7 @@ import {
     fetchModelCatalog,
     getModelPricesFromCatalog,
 } from "./model-catalog.ts";
-import { getModelDisplayName } from "./model-info.ts";
+import { matchesParsedQuery, parseModelQuery } from "./model-query.ts";
 import type { ModelScope, ModelSort } from "./model-search.ts";
 import { sortModels } from "./model-sort.ts";
 import {
@@ -116,11 +116,9 @@ const SEARCH_LABELS: Record<SectionType, string> = {
     agent: "agent",
 };
 
-function matchesQuery(model: ModelPrice, query: string): boolean {
-    if (!query) return true;
-    const displayName = getModelDisplayName(model) ?? "";
-    const haystack = `${displayName} ${model.brand ?? ""}`.toLowerCase();
-    return haystack.includes(query);
+function matchesQuery(model: ModelPrice, rawQuery: string): boolean {
+    if (!rawQuery) return true;
+    return matchesParsedQuery(model, parseModelQuery(rawQuery));
 }
 
 function categorizeModels(
@@ -419,7 +417,8 @@ export const Models: FC = () => {
                                     pushSearch(normalizedSearch);
                                 }}
                                 placeholder={`Search ${searchTarget}…`}
-                                aria-label={`Search ${searchTarget}`}
+                                aria-label={`Search ${searchTarget}. Filters: access:, owner:, id:, type:, capability:`}
+                                title="Filters: access:paid access:quest access:free owner:<login> id:<model-id> type:<category> capability:<capability>"
                                 className="w-full pl-9"
                             />
                         </div>

--- a/enter.pollinations.ai/test/model-query.test.ts
+++ b/enter.pollinations.ai/test/model-query.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, test } from "vitest";
+import {
+    matchesParsedQuery,
+    parseModelQuery,
+} from "../frontend/src/components/models/model-query.ts";
+import type { ModelPrice } from "../frontend/src/components/models/types.ts";
+
+function makeModel(
+    overrides: Partial<ModelPrice> & { name: string },
+): ModelPrice {
+    return {
+        type: "text",
+        capabilities: [],
+        prices: [],
+        ...overrides,
+    };
+}
+
+const communityModel = makeModel({
+    name: "alice/quick-coder",
+    displayName: "Quick Coder",
+    description: "Fast coding assistant",
+    brand: "Alice AI",
+    community: true,
+    capabilities: ["reasoning"],
+    inputModalities: ["text", "image"],
+});
+
+const paidRegistryModel = makeModel({
+    name: "openai-large",
+    displayName: "OpenAI Large",
+    paidOnly: true,
+});
+
+const freeModel = makeModel({
+    name: "flux",
+    type: "image",
+    free: true,
+});
+
+describe("parseModelQuery", () => {
+    test("splits text terms from known key:value filters", () => {
+        expect(parseModelQuery("coder access:free alice")).toEqual({
+            text: ["coder", "alice"],
+            filters: [{ key: "access", value: "free" }],
+        });
+    });
+
+    test("unknown keys stay text terms", () => {
+        // "foo:bar" is not a filter — searched as plain text.
+        expect(parseModelQuery("foo:bar")).toEqual({
+            text: ["foo:bar"],
+            filters: [],
+        });
+    });
+
+    test("empty and bare-colon tokens are text or dropped", () => {
+        expect(parseModelQuery("  ")).toEqual({ text: [], filters: [] });
+        expect(parseModelQuery("access:")).toEqual({
+            text: ["access:"],
+            filters: [],
+        });
+    });
+
+    test("multiple filters of different keys are all kept", () => {
+        const parsed = parseModelQuery(
+            "type:image access:paid capability:reasoning owner:bob",
+        );
+        expect(parsed.text).toEqual([]);
+        expect(parsed.filters).toHaveLength(4);
+    });
+
+    test("keys are case-insensitive", () => {
+        expect(parseModelQuery("ACCESS:free")).toEqual({
+            text: [],
+            filters: [{ key: "access", value: "free" }],
+        });
+    });
+});
+
+describe("matchesParsedQuery", () => {
+    test("empty query matches everything", () => {
+        expect(
+            matchesParsedQuery(communityModel, { text: [], filters: [] }),
+        ).toBe(true);
+    });
+
+    test("text terms search id, title, description, brand", () => {
+        const parsed = parseModelQuery("quick coder");
+        expect(matchesParsedQuery(communityModel, parsed)).toBe(true);
+
+        // Brand match
+        expect(
+            matchesParsedQuery(communityModel, parseModelQuery("alice ai")),
+        ).toBe(true);
+
+        // Canonical id match
+        expect(
+            matchesParsedQuery(
+                communityModel,
+                parseModelQuery("alice/quick-coder"),
+            ),
+        ).toBe(true);
+
+        // No match anywhere
+        expect(
+            matchesParsedQuery(communityModel, parseModelQuery("video")),
+        ).toBe(false);
+    });
+
+    test("all text terms must match (AND)", () => {
+        expect(
+            matchesParsedQuery(communityModel, parseModelQuery("fast coder")),
+        ).toBe(true);
+        expect(
+            matchesParsedQuery(
+                communityModel,
+                parseModelQuery("fast unrelated"),
+            ),
+        ).toBe(false);
+    });
+
+    test("access:paid / quest / free", () => {
+        expect(
+            matchesParsedQuery(
+                paidRegistryModel,
+                parseModelQuery("access:paid"),
+            ),
+        ).toBe(true);
+        expect(
+            matchesParsedQuery(
+                paidRegistryModel,
+                parseModelQuery("access:quest"),
+            ),
+        ).toBe(false);
+        expect(
+            matchesParsedQuery(freeModel, parseModelQuery("access:free")),
+        ).toBe(true);
+        // A model that is neither paid-only nor free uses Quest pollen.
+        expect(
+            matchesParsedQuery(communityModel, parseModelQuery("access:quest")),
+        ).toBe(true);
+    });
+
+    test("owner:<login> matches community models only", () => {
+        expect(
+            matchesParsedQuery(communityModel, parseModelQuery("owner:alice")),
+        ).toBe(true);
+        expect(
+            matchesParsedQuery(communityModel, parseModelQuery("owner:bob")),
+        ).toBe(false);
+        expect(
+            matchesParsedQuery(
+                paidRegistryModel,
+                parseModelQuery("owner:openai"),
+            ),
+        ).toBe(false);
+    });
+
+    test("id:<model-id> is an exact canonical-id filter", () => {
+        expect(
+            matchesParsedQuery(
+                communityModel,
+                parseModelQuery("id:alice/quick-coder"),
+            ),
+        ).toBe(true);
+        expect(
+            matchesParsedQuery(communityModel, parseModelQuery("id:alice")),
+        ).toBe(false);
+    });
+
+    test("type:<category>", () => {
+        expect(
+            matchesParsedQuery(freeModel, parseModelQuery("type:image")),
+        ).toBe(true);
+        expect(
+            matchesParsedQuery(freeModel, parseModelQuery("type:text")),
+        ).toBe(false);
+    });
+
+    test("capability:<capability> reads the displayed capabilities", () => {
+        expect(
+            matchesParsedQuery(
+                communityModel,
+                parseModelQuery("capability:reasoning"),
+            ),
+        ).toBe(true);
+        // GitHub-style hyphens normalize to underscores.
+        expect(
+            matchesParsedQuery(
+                communityModel,
+                parseModelQuery("capability:web-search"),
+            ),
+        ).toBe(false);
+        expect(
+            matchesParsedQuery(freeModel, parseModelQuery("capability:tool")),
+        ).toBe(false);
+    });
+
+    test("text terms and filters combine with AND", () => {
+        expect(
+            matchesParsedQuery(
+                communityModel,
+                parseModelQuery("coder owner:alice"),
+            ),
+        ).toBe(true);
+        expect(
+            matchesParsedQuery(
+                communityModel,
+                parseModelQuery("coder owner:bob"),
+            ),
+        ).toBe(false);
+    });
+
+    test("modalities are searchable as text", () => {
+        expect(
+            matchesParsedQuery(communityModel, parseModelQuery("image")),
+        ).toBe(true);
+        expect(
+            matchesParsedQuery(communityModel, parseModelQuery("audio")),
+        ).toBe(false);
+    });
+});


### PR DESCRIPTION
Closes #13907

## What

**New module `model-query.ts`** — a pure, dependency-free query engine:

- **Free text** now matches canonical model id, display title, description, publisher/brand, base model, input/output modalities, and displayed capabilities (was: title + brand only).
- **Documented `key:value` filters**, GitHub-search-inspired:
  - `access:paid` / `access:quest` / `access:free`
  - `owner:<github-login>` (community models; uses the public login from the canonical `owner/model` id)
  - `id:<model-id>` (exact match on canonical id)
  - `type:<category>`
  - `capability:<capability>` (reads the same displayed capabilities as the row chips; hyphens normalize to underscores so `web-search` works)
- Terms and filters combine with AND. Unknown `key:value` tokens degrade to plain text, so existing queries behave identically.
- **Discoverability without UI weight**: the filter vocabulary lives in the input's `title` tooltip and `aria-label`.

**Wiring**: `matchesQuery` in `models.tsx` now delegates to the parser/matcher. URL search state (`?q=`), scope, category tabs, and sort are untouched — direct links and reloads keep working since the query still round-trips through the same state.

## Constraints honored

Frontend-only; no search library, backend index, API changes, fuzzy ranking, autocomplete framework, negation, parentheses, or full GitHub grammar.

## Verification

- New `test/model-query.test.ts`: 15 focused tests covering parsing (known/unknown keys, case-insensitivity, bare colons) and matching (each filter, AND semantics, modality/capability text search). **15/15 pass.**
- Full billing + endpoint suite: **116/116 pass.**
- `tsc --noEmit`: clean · biome: clean.