### PR TITLE
docs: add reasoning quickstart to text generation docs

### DIFF
--- a/gen.pollinations.ai/src/docs/text-generation.md
+++ b/gen.pollinations.ai/src/docs/text-generation.md
@@ -9,6 +9,30 @@ Generate text responses using AI models. Fully compatible with the OpenAI Chat C
 
 **Available models:** {{TEXT_MODELS}}
 
+### Reasoning
+
+Models that support adjustable reasoning accept a `reasoning_effort` field: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`. `"none"` requests no reasoning; on models without reasoning support the parameter is ignored. Model metadata reports support — reasoning-capable models return `"reasoning": true` from [`/text/models`](https://gen.pollinations.ai/text/models).
+
+`POST /v1/chat/completions`:
+
+```json
+{
+  "model": "deepseek",
+  "reasoning_effort": "high",
+  "messages": [{ "role": "user", "content": "Explain the P versus NP problem" }]
+}
+```
+
+`POST /text` accepts the same body and returns plain text:
+
+```json
+{
+  "model": "deepseek",
+  "reasoning_effort": "low",
+  "messages": [{ "role": "user", "content": "Outline a URL shortener design" }]
+}
+```
+
 ### Prompt caching
 
 On Gemini, Claude, and Nova models, a large static prompt prefix can be cached so repeat requests bill it at a fraction of the input rate. Mark the end of the static prefix with `cache_control` on a content block (not on the message); everything before the marker must be byte-identical across requests, everything dynamic goes after. The first request creates the cache (`usage` reports `cache_creation_input_tokens`); repeat requests within the TTL report `prompt_tokens_details.cached_tokens` at the discounted rate.

--- a/gen.pollinations.ai/src/schemas/text.ts
+++ b/gen.pollinations.ai/src/schemas/text.ts
@@ -49,7 +49,10 @@ export const GenerateTextRequestQueryParamsSchema = z.object({
     repetition_penalty: FloatQueryParamSchema,
     max_tokens: IntQueryParamSchema,
     max_completion_tokens: IntQueryParamSchema,
-    reasoning_effort: z.string().optional(),
+    reasoning_effort: z.string().optional().meta({
+        description:
+            'Requests reasoning depth for models that support adjustable reasoning. "none" requests no reasoning. Models that support it report `"reasoning": true` in `/text/models`.',
+    }),
     voice: z.string().optional(),
     stream: BooleanQueryParamSchema.optional().default(false).meta({
         description:

--- a/shared/schemas/openai.ts
+++ b/shared/schemas/openai.ts
@@ -328,7 +328,7 @@ export const CreateChatCompletionRequestSchema = z
         reasoning_effort: z
             .enum(["none", "minimal", "low", "medium", "high", "xhigh", "max"])
             .describe(
-                'Requests reasoning depth for models that support adjustable reasoning. "none" requests no reasoning.',
+                'Requests reasoning depth for models that support adjustable reasoning. "none" requests no reasoning. Models that support it report `"reasoning": true` in `/text/models`.',
             )
             .optional(),
         web_search_options: z


### PR DESCRIPTION
Fixes #13904

Added a quick Reasoning section to the text generation docs. Shows how to use `reasoning_effort` with `POST /v1/chat/completions` and `POST /text`, and points to the `reasoning` flag in `/text/models` so you can check which models actually support it.

- Text generation guide now has two minimal examples (chat completions + text)
- Updated `reasoning_effort` description to mention the `/text/models` flag
- Documented the `reasoning_effort` query param on `GET /text/{prompt}` which had no description before

No runtime changes, APIDOCS gets regenerated on deploy.
