### PR TITLE
feat(community): add quest leaderboard to the community page

### DIFF
--- a/enter.pollinations.ai/src/routes/quests.ts
+++ b/enter.pollinations.ai/src/routes/quests.ts
@@ -1,7 +1,7 @@
 import { claimReward } from "@shared/billing/rewards.ts";
 import * as schema from "@shared/db/better-auth.ts";
 import { rewards as rewardsTable } from "@shared/db/better-auth.ts";
-import { desc, eq } from "drizzle-orm";
+import { desc, eq, like } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
@@ -22,6 +22,9 @@ import { requireAccountPermission } from "./account-permissions.ts";
 const CACHE_KEY = "quests:catalog:v29";
 const CACHE_TTL = 60;
 const QUEST_CHECK_THROTTLE_SECONDS = 60;
+const LEADERBOARD_CACHE_KEY = "quests:leaderboard:v1";
+const LEADERBOARD_CACHE_TTL = 300;
+const LEADERBOARD_SIZE = 10;
 
 export type QuestCatalogResponse = {
     quests: QuestCard[];
@@ -46,6 +49,17 @@ const questCatalogItemSchema = z.object({
 
 const questCatalogResponseSchema = z.object({
     quests: z.array(questCatalogItemSchema),
+});
+
+const leaderboardEntrySchema = z.object({
+    githubUsername: z.string(),
+    avatarUrl: z.string().nullable(),
+    completedQuests: z.number().int().nonnegative(),
+    totalPollen: z.number(),
+});
+
+const questLeaderboardResponseSchema = z.object({
+    leaderboard: z.array(leaderboardEntrySchema),
 });
 
 const rewardSchema = z.object({
@@ -118,6 +132,87 @@ export const questsRoutes = new Hono<Env>()
                 expirationTtl: CACHE_TTL,
             });
             return c.json(catalog);
+        },
+    )
+    .get(
+        "/leaderboard",
+        describeRoute({
+            tags: ["✨ Quests"],
+            summary: "Get Quest Leaderboard",
+            security: [],
+            description:
+                "Public aggregate over the quest reward ledger: contributors ranked by total pollen earned from completed public GitHub POLLEN-QUEST issues.",
+            responses: {
+                200: {
+                    description: "Quest leaderboard",
+                    content: {
+                        "application/json": {
+                            schema: resolver(questLeaderboardResponseSchema),
+                        },
+                    },
+                },
+            },
+        }),
+        async (c) => {
+            const cached = await c.env.KV.get<unknown>(
+                LEADERBOARD_CACHE_KEY,
+                "json",
+            );
+            if (cached) return c.json(cached);
+
+            const db = drizzle(c.env.DB);
+            const rows = await db
+                .select({
+                    githubUsername: schema.user.githubUsername,
+                    avatarUrl: schema.user.image,
+                    questId: rewardsTable.questId,
+                    pollenAmount: rewardsTable.pollenAmount,
+                })
+                .from(rewardsTable)
+                .innerJoin(schema.user, eq(rewardsTable.userId, schema.user.id))
+                .where(like(rewardsTable.questId, "github:issue:%"));
+
+            const byUser = new Map<
+                string,
+                {
+                    avatarUrl: string | null;
+                    completedQuests: number;
+                    totalPollen: number;
+                }
+            >();
+            for (const row of rows) {
+                if (!row.githubUsername) continue;
+                const entry = byUser.get(row.githubUsername) ?? {
+                    avatarUrl: row.avatarUrl,
+                    completedQuests: 0,
+                    totalPollen: 0,
+                };
+                entry.completedQuests += 1;
+                entry.totalPollen += row.pollenAmount;
+                byUser.set(row.githubUsername, entry);
+            }
+
+            const leaderboard = [...byUser.entries()]
+                .map(([githubUsername, entry]) => ({
+                    githubUsername,
+                    avatarUrl: entry.avatarUrl,
+                    completedQuests: entry.completedQuests,
+                    totalPollen: Math.round(entry.totalPollen * 100) / 100,
+                }))
+                .sort(
+                    (a, b) =>
+                        b.totalPollen - a.totalPollen ||
+                        b.completedQuests - a.completedQuests,
+                )
+                .slice(0, LEADERBOARD_SIZE);
+
+            const response = { leaderboard };
+            await c.env.KV.put(
+                LEADERBOARD_CACHE_KEY,
+                JSON.stringify(response),
+                { expirationTtl: LEADERBOARD_CACHE_TTL },
+            );
+            return c.json(response);
         },
     )
     .post(

--- a/enter.pollinations.ai/test/quest-leaderboard.test.ts
+++ b/enter.pollinations.ai/test/quest-leaderboard.test.ts
@@ -1,0 +1,135 @@
+import { env, SELF } from "cloudflare:test";
+import * as schema from "@shared/db/better-auth.ts";
+import { rewards as rewardsTable } from "@shared/db/better-auth.ts";
+import { drizzle } from "drizzle-orm/d1";
+import { expect } from "vitest";
+import { test } from "./fixtures.ts";
+
+test("GET /api/quests/leaderboard aggregates public GitHub quest rewards", async () => {
+    const db = drizzle(env.DB, { schema });
+    const now = new Date();
+
+    await db.insert(schema.user).values([
+        {
+            id: "lb-alice",
+            name: "lb-alice",
+            email: "lb-alice@example.com",
+            githubId: 901,
+            githubUsername: "alice",
+            image: "https://avatars.example.com/alice.png",
+            createdAt: now,
+            updatedAt: now,
+        },
+        {
+            id: "lb-bob",
+            name: "lb-bob",
+            email: "lb-bob@example.com",
+            githubId: 902,
+            githubUsername: "bob",
+            createdAt: now,
+            updatedAt: now,
+        },
+        {
+            id: "lb-carol",
+            name: "lb-carol",
+            email: "lb-carol@example.com",
+            createdAt: now,
+            updatedAt: now,
+        },
+    ]);
+
+    await db.insert(rewardsTable).values([
+        {
+            id: "lb-r1",
+            idempotencyKey: "lb-r1",
+            userId: "lb-alice",
+            questId: "github:issue:100",
+            title: "Quest A",
+            pollenAmount: 10,
+            balanceBucket: "tier",
+            earnedAt: now,
+        },
+        {
+            id: "lb-r2",
+            idempotencyKey: "lb-r2",
+            userId: "lb-alice",
+            questId: "github:issue:101",
+            title: "Quest B",
+            pollenAmount: 5.25,
+            balanceBucket: "tier",
+            earnedAt: now,
+        },
+        {
+            id: "lb-r3",
+            idempotencyKey: "lb-r3",
+            userId: "lb-bob",
+            questId: "github:issue:102",
+            title: "Quest C",
+            pollenAmount: 10,
+            balanceBucket: "tier",
+            earnedAt: now,
+        },
+        // One-off grant without a quest id — never counted.
+        {
+            id: "lb-r4",
+            idempotencyKey: "lb-r4",
+            userId: "lb-alice",
+            questId: null,
+            title: "Thank-you",
+            pollenAmount: 50,
+            balanceBucket: "tier",
+            earnedAt: now,
+        },
+        // Quest id outside the public GitHub issue namespace — not counted.
+        {
+            id: "lb-r5",
+            idempotencyKey: "lb-r5",
+            userId: "lb-bob",
+            questId: "merged_pr",
+            title: "Contribute a pull request",
+            pollenAmount: 99,
+            balanceBucket: "tier",
+            earnedAt: now,
+        },
+    ]);
+
+    const response = await SELF.fetch(
+        "http://localhost:3000/api/quests/leaderboard",
+    );
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+        leaderboard: Array<{
+            githubUsername: string;
+            avatarUrl: string | null;
+            completedQuests: number;
+            totalPollen: number;
+        }>;
+    };
+
+    expect(body.leaderboard[0]).toEqual({
+        githubUsername: "alice",
+        avatarUrl: "https://avatars.example.com/alice.png",
+        completedQuests: 2,
+        totalPollen: 15.25,
+    });
+    expect(body.leaderboard[1]).toEqual({
+        githubUsername: "bob",
+        avatarUrl: null,
+        completedQuests: 1,
+        totalPollen: 10,
+    });
+    // Carol has an account but no public quest rewards — not listed.
+    expect(
+        body.leaderboard.find((e) => e.githubUsername === "carol"),
+    ).toBeUndefined();
+});
+
+test("GET /api/quests/leaderboard returns an empty list with no quest rewards", async () => {
+    const response = await SELF.fetch(
+        "http://localhost:3000/api/quests/leaderboard",
+    );
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { leaderboard: unknown[] };
+    expect(body.leaderboard).toEqual([]);
+});

--- a/pollinations.ai/src/copy/content/socialLinks.ts
+++ b/pollinations.ai/src/copy/content/socialLinks.ts
@@ -56,6 +56,7 @@ export const SOCIAL_LINKS = {
 export const LINKS = {
     enter: "https://enter.pollinations.ai",
     enterKeys: "https://enter.pollinations.ai/keys",
+    enterQuests: "https://enter.pollinations.ai/quests",
     enterDocs: "https://gen.pollinations.ai/docs",
     enterApiDocs: "https://gen.pollinations.ai/docs",
     enterQuestsFaq: "https://enter.pollinations.ai/news#how-do-quests-work",

--- a/pollinations.ai/src/ui/components/QuestLeaderboard.tsx
+++ b/pollinations.ai/src/ui/components/QuestLeaderboard.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useState } from "react";
+import { LINKS } from "../../copy/content/socialLinks";
+import { ExternalLinkIcon } from "../assets/ExternalLinkIcon";
+import { Divider } from "./ui/divider";
+import { Body, Heading } from "./ui/typography";
+
+interface LeaderboardEntry {
+    githubUsername: string;
+    avatarUrl: string | null;
+    completedQuests: number;
+    totalPollen: number;
+}
+
+export function QuestLeaderboard() {
+    const [entries, setEntries] = useState<LeaderboardEntry[]>([]);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        let cancelled = false;
+
+        const fetchLeaderboard = async () => {
+            try {
+                const res = await fetch(
+                    "https://enter.pollinations.ai/api/quests/leaderboard",
+                );
+                if (!res.ok) return;
+                const data = await res.json();
+                if (!cancelled && Array.isArray(data.leaderboard)) {
+                    setEntries(data.leaderboard);
+                }
+            } catch {
+                // Leaderboard is decorative; stay hidden on failure.
+            } finally {
+                if (!cancelled) setLoading(false);
+            }
+        };
+
+        fetchLeaderboard();
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    if (loading && entries.length === 0) return null;
+    if (entries.length === 0) return null;
+
+    return (
+        <>
+            <div className="mb-12">
+                <Heading variant="section">Quest leaderboard</Heading>
+                <Body size="sm" spacing="comfortable">
+                    Top quest hunters ranked by Quest Pollen earned from
+                    completed GitHub quest issues.{" "}
+                    <a
+                        href={LINKS.enterQuests}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="font-headline text-xs font-black hover:underline inline-flex items-center gap-1 text-dark bg-accent-strong px-2 py-0.5"
+                    >
+                        Join the quests
+                        <ExternalLinkIcon className="w-3 h-3" strokeWidth="4" />
+                    </a>
+                </Body>
+                <div className="overflow-hidden rounded-sub-card border-2 border-dark border-r-4 border-b-4">
+                    <table className="w-full text-left">
+                        <thead>
+                            <tr className="bg-primary-light">
+                                <th
+                                    scope="col"
+                                    className="px-4 py-2 font-headline text-[10px] font-black uppercase text-dark"
+                                >
+                                    #
+                                </th>
+                                <th
+                                    scope="col"
+                                    className="px-4 py-2 font-headline text-[10px] font-black uppercase text-dark"
+                                >
+                                    Contributor
+                                </th>
+                                <th
+                                    scope="col"
+                                    className="px-4 py-2 text-right font-headline text-[10px] font-black uppercase text-dark"
+                                >
+                                    Quests
+                                </th>
+                                <th
+                                    scope="col"
+                                    className="px-4 py-2 text-right font-headline text-[10px] font-black uppercase text-dark"
+                                >
+                                    Quest Pollen
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {entries.map((entry, index) => (
+                                <tr
+                                    key={entry.githubUsername}
+                                    className="border-t border-border-subtle bg-white/60"
+                                >
+                                    <td className="px-4 py-2 font-mono text-xs text-subtle">
+                                        {index + 1}
+                                    </td>
+                                    <td className="px-4 py-2">
+                                        <a
+                                            href={`https://github.com/${entry.githubUsername}`}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="flex items-center gap-2 font-headline text-xs font-black text-dark hover:underline"
+                                        >
+                                            {entry.avatarUrl && (
+                                                <img
+                                                    src={entry.avatarUrl}
+                                                    alt=""
+                                                    className="h-6 w-6 rounded-full"
+                                                    loading="lazy"
+                                                    decoding="async"
+                                                    width={24}
+                                                    height={24}
+                                                />
+                                            )}
+                                            {entry.githubUsername}
+                                        </a>
+                                    </td>
+                                    <td className="px-4 py-2 text-right font-mono text-xs text-dark">
+                                        {entry.completedQuests}
+                                    </td>
+                                    <td className="px-4 py-2 text-right font-mono text-xs font-bold text-dark">
+                                        {entry.totalPollen}
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            <Divider />
+        </>
+    );
+}

--- a/pollinations.ai/src/ui/pages/CommunityPage.tsx
+++ b/pollinations.ai/src/ui/pages/CommunityPage.tsx
@@ -5,6 +5,7 @@ import { usePageCopy } from "../../hooks/usePageCopy";
 import { useTranslate } from "../../hooks/useTranslate";
 import { ExternalLinkIcon } from "../assets/ExternalLinkIcon";
 import { BuildDiary } from "../components/BuildDiary";
+import { QuestLeaderboard } from "../components/QuestLeaderboard";
 import { TopContributors } from "../components/TopContributors";
 import { Button } from "../components/ui/button";
 import { Divider } from "../components/ui/divider";
@@ -323,6 +324,8 @@ export default function CommunityPage() {
                 <Divider />
 
                 <TopContributors />
+
+                <QuestLeaderboard />
 
                 {/* Section 5 — Build Diary + Supporters */}
                 <div className="mb-12">


### PR DESCRIPTION
﻿Closes #13909

Adds a compact quest leaderboard to the `/community` page:

- New public `GET /api/quests/leaderboard` aggregate over the existing reward ledger. It counts only rewards whose `questId` sits in the public `github:issue:` namespace, so one-off grants and product quests stay out. Rows join to the user table for the public GitHub username and avatar, then rank by total pollen (quest count as tiebreak), top 10, KV-cached for 5 minutes.
- `QuestLeaderboard` section on the community page renders rank, GitHub identity, completed quest count and total Quest Pollen, with a "Join the quests" link to the Quests page. Hidden entirely when the aggregate is empty or unreachable.
- Focused tests cover the aggregation (including the excluded reward shapes) and the empty case.
