### PR TITLE
fix: restore Pointsflyer history and add credit vendors

### DIFF
--- a/.claude/skills/economics-provider-collection/references/providers/exa.md
+++ b/.claude/skills/economics-provider-collection/references/providers/exa.md
@@ -1,0 +1,28 @@
+# Exa Connector Guide
+
+Canonical vendor: `exa`
+
+## Verified — 2026-08-26
+
+- Account: `elliot@myceli.ai`
+- Billing: <https://dashboard.exa.ai/billing>
+- Usage: <https://dashboard.exa.ai/usage>
+- Collection method: dashboard
+- Billing currency: USD
+- The visible balance is promotional credit, not prepaid cash.
+- Usage analytics use UTC.
+
+Collection steps:
+
+1. Open the billing page in the `myceli.ai` browser workspace.
+2. Record the remaining balance as provider credit and the exact check time.
+3. Open the usage page and select the complete calendar month in UTC.
+4. Save any available usage export separately from the balance snapshot.
+5. Archive invoices when they exist; the account had no payment method or
+   invoices at verification time.
+
+Known traps:
+
+- Do not classify the promotional balance as prepaid cash.
+- A balance snapshot is not monthly usage evidence.
+- No activity was visible for August 19–26 at verification time.

--- a/.claude/skills/economics-provider-collection/references/providers/regolo.md
+++ b/.claude/skills/economics-provider-collection/references/providers/regolo.md
@@ -1,0 +1,28 @@
+# Regolo.ai Connector Guide
+
+Canonical vendor: `regolo`
+
+## Verified — 2026-08-26
+
+- Account: `thomash@pollinations.ai`
+- Subscription: <https://dashboard.regolo.ai/subscriptions>
+- Usage: <https://dashboard.regolo.ai/usage>
+- Collection method: dashboard
+- Billing currency: EUR
+- The Partner Program is a free, unlimited trial with no charge.
+- The dashboard showed 21 days remaining at verification time.
+
+Collection steps:
+
+1. Open the subscription page in the `pollinations.ai` browser workspace.
+2. Record the remaining trial days as a non-monetary `usage-quota` balance.
+3. Open the usage page and select the complete calendar month.
+4. Preserve model-level usage when the dashboard exposes it.
+5. Record provider usage as credit-funded while the Partner Program remains
+   active; keep invoices separate if billing starts later.
+
+Known traps:
+
+- The trial has no numeric wallet balance. Do not invent a monetary credit.
+- Dashboard usage costs are informational and are not billed during the trial.
+- At verification time, the current period showed €0.00 and no model usage.

--- a/enter.pollinations.ai/observability/materializations/economics_pollen_usage_mv.pipe
+++ b/enter.pollinations.ai/observability/materializations/economics_pollen_usage_mv.pipe
@@ -1,27 +1,55 @@
 DESCRIPTION >
     Materializes canonical Pollen economics directly from generation_event_v2.
+    The January 2026 combined meter is attributed from its recorded balance
+    priority (Quest first, then paid), and the retired crypto meter is paid.
+    Azure-2 and BPAI are the time-bounded Pointsflyer grant through April 2026.
     Community sale price is retained, while community provider cost is zero;
     owner payouts remain in model_paid and model_quests.
 
 NODE economics_pollen_usage_mv_node
 SQL >
     SELECT
-        formatDateTime(toStartOfMonth(start_time), '%Y-%m') AS month,
-        model_provider_used AS vendor,
-        resolved_model_requested AS model,
-        sumState(if(selected_meter_slug = 'v1:meter:pack' AND total_price > 0 AND model_provider_used != 'community', total_cost, 0)) AS cost_paid,
-        sumState(if(selected_meter_slug = 'v1:meter:tier' AND total_price > 0 AND model_provider_used != 'community', total_cost, 0)) AS cost_quests,
-        sumState(if(selected_meter_slug = 'v1:meter:pack' AND total_price > 0, total_price, 0)) AS price_paid,
-        sumState(if(selected_meter_slug = 'v1:meter:tier' AND total_price > 0, total_price, 0)) AS price_quests,
-        sumState(toUInt64(selected_meter_slug = 'v1:meter:pack' AND total_price > 0)) AS requests_paid,
-        sumState(toUInt64(selected_meter_slug = 'v1:meter:tier' AND total_price > 0)) AS requests_quests,
-        sumState(if(api_key_created_for_user_id != 'undefined' AND total_price > dev_price AND selected_meter_slug = 'v1:meter:pack', total_price - dev_price, 0)) AS byop_paid,
-        sumState(if(api_key_created_for_user_id != 'undefined' AND total_price > dev_price AND selected_meter_slug = 'v1:meter:tier', total_price - dev_price, 0)) AS byop_quests,
-        sumState(if(community_model_reward_user_id != 'undefined' AND community_model_reward_amount > 0 AND selected_meter_slug = 'v1:meter:pack', community_model_reward_amount, 0)) AS model_paid,
-        sumState(if(community_model_reward_user_id != 'undefined' AND community_model_reward_amount > 0 AND selected_meter_slug = 'v1:meter:tier', community_model_reward_amount, 0)) AS model_quests
-    FROM generation_event_v2
-    WHERE start_time >= toDateTime('2026-01-01 00:00:00')
-      AND (total_price > 0 OR community_model_reward_amount > 0)
+        month,
+        vendor,
+        model,
+        sumState(if(funding = 'paid' AND total_price > 0 AND vendor != 'community', total_cost, 0)) AS cost_paid,
+        sumState(if(funding = 'quest' AND total_price > 0 AND vendor != 'community', total_cost, 0)) AS cost_quests,
+        sumState(if(funding = 'paid' AND total_price > 0, total_price, 0)) AS price_paid,
+        sumState(if(funding = 'quest' AND total_price > 0, total_price, 0)) AS price_quests,
+        sumState(toUInt64(funding = 'paid' AND total_price > 0)) AS requests_paid,
+        sumState(toUInt64(funding = 'quest' AND total_price > 0)) AS requests_quests,
+        sumState(if(api_key_created_for_user_id != 'undefined' AND total_price > dev_price AND funding = 'paid', total_price - dev_price, 0)) AS byop_paid,
+        sumState(if(api_key_created_for_user_id != 'undefined' AND total_price > dev_price AND funding = 'quest', total_price - dev_price, 0)) AS byop_quests,
+        sumState(if(community_model_reward_user_id != 'undefined' AND community_model_reward_amount > 0 AND funding = 'paid', community_model_reward_amount, 0)) AS model_paid,
+        sumState(if(community_model_reward_user_id != 'undefined' AND community_model_reward_amount > 0 AND funding = 'quest', community_model_reward_amount, 0)) AS model_quests
+    FROM
+    (
+        SELECT
+            formatDateTime(toStartOfMonth(start_time), '%Y-%m') AS month,
+            if(
+                start_time < toDateTime('2026-05-01 00:00:00')
+                AND model_provider_used IN ('azure-2', 'bpai'),
+                'pointsflyer',
+                model_provider_used
+            ) AS vendor,
+            resolved_model_requested AS model,
+            multiIf(
+                selected_meter_slug IN ('v1:meter:pack', 'v1:meter:crypto'), 'paid',
+                selected_meter_slug = 'v1:meter:tier', 'quest',
+                selected_meter_slug = 'local:combined' AND balances['local:tier'] > 0, 'quest',
+                selected_meter_slug = 'local:combined' AND balances['local:pack'] > 0, 'paid',
+                ''
+            ) AS funding,
+            total_cost,
+            total_price,
+            dev_price,
+            api_key_created_for_user_id,
+            community_model_reward_user_id,
+            community_model_reward_amount
+        FROM generation_event_v2
+        WHERE start_time >= toDateTime('2026-01-01 00:00:00')
+          AND (total_price > 0 OR community_model_reward_amount > 0)
+    )
     GROUP BY month, vendor, model
 
 TYPE MATERIALIZED

--- a/operations/economics/provider-registry.json
+++ b/operations/economics/provider-registry.json
@@ -1,5 +1,5 @@
 {
-  "version": 12,
+  "version": 13,
   "providers": [
     {
       "id": "airforce",
@@ -249,6 +249,31 @@
         {
           "workspace": "myceli.ai",
           "url": "https://elevenlabs.io/app/subscription/creative"
+        }
+      ]
+    },
+    {
+      "id": "exa",
+      "label": "Exa",
+      "meteringBasis": "direct",
+      "aliases": [],
+      "connector": "exa",
+      "monthlyReview": true,
+      "accounts": [
+        {
+          "id": "elliot@myceli.ai",
+          "label": "Myceli.AI",
+          "activeFrom": "2026-08",
+          "activeTo": null
+        }
+      ],
+      "balanceTracking": true,
+      "collectionMethod": "dashboard",
+      "access": [
+        {
+          "workspace": "myceli.ai",
+          "url": "https://dashboard.exa.ai/billing",
+          "accountId": "elliot@myceli.ai"
         }
       ]
     },
@@ -629,6 +654,31 @@
         {
           "workspace": "myceli.ai",
           "url": "https://replicate.com/account/billing"
+        }
+      ]
+    },
+    {
+      "id": "regolo",
+      "label": "Regolo.ai",
+      "meteringBasis": "direct",
+      "aliases": [],
+      "connector": "regolo",
+      "monthlyReview": true,
+      "accounts": [
+        {
+          "id": "thomash@pollinations.ai",
+          "label": "Pollinations.ai",
+          "activeFrom": "2026-08",
+          "activeTo": null
+        }
+      ],
+      "balanceTracking": true,
+      "collectionMethod": "dashboard",
+      "access": [
+        {
+          "workspace": "pollinations.ai",
+          "url": "https://dashboard.regolo.ai/subscriptions",
+          "accountId": "thomash@pollinations.ai"
         }
       ]
     },

--- a/operations/economics/web/src/lib/providerRegistry.test.ts
+++ b/operations/economics/web/src/lib/providerRegistry.test.ts
@@ -142,6 +142,20 @@ describe("provider registry", () => {
                 (account) => account.id,
             ),
         ).toEqual(["myceli"]);
+
+        const exa = resolveProvider("exa");
+        expect(exa).toBeDefined();
+        if (!exa) throw new Error("Exa is not registered");
+        expect(activeProviderAccounts(exa, "2026-08")).toEqual([
+            expect.objectContaining({ id: "elliot@myceli.ai" }),
+        ]);
+
+        const regolo = resolveProvider("regolo");
+        expect(regolo).toBeDefined();
+        if (!regolo) throw new Error("Regolo.ai is not registered");
+        expect(activeProviderAccounts(regolo, "2026-08")).toEqual([
+            expect.objectContaining({ id: "thomash@pollinations.ai" }),
+        ]);
     });
 
     it("keeps source-backed Pollen witness explanations unique and canonical", () => {


### PR DESCRIPTION
- Restores legacy Pointsflyer Pollen attribution from `generation_event_v2` without changing total requests or cost.
- Preserves the historical paid and Quest split for legacy combined-balance events.
- Registers Exa and Regolo.ai with account identities, dashboard URLs, balance tracking, and monthly collection guides.
- Adds registry lifecycle coverage for both new vendor accounts.
- Verified against Tinybird staging; production data is unchanged.