### PR TITLE
docs: add reasoning quickstart for chat and text endpoints

### DIFF
--- a/gen.pollinations.ai/src/docs/text-generation.md
+++ b/gen.pollinations.ai/src/docs/text-generation.md
@@ -9,6 +9,24 @@ Generate text responses using AI models. Fully compatible with the OpenAI Chat C
 
 **Available models:** {{TEXT_MODELS}}
 
+### Reasoning
+
+Some models expose adjustable reasoning. Pass `reasoning_effort` (`none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`) — omit it for default behavior. Only models with `reasoning: true` in `GET /v1/models` support it.
+
+```json
+{
+  "model": "openai-reasoning",
+  "messages": [{ "role": "user", "content": "Prove the Pythagorean theorem" }],
+  "reasoning_effort": "high"
+}
+```
+
+For the `GET /text/{prompt}` endpoint, use the same parameter as a query string:
+
+```
+GET https://gen.pollinations.ai/text/Prove%20the%20Pythagorean%20theorem?model=openai-reasoning&reasoning_effort=high
+```
+
 ### Prompt caching
 
 On Gemini, Claude, and Nova models, a large static prompt prefix can be cached so repeat requests bill it at a fraction of the input rate. Mark the end of the static prefix with `cache_control` on a content block (not on the message); everything before the marker must be byte-identical across requests, everything dynamic goes after. The first request creates the cache (`usage` reports `cache_creation_input_tokens`); repeat requests within the TTL report `prompt_tokens_details.cached_tokens` at the discounted rate.

--- a/gen.pollinations.ai/src/routes/docs-samples.ts
+++ b/gen.pollinations.ai/src/routes/docs-samples.ts
@@ -47,6 +47,18 @@ export const CODE_SAMPLES: Record<
   }'`,
         },
         {
+            label: "Reasoning",
+            lang: "Shell",
+            source: `curl https://gen.pollinations.ai/v1/chat/completions \\
+  -H "Authorization: Bearer YOUR_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "model": "openai-reasoning",
+    "messages": [{"role": "user", "content": "Prove the Pythagorean theorem"}],
+    "reasoning_effort": "high"
+  }'`,
+        },
+        {
             label: "Python",
             lang: "Python",
             source: `from openai import OpenAI
@@ -84,6 +96,12 @@ console.log(response.choices[0].message.content);`,
             label: "cURL",
             lang: "Shell",
             source: `curl "https://gen.pollinations.ai/text/Write%20a%20haiku?model=openai" \\
+  -H "Authorization: Bearer YOUR_API_KEY"`,
+        },
+        {
+            label: "Reasoning",
+            lang: "Shell",
+            source: `curl "https://gen.pollinations.ai/text/Prove%20the%20Pythagorean%20theorem?model=openai-reasoning&reasoning_effort=high" \\
   -H "Authorization: Bearer YOUR_API_KEY"`,
         },
         {


### PR DESCRIPTION
﻿Closes #13904

Adds concise reasoning guidance where the API docs are actually edited (`text-generation.md` so the generated reference picks it up) and matching shell samples for both `POST /v1/chat/completions` and `GET /text/{prompt}`.

- `reasoning_effort` values noted and readers pointed to `GET /v1/models` (`reasoning: true`) for support.
- No runtime changes, no provider matrix, no manual `APIDOCS.md` edits.
