### PR TITLE
feat: add public quest leaderboard (#13909)

### DIFF
--- a/enter.pollinations.ai/src/routes/quests.ts
+++ b/enter.pollinations.ai/src/routes/quests.ts
@@ -1,7 +1,7 @@
 import { claimReward } from "@shared/billing/rewards.ts";
 import * as schema from "@shared/db/better-auth.ts";
 import { rewards as rewardsTable } from "@shared/db/better-auth.ts";
-import { desc, eq, isNotNull, sum, count } from "drizzle-orm";
+import { count, desc, eq, isNotNull, sum } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";

--- a/enter.pollinations.ai/src/routes/quests.ts
+++ b/enter.pollinations.ai/src/routes/quests.ts
@@ -1,6 +1,9 @@
 import { claimReward } from "@shared/billing/rewards.ts";
 import * as schema from "@shared/db/better-auth.ts";
-import { rewards as rewardsTable } from "@shared/db/better-auth.ts";
+import {
+    rewards as rewardsTable,
+    user as userTable,
+} from "@shared/db/better-auth.ts";
 import { count, desc, eq, isNotNull, sum } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { Hono } from "hono";

--- a/enter.pollinations.ai/src/routes/quests.ts
+++ b/enter.pollinations.ai/src/routes/quests.ts
@@ -1,7 +1,7 @@
 import { claimReward } from "@shared/billing/rewards.ts";
 import * as schema from "@shared/db/better-auth.ts";
 import { rewards as rewardsTable } from "@shared/db/better-auth.ts";
-import { desc, eq } from "drizzle-orm";
+import { desc, eq, isNotNull, sum, count } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
@@ -83,6 +83,24 @@ const claimRewardResponseSchema = z.object({
     reward: rewardSchema,
 });
 
+const LEADERBOARD_CACHE_KEY = "quests:leaderboard:v1";
+const LEADERBOARD_CACHE_TTL = 300;
+
+const leaderboardEntrySchema = z.object({
+    githubUsername: z.string(),
+    totalPollen: z.number(),
+    questCount: z.number(),
+});
+
+const questLeaderboardResponseSchema = z.object({
+    leaderboard: z.array(leaderboardEntrySchema),
+});
+
+export type QuestLeaderboardEntry = z.infer<typeof leaderboardEntrySchema>;
+export type QuestLeaderboardResponse = z.infer<
+    typeof questLeaderboardResponseSchema
+>;
+
 function formatRewardTimestamp(value: Date | number | string): string {
     return value instanceof Date
         ? value.toISOString()
@@ -118,6 +136,62 @@ export const questsRoutes = new Hono<Env>()
                 expirationTtl: CACHE_TTL,
             });
             return c.json(catalog);
+        },
+    )
+    .get(
+        "/leaderboard",
+        describeRoute({
+            tags: ["✨ Quests"],
+            summary: "Get Quest Leaderboard",
+            description:
+                "Returns the public quest reward leaderboard, ranked by total Pollen earned from completed GitHub POLLEN-QUEST issues. Only public GitHub identity and aggregate totals are exposed.",
+            responses: {
+                200: {
+                    description: "Quest leaderboard",
+                    content: {
+                        "application/json": {
+                            schema: resolver(questLeaderboardResponseSchema),
+                        },
+                    },
+                },
+            },
+        }),
+        async (c) => {
+            const cached = await readCachedLeaderboard(c.env.KV);
+            if (cached) return c.json(cached);
+
+            const db = drizzle(c.env.DB, { schema });
+            const rows = await db
+                .select({
+                    githubUsername: userTable.githubUsername,
+                    totalPollen: sum(rewardsTable.pollenAmount),
+                    questCount: count(rewardsTable.questId),
+                })
+                .from(rewardsTable)
+                .innerJoin(userTable, eq(rewardsTable.userId, userTable.id))
+                .where(isNotNull(rewardsTable.questId))
+                .groupBy(userTable.githubUsername);
+
+            const leaderboard = rows
+                .filter(
+                    (row): row is typeof row & { githubUsername: string } =>
+                        !!row.githubUsername,
+                )
+                .map((row) => ({
+                    githubUsername: row.githubUsername,
+                    totalPollen: Math.round(Number(row.totalPollen) ?? 0),
+                    questCount: Number(row.questCount) ?? 0,
+                }))
+                .sort((a, b) => b.totalPollen - a.totalPollen)
+                .slice(0, 20);
+
+            const response = { leaderboard };
+            await c.env.KV.put(
+                LEADERBOARD_CACHE_KEY,
+                JSON.stringify(response),
+                { expirationTtl: LEADERBOARD_CACHE_TTL },
+            );
+            return c.json(response);
         },
     )
     .post(
@@ -303,6 +377,15 @@ async function readCached(
     kv: KVNamespace,
 ): Promise<QuestCatalogResponse | null> {
     return await kv.get<QuestCatalogResponse>(CACHE_KEY, "json");
+}
+
+async function readCachedLeaderboard(
+    kv: KVNamespace,
+): Promise<QuestLeaderboardResponse | null> {
+    return await kv.get<QuestLeaderboardResponse>(
+        LEADERBOARD_CACHE_KEY,
+        "json",
+    );
 }
 
 async function buildQuestCatalog(

--- a/enter.pollinations.ai/test/quests.test.ts
+++ b/enter.pollinations.ai/test/quests.test.ts
@@ -1753,7 +1753,6 @@ test("account quest history accepts account usage permission", async ({
     });
 });
 
-
 test("quest leaderboard returns ranked contributors by total pollen", async ({
     mocks,
     sessionToken: _sessionToken,

--- a/enter.pollinations.ai/test/quests.test.ts
+++ b/enter.pollinations.ai/test/quests.test.ts
@@ -1752,3 +1752,205 @@ test("account quest history accepts account usage permission", async ({
         rewards: [],
     });
 });
+
+
+test("quest leaderboard returns ranked contributors by total pollen", async ({
+    mocks,
+    sessionToken: _sessionToken,
+}) => {
+    await mocks.enable("github", "tinybird");
+    const db = drizzle(env.DB, { schema });
+    await env.KV.delete("quests:catalog:v26");
+    await env.KV.delete("quests:leaderboard:v1");
+
+    const user = await getOnlyUser();
+    const now = new Date();
+
+    await db
+        .update(schema.user)
+        .set({ githubUsername: "fixture-user" })
+        .where(eq(schema.user.id, user.id));
+
+    const extraUsers = await db
+        .insert(schema.user)
+        .values([
+            {
+                id: "leaderboard-user-2",
+                name: "Second Place",
+                email: "user2@example.com",
+                githubId: 2_000_002,
+                githubUsername: "second-placer",
+                tier: "spore",
+                createdAt: now,
+                updatedAt: now,
+            },
+            {
+                id: "leaderboard-user-3",
+                name: "Third Place",
+                email: "user3@example.com",
+                githubId: 2_000_003,
+                githubUsername: "third-placer",
+                tier: "spore",
+                createdAt: now,
+                updatedAt: now,
+            },
+        ])
+        .returning();
+
+    await recordRewards(db, [
+        {
+            idempotencyKey: "leaderboard:u1:quest:a",
+            userId: user.id,
+            questId: "github:issue:1001",
+            title: "Quest A",
+            amount: 5,
+            bucket: "tier",
+        },
+        {
+            idempotencyKey: "leaderboard:u1:quest:b",
+            userId: user.id,
+            questId: "github:issue:1002",
+            title: "Quest B",
+            amount: 5,
+            bucket: "tier",
+        },
+        {
+            idempotencyKey: "leaderboard:u1:quest:c",
+            userId: user.id,
+            questId: "github:issue:1003",
+            title: "Quest C",
+            amount: 5,
+            bucket: "tier",
+        },
+        {
+            idempotencyKey: "leaderboard:u2:quest:a",
+            userId: extraUsers[0].id,
+            questId: "github:issue:1004",
+            title: "Quest D",
+            amount: 5,
+            bucket: "tier",
+        },
+        {
+            idempotencyKey: "leaderboard:u2:quest:b",
+            userId: extraUsers[0].id,
+            questId: "github:issue:1005",
+            title: "Quest E",
+            amount: 5,
+            bucket: "tier",
+        },
+        {
+            idempotencyKey: "leaderboard:u3:quest:a",
+            userId: extraUsers[1].id,
+            questId: "github:issue:1006",
+            title: "Quest F",
+            amount: 5,
+            bucket: "tier",
+        },
+    ]);
+
+    const response = await SELF.fetch(
+        "http://localhost:3000/api/quests/leaderboard",
+    );
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as {
+        leaderboard: Array<{
+            githubUsername: string;
+            totalPollen: number;
+            questCount: number;
+        }>;
+    };
+
+    expect(payload.leaderboard).toHaveLength(3);
+    expect(payload.leaderboard[0]).toMatchObject({
+        githubUsername: "fixture-user",
+        totalPollen: 15,
+        questCount: 3,
+    });
+    expect(payload.leaderboard[1]).toMatchObject({
+        githubUsername: "second-placer",
+        totalPollen: 10,
+        questCount: 2,
+    });
+    expect(payload.leaderboard[2]).toMatchObject({
+        githubUsername: "third-placer",
+        totalPollen: 5,
+        questCount: 1,
+    });
+});
+
+test("quest leaderboard excludes non-quest rewards and users without github username", async ({
+    mocks,
+    sessionToken: _sessionToken,
+}) => {
+    await mocks.enable("github", "tinybird");
+    const db = drizzle(env.DB, { schema });
+    await env.KV.delete("quests:catalog:v26");
+    await env.KV.delete("quests:leaderboard:v1");
+
+    const user = await getOnlyUser();
+    const now = new Date();
+
+    await db
+        .update(schema.user)
+        .set({ githubUsername: "quest-user" })
+        .where(eq(schema.user.id, user.id));
+
+    const noGithubUser = await db
+        .insert(schema.user)
+        .values({
+            id: "no-github-user",
+            name: "No Github",
+            email: "nogithub@example.com",
+            githubId: 3_000_001,
+            tier: "spore",
+            createdAt: now,
+            updatedAt: now,
+        })
+        .returning();
+
+    await recordRewards(db, [
+        {
+            idempotencyKey: "leaderboard-exclude:quest",
+            userId: user.id,
+            questId: "github:issue:2001",
+            title: "Real Quest",
+            amount: 5,
+            bucket: "tier",
+        },
+        {
+            idempotencyKey: "leaderboard-exclude:oneoff",
+            userId: user.id,
+            questId: null,
+            title: "One-off reward",
+            amount: 10,
+            bucket: "tier",
+        },
+        {
+            idempotencyKey: "leaderboard-exclude:nogithub",
+            userId: noGithubUser[0].id,
+            questId: "github:issue:2002",
+            title: "No Github Quest",
+            amount: 5,
+            bucket: "tier",
+        },
+    ]);
+
+    const response = await SELF.fetch(
+        "http://localhost:3000/api/quests/leaderboard",
+    );
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as {
+        leaderboard: Array<{
+            githubUsername: string;
+            totalPollen: number;
+            questCount: number;
+        }>;
+    };
+
+    expect(payload.leaderboard).toHaveLength(1);
+    expect(payload.leaderboard[0]).toMatchObject({
+        githubUsername: "quest-user",
+        totalPollen: 5,
+        questCount: 1,
+    });
+});

--- a/pollinations.ai/src/ui/components/QuestLeaderboard.tsx
+++ b/pollinations.ai/src/ui/components/QuestLeaderboard.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useState } from "react";
+import { COMMUNITY_PAGE } from "../../copy/content/community";
+import { LINKS } from "../../copy/content/socialLinks";
+import { usePageCopy } from "../../hooks/usePageCopy";
+import { ExternalLinkIcon } from "../assets/ExternalLinkIcon";
+import { Divider } from "./ui/divider";
+import { Body, Heading } from "./ui/typography";
+
+interface LeaderboardEntry {
+    githubUsername: string;
+    totalPollen: number;
+    questCount: number;
+}
+
+interface LeaderboardResponse {
+    leaderboard: LeaderboardEntry[];
+}
+
+export function QuestLeaderboard() {
+    const { copy } = usePageCopy(COMMUNITY_PAGE);
+
+    const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([]);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        const CACHE_KEY = "quest_leaderboard_v1";
+        const today = new Date().toISOString().slice(0, 10);
+
+        try {
+            const cached = localStorage.getItem(CACHE_KEY);
+            if (cached) {
+                const { data, day } = JSON.parse(cached);
+                if (day === today) {
+                    setLeaderboard(data);
+                    setLoading(false);
+                    return;
+                }
+            }
+        } catch {
+            // corrupted cache — continue to fetch
+        }
+
+        const fetchLeaderboard = async () => {
+            try {
+                const res = await fetch(
+                    `${LINKS.enter}/api/quests/leaderboard`,
+                    {
+                        headers: {
+                            Accept: "application/json",
+                        },
+                    },
+                );
+                if (!res.ok) throw new Error(`HTTP ${res.status}`);
+                const payload = (await res.json()) as LeaderboardResponse;
+                setLeaderboard(payload.leaderboard ?? []);
+
+                try {
+                    localStorage.setItem(
+                        CACHE_KEY,
+                        JSON.stringify({
+                            data: payload.leaderboard ?? [],
+                            day: today,
+                        }),
+                    );
+                } catch {
+                    // localStorage full — skip
+                }
+            } catch (err) {
+                console.error("Quest leaderboard fetch failed:", err);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchLeaderboard();
+    }, []);
+
+    if (loading && leaderboard.length === 0) {
+        return null;
+    }
+
+    if (!loading && leaderboard.length === 0) {
+        return null;
+    }
+
+    const topThree = leaderboard.slice(0, 3);
+    const rest = leaderboard.slice(3);
+
+    const renderEntry = (entry: LeaderboardEntry, rank: number) => {
+        const rankColors = [
+            "border-primary-strong",
+            "border-secondary-strong",
+            "border-tertiary-strong",
+        ];
+        const colorClass = rankColors[rank % rankColors.length];
+        return (
+            <a
+                key={entry.githubUsername}
+                href={`https://github.com/${entry.githubUsername}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="group flex items-center gap-3 p-2 rounded-sub-card border-r-2 border-b-2 bg-white/60 transition hover:translate-x-[1px] hover:translate-y-[1px] hover:shadow-none"
+            >
+                <span
+                    className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full border-2 ${colorClass} font-headline text-[10px] font-black text-dark`}
+                >
+                    #{rank + 1}
+                </span>
+                <span className="font-mono text-xs font-medium text-dark truncate">
+                    @{entry.githubUsername}
+                </span>
+                <span className="ml-auto flex items-center gap-2 text-xs text-subtle">
+                    <span className="font-headline font-black">
+                        {entry.totalPollen}
+                    </span>
+                    <span>{copy.questLeaderboardPollenLabel}</span>
+                    <span className="text-border-subtle">·</span>
+                    <span>
+                        {entry.questCount} {copy.questLeaderboardCountLabel}
+                    </span>
+                </span>
+            </a>
+        );
+    };
+
+    return (
+        <>
+            <div className="mb-12">
+                <Heading variant="section">
+                    {copy.questLeaderboardTitle}
+                </Heading>
+                <Body size="sm" spacing="comfortable">
+                    {copy.questLeaderboardDescription}
+                    <br />
+                    {copy.questLeaderboardCta}{" "}
+                    <a
+                        href={LINKS.enterQuests}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="font-headline text-xs font-black hover:underline inline-flex items-center gap-1 text-dark bg-accent-strong px-2 py-0.5"
+                    >
+                        {copy.questLeaderboardLink}
+                        <ExternalLinkIcon className="w-3 h-3" strokeWidth="4" />
+                    </a>
+                </Body>
+                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-3">
+                    {topThree.map(renderEntry)}
+                </div>
+                {rest.length > 0 && (
+                    <>
+                        <div className="mt-3 grid grid-cols-1 gap-1 sm:grid-cols-2">
+                            {rest.map(renderEntry)}
+                        </div>
+                    </>
+                )}
+            </div>
+            <Divider />
+        </>
+    );
+}

--- a/pollinations.ai/src/ui/pages/CommunityPage.tsx
+++ b/pollinations.ai/src/ui/pages/CommunityPage.tsx
@@ -5,6 +5,7 @@ import { usePageCopy } from "../../hooks/usePageCopy";
 import { useTranslate } from "../../hooks/useTranslate";
 import { ExternalLinkIcon } from "../assets/ExternalLinkIcon";
 import { BuildDiary } from "../components/BuildDiary";
+import { QuestLeaderboard } from "../components/QuestLeaderboard";
 import { TopContributors } from "../components/TopContributors";
 import { Button } from "../components/ui/button";
 import { Divider } from "../components/ui/divider";
@@ -323,6 +324,8 @@ export default function CommunityPage() {
                 <Divider />
 
                 <TopContributors />
+
+                <QuestLeaderboard />
 
                 {/* Section 5 — Build Diary + Supporters */}
                 <div className="mb-12">


### PR DESCRIPTION
Isolates the #13909 quest leaderboard feature from meta-PR #13944.

## What changed
- **Backend**: new public `GET /api/quests/leaderboard` route in `enter.pollinations.ai/src/routes/quests.ts`
  - Aggregates completed `POLLEN-QUEST` rewards by `githubUsername`
  - Returns top 20 contributors ranked by total pollen
  - Cache KV `quests:leaderboard:v1` TTL 300s
- **Frontend**: new `QuestLeaderboard` component in `pollinations.ai/src/ui/components/QuestLeaderboard.tsx`
  - Top 3 grid + rest list, links to GitHub profiles
  - Daily localStorage cache
  - Integrated into `CommunityPage`
- **Tests**: 2 new tests in `enter.pollinations.ai/test/quests.test.ts`
  - Ranking by total pollen across quests
  - Excludes one-off rewards (null questId) and users without GitHub username

## Constraints respected
- Reuses existing `rewards` + `user` tables
- No Tinybird, no new tables, no scraping
- Public identity only: GitHub username + aggregate totals