### PR TITLE
feat: add quest leaderboard to Community page (issue #13909)

### DIFF
--- a/enter.pollinations.ai/src/routes/quests.ts
+++ b/enter.pollinations.ai/src/routes/quests.ts
@@ -1,7 +1,7 @@
 import { claimReward } from "@shared/billing/rewards.ts";
 import * as schema from "@shared/db/better-auth.ts";
 import { rewards as rewardsTable } from "@shared/db/better-auth.ts";
-import { desc, eq } from "drizzle-orm";
+import { and, asc, desc, eq, isNotNull, like, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
@@ -81,6 +81,17 @@ const claimRewardResponseSchema = z.object({
     claimed: z.boolean(),
     newBalance: z.number().nullable(),
     reward: rewardSchema,
+});
+
+const leaderboardEntrySchema = z.object({
+    rank: z.number(),
+    githubUsername: z.string(),
+    totalPollen: z.number(),
+    completedQuests: z.number(),
+});
+
+const leaderboardResponseSchema = z.object({
+    leaderboard: z.array(leaderboardEntrySchema),
 });
 
 function formatRewardTimestamp(value: Date | number | string): string {
@@ -296,6 +307,79 @@ export const questsRoutes = new Hono<Env>()
                         : null,
                 },
             });
+        },
+    )
+    .get(
+        "/leaderboard",
+        describeRoute({
+            tags: ["✨ Quests"],
+            summary: "Get Quest Leaderboard",
+            security: [],
+            description:
+                "Public leaderboard of contributors ranked by total Quest Pollen earned from completed public GitHub POLLEN-QUEST issues. Shows each contributor's GitHub username, completed quest count, and total Quest Pollen.",
+            responses: {
+                200: {
+                    description: "Quest leaderboard",
+                    content: {
+                        "application/json": {
+                            schema: resolver(leaderboardResponseSchema),
+                        },
+                    },
+                },
+            },
+        }),
+        async (c) => {
+            const db = drizzle(c.env.DB, { schema });
+            const rows = await db
+                .select({
+                    githubUsername: schema.user.githubUsername,
+                    totalPollen:
+                        sql<number>`SUM(${rewardsTable.pollenAmount})`.mapWith(
+                            Number,
+                        ),
+                    completedQuests:
+                        sql<number>`COUNT(DISTINCT ${rewardsTable.questId})`.mapWith(
+                            Number,
+                        ),
+                })
+                .from(rewardsTable)
+                .innerJoin(schema.user, eq(rewardsTable.userId, schema.user.id))
+                .where(
+                    and(
+                        // Only public GitHub POLLEN-QUEST issue bounties count;
+                        // product quests (setup, top-up, app) do not.
+                        like(rewardsTable.questId, "github:issue:%"),
+                        // Pollen only counts once the contributor claimed it.
+                        isNotNull(rewardsTable.claimedAt),
+                        isNotNull(schema.user.githubUsername),
+                    ),
+                )
+                .groupBy(schema.user.githubUsername)
+                .orderBy(
+                    desc(sql`SUM(${rewardsTable.pollenAmount})`),
+                    desc(sql`COUNT(DISTINCT ${rewardsTable.questId})`),
+                    asc(schema.user.githubUsername),
+                )
+                .limit(20);
+
+            const leaderboard = rows
+                .filter(
+                    (
+                        row,
+                    ): row is {
+                        githubUsername: string;
+                        totalPollen: number;
+                        completedQuests: number;
+                    } => row.githubUsername !== null,
+                )
+                .map((row, index) => ({
+                    rank: index + 1,
+                    githubUsername: row.githubUsername,
+                    totalPollen: row.totalPollen,
+                    completedQuests: row.completedQuests,
+                }));
+
+            return c.json({ leaderboard });
         },
     );
 

--- a/enter.pollinations.ai/test/quests.test.ts
+++ b/enter.pollinations.ai/test/quests.test.ts
@@ -1752,3 +1752,245 @@ test("account quest history accepts account usage permission", async ({
         rewards: [],
     });
 });
+
+test("GET /api/quests/leaderboard aggregates GitHub POLLEN-QUEST rewards by contributor", async ({
+    sessionToken: _sessionToken,
+}) => {
+    const db = drizzle(env.DB, { schema });
+    const now = new Date();
+
+    await db.insert(schema.user).values([
+        {
+            id: "leaderboard-alice",
+            name: "Alice Quester",
+            email: "alice@example.com",
+            emailVerified: false,
+            image: null,
+            createdAt: now,
+            updatedAt: now,
+            githubId: 1001,
+            githubUsername: "alice-quester",
+            tierBalance: 0,
+            packBalance: 0,
+        },
+        {
+            id: "leaderboard-bob",
+            name: "Bob Quester",
+            email: "bob@example.com",
+            emailVerified: false,
+            image: null,
+            createdAt: now,
+            updatedAt: now,
+            githubId: 1002,
+            githubUsername: "bob-quester",
+            tierBalance: 0,
+            packBalance: 0,
+        },
+        {
+            id: "leaderboard-carol",
+            name: "Carol Quester",
+            email: "carol@example.com",
+            emailVerified: false,
+            image: null,
+            createdAt: now,
+            updatedAt: now,
+            githubId: 1003,
+            githubUsername: "carol-quester",
+            tierBalance: 0,
+            packBalance: 0,
+        },
+        // A linked account without a public GitHub username must never rank.
+        {
+            id: "leaderboard-nogithub",
+            name: "No GitHub",
+            email: "nogithub@example.com",
+            emailVerified: false,
+            image: null,
+            createdAt: now,
+            updatedAt: now,
+            githubId: 1004,
+            githubUsername: null,
+            tierBalance: 0,
+            packBalance: 0,
+        },
+    ]);
+
+    await db.insert(schema.rewards).values([
+        // alice: two claimed bounties -> 12 pollen, 2 quests.
+        {
+            id: "lb-r-a1",
+            idempotencyKey: "quest:github:issue:101",
+            userId: "leaderboard-alice",
+            questId: "github:issue:101",
+            title: "Ship bounty #101",
+            pollenAmount: 5,
+            balanceBucket: "tier",
+            earnedAt: now,
+            claimedAt: now,
+        },
+        {
+            id: "lb-r-a2",
+            idempotencyKey: "quest:github:issue:102",
+            userId: "leaderboard-alice",
+            questId: "github:issue:102",
+            title: "Ship bounty #102",
+            pollenAmount: 7,
+            balanceBucket: "tier",
+            earnedAt: now,
+            claimedAt: now,
+        },
+        // bob: one claimed bounty -> 15 pollen, 1 quest (ranked first).
+        {
+            id: "lb-r-b1",
+            idempotencyKey: "quest:github:issue:201",
+            userId: "leaderboard-bob",
+            questId: "github:issue:201",
+            title: "Ship bounty #201",
+            pollenAmount: 15,
+            balanceBucket: "tier",
+            earnedAt: now,
+            claimedAt: now,
+        },
+        // carol: one claimed bounty + a product quest that must not count.
+        {
+            id: "lb-r-c1",
+            idempotencyKey: "quest:github:issue:301",
+            userId: "leaderboard-carol",
+            questId: "github:issue:301",
+            title: "Ship bounty #301",
+            pollenAmount: 3,
+            balanceBucket: "tier",
+            earnedAt: now,
+            claimedAt: now,
+        },
+        {
+            id: "lb-r-c2",
+            idempotencyKey: "quest:merged_pr:leaderboard-carol",
+            userId: "leaderboard-carol",
+            questId: "merged_pr",
+            title: "Contribute a pull request",
+            pollenAmount: 5,
+            balanceBucket: "tier",
+            earnedAt: now,
+            claimedAt: now,
+        },
+        // Claimed bounty for an account without a GitHub username: excluded.
+        {
+            id: "lb-r-n1",
+            idempotencyKey: "quest:github:issue:401",
+            userId: "leaderboard-nogithub",
+            questId: "github:issue:401",
+            title: "Ship bounty #401",
+            pollenAmount: 9,
+            balanceBucket: "tier",
+            earnedAt: now,
+            claimedAt: now,
+        },
+    ]);
+
+    const response = await SELF.fetch(
+        "http://localhost:3000/api/quests/leaderboard",
+    );
+    expect(response.status).toBe(200);
+
+    const payload = (await response.json()) as {
+        leaderboard: {
+            rank: number;
+            githubUsername: string;
+            totalPollen: number;
+            completedQuests: number;
+        }[];
+    };
+
+    // Ranked by claimed Pollen from completed GitHub POLLEN-QUEST issues only.
+    expect(payload.leaderboard).toEqual([
+        {
+            rank: 1,
+            githubUsername: "bob-quester",
+            totalPollen: 15,
+            completedQuests: 1,
+        },
+        {
+            rank: 2,
+            githubUsername: "alice-quester",
+            totalPollen: 12,
+            completedQuests: 2,
+        },
+        {
+            rank: 3,
+            githubUsername: "carol-quester",
+            totalPollen: 3,
+            completedQuests: 1,
+        },
+    ]);
+});
+
+test("GET /api/quests/leaderboard excludes unclaimed rewards", async ({
+    sessionToken: _sessionToken,
+}) => {
+    const db = drizzle(env.DB, { schema });
+    const now = new Date();
+
+    await db.insert(schema.user).values({
+        id: "leaderboard-unclaimed",
+        name: "Unclaimed Quester",
+        email: "unclaimed@example.com",
+        emailVerified: false,
+        image: null,
+        createdAt: now,
+        updatedAt: now,
+        githubId: 1005,
+        githubUsername: "unclaimed-quester",
+        tierBalance: 0,
+        packBalance: 0,
+    });
+
+    await db.insert(schema.rewards).values([
+        {
+            id: "lb-r-u1",
+            idempotencyKey: "quest:github:issue:501",
+            userId: "leaderboard-unclaimed",
+            questId: "github:issue:501",
+            title: "Ship bounty #501",
+            pollenAmount: 10,
+            balanceBucket: "tier",
+            earnedAt: now,
+            claimedAt: now,
+        },
+        {
+            id: "lb-r-u2",
+            idempotencyKey: "quest:github:issue:502",
+            userId: "leaderboard-unclaimed",
+            questId: "github:issue:502",
+            title: "Ship bounty #502",
+            pollenAmount: 10,
+            balanceBucket: "tier",
+            earnedAt: now,
+            claimedAt: null,
+        },
+    ]);
+
+    const response = await SELF.fetch(
+        "http://localhost:3000/api/quests/leaderboard",
+    );
+    expect(response.status).toBe(200);
+
+    const payload = (await response.json()) as {
+        leaderboard: {
+            rank: number;
+            githubUsername: string;
+            totalPollen: number;
+            completedQuests: number;
+        }[];
+    };
+
+    // Only the claimed bounty is credited; the pending one is not yet earned.
+    expect(payload.leaderboard).toEqual([
+        {
+            rank: 1,
+            githubUsername: "unclaimed-quester",
+            totalPollen: 10,
+            completedQuests: 1,
+        },
+    ]);
+});

--- a/pollinations.ai/src/copy/content/community.ts
+++ b/pollinations.ai/src/copy/content/community.ts
@@ -99,9 +99,9 @@ export const COMMUNITY_PAGE = {
     // Quest Leaderboard
     questLeaderboardTitle: "Quest leaderboard",
     questLeaderboardDescription:
-        "Top questers ranked by total Pollen earned from completing public GitHub quests.",
-    questLeaderboardCta: "Want to earn Pollen?",
-    questsPageLink: "Browse the quests page",
+        "Top contributors ranked by Pollen earned from completing GitHub quests. Want to join them?",
+    questLeaderboardCta: "Earn Pollen by completing quests",
+    questsPageLink: "Browse quests",
     questsLabel: "quests",
     questLabel: "quest",
     pollenLabel: "Pollen",

--- a/pollinations.ai/src/copy/content/community.ts
+++ b/pollinations.ai/src/copy/content/community.ts
@@ -96,6 +96,16 @@ export const COMMUNITY_PAGE = {
     commitLabel: "commit",
     votesLabel: "votes",
 
+    // Quest Leaderboard
+    questLeaderboardTitle: "Quest leaderboard",
+    questLeaderboardDescription:
+        "Top questers ranked by total Pollen earned from completing public GitHub quests.",
+    questLeaderboardCta: "Want to earn Pollen?",
+    questsPageLink: "Browse the quests page",
+    questsLabel: "quests",
+    questLabel: "quest",
+    pollenLabel: "Pollen",
+
     // Section 5 — Build Diary + Supporters
     buildDiaryTitle: "Build diary",
     buildDiarySubtitle: "A visual log of what we ship every day.",

--- a/pollinations.ai/src/copy/content/socialLinks.ts
+++ b/pollinations.ai/src/copy/content/socialLinks.ts
@@ -59,6 +59,7 @@ export const LINKS = {
     enterDocs: "https://gen.pollinations.ai/docs",
     enterApiDocs: "https://gen.pollinations.ai/docs",
     enterQuestsFaq: "https://enter.pollinations.ai/news#how-do-quests-work",
+    enterQuests: "https://enter.pollinations.ai/quests",
     enterModels: "https://enter.pollinations.ai/models",
     apidocsRaw:
         "https://raw.githubusercontent.com/pollinations/pollinations/production/APIDOCS.md",

--- a/pollinations.ai/src/ui/components/QuestLeaderboard.tsx
+++ b/pollinations.ai/src/ui/components/QuestLeaderboard.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useState } from "react";
+import { COMMUNITY_PAGE } from "../../copy/content/community";
+import { LINKS } from "../../copy/content/socialLinks";
+import { usePageCopy } from "../../hooks/usePageCopy";
+import { ExternalLinkIcon } from "../assets/ExternalLinkIcon";
+import { Divider } from "./ui/divider";
+import { Body, Heading } from "./ui/typography";
+
+interface LeaderboardEntry {
+    rank: number;
+    githubUsername: string;
+    totalPollen: number;
+    completedQuests: number;
+}
+
+const LEADERBOARD_ENDPOINT =
+    "https://enter.pollinations.ai/api/quests/leaderboard";
+
+export function QuestLeaderboard() {
+    const { copy } = usePageCopy(COMMUNITY_PAGE);
+
+    const [entries, setEntries] = useState<LeaderboardEntry[]>([]);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        const CACHE_KEY = "quest_leaderboard_v1";
+        const today = new Date().toISOString().slice(0, 10);
+
+        // Check localStorage cache (expires at start of new UTC day)
+        try {
+            const cached = localStorage.getItem(CACHE_KEY);
+            if (cached) {
+                const { data, day } = JSON.parse(cached);
+                if (day === today) {
+                    setEntries(data);
+                    setLoading(false);
+                    return;
+                }
+            }
+        } catch {
+            // corrupted cache — continue to fetch
+        }
+
+        const loadLeaderboard = async () => {
+            try {
+                const res = await fetch(LEADERBOARD_ENDPOINT);
+                if (!res.ok) return;
+                const data = (await res.json()) as {
+                    leaderboard?: LeaderboardEntry[];
+                };
+                const leaderboard = data.leaderboard ?? [];
+
+                setEntries(leaderboard);
+
+                // Cache the results
+                try {
+                    localStorage.setItem(
+                        CACHE_KEY,
+                        JSON.stringify({ data: leaderboard, day: today }),
+                    );
+                } catch {
+                    // localStorage full — skip
+                }
+            } catch (err) {
+                console.error("Quest leaderboard fetch failed:", err);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        loadLeaderboard();
+    }, []);
+
+    if (loading || entries.length === 0) {
+        return null;
+    }
+
+    return (
+        <>
+            <div className="mb-12">
+                <Heading variant="section">
+                    {copy.questLeaderboardTitle}
+                </Heading>
+                <Body size="sm" spacing="comfortable">
+                    {copy.questLeaderboardDescription}
+                </Body>
+                <div className="mt-4 flex flex-col gap-2">
+                    {entries.map((entry) => (
+                        <a
+                            key={entry.githubUsername}
+                            href={`https://github.com/${entry.githubUsername}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="flex items-center gap-3 p-2 rounded-lg hover:bg-white/40 transition"
+                        >
+                            <span className="w-6 text-center font-headline text-xs font-black text-muted">
+                                {entry.rank}
+                            </span>
+                            <img
+                                src={`https://github.com/${entry.githubUsername}.png?size=64`}
+                                alt={entry.githubUsername}
+                                className="w-8 h-8 rounded-full"
+                                width={32}
+                                height={32}
+                                loading="lazy"
+                                decoding="async"
+                            />
+                            <span className="font-headline text-sm font-black text-dark flex-1 truncate">
+                                {entry.githubUsername}
+                            </span>
+                            <span className="text-xs text-muted">
+                                {entry.completedQuests}{" "}
+                                {entry.completedQuests === 1
+                                    ? copy.questLabel
+                                    : copy.questsLabel}
+                            </span>
+                            <span className="font-headline text-xs font-black text-primary">
+                                {entry.totalPollen} {copy.pollenLabel}
+                            </span>
+                        </a>
+                    ))}
+                </div>
+                <Body size="sm" spacing="comfortable" className="text-muted">
+                    {copy.questLeaderboardCta}{" "}
+                    <a
+                        href={LINKS.enterQuests}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="font-headline text-xs font-black hover:underline inline-flex items-center gap-1 text-dark bg-accent-strong px-2 py-0.5"
+                    >
+                        {copy.questsPageLink}
+                        <ExternalLinkIcon className="w-3 h-3" strokeWidth="4" />
+                    </a>
+                </Body>
+            </div>
+            <Divider />
+        </>
+    );
+}

--- a/pollinations.ai/src/ui/components/QuestLeaderboard.tsx
+++ b/pollinations.ai/src/ui/components/QuestLeaderboard.tsx
@@ -16,6 +16,14 @@ interface LeaderboardEntry {
 const LEADERBOARD_ENDPOINT =
     "https://enter.pollinations.ai/api/quests/leaderboard";
 
+const MEDALS = ["🥇", "🥈", "🥉"];
+
+const COLOR_CLASSES = [
+    "border-primary-strong shadow-[2px_2px_0_rgb(var(--primary-strong)_/_0.3)]",
+    "border-secondary-strong shadow-[2px_2px_0_rgb(var(--secondary-strong)_/_0.3)]",
+    "border-tertiary-strong shadow-[2px_2px_0_rgb(var(--tertiary-strong)_/_0.3)]",
+];
+
 export function QuestLeaderboard() {
     const { copy } = usePageCopy(COMMUNITY_PAGE);
 
@@ -84,43 +92,68 @@ export function QuestLeaderboard() {
                 <Body size="sm" spacing="comfortable">
                     {copy.questLeaderboardDescription}
                 </Body>
-                <div className="mt-4 flex flex-col gap-2">
-                    {entries.map((entry) => (
-                        <a
-                            key={entry.githubUsername}
-                            href={`https://github.com/${entry.githubUsername}`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="flex items-center gap-3 p-2 rounded-lg hover:bg-white/40 transition"
-                        >
-                            <span className="w-6 text-center font-headline text-xs font-black text-muted">
-                                {entry.rank}
-                            </span>
-                            <img
-                                src={`https://github.com/${entry.githubUsername}.png?size=64`}
-                                alt={entry.githubUsername}
-                                className="w-8 h-8 rounded-full"
-                                width={32}
-                                height={32}
-                                loading="lazy"
-                                decoding="async"
-                            />
-                            <span className="font-headline text-sm font-black text-dark flex-1 truncate">
-                                {entry.githubUsername}
-                            </span>
-                            <span className="text-xs text-muted">
-                                {entry.completedQuests}{" "}
-                                {entry.completedQuests === 1
-                                    ? copy.questLabel
-                                    : copy.questsLabel}
-                            </span>
-                            <span className="font-headline text-xs font-black text-primary">
-                                {entry.totalPollen} {copy.pollenLabel}
-                            </span>
-                        </a>
-                    ))}
+                <div className="mt-4 flex flex-col gap-3">
+                    {entries.map((entry) => {
+                        const isTop3 = entry.rank <= 3;
+                        const colorClass =
+                            COLOR_CLASSES[
+                                (entry.githubUsername.charCodeAt(0) +
+                                    entry.githubUsername.charCodeAt(1)) %
+                                    COLOR_CLASSES.length
+                            ];
+                        const medal = isTop3 ? MEDALS[entry.rank - 1] : null;
+
+                        return (
+                            <a
+                                key={entry.githubUsername}
+                                href={`https://github.com/${entry.githubUsername}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className={`group flex items-center gap-4 p-3 bg-white/60 rounded-sub-card border-r-2 border-b-2 ${colorClass} transition hover:translate-x-[1px] hover:translate-y-[1px] hover:shadow-none`}
+                            >
+                                {medal ? (
+                                    <span className="w-8 text-center text-lg">
+                                        {medal}
+                                    </span>
+                                ) : (
+                                    <span className="w-8 text-center font-headline text-xs font-black text-muted">
+                                        #{entry.rank}
+                                    </span>
+                                )}
+                                <div
+                                    className={`w-12 h-12 overflow-hidden rounded-full border-2 border-r-4 border-b-4 ${colorClass} shadow-[3px_3px_0_rgb(17_5_24_/_0.15)] group-hover:shadow-none transition`}
+                                >
+                                    <img
+                                        src={`https://github.com/${entry.githubUsername}.png?size=96`}
+                                        alt={entry.githubUsername}
+                                        className="w-full h-full object-cover"
+                                        width={48}
+                                        height={48}
+                                        loading="lazy"
+                                        decoding="async"
+                                    />
+                                </div>
+                                <span className="font-headline text-sm font-black text-dark flex-1 truncate">
+                                    {entry.githubUsername}
+                                </span>
+                                <span className="text-xs text-muted hidden sm:inline">
+                                    {entry.completedQuests}{" "}
+                                    {entry.completedQuests === 1
+                                        ? copy.questLabel
+                                        : copy.questsLabel}
+                                </span>
+                                <span className="font-headline text-sm font-black text-primary bg-accent-light px-2 py-0.5 rounded-sub-card">
+                                    {entry.totalPollen} {copy.pollenLabel}
+                                </span>
+                            </a>
+                        );
+                    })}
                 </div>
-                <Body size="sm" spacing="comfortable" className="text-muted">
+                <Body
+                    size="sm"
+                    spacing="comfortable"
+                    className="text-muted mt-4"
+                >
                     {copy.questLeaderboardCta}{" "}
                     <a
                         href={LINKS.enterQuests}

--- a/pollinations.ai/src/ui/pages/CommunityPage.tsx
+++ b/pollinations.ai/src/ui/pages/CommunityPage.tsx
@@ -5,6 +5,7 @@ import { usePageCopy } from "../../hooks/usePageCopy";
 import { useTranslate } from "../../hooks/useTranslate";
 import { ExternalLinkIcon } from "../assets/ExternalLinkIcon";
 import { BuildDiary } from "../components/BuildDiary";
+import { QuestLeaderboard } from "../components/QuestLeaderboard";
 import { TopContributors } from "../components/TopContributors";
 import { Button } from "../components/ui/button";
 import { Divider } from "../components/ui/divider";
@@ -323,6 +324,8 @@ export default function CommunityPage() {
                 <Divider />
 
                 <TopContributors />
+
+                <QuestLeaderboard />
 
                 {/* Section 5 — Build Diary + Supporters */}
                 <div className="mb-12">


### PR DESCRIPTION
- Adds \GET /api/quests/leaderboard\ - public aggregate of contributors ranked by total Quest Pollen earned from completed public GitHub POLLEN-QUEST issues
- Adds \QuestLeaderboard\ to the \/community\ page showing GitHub identity, completed quest count, and total Quest Pollen, with a clear link to the Quests page
- Counts only claimed rewards for \github:issue:*\ bounties; product quests and accounts without a public GitHub identity are excluded
- Adds focused tests covering the aggregate and the exact leaderboard payload the community page renders

Fixes #13909