### PR TITLE
feat: support multiple inputs in FFmpeg MCP

### DIFF
--- a/apps/ffmpeg-mcp/container.js
+++ b/apps/ffmpeg-mcp/container.js
@@ -22,26 +22,30 @@ async function decodeStream(stream) {
 export class FfmpegContainer extends Container {
     enableInternet = false;
 
-    async run(input, args, outputExtension, deadlineMs) {
+    async run(inputs, args, outputExtension, deadlineMs) {
         const runtime = this.ctx.container;
         if (!runtime.running) {
             await this.start({ enableInternet: false });
         }
 
-        const inputPath = `${WORK_DIR}/input`;
-        const write = await runtime.exec(["tee", inputPath], {
-            stdin: input,
-            stdout: "ignore",
-        });
-        const [writeExitCode, writeError] = await Promise.all([
-            write.exitCode,
-            decodeStream(write.stderr),
-        ]);
-        if (writeExitCode !== 0) {
-            return {
-                ok: false,
-                stderr: writeError || "FFmpeg input could not be saved",
-            };
+        for (const [index, input] of inputs.entries()) {
+            const write = await runtime.exec(
+                ["tee", `${WORK_DIR}/input${index}`],
+                {
+                    stdin: input,
+                    stdout: "ignore",
+                },
+            );
+            const [writeExitCode, writeError] = await Promise.all([
+                write.exitCode,
+                decodeStream(write.stderr),
+            ]);
+            if (writeExitCode !== 0) {
+                return {
+                    ok: false,
+                    stderr: writeError || "FFmpeg input could not be saved",
+                };
+            }
         }
 
         const remainingMs = deadlineMs - Date.now();
@@ -61,8 +65,6 @@ export class FfmpegContainer extends Container {
                 "error",
                 "-nostdin",
                 "-y",
-                "-i",
-                inputPath,
                 ...args,
                 outputPath,
             ],

--- a/apps/ffmpeg-mcp/container.js
+++ b/apps/ffmpeg-mcp/container.js
@@ -27,6 +27,23 @@ export class FfmpegContainer extends Container {
         if (!runtime.running) {
             await this.start({ enableInternet: false });
         }
+
+        const inputPath = `${WORK_DIR}/input`;
+        const write = await runtime.exec(["tee", inputPath], {
+            stdin: input,
+            stdout: "ignore",
+        });
+        const [writeExitCode, writeError] = await Promise.all([
+            write.exitCode,
+            decodeStream(write.stderr),
+        ]);
+        if (writeExitCode !== 0) {
+            return {
+                ok: false,
+                stderr: writeError || "FFmpeg input could not be saved",
+            };
+        }
+
         const remainingMs = deadlineMs - Date.now();
         if (remainingMs <= 0) {
             return {
@@ -45,11 +62,11 @@ export class FfmpegContainer extends Container {
                 "-nostdin",
                 "-y",
                 "-i",
-                "pipe:0",
+                inputPath,
                 ...args,
                 outputPath,
             ],
-            { stdin: input, stdout: "ignore" },
+            { stdout: "ignore" },
         );
         const timer = setTimeout(() => process.kill(9), remainingMs);
         const [exitCode, stderr] = await Promise.all([

--- a/apps/ffmpeg-mcp/ffmpeg.js
+++ b/apps/ffmpeg-mcp/ffmpeg.js
@@ -5,21 +5,6 @@ export const FFMPEG_MAX_MEDIA_BYTES = 100 * 1024 * 1024;
 export const FFMPEG_COST_PER_SECOND =
     0.25 * 0.00002 + 1 * 0.0000025 + 4 * 0.00000007;
 
-export const FFMPEG_OUTPUT_EXTENSIONS = [
-    "mp4",
-    "webm",
-    "mov",
-    "mp3",
-    "m4a",
-    "wav",
-    "flac",
-    "ogg",
-    "gif",
-    "jpg",
-    "jpeg",
-    "png",
-];
-
 export function calculateFfmpegCharge(runtimeMs) {
     return (Math.max(0, runtimeMs) / 1000) * FFMPEG_COST_PER_SECOND;
 }

--- a/apps/ffmpeg-mcp/worker.js
+++ b/apps/ffmpeg-mcp/worker.js
@@ -82,10 +82,14 @@ async function fetchSource(source, fetchImpl, createFixedLengthStream) {
 }
 
 async function runTool(params, env, dependencies, reportUsage) {
-    const input = await fetchSource(
-        params.source,
-        dependencies.fetchImpl,
-        dependencies.createFixedLengthStreamImpl,
+    const inputs = await Promise.all(
+        params.sources.map((source) =>
+            fetchSource(
+                source,
+                dependencies.fetchImpl,
+                dependencies.createFixedLengthStreamImpl,
+            ),
+        ),
     );
     const requestId = crypto.randomUUID();
     const startedAt = Date.now();
@@ -101,7 +105,7 @@ async function runTool(params, env, dependencies, reportUsage) {
         let result;
         try {
             result = await container.run(
-                input,
+                inputs,
                 params.args,
                 params.outputExtension,
                 startedAt + FFMPEG_MAX_RUN_MS,
@@ -165,7 +169,7 @@ async function runTool(params, env, dependencies, reportUsage) {
             {
                 type: "text",
                 text: JSON.stringify({
-                    source: params.source,
+                    sources: params.sources,
                     args: params.args,
                     outputExtension: params.outputExtension,
                     url: output.url,
@@ -181,28 +185,30 @@ function buildServer(env, dependencies, reportUsage) {
         { name: "pollinations-ffmpeg-mcp", version: "0.1.0" },
         {
             instructions:
-                "Run native FFmpeg commands against public HTTPS media. Pollinations supplies the input and hosted output; provide only arguments between them.",
+                "Run native FFmpeg commands against public HTTPS media. Sources are saved as input0, input1, and so on; pass ordinary FFmpeg arguments and Pollinations hosts the output.",
             capabilities: { tools: {} },
         },
     );
     server.registerTool(
         "runFfmpeg",
         {
-            description: `Run native FFmpeg arguments against a public HTTPS media URL and return an unlisted hosted resource link. Omit ffmpeg, -i, and the output path. Maximum input/output size is 100 MB and runtime is ${FFMPEG_MAX_RUN_MS / 1000} seconds. Billed at ${FFMPEG_COST_PER_SECOND.toFixed(8)} Pollen per active second.`,
+            description: `Run native FFmpeg arguments against public HTTPS media and return an unlisted hosted resource link. Sources are available as input0, input1, and so on. Include each needed -i argument, but omit ffmpeg and the output path. Maximum size per input/output is 100 MB and runtime is ${FFMPEG_MAX_RUN_MS / 1000} seconds. Billed at ${FFMPEG_COST_PER_SECOND.toFixed(8)} Pollen per active second.`,
             inputSchema: z.object({
-                source: z.url().refine((value) => {
-                    const validation = validateUserMediaUrl(value);
-                    return (
-                        validation.ok && validation.url.protocol === "https:"
-                    );
-                }, "source must be a public HTTPS URL without credentials"),
-                args: z
-                    .array(z.string().min(1).max(1024))
-                    .max(64)
-                    .refine(
-                        (args) => !args.includes("-i"),
-                        "omit -i; Pollinations supplies the input",
+                sources: z
+                    .array(
+                        z.url().refine((value) => {
+                            const validation = validateUserMediaUrl(value);
+                            return (
+                                validation.ok &&
+                                validation.url.protocol === "https:"
+                            );
+                        }, "sources must be public HTTPS URLs without credentials"),
+                    )
+                    .min(1)
+                    .describe(
+                        "Ordered source URLs, saved as input0, input1, and so on.",
                     ),
+                args: z.array(z.string().min(1).max(1024)).max(64),
                 outputExtension: z
                     .string()
                     .regex(

--- a/apps/ffmpeg-mcp/worker.js
+++ b/apps/ffmpeg-mcp/worker.js
@@ -7,7 +7,6 @@ import {
     FFMPEG_COST_PER_SECOND,
     FFMPEG_MAX_MEDIA_BYTES,
     FFMPEG_MAX_RUN_MS,
-    FFMPEG_OUTPUT_EXTENSIONS,
 } from "./ffmpeg.js";
 
 const MAX_SOURCE_REDIRECTS = 5;
@@ -116,7 +115,9 @@ async function runTool(params, env, dependencies, reportUsage) {
         if (!result.ok) {
             throw new ToolFailure(422, result.stderr || "FFmpeg failed");
         }
-        const contentType = MIME_TYPES[params.outputExtension];
+        const contentType =
+            MIME_TYPES[params.outputExtension.toLowerCase()] ??
+            "application/octet-stream";
         const mediaBody = dependencies.createFixedLengthStreamImpl(
             result.bytes,
         );
@@ -202,7 +203,15 @@ function buildServer(env, dependencies, reportUsage) {
                         (args) => !args.includes("-i"),
                         "omit -i; Pollinations supplies the input",
                     ),
-                outputExtension: z.enum(FFMPEG_OUTPUT_EXTENSIONS),
+                outputExtension: z
+                    .string()
+                    .regex(
+                        /^[a-zA-Z0-9]{1,16}$/,
+                        "outputExtension must contain only letters and numbers",
+                    )
+                    .describe(
+                        "Output filename extension without a dot. Any single-file format supported by FFmpeg is accepted.",
+                    ),
             }),
         },
         (params) => runTool(params, env, dependencies, reportUsage),

--- a/apps/ffmpeg-mcp/worker.test.js
+++ b/apps/ffmpeg-mcp/worker.test.js
@@ -176,10 +176,11 @@ test("accepts public HTTPS media and a single supplied input", async () => {
         arguments: {
             source: publicSource,
             args: [],
-            outputExtension: "mp4",
+            outputExtension: "mkv",
         },
     });
     assert.equal(success.isError, undefined);
+    assert.equal(calls.upload[0].input.contentType, "application/octet-stream");
 
     const extraInput = await client.callTool({
         name: "runFfmpeg",

--- a/apps/ffmpeg-mcp/worker.test.js
+++ b/apps/ffmpeg-mcp/worker.test.js
@@ -8,6 +8,7 @@ import { MCP_USAGE_HEADERS } from "../../shared/registry/mcp.ts";
 import { createWorker } from "./worker.js";
 
 const SOURCE = "https://media.pollinations.ai/source";
+const SECOND_SOURCE = "https://media.pollinations.ai/second-source";
 
 function createHarness(options = {}) {
     const calls = {
@@ -18,9 +19,16 @@ function createHarness(options = {}) {
         sourceFetches: [],
     };
     const container = {
-        async run(input, args, outputExtension, deadlineMs) {
+        async run(inputs, args, outputExtension, deadlineMs) {
             calls.run.push({
-                input: new Uint8Array(await new Response(input).arrayBuffer()),
+                inputs: await Promise.all(
+                    inputs.map(
+                        async (input) =>
+                            new Uint8Array(
+                                await new Response(input).arrayBuffer(),
+                            ),
+                    ),
+                ),
                 args,
                 outputExtension,
                 deadlineMs,
@@ -65,7 +73,13 @@ function createHarness(options = {}) {
             calls.sourceFetches.push(url.toString());
             assert.equal(init.redirect, "manual");
             if (options.fetchImpl) return options.fetchImpl(url, init);
-            assert.equal(url.toString(), options.expectedSource ?? SOURCE);
+            assert.ok(
+                (
+                    options.expectedSources ?? [
+                        options.expectedSource ?? SOURCE,
+                    ]
+                ).includes(url.toString()),
+            );
             return (
                 options.sourceResponse ??
                 new Response(new Uint8Array([1, 2, 3]), {
@@ -130,14 +144,23 @@ test("rejects JSON-RPC batches before running tools", async () => {
     assert.equal(calls.run.length, 0);
 });
 
-test("runs FFmpeg, uploads the output, and reports trusted usage", async () => {
-    const { calls, env, worker } = createHarness();
+test("runs multi-input FFmpeg, uploads the output, and reports trusted usage", async () => {
+    const { calls, env, worker } = createHarness({
+        expectedSources: [SOURCE, SECOND_SOURCE],
+    });
     const client = await connect(worker, env, calls);
     const result = await client.callTool({
         name: "runFfmpeg",
         arguments: {
-            source: SOURCE,
-            args: ["-t", "1", "-vf", "scale=32:32"],
+            sources: [SOURCE, SECOND_SOURCE],
+            args: [
+                "-i",
+                "input0",
+                "-i",
+                "input1",
+                "-filter_complex",
+                "[0:v][1:v]overlay",
+            ],
             outputExtension: "mp4",
         },
     });
@@ -149,8 +172,18 @@ test("runs FFmpeg, uploads the output, and reports trusted usage", async () => {
         name: "FFmpeg output",
         mimeType: "video/mp4",
     });
-    assert.deepEqual(calls.run[0].input, new Uint8Array([1, 2, 3]));
-    assert.deepEqual(calls.run[0].args, ["-t", "1", "-vf", "scale=32:32"]);
+    assert.deepEqual(calls.run[0].inputs, [
+        new Uint8Array([1, 2, 3]),
+        new Uint8Array([1, 2, 3]),
+    ]);
+    assert.deepEqual(calls.run[0].args, [
+        "-i",
+        "input0",
+        "-i",
+        "input1",
+        "-filter_complex",
+        "[0:v][1:v]overlay",
+    ]);
     assert.deepEqual(calls.upload[0].body, new Uint8Array([4, 5, 6]));
     assert.equal(calls.destroy, 1);
 
@@ -165,7 +198,7 @@ test("runs FFmpeg, uploads the output, and reports trusted usage", async () => {
     await client.close();
 });
 
-test("accepts public HTTPS media and a single supplied input", async () => {
+test("accepts public HTTPS media and raw FFmpeg input arguments", async () => {
     const publicSource = "https://cdn.example.com/source.mp4";
     const { calls, env, worker } = createHarness({
         expectedSource: publicSource,
@@ -174,23 +207,14 @@ test("accepts public HTTPS media and a single supplied input", async () => {
     const success = await client.callTool({
         name: "runFfmpeg",
         arguments: {
-            source: publicSource,
-            args: [],
+            sources: [publicSource],
+            args: ["-i", "input0"],
             outputExtension: "mkv",
         },
     });
     assert.equal(success.isError, undefined);
     assert.equal(calls.upload[0].input.contentType, "application/octet-stream");
 
-    const extraInput = await client.callTool({
-        name: "runFfmpeg",
-        arguments: {
-            source: publicSource,
-            args: ["-i", "https://example.com/other.mp4"],
-            outputExtension: "mp4",
-        },
-    });
-    assert.equal(extraInput.isError, true);
     assert.equal(calls.run.length, 1);
     await client.close();
 });
@@ -216,8 +240,8 @@ test("revalidates public HTTPS redirects", async () => {
     const result = await client.callTool({
         name: "runFfmpeg",
         arguments: {
-            source: SOURCE,
-            args: [],
+            sources: [SOURCE],
+            args: ["-i", "input0"],
             outputExtension: "mp4",
         },
     });
@@ -236,8 +260,8 @@ test("revalidates public HTTPS redirects", async () => {
     const unsafeResult = await unsafeClient.callTool({
         name: "runFfmpeg",
         arguments: {
-            source: SOURCE,
-            args: [],
+            sources: [SOURCE],
+            args: ["-i", "input0"],
             outputExtension: "mp4",
         },
     });
@@ -261,7 +285,11 @@ test("rejects unsafe source URLs before execution", async () => {
     ]) {
         const result = await client.callTool({
             name: "runFfmpeg",
-            arguments: { source, args: [], outputExtension: "mp4" },
+            arguments: {
+                sources: [source],
+                args: ["-i", "input0"],
+                outputExtension: "mp4",
+            },
         });
         assert.equal(result.isError, true);
     }
@@ -283,8 +311,8 @@ test("rejects source responses without a known size", async () => {
     const result = await client.callTool({
         name: "runFfmpeg",
         arguments: {
-            source: SOURCE,
-            args: [],
+            sources: [SOURCE],
+            args: ["-i", "input0"],
             outputExtension: "mp4",
         },
     });
@@ -307,8 +335,8 @@ test("reports usage for executed failures", async () => {
         const result = await client.callTool({
             name: "runFfmpeg",
             arguments: {
-                source: SOURCE,
-                args: [],
+                sources: [SOURCE],
+                args: ["-i", "input0"],
                 outputExtension: "mp4",
             },
         });


### PR DESCRIPTION
- Downloads public HTTPS sources into seekable container files named `input0`, `input1`, and so on
- Passes caller-supplied FFmpeg arguments directly, including positional `-i` options
- Accepts any safe single-file output extension and uploads the result to Pollinations Media
- Keeps Gen authentication, usage billing, and hosted resource links unchanged

Tests:
- `npm test` (8/8)
- `npm run check`
- Local two-input video + audio FFmpeg smoke test