### PR TITLE
docs: publish concise community-model naming guidance (#12885)

### DIFF
--- a/BRING_YOUR_OWN_MODEL.md
+++ b/BRING_YOUR_OWN_MODEL.md
@@ -43,6 +43,8 @@ Owners receive 75% of the Pollen spent on their models. Paid and Quest Pollen ea
 
 The upstream credential is used by Pollinations to proxy requests to your endpoint. Do not place it in a model name, description, public URL, or example.
 
+See the [Community Model Naming Guide](./COMMUNITY_MODEL_NAMING.md) for tips on choosing a stable model ID and clear display title.
+
 ## Register with the CLI
 
 The CLI manages text, image, and transcription model registrations. Sign in, test the endpoint, then create the model:

--- a/COMMUNITY_MODEL_NAMING.md
+++ b/COMMUNITY_MODEL_NAMING.md
@@ -1,0 +1,54 @@
+# Community Model Naming Guide
+
+Community models have three public fields: a **stable model ID**, a **display title**, and a **description**. This guide helps you pick good values for each. Community models do not need to follow the stricter first-party naming convention — clarity and stability are what matter.
+
+## Model ID
+
+The ID is the permanent public identifier: `{username}/{model-id}`. It appears in API calls, URLs, and the catalog, and **cannot change after registration**.
+
+Keep IDs stable. Avoid mutable details such as:
+
+- Pricing or billing mode (`free`, `cheap`, `pay-per-token`)
+- Provider routing or upstream vendor names (`replicate-`, `openrouter-`)
+- Context window size, latency, or throughput (`-128k`, `-fast`)
+- Version numbers that change frequently
+
+**Good:** `my-fast-coder`, `story-writer`, `image-enhancer`, `multimodal-lab`
+
+**Avoid:** `free-gpt-4-turbo-128k`, `replicate-flux-fast`, `openrouter-cheap`
+
+Custom creative names are welcome — the ID just needs to stay stable and unambiguous.
+
+## Display Title
+
+The title is the friendly name shown in the Models list. It **can change freely** after registration, so use it to say what the model does in plain language.
+
+| Model type | ID | Title |
+|---|---|---|
+| Direct upstream | `acme/flash-chat` | Acme Flash Chat |
+| Custom fine-tune | `data-scientist/code-llama-70b` | Code Llama 70B (Python/TS fine-tune) |
+| Router / fallback | `team-alpha/model-router` | Team Alpha Multi-Model Router |
+| Rebranded upstream | `my-org/summarizer` | MyOrg Summarizer (BART-large) |
+
+## Description
+
+A short one-liner about what the model is good at. For routers and rebranded models, clearly state what the model is or what it routes to — be transparent about provenance.
+
+| ID | Description |
+|---|---|
+| `acme/flash-chat` | Low-latency chat model for customer support |
+| `data-scientist/code-llama-70b` | Code Llama 70B fine-tuned for Python and TypeScript |
+| `team-alpha/model-router` | Routes to the cheapest available chat model per request |
+| `my-org/summarizer` | BART-large fine-tuned for meeting summaries |
+
+## Quick Reference
+
+| Field | Purpose | Can change? |
+|---|---|---|
+| **Model ID** | Permanent API identifier | No |
+| **Title** | Friendly catalog name | Yes |
+| **Description** | One-liner about capabilities | Yes |
+
+## See Also
+
+- [Publish a Model](./BRING_YOUR_OWN_MODEL.md) — full registration and pricing guide

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/model-listing-fields.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/model-listing-fields.tsx
@@ -2,6 +2,7 @@ import {
     ButtonGroup,
     CheckIcon,
     FieldStack,
+    InlineLink,
     Input,
     TabButton,
 } from "@pollinations/ui";
@@ -114,9 +115,22 @@ export function ModelListingFields({
                 <FieldStack
                     label={isAgent ? "ID" : "Model ID"}
                     helper={
-                        isAgent
-                            ? "Public ID: {username}/{id}."
-                            : "Public ID: {username}/{model-id}."
+                        isAgent ? (
+                            "Public ID: {username}/{id}."
+                        ) : (
+                            <>
+                                Public ID: {"{username}"}/{"{model-id}"}. See
+                                the{" "}
+                                <InlineLink
+                                    href="https://github.com/pollinations/pollinations/blob/main/COMMUNITY_MODEL_NAMING.md"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    naming guide
+                                </InlineLink>{" "}
+                                for tips on a stable ID and clear title.
+                            </>
+                        )
                     }
                     alignLabelRow
                 >


### PR DESCRIPTION
Closes #12885

## What

- **`COMMUNITY_MODEL_NAMING.md`** — one concise guide covering the three public fields:
  - **Model ID**: permanent `{username}/{model-id}`; avoid mutable details (pricing, provider routing, context size, fast-changing versions); good/avoid examples
  - **Display Title**: changeable, plain-language; example table across direct upstream, custom fine-tune, router, and rebranded models
  - **Description**: transparent one-liner, especially for routers/rebrands
  - Quick-reference table (purpose + mutability per field)
- **Linked from `BRING_YOUR_OWN_MODEL.md`** (the existing publishing docs)
- **Linked from the Add model form** — the Model ID field helper now points to the guide (models only; agent IDs keep their existing helper)

Community models explicitly do **not** need the stricter first-party convention from #13587 — the guide says so.

## Constraints honored

No schema enforcement, dashboard warnings, aliases, migrations, automatic renaming, compatibility layers, or changes to existing model IDs.

## Verification

- `tsc --noEmit`: clean · biome: clean · markdown links resolve to repo paths