### PR TITLE
feat(models): add Try in Play action to model cards

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
@@ -373,7 +373,7 @@ export const ModelRow: FC<ModelRowProps> = ({ model }) => {
                             </div>
                         )}
                     </div>
-                    <div className="mt-1.5 flex min-w-0 flex-wrap items-center gap-1.5">
+                    <div className="mt-1.5 flex min-w-0 flex-wrap items-center gap-2">
                         <ModelStatusChips
                             showNew={showNew}
                             showAlpha={showAlpha}
@@ -382,6 +382,25 @@ export const ModelRow: FC<ModelRowProps> = ({ model }) => {
                             access={balanceAccess}
                             className="whitespace-nowrap"
                         />
+                        <Tooltip
+                            content="Try in Play"
+                            ariaLabel={`Try ${model.name} in Play`}
+                            tapEnabled
+                        >
+                            <a
+                                href={`/play?model=${encodeURIComponent(model.name)}`}
+                                aria-label={`Try ${model.name} in Play`}
+                                className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-divider bg-surface text-theme-text-muted transition-colors hover:bg-surface-opaque hover:text-theme-text-soft"
+                            >
+                                <span
+                                    aria-hidden="true"
+                                    className="text-[11px] leading-none"
+                                >
+                                    ▶
+                                </span>
+                                <span className="sr-only">Try in Play</span>
+                            </a>
+                        </Tooltip>
                     </div>
                 </div>
             </div>

--- a/pollinations.ai/src/ui/pages/PlayPage.tsx
+++ b/pollinations.ai/src/ui/pages/PlayPage.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { PLAY_PAGE } from "../../copy/content/play";
 import { LINKS } from "../../copy/content/socialLinks";
 import { useAuth } from "../../hooks/useAuth";
@@ -14,7 +15,11 @@ import { PageContainer } from "../components/ui/page-container";
 import { Body, Title } from "../components/ui/typography";
 
 function PlayPage() {
-    const [selectedModel, setSelectedModel] = useState("flux");
+    const [searchParams] = useSearchParams();
+    const urlModel = searchParams.get("model");
+    const [selectedModel, setSelectedModel] = useState(
+        () => urlModel || "flux",
+    );
     const [prompt, setPrompt] = useState("");
     const { apiKey, isLoggedIn, login } = useAuth();
     const {
@@ -25,6 +30,16 @@ function PlayPage() {
         allowedAudioModelIds,
         isLoading: isLoadingModels,
     } = useModelList(apiKey);
+
+    useEffect(() => {
+        if (
+            urlModel &&
+            registryModels.some((m) => m.id === urlModel) &&
+            urlModel !== selectedModel
+        ) {
+            setSelectedModel(urlModel);
+        }
+    }, [urlModel, registryModels, selectedModel]);
 
     // Get translated copy
     const { copy: pageCopy, isTranslating } = usePageCopy(PLAY_PAGE);


### PR DESCRIPTION
﻿Closes #13903

Each model row now shows a compact icon action that opens `/play?model=<id>` with a "Try in Play" tooltip and accessible label. `PlayPage` reads `?model=` from the URL and preselects it when it matches a known model, so the existing model category selection updates automatically. Works for all model types Play already supports.

Kept the card compact - icon-only, no new playground or backend changes.
