### PR TITLE
feat(models): add searchable metadata and key:value filters

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/model-catalog.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-catalog.ts
@@ -63,6 +63,8 @@ export type ApiModelInfo = {
     alpha?: boolean;
     flat_rate?: boolean;
     added_date?: number;
+    owner?: string;
+    ownerLogin?: string;
 };
 
 type PriceField =
@@ -267,6 +269,7 @@ function baseModelPrice(model: ApiModelInfo): ModelPrice | null {
         outputSortPrice,
         prices: [],
         priceAdjustments: model.pricing_adjustments,
+        ownerLogin: model.ownerLogin ?? model.owner ?? undefined,
     };
 }
 

--- a/enter.pollinations.ai/frontend/src/components/models/model-search.test.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-search.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import { matchesModelPrice, parseModelSearchQuery } from "./model-search.ts";
+import type { ModelPrice } from "./types.ts";
+
+function model(overrides: Partial<ModelPrice> = {}): ModelPrice {
+    return {
+        name: "test-model",
+        type: "text",
+        capabilities: [],
+        prices: [],
+        free: false,
+        paidOnly: false,
+        ...overrides,
+    } as ModelPrice;
+}
+
+describe("parseModelSearchQuery", () => {
+    it("splits free text", () => {
+        expect(parseModelSearchQuery("hello world")).toEqual({
+            freeText: ["hello", "world"],
+            filters: {},
+        });
+    });
+
+    it("extracts known filters", () => {
+        const { freeText, filters } = parseModelSearchQuery(
+            "access:free owner:alice",
+        );
+        expect(freeText).toEqual([]);
+        expect(filters).toEqual({
+            access: ["free"],
+            owner: ["alice"],
+        });
+    });
+
+    it("mixes free text and filters", () => {
+        const { freeText, filters } = parseModelSearchQuery(
+            "vision access:quest capability:reasoning",
+        );
+        expect(freeText).toEqual(["vision"]);
+        expect(filters.access).toEqual(["quest"]);
+        expect(filters.capability).toEqual(["reasoning"]);
+    });
+
+    it("is case-insensitive for keys and values", () => {
+        const { filters } = parseModelSearchQuery("Access:Paid Type:TEXT");
+        expect(filters.access).toEqual(["paid"]);
+        expect(filters.type).toEqual(["text"]);
+    });
+
+    it("treats unknown keys as free text", () => {
+        const { freeText, filters } = parseModelSearchQuery("foo:bar hello");
+        expect(filters).toEqual({});
+        expect(freeText).toEqual(["foo:bar", "hello"]);
+    });
+
+    it("handles id filter with model ids", () => {
+        const { filters } = parseModelSearchQuery("id:openai-fast");
+        expect(filters.id).toEqual(["openai-fast"]);
+    });
+});
+
+describe("matchesModelPrice", () => {
+    it("matches free text against name, brand and description", () => {
+        const m = model({
+            name: "openai-fast",
+            brand: "OpenAI",
+            description: "Fast reasoning model",
+        });
+        expect(matchesModelPrice(m, "openai")).toBe(true);
+        expect(matchesModelPrice(m, "reasoning")).toBe(true);
+        expect(matchesModelPrice(m, "anthropic")).toBe(false);
+    });
+
+    it("matches base model and modalities", () => {
+        const m = model({
+            name: "vision-model",
+            baseModel: "gpt-4o",
+            inputModalities: ["image", "text"],
+        });
+        expect(matchesModelPrice(m, "gpt-4o")).toBe(true);
+        expect(matchesModelPrice(m, "image")).toBe(true);
+    });
+
+    it("filters by access", () => {
+        const free = model({ name: "a", free: true });
+        const paid = model({ name: "b", paidOnly: true });
+        const quest = model({ name: "c" });
+        expect(matchesModelPrice(free, "access:free")).toBe(true);
+        expect(matchesModelPrice(free, "access:paid")).toBe(false);
+        expect(matchesModelPrice(paid, "access:paid")).toBe(true);
+        expect(matchesModelPrice(quest, "access:quest")).toBe(true);
+    });
+
+    it("filters by owner", () => {
+        const m = model({ name: "alice/model", ownerLogin: "alice" });
+        expect(matchesModelPrice(m, "owner:alice")).toBe(true);
+        expect(matchesModelPrice(m, "owner:bob")).toBe(false);
+        expect(matchesModelPrice(model({ name: "x" }), "owner:alice")).toBe(
+            false,
+        );
+    });
+
+    it("filters by id", () => {
+        const m = model({ name: "openai-fast" });
+        expect(matchesModelPrice(m, "id:openai-fast")).toBe(true);
+        expect(matchesModelPrice(m, "id:openai")).toBe(true);
+        expect(matchesModelPrice(m, "id:other")).toBe(false);
+    });
+
+    it("filters by type", () => {
+        const m = model({ name: "a", type: "image" });
+        expect(matchesModelPrice(m, "type:image")).toBe(true);
+        expect(matchesModelPrice(m, "type:text")).toBe(false);
+    });
+
+    it("filters by capability", () => {
+        const m = model({
+            name: "a",
+            capabilities: ["reasoning" as never],
+        });
+        expect(matchesModelPrice(m, "capability:reasoning")).toBe(true);
+        expect(matchesModelPrice(m, "capability:web_search")).toBe(false);
+    });
+
+    it("combines free text and filters with AND", () => {
+        const m = model({
+            name: "openai-fast",
+            brand: "OpenAI",
+            type: "text",
+            capabilities: ["reasoning" as never],
+        });
+        expect(matchesModelPrice(m, "openai capability:reasoning")).toBe(true);
+        expect(matchesModelPrice(m, "openai capability:web_search")).toBe(
+            false,
+        );
+        expect(matchesModelPrice(m, "anthropic capability:reasoning")).toBe(
+            false,
+        );
+    });
+
+    it("requires all free-text terms", () => {
+        const m = model({ name: "a", description: "fast open model" });
+        expect(matchesModelPrice(m, "fast open")).toBe(true);
+        expect(matchesModelPrice(m, "fast missing")).toBe(false);
+    });
+});

--- a/enter.pollinations.ai/frontend/src/components/models/model-search.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-search.ts
@@ -34,6 +34,106 @@ export type ModelSearch = {
     sort?: ModelSort;
 };
 
+import { getModelCapabilities, getModelDisplayName } from "./model-info.ts";
+import type { ModelPrice } from "./types.ts";
+
+export const MODEL_SEARCH_FILTER_KEYS = [
+    "access",
+    "owner",
+    "id",
+    "type",
+    "capability",
+] as const;
+
+export type ModelSearchFilterKey = (typeof MODEL_SEARCH_FILTER_KEYS)[number];
+
+export type ParsedModelSearch = {
+    freeText: string[];
+    filters: Partial<Record<ModelSearchFilterKey, string[]>>;
+};
+
+export function parseModelSearchQuery(query: string): ParsedModelSearch {
+    const tokens = query.trim().split(/\s+/).filter(Boolean);
+    const freeText: string[] = [];
+    const filters: Partial<Record<ModelSearchFilterKey, string[]>> = {};
+
+    for (const token of tokens) {
+        const colon = token.indexOf(":");
+        if (colon > 0) {
+            const key = token
+                .slice(0, colon)
+                .toLowerCase() as ModelSearchFilterKey;
+            const value = token.slice(colon + 1).toLowerCase();
+            if (
+                value &&
+                (MODEL_SEARCH_FILTER_KEYS as readonly string[]).includes(key)
+            ) {
+                (filters[key] ??= []).push(value);
+                continue;
+            }
+        }
+        freeText.push(token.toLowerCase());
+    }
+
+    return { freeText, filters };
+}
+
+export function matchesModelPrice(model: ModelPrice, query: string): boolean {
+    if (!query.trim()) return true;
+
+    const { freeText, filters } = parseModelSearchQuery(query);
+
+    if (filters.access?.length) {
+        const modelAccess = model.free
+            ? "free"
+            : model.paidOnly
+              ? "paid"
+              : "quest";
+        if (!filters.access.includes(modelAccess)) return false;
+    }
+
+    if (filters.owner?.length) {
+        const owner = (model.ownerLogin ?? "").toLowerCase();
+        if (!owner || !filters.owner.some((v) => owner === v)) return false;
+    }
+
+    if (filters.id?.length) {
+        const id = model.name.toLowerCase();
+        if (!filters.id.some((v) => id === v || id.includes(v))) return false;
+    }
+
+    if (filters.type?.length) {
+        if (!filters.type.includes(model.type)) return false;
+    }
+
+    if (filters.capability?.length) {
+        const caps = getModelCapabilities(model).map((c) => c.toLowerCase());
+        const rawCaps = model.capabilities.map((c) => c.toLowerCase());
+        const allCaps = new Set([...caps, ...rawCaps]);
+        if (!filters.capability.some((v) => allCaps.has(v))) return false;
+    }
+
+    if (freeText.length === 0) return true;
+
+    const haystack = [
+        model.name,
+        getModelDisplayName(model) ?? "",
+        model.description ?? "",
+        model.brand ?? "",
+        model.baseModel ?? "",
+        model.ownerLogin ?? "",
+        model.type,
+        ...(model.inputModalities ?? []),
+        ...(model.outputModalities ?? []),
+        ...getModelCapabilities(model),
+        ...model.capabilities,
+    ]
+        .join(" ")
+        .toLowerCase();
+
+    return freeText.every((term) => haystack.includes(term));
+}
+
 function includes<T extends string>(
     values: readonly T[],
     value: unknown,

--- a/enter.pollinations.ai/frontend/src/components/models/models.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/models.tsx
@@ -34,8 +34,8 @@ import {
     fetchModelCatalog,
     getModelPricesFromCatalog,
 } from "./model-catalog.ts";
-import { getModelDisplayName } from "./model-info.ts";
 import type { ModelScope, ModelSort } from "./model-search.ts";
+import { matchesModelPrice } from "./model-search.ts";
 import { sortModels } from "./model-sort.ts";
 import {
     type SectionType,
@@ -116,11 +116,8 @@ const SEARCH_LABELS: Record<SectionType, string> = {
     agent: "agent",
 };
 
-function matchesQuery(model: ModelPrice, query: string): boolean {
-    if (!query) return true;
-    const displayName = getModelDisplayName(model) ?? "";
-    const haystack = `${displayName} ${model.brand ?? ""}`.toLowerCase();
-    return haystack.includes(query);
+export function matchesQuery(model: ModelPrice, query: string): boolean {
+    return matchesModelPrice(model, query);
 }
 
 function categorizeModels(
@@ -404,25 +401,26 @@ export const Models: FC = () => {
                             })}
                         </div>
                     </div>
-                    <div className="flex w-full items-center justify-between gap-2">
-                        <div className="relative min-w-0 max-w-md flex-1">
-                            <SearchIcon className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-theme-text-muted" />
-                            <Input
-                                type="search"
-                                value={search}
-                                onChange={(event) =>
-                                    setSearch(event.target.value)
-                                }
-                                onBlur={() => {
-                                    const normalizedSearch = search.trim();
-                                    setSearch(normalizedSearch);
-                                    pushSearch(normalizedSearch);
-                                }}
-                                placeholder={`Search ${searchTarget}…`}
-                                aria-label={`Search ${searchTarget}`}
-                                className="w-full pl-9"
-                            />
-                        </div>
+                    <div className="flex w-full flex-col gap-1.5">
+                        <div className="flex w-full items-center justify-between gap-2">
+                            <div className="relative min-w-0 max-w-md flex-1">
+                                <SearchIcon className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-theme-text-muted" />
+                                <Input
+                                    type="search"
+                                    value={search}
+                                    onChange={(event) =>
+                                        setSearch(event.target.value)
+                                    }
+                                    onBlur={() => {
+                                        const normalizedSearch = search.trim();
+                                        setSearch(normalizedSearch);
+                                        pushSearch(normalizedSearch);
+                                    }}
+                                    placeholder={`Search ${searchTarget}…`}
+                                    aria-label={`Search ${searchTarget}`}
+                                    className="w-full pl-9"
+                                />
+                            </div>
                         <Dropdown
                             align="end"
                             className="w-max p-2"
@@ -474,6 +472,13 @@ export const Models: FC = () => {
                             )}
                         </Dropdown>
                     </div>
+                    <p className="text-xs text-theme-text-muted">
+                        Filters: <code className="rounded bg-theme-bg-active px-1 py-0.5">access:free|quest|paid</code>{" "}
+                        <code className="rounded bg-theme-bg-active px-1 py-0.5">owner:&lt;login&gt;</code>{" "}
+                        <code className="rounded bg-theme-bg-active px-1 py-0.5">id:&lt;model&gt;</code>{" "}
+                        <code className="rounded bg-theme-bg-active px-1 py-0.5">type:&lt;category&gt;</code>{" "}
+                        <code className="rounded bg-theme-bg-active px-1 py-0.5">capability:&lt;name&gt;</code> — combine with free text
+                    </p>
                 </div>
                 {activeScope === "community" && (
                     <Alert

--- a/enter.pollinations.ai/frontend/src/components/models/types.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/types.ts
@@ -91,4 +91,5 @@ export type ModelPrice = {
     priceAdjustments?: ModelPriceAdjustment[];
     // Real usage data from Tinybird (rolling 7-day average)
     realAvgCost?: number;
+    ownerLogin?: string;
 };


### PR DESCRIPTION
﻿Closes #13907

Makes the Models search actually useful:

- Free-text now looks at the metadata already loaded on the page — id, title, description, brand/publisher, base model, input/output modalities and capabilities — not just the display name.
- Adds a small `key:value` syntax (inspired by GitHub search) for precise filtering: `access:free|quest|paid`, `owner:<login>` (community), `id:<model>`, `type:<category>`, `capability:<name>`. Filters and free-text can be combined and all conditions are ANDed.
- Keeps the existing scope, category, sort and `?q=` URL state intact — direct links and reloads still work.
- Filters are discoverable via a compact hint under the search box, no new search UI.

Parsing and matching are covered by focused tests.
