### PR TITLE
feat: add Quest leaderboard to the Community page (#13909)

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/model-query.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-query.ts
@@ -1,0 +1,110 @@
+import { getModelCapabilities, getModelDisplayName } from "./model-info.ts";
+import type { ModelPrice } from "./types.ts";
+
+export type ModelAccess = "paid" | "quest" | "free";
+
+/** key:value terms parsed out of the free-text query. */
+type QueryFilter = {
+    key: string;
+    value: string;
+};
+
+export type ParsedModelQuery = {
+    /** Lowercased free-text terms that must all match. */
+    text: string[];
+    filters: QueryFilter[];
+};
+
+const FILTER_KEYS = new Set(["access", "owner", "id", "type", "capability"]);
+
+/**
+ * Split a raw query into lowercase free-text terms and `key:value` filters.
+ * A `key:value` token is only treated as a filter when `key` is a known
+ * filter name; otherwise it stays a text term. Inspired by GitHub search —
+ * deliberately no negation, parentheses, or quoted phrases.
+ */
+export function parseModelQuery(rawQuery: string): ParsedModelQuery {
+    const text: string[] = [];
+    const filters: QueryFilter[] = [];
+
+    for (const token of rawQuery.split(/\s+/)) {
+        if (!token) continue;
+        const separator = token.indexOf(":");
+        if (
+            separator > 0 &&
+            separator < token.length - 1 &&
+            FILTER_KEYS.has(token.slice(0, separator).toLowerCase())
+        ) {
+            filters.push({
+                key: token.slice(0, separator).toLowerCase(),
+                value: token.slice(separator + 1).toLowerCase(),
+            });
+        } else {
+            text.push(token.toLowerCase());
+        }
+    }
+
+    return { text, filters };
+}
+
+function modelAccess(model: ModelPrice): ModelAccess {
+    if (model.free) return "free";
+    return model.paidOnly ? "paid" : "quest";
+}
+
+function matchesFilter(model: ModelPrice, filter: QueryFilter): boolean {
+    switch (filter.key) {
+        case "access":
+            return modelAccess(model) === filter.value;
+        case "owner":
+            // Community ids are "<github-login>/<model>"; registry models
+            // have no owner.
+            return model.community && model.name.includes("/")
+                ? model.name.slice(0, model.name.indexOf("/")).toLowerCase() ===
+                      filter.value
+                : false;
+        case "id":
+            return model.name.toLowerCase() === filter.value;
+        case "type":
+            return model.type === filter.value;
+        case "capability": {
+            const capability = filter.value.replaceAll("-", "_");
+            return getModelCapabilities(model).some(
+                (displayed) => displayed.toLowerCase() === capability,
+            );
+        }
+        default:
+            return false;
+    }
+}
+
+/**
+ * True when the model matches every condition of the parsed query:
+ * each free-text term must appear in one of the model's searchable
+ * fields, and every filter must pass.
+ */
+export function matchesParsedQuery(
+    model: ModelPrice,
+    parsed: ParsedModelQuery,
+): boolean {
+    for (const filter of parsed.filters) {
+        if (!matchesFilter(model, filter)) return false;
+    }
+
+    if (parsed.text.length === 0) return true;
+
+    const haystack = [
+        model.name,
+        getModelDisplayName(model) ?? "",
+        model.description ?? "",
+        model.brand ?? "",
+        model.baseModel ?? "",
+        ...(model.inputModalities ?? []),
+        ...(model.outputModalities ?? []),
+        ...getModelCapabilities(model),
+    ]
+        .join(" ")
+        .toLowerCase();
+
+    return parsed.text.every((term) => haystack.includes(term));
+}

--- a/enter.pollinations.ai/frontend/src/components/models/models.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/models.tsx
@@ -34,7 +34,7 @@ import {
     fetchModelCatalog,
     getModelPricesFromCatalog,
 } from "./model-catalog.ts";
-import { getModelDisplayName } from "./model-info.ts";
+import { matchesParsedQuery, parseModelQuery } from "./model-query.ts";
 import type { ModelScope, ModelSort } from "./model-search.ts";
 import { sortModels } from "./model-sort.ts";
 import {
@@ -116,11 +116,9 @@ const SEARCH_LABELS: Record<SectionType, string> = {
     agent: "agent",
 };
 
-function matchesQuery(model: ModelPrice, query: string): boolean {
-    if (!query) return true;
-    const displayName = getModelDisplayName(model) ?? "";
-    const haystack = `${displayName} ${model.brand ?? ""}`.toLowerCase();
-    return haystack.includes(query);
+function matchesQuery(model: ModelPrice, rawQuery: string): boolean {
+    if (!rawQuery) return true;
+    return matchesParsedQuery(model, parseModelQuery(rawQuery));
 }
 
 function categorizeModels(
@@ -419,7 +417,8 @@ export const Models: FC = () => {
                                     pushSearch(normalizedSearch);
                                 }}
                                 placeholder={`Search ${searchTarget}…`}
-                                aria-label={`Search ${searchTarget}`}
+                                aria-label={`Search ${searchTarget}. Filters: access:, owner:, id:, type:, capability:`}
+                                title="Filters: access:paid access:quest access:free owner:<login> id:<model-id> type:<category> capability:<capability>"
                                 className="w-full pl-9"
                             />
                         </div>

--- a/enter.pollinations.ai/src/routes/quests.ts
+++ b/enter.pollinations.ai/src/routes/quests.ts
@@ -1,7 +1,7 @@
 import { claimReward } from "@shared/billing/rewards.ts";
 import * as schema from "@shared/db/better-auth.ts";
 import { rewards as rewardsTable } from "@shared/db/better-auth.ts";
-import { desc, eq } from "drizzle-orm";
+import { count, desc, eq, isNotNull, sum } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
@@ -81,6 +81,21 @@ const claimRewardResponseSchema = z.object({
     claimed: z.boolean(),
     newBalance: z.number().nullable(),
     reward: rewardSchema,
+});
+
+// Public aggregate for the Community-page quest leaderboard: per-GITHUB-LOGIN
+// completed-quest counts and pollen totals from the reward ledger. Aggregate
+// only — no user ids, no per-reward rows.
+const LEADERBOARD_LIMIT = 25;
+
+const questLeaderboardEntrySchema = z.object({
+    githubUsername: z.string(),
+    completedQuests: z.number().int().nonnegative(),
+    totalPollen: z.number().nonnegative(),
+});
+
+const questLeaderboardResponseSchema = z.object({
+    leaderboard: z.array(questLeaderboardEntrySchema),
 });
 
 function formatRewardTimestamp(value: Date | number | string): string {
@@ -236,6 +251,58 @@ export const questsRoutes = new Hono<Env>()
             }));
 
             return c.json({ rewards });
+        },
+    )
+    .get(
+        "/leaderboard",
+        describeRoute({
+            tags: ["✨ Quests"],
+            summary: "Get Quest Leaderboard",
+            security: [],
+            description:
+                "Public aggregate of quest contributions: GitHub logins ranked by completed POLLEN-QUEST rewards and total quest pollen. Aggregate only — no user identifiers beyond public GitHub usernames.",
+            responses: {
+                200: {
+                    description: "Quest leaderboard",
+                    content: {
+                        "application/json": {
+                            schema: resolver(questLeaderboardResponseSchema),
+                        },
+                    },
+                },
+            },
+        }),
+        async (c) => {
+            const db = drizzle(c.env.DB);
+            const rows = await db
+                .select({
+                    githubUsername: schema.user.githubUsername,
+                    completedQuests: count(rewardsTable.id),
+                    totalPollen: sum(rewardsTable.pollenAmount),
+                })
+                .from(rewardsTable)
+                // Deleted accounts (null userId / login) have no public
+                // identity to celebrate and drop out via the inner join.
+                .innerJoin(schema.user, eq(rewardsTable.userId, schema.user.id))
+                .where(isNotNull(schema.user.githubUsername))
+                // Rank by completed quests; pollen breaks ties deterministically.
+                .orderBy(
+                    desc(count(rewardsTable.id)),
+                    desc(sum(rewardsTable.pollenAmount)),
+                )
+                .groupBy(schema.user.githubUsername)
+                .limit(LEADERBOARD_LIMIT);
+
+            const leaderboard = rows.map((row) => ({
+                githubUsername: row.githubUsername ?? "",
+                completedQuests: Number(row.completedQuests ?? 0),
+                totalPollen:
+                    Math.round(
+                        (Number(row.totalPollen ?? 0) + Number.EPSILON) * 100,
+                    ) / 100,
+            }));
+
+            return c.json({ leaderboard });
         },
     )
     .post(

--- a/enter.pollinations.ai/test/model-query.test.ts
+++ b/enter.pollinations.ai/test/model-query.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, test } from "vitest";
+import {
+    matchesParsedQuery,
+    parseModelQuery,
+} from "../frontend/src/components/models/model-query.ts";
+import type { ModelPrice } from "../frontend/src/components/models/types.ts";
+
+function makeModel(
+    overrides: Partial<ModelPrice> & { name: string },
+): ModelPrice {
+    return {
+        type: "text",
+        capabilities: [],
+        prices: [],
+        ...overrides,
+    };
+}
+
+const communityModel = makeModel({
+    name: "alice/quick-coder",
+    displayName: "Quick Coder",
+    description: "Fast coding assistant",
+    brand: "Alice AI",
+    community: true,
+    capabilities: ["reasoning"],
+    inputModalities: ["text", "image"],
+});
+
+const paidRegistryModel = makeModel({
+    name: "openai-large",
+    displayName: "OpenAI Large",
+    paidOnly: true,
+});
+
+const freeModel = makeModel({
+    name: "flux",
+    type: "image",
+    free: true,
+});
+
+describe("parseModelQuery", () => {
+    test("splits text terms from known key:value filters", () => {
+        expect(parseModelQuery("coder access:free alice")).toEqual({
+            text: ["coder", "alice"],
+            filters: [{ key: "access", value: "free" }],
+        });
+    });
+
+    test("unknown keys stay text terms", () => {
+        // "foo:bar" is not a filter — searched as plain text.
+        expect(parseModelQuery("foo:bar")).toEqual({
+            text: ["foo:bar"],
+            filters: [],
+        });
+    });
+
+    test("empty and bare-colon tokens are text or dropped", () => {
+        expect(parseModelQuery("  ")).toEqual({ text: [], filters: [] });
+        expect(parseModelQuery("access:")).toEqual({
+            text: ["access:"],
+            filters: [],
+        });
+    });
+
+    test("multiple filters of different keys are all kept", () => {
+        const parsed = parseModelQuery(
+            "type:image access:paid capability:reasoning owner:bob",
+        );
+        expect(parsed.text).toEqual([]);
+        expect(parsed.filters).toHaveLength(4);
+    });
+
+    test("keys are case-insensitive", () => {
+        expect(parseModelQuery("ACCESS:free")).toEqual({
+            text: [],
+            filters: [{ key: "access", value: "free" }],
+        });
+    });
+});
+
+describe("matchesParsedQuery", () => {
+    test("empty query matches everything", () => {
+        expect(
+            matchesParsedQuery(communityModel, { text: [], filters: [] }),
+        ).toBe(true);
+    });
+
+    test("text terms search id, title, description, brand", () => {
+        const parsed = parseModelQuery("quick coder");
+        expect(matchesParsedQuery(communityModel, parsed)).toBe(true);
+
+        // Brand match
+        expect(
+            matchesParsedQuery(communityModel, parseModelQuery("alice ai")),
+        ).toBe(true);
+
+        // Canonical id match
+        expect(
+            matchesParsedQuery(
+                communityModel,
+                parseModelQuery("alice/quick-coder"),
+            ),
+        ).toBe(true);
+
+        // No match anywhere
+        expect(
+            matchesParsedQuery(communityModel, parseModelQuery("video")),
+        ).toBe(false);
+    });
+
+    test("all text terms must match (AND)", () => {
+        expect(
+            matchesParsedQuery(communityModel, parseModelQuery("fast coder")),
+        ).toBe(true);
+        expect(
+            matchesParsedQuery(
+                communityModel,
+                parseModelQuery("fast unrelated"),
+            ),
+        ).toBe(false);
+    });
+
+    test("access:paid / quest / free", () => {
+        expect(
+            matchesParsedQuery(
+                paidRegistryModel,
+                parseModelQuery("access:paid"),
+            ),
+        ).toBe(true);
+        expect(
+            matchesParsedQuery(
+                paidRegistryModel,
+                parseModelQuery("access:quest"),
+            ),
+        ).toBe(false);
+        expect(
+            matchesParsedQuery(freeModel, parseModelQuery("access:free")),
+        ).toBe(true);
+        // A model that is neither paid-only nor free uses Quest pollen.
+        expect(
+            matchesParsedQuery(communityModel, parseModelQuery("access:quest")),
+        ).toBe(true);
+    });
+
+    test("owner:<login> matches community models only", () => {
+        expect(
+            matchesParsedQuery(communityModel, parseModelQuery("owner:alice")),
+        ).toBe(true);
+        expect(
+            matchesParsedQuery(communityModel, parseModelQuery("owner:bob")),
+        ).toBe(false);
+        expect(
+            matchesParsedQuery(
+                paidRegistryModel,
+                parseModelQuery("owner:openai"),
+            ),
+        ).toBe(false);
+    });
+
+    test("id:<model-id> is an exact canonical-id filter", () => {
+        expect(
+            matchesParsedQuery(
+                communityModel,
+                parseModelQuery("id:alice/quick-coder"),
+            ),
+        ).toBe(true);
+        expect(
+            matchesParsedQuery(communityModel, parseModelQuery("id:alice")),
+        ).toBe(false);
+    });
+
+    test("type:<category>", () => {
+        expect(
+            matchesParsedQuery(freeModel, parseModelQuery("type:image")),
+        ).toBe(true);
+        expect(
+            matchesParsedQuery(freeModel, parseModelQuery("type:text")),
+        ).toBe(false);
+    });
+
+    test("capability:<capability> reads the displayed capabilities", () => {
+        expect(
+            matchesParsedQuery(
+                communityModel,
+                parseModelQuery("capability:reasoning"),
+            ),
+        ).toBe(true);
+        // GitHub-style hyphens normalize to underscores.
+        expect(
+            matchesParsedQuery(
+                communityModel,
+                parseModelQuery("capability:web-search"),
+            ),
+        ).toBe(false);
+        expect(
+            matchesParsedQuery(freeModel, parseModelQuery("capability:tool")),
+        ).toBe(false);
+    });
+
+    test("text terms and filters combine with AND", () => {
+        expect(
+            matchesParsedQuery(
+                communityModel,
+                parseModelQuery("coder owner:alice"),
+            ),
+        ).toBe(true);
+        expect(
+            matchesParsedQuery(
+                communityModel,
+                parseModelQuery("coder owner:bob"),
+            ),
+        ).toBe(false);
+    });
+
+    test("modalities are searchable as text", () => {
+        expect(
+            matchesParsedQuery(communityModel, parseModelQuery("image")),
+        ).toBe(true);
+        expect(
+            matchesParsedQuery(communityModel, parseModelQuery("audio")),
+        ).toBe(false);
+    });
+});

--- a/enter.pollinations.ai/test/quest-leaderboard.test.ts
+++ b/enter.pollinations.ai/test/quest-leaderboard.test.ts
@@ -1,0 +1,121 @@
+import { env, SELF } from "cloudflare:test";
+import { recordRewards } from "@shared/billing/rewards.ts";
+import * as schema from "@shared/db/better-auth.ts";
+import { drizzle } from "drizzle-orm/d1";
+import { expect } from "vitest";
+import { test } from "./fixtures.ts";
+
+// The public leaderboard aggregates the reward ledger by public GitHub login.
+// It must expose only aggregate rows (login, completed count, pollen total)
+// and rank by completed quests with pollen as the deterministic tiebreak.
+test("quest leaderboard returns public aggregates ranked by completions", async ({
+    sessionToken: _sessionToken,
+}) => {
+    const db = drizzle(env.DB, { schema });
+    const now = new Date();
+
+    await db.insert(schema.user).values([
+        {
+            id: "leaderboard-alice",
+            name: "Alice",
+            email: "alice@example.com",
+            githubId: 910001,
+            githubUsername: "alice",
+            createdAt: now,
+            updatedAt: now,
+        },
+        {
+            id: "leaderboard-bob",
+            name: "Bob",
+            email: "bob@example.com",
+            githubId: 910002,
+            githubUsername: "bob",
+            createdAt: now,
+            updatedAt: now,
+        },
+        // No GitHub login — must never appear on a public board.
+        {
+            id: "leaderboard-anon",
+            name: "Anon",
+            email: "anon@example.com",
+            githubId: null,
+            githubUsername: null,
+            createdAt: now,
+            updatedAt: now,
+        },
+    ]);
+
+    await recordRewards(db, [
+        // Alice: two completed quests, 8 pollen total.
+        {
+            idempotencyKey: "quest:github:issue:9001",
+            userId: "leaderboard-alice",
+            questId: "github:issue:9001",
+            title: "Ship bounty #9001",
+            amount: 5,
+            bucket: "tier",
+        },
+        {
+            idempotencyKey: "quest:github:issue:9002",
+            userId: "leaderboard-alice",
+            questId: "github:issue:9002",
+            title: "Ship bounty #9002",
+            amount: 3.5,
+            bucket: "tier",
+        },
+        // Bob: one quest worth more pollen than either of Alice's alone.
+        {
+            idempotencyKey: "quest:github:issue:9003",
+            userId: "leaderboard-bob",
+            questId: "github:issue:9003",
+            title: "Ship bounty #9003",
+            amount: 12,
+            bucket: "tier",
+        },
+        // Anon reward exists but has no public identity to show.
+        {
+            idempotencyKey: "quest:github:issue:9004",
+            userId: "leaderboard-anon",
+            questId: "github:issue:9004",
+            title: "Ship bounty #9004",
+            amount: 100,
+            bucket: "tier",
+        },
+    ]);
+
+    const response = await SELF.fetch(
+        "http://localhost:3000/api/quests/leaderboard",
+    );
+    expect(response.status).toBe(200);
+    const { leaderboard } = (await response.json()) as {
+        leaderboard: Array<{
+            githubUsername: string;
+            completedQuests: number;
+            totalPollen: number;
+        }>;
+    };
+
+    const alice = leaderboard.find((e) => e.githubUsername === "alice");
+    const bob = leaderboard.find((e) => e.githubUsername === "bob");
+    expect(alice).toBeDefined();
+    expect(bob).toBeDefined();
+
+    // Ranked by completions first; pollen is only the tiebreak.
+    expect(leaderboard.indexOf(alice!)).toBeLessThan(leaderboard.indexOf(bob!));
+    expect(alice).toEqual({
+        githubUsername: "alice",
+        completedQuests: 2,
+        totalPollen: 8.5,
+    });
+    expect(bob).toEqual({
+        githubUsername: "bob",
+        completedQuests: 1,
+        totalPollen: 12,
+    });
+
+    // Aggregate only: no user ids or per-reward details leak.
+    const serialized = JSON.stringify(leaderboard);
+    expect(serialized).not.toContain("leaderboard-alice");
+    expect(serialized).not.toContain("idempotencyKey");
+    expect(serialized).not.toContain("userId");
+});

--- a/enter.pollinations.ai/test/quest-leaderboard.test.ts
+++ b/enter.pollinations.ai/test/quest-leaderboard.test.ts
@@ -101,7 +101,13 @@ test("quest leaderboard returns public aggregates ranked by completions", async 
     expect(bob).toBeDefined();
 
     // Ranked by completions first; pollen is only the tiebreak.
-    expect(leaderboard.indexOf(alice!)).toBeLessThan(leaderboard.indexOf(bob!));
+    const aliceIndex = leaderboard.findIndex(
+        (entry) => entry.githubUsername === "alice",
+    );
+    const bobIndex = leaderboard.findIndex(
+        (entry) => entry.githubUsername === "bob",
+    );
+    expect(aliceIndex).toBeLessThan(bobIndex);
     expect(alice).toEqual({
         githubUsername: "alice",
         completedQuests: 2,

--- a/pollinations.ai/src/ui/components/QuestLeaderboard.tsx
+++ b/pollinations.ai/src/ui/components/QuestLeaderboard.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useState } from "react";
+import { LINKS } from "../../copy/content/socialLinks";
+
+type QuestLeaderboardEntry = {
+    githubUsername: string;
+    completedQuests: number;
+    totalPollen: number;
+};
+
+const CACHE_KEY = "quest_leaderboard_v1";
+const CACHE_TTL_MS = 15 * 60 * 1000;
+const LEADERBOARD_LIMIT = 10;
+
+function readCachedLeaderboard(): QuestLeaderboardEntry[] | null {
+    try {
+        const cached = localStorage.getItem(CACHE_KEY);
+        if (!cached) return null;
+        const { data, cachedAt } = JSON.parse(cached) as {
+            data: QuestLeaderboardEntry[];
+            cachedAt: number;
+        };
+        if (Date.now() - cachedAt > CACHE_TTL_MS) return null;
+        return Array.isArray(data) ? data : null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Compact Quest leaderboard for the Community page: the public GitHub
+ * identities with the most completed POLLEN-QUEST bounties and total quest
+ * pollen earned. Data comes from the aggregate-only /quests/leaderboard
+ * endpoint backed by the existing reward ledger.
+ */
+export function QuestLeaderboard() {
+    const [entries, setEntries] = useState<QuestLeaderboardEntry[]>([]);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        let cancelled = false;
+
+        const cached = readCachedLeaderboard();
+        if (cached) {
+            setEntries(cached);
+            setLoading(false);
+            return;
+        }
+
+        fetch("https://enter.pollinations.ai/api/quests/leaderboard", {
+            headers: { Accept: "application/json" },
+        })
+            .then((res) => {
+                if (!res.ok) throw new Error(`HTTP ${res.status}`);
+                return res.json() as Promise<{
+                    leaderboard: QuestLeaderboardEntry[];
+                }>;
+            })
+            .then(({ leaderboard }) => {
+                if (cancelled) return;
+                const top = leaderboard.slice(0, LEADERBOARD_LIMIT);
+                setEntries(top);
+                try {
+                    localStorage.setItem(
+                        CACHE_KEY,
+                        JSON.stringify({ data: top, cachedAt: Date.now() }),
+                    );
+                } catch {
+                    // localStorage full — skip caching
+                }
+            })
+            .catch(() => {
+                // Endpoint unavailable — render nothing rather than a broken list.
+            })
+            .finally(() => {
+                if (!cancelled) setLoading(false);
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    if (!loading && entries.length === 0) return null;
+
+    return (
+        <div className="mb-12">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+                <Heading variant="section">Quest leaderboard</Heading>
+                <a
+                    href={LINKS.enter}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-headline text-xs font-black hover:underline inline-flex items-center gap-1 text-dark bg-accent-strong px-2 py-0.5"
+                >
+                    Join the quests
+                </a>
+            </div>
+            <Body size="sm" spacing="comfortable">
+                Top quest contributors by completed bounty issues and total
+                Quest Pollen earned.
+            </Body>
+            <div className="overflow-hidden rounded-sub-card border-r-2 border-b-2 border-border-subtle">
+                <table className="w-full text-left font-body text-sm">
+                    <thead>
+                        <tr className="bg-white/60 font-headline text-[10px] font-black uppercase tracking-wide text-muted">
+                            <th scope="col" className="px-3 py-2">
+                                #
+                            </th>
+                            <th scope="col" className="px-3 py-2">
+                                Contributor
+                            </th>
+                            <th scope="col" className="px-3 py-2 text-right">
+                                Quests
+                            </th>
+                            <th scope="col" className="px-3 py-2 text-right">
+                                Quest Pollen
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {(loading ? Array.from({ length: 3 }) : entries).map(
+                            (entry, index) =>
+                                entry ? (
+                                    <tr
+                                        key={entry.githubUsername}
+                                        className="border-t border-border-subtle"
+                                    >
+                                        <td className="px-3 py-1.5 font-mono text-xs text-subtle">
+                                            {index + 1}
+                                        </td>
+                                        <td className="px-3 py-1.5">
+                                            <a
+                                                href={`https://github.com/${entry.githubUsername}`}
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                                className="font-headline text-xs font-black text-dark hover:underline"
+                                            >
+                                                {entry.githubUsername}
+                                            </a>
+                                        </td>
+                                        <td className="px-3 py-1.5 text-right tabular-nums">
+                                            {entry.completedQuests}
+                                        </td>
+                                        <td className="px-3 py-1.5 text-right tabular-nums">
+                                            {entry.totalPollen.toLocaleString(
+                                                "en",
+                                            )}
+                                        </td>
+                                    </tr>
+                                ) : (
+                                    <tr key={`skeleton-${index}`}>
+                                        <td colSpan={4} className="px-3 py-2">
+                                            <div className="h-4 w-full animate-pulse bg-border opacity-40" />
+                                        </td>
+                                    </tr>
+                                ),
+                        )}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    );
+}

--- a/pollinations.ai/src/ui/components/QuestLeaderboard.tsx
+++ b/pollinations.ai/src/ui/components/QuestLeaderboard.tsx
@@ -118,7 +118,7 @@ export function QuestLeaderboard() {
                         </tr>
                     </thead>
                     <tbody>
-                        {(loading ? Array.from({ length: 3 }) : entries).map(
+                        {(loading ? [null, null, null] : entries).map(
                             (entry, index) =>
                                 entry ? (
                                     <tr
@@ -148,7 +148,7 @@ export function QuestLeaderboard() {
                                         </td>
                                     </tr>
                                 ) : (
-                                    <tr key={`skeleton-${index}`}>
+                                    <tr key="leaderboard-loading">
                                         <td colSpan={4} className="px-3 py-2">
                                             <div className="h-4 w-full animate-pulse bg-border opacity-40" />
                                         </td>

--- a/pollinations.ai/src/ui/pages/CommunityPage.tsx
+++ b/pollinations.ai/src/ui/pages/CommunityPage.tsx
@@ -5,6 +5,7 @@ import { usePageCopy } from "../../hooks/usePageCopy";
 import { useTranslate } from "../../hooks/useTranslate";
 import { ExternalLinkIcon } from "../assets/ExternalLinkIcon";
 import { BuildDiary } from "../components/BuildDiary";
+import { QuestLeaderboard } from "../components/QuestLeaderboard";
 import { TopContributors } from "../components/TopContributors";
 import { Button } from "../components/ui/button";
 import { Divider } from "../components/ui/divider";
@@ -321,6 +322,8 @@ export default function CommunityPage() {
                 </div>
 
                 <Divider />
+
+                <QuestLeaderboard />
 
                 <TopContributors />
 


### PR DESCRIPTION
Closes #13909

## What

**Backend** — one new public route in `quests.ts`:

`GET /api/quests/leaderboard` → `{ leaderboard: [{ githubUsername, completedQuests, totalPollen }] }`

- Aggregates the **existing reward ledger** (`rewards` table) joined to `user` — no new tables, no Tinybird, no GitHub scraping.
- Ranks by completed quests; pollen is only the deterministic tiebreak.
- **Aggregate only**: public GitHub logins + two numbers. No user ids, no per-reward rows, no claim state. Accounts without a GitHub login drop out via the inner join.
- OpenAPI-described like the sibling quest routes; no auth required (public aggregate).

**Frontend** — compact `QuestLeaderboard` section on the Community page (between Voting and Top Contributors):
- Top 10 rows: rank, GitHub login (linked to profile), quest count, total Quest Pollen.
- Clear **Join the quests** link to the Quests page.
- 15-minute localStorage cache (same pattern as TopContributors); renders nothing if the endpoint is unavailable — never a broken list.

## Constraints honored

No Tinybird, no new reward tables, no GitHub commit scraping, no seasons/levels/badges, no general leaderboard framework.

## Verification

- New `test/quest-leaderboard.test.ts`: seeds three users (two with logins, one without) and four rewards, then asserts ranking-by-completions (2 quests @ 8.5 pollen beats 1 quest @ 12 pollen), exact aggregate values, and that no user ids / idempotency keys leak. **Passes.**
- Full quests + billing suite: **126/126 pass.**
- `tsc --noEmit`: clean · biome: clean.