### PR TITLE
feat(models): show context window and video duration in Models dashboard

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/model-catalog.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-catalog.ts
@@ -57,6 +57,10 @@ export type ApiModelInfo = {
     tools?: boolean;
     reasoning?: boolean;
     context_length?: number;
+    min_duration?: number;
+    max_duration?: number;
+    default_duration?: number;
+    allowed_durations?: number[];
     voices?: string[];
     is_specialized?: boolean;
     paid_only?: boolean;
@@ -263,6 +267,11 @@ function baseModelPrice(model: ApiModelInfo): ModelPrice | null {
             outputSortPrice === undefined,
         alpha: model.alpha,
         addedDate: model.added_date,
+        contextLength: model.context_length,
+        minDuration: model.min_duration,
+        maxDuration: model.max_duration,
+        defaultDuration: model.default_duration,
+        allowedDurations: model.allowed_durations,
         inputSortPrice,
         outputSortPrice,
         prices: [],

--- a/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
@@ -30,6 +30,7 @@ import {
 import {
     type BalanceAccess,
     BalanceAccessChip,
+    ModelLimitChips,
     ModelRateValue,
     ModelStatusChips,
     PerUserRateLimit,
@@ -382,6 +383,7 @@ export const ModelRow: FC<ModelRowProps> = ({ model }) => {
                             access={balanceAccess}
                             className="whitespace-nowrap"
                         />
+                        <ModelLimitChips model={model} />
                     </div>
                 </div>
             </div>

--- a/enter.pollinations.ai/frontend/src/components/models/model-status-chips.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-status-chips.tsx
@@ -1,6 +1,7 @@
 import { Chip, SparklesIcon, Tooltip } from "@pollinations/ui";
 import { PaidChip, TierChip, WalletKindIcon } from "@pollinations/ui/wallet";
 import type { FC } from "react";
+import type { ModelPrice } from "./types.ts";
 
 export type BalanceAccess = "quest" | "paid" | "free";
 
@@ -171,5 +172,118 @@ export const BalanceAccessChip: FC<BalanceAccessChipProps> = ({
         >
             {chip}
         </Tooltip>
+    );
+};
+
+// --- Model limit chips: context window + video duration ---
+
+function trimNumber(value: number): string {
+    const rounded = Math.round(value * 10) / 10;
+    return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+}
+
+function formatContextLength(contextLength?: number): string | undefined {
+    if (contextLength == null) return undefined;
+    if (contextLength >= 1_000_000) {
+        return `${trimNumber(contextLength / 1_000_000)}M ctx`;
+    }
+    if (contextLength >= 1_000) {
+        return `${trimNumber(contextLength / 1_000)}k ctx`;
+    }
+    return `${contextLength} ctx`;
+}
+
+function getVideoDurationRange(model: ModelPrice): {
+    lo: number;
+    hi: number;
+} | null {
+    if (model.type !== "video") return null;
+    const allowed = model.allowedDurations;
+    let min: number | undefined;
+    let max: number | undefined;
+    if (allowed && allowed.length > 0) {
+        min = Math.min(...allowed);
+        max = Math.max(...allowed);
+    } else {
+        min = model.minDuration;
+        max = model.maxDuration;
+    }
+    const candidates = [min, max, model.defaultDuration].filter(
+        (value): value is number => value != null,
+    );
+    if (candidates.length === 0) return null;
+    return { lo: Math.min(...candidates), hi: Math.max(...candidates) };
+}
+
+function formatVideoDuration(model: ModelPrice): string | undefined {
+    const range = getVideoDurationRange(model);
+    if (!range) return undefined;
+    return range.lo === range.hi ? `${range.lo}s` : `${range.lo}–${range.hi}s`;
+}
+
+function videoDurationTooltip(model: ModelPrice): string {
+    const range = getVideoDurationRange(model);
+    if (!range) return "";
+    return range.lo === range.hi
+        ? `Duration: ${range.lo} seconds`
+        : `Supported duration: ${range.lo}–${range.hi} seconds`;
+}
+
+export const ModelLimitChips: FC<{ model: ModelPrice }> = ({ model }) => {
+    const context = formatContextLength(model.contextLength);
+    const duration = formatVideoDuration(model);
+    if (!context && !duration) return null;
+
+    return (
+        <span className="inline-flex shrink-0 items-center gap-1.5">
+            {context && (
+                <Tooltip
+                    triggerAs="span"
+                    content={
+                        <span>
+                            <strong className="font-semibold text-theme-text-strong">
+                                Context window:
+                            </strong>{" "}
+                            {new Intl.NumberFormat("en").format(
+                                model.contextLength ?? 0,
+                            )}{" "}
+                            tokens
+                        </span>
+                    }
+                    ariaLabel={
+                        model.contextLength != null
+                            ? `Context window: ${new Intl.NumberFormat("en").format(model.contextLength)} tokens`
+                            : ""
+                    }
+                    tapEnabled
+                    displayContents
+                >
+                    <Chip
+                        intent="neutral"
+                        size="sm"
+                        className="whitespace-nowrap tabular-nums"
+                    >
+                        {context}
+                    </Chip>
+                </Tooltip>
+            )}
+            {duration && (
+                <Tooltip
+                    triggerAs="span"
+                    content={<span>{videoDurationTooltip(model)}</span>}
+                    ariaLabel={videoDurationTooltip(model)}
+                    tapEnabled
+                    displayContents
+                >
+                    <Chip
+                        intent="neutral"
+                        size="sm"
+                        className="whitespace-nowrap tabular-nums"
+                    >
+                        {duration}
+                    </Chip>
+                </Tooltip>
+            )}
+        </span>
     );
 };

--- a/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
@@ -29,6 +29,7 @@ import type { ModelCategory } from "./model-search.ts";
 import {
     type BalanceAccess,
     BalanceAccessChip,
+    ModelLimitChips,
     ModelStatusChips,
     PerUserRateLimit,
 } from "./model-status-chips.tsx";
@@ -277,6 +278,7 @@ const MobileModelRow: FC<MobileModelRowProps> = ({ model }) => {
                             access={balanceAccess}
                             className="whitespace-nowrap"
                         />
+                        <ModelLimitChips model={model} />
                     </div>
                 </div>
             </div>

--- a/enter.pollinations.ai/frontend/src/components/models/types.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/types.ts
@@ -83,6 +83,11 @@ export type ModelPrice = {
     free?: boolean;
     alpha?: boolean;
     addedDate?: number;
+    contextLength?: number;
+    minDuration?: number;
+    maxDuration?: number;
+    defaultDuration?: number;
+    allowedDurations?: number[];
     inputSortPrice?: number;
     outputSortPrice?: number;
     prices: ModelPriceLine[];


### PR DESCRIPTION
## Summary
Implements pollinations/pollinations#13905 — surface important model limits in the Models dashboard without adding clutter.

## What changed
- `shared/registry/model-info.ts` already exposes `context_length` and video duration metadata (`min_duration` / `max_duration` / `default_duration` / `allowed_durations`) in the `/models` response. The frontend catalog mapping was not threading these into the dashboard.
- `ApiModelInfo` (model-catalog.ts): added `min_duration`, `max_duration`, `default_duration`, `allowed_durations` so the existing duration metadata is captured from the catalog.
- `ModelPrice` (types.ts) + `baseModelPrice`: thread `contextLength` and the duration fields through to the dashboard model.
- New `ModelLimitChips` (model-status-chips.tsx): compact, tooltip-bearing chips showing:
  - Context window as `Xk ctx` / `XM ctx` (e.g. `128k ctx`) with an exact-token tooltip, when `context_length` is available.
  - Video duration as a range `X–Ys` or fixed `Xs` (e.g. `4–8s`) with a tooltip, for video models.
- Rendered in both `ModelRow` (desktop) and `MobileModelRow` (mobile) status rows, so it stays compact and accessible on both.

## Constraints honored
- No API, registry, pricing, sorting, or filtering changes.
- No separate model-details view added.
- Only the catalog → dashboard mapping was extended.

## Verification
- `biome check` (lint) passes on all five changed files with no errors.
- Full frontend build / type-check could not be executed locally in this environment; relying on CI.