### PR TITLE
docs: publish concise community-model naming guidance (issue #12885)

### DIFF
--- a/BRING_YOUR_OWN_MODEL.md
+++ b/BRING_YOUR_OWN_MODEL.md
@@ -43,6 +43,8 @@ Owners receive 75% of the Pollen spent on their models. Paid and Quest Pollen ea
 
 The upstream credential is used by Pollinations to proxy requests to your endpoint. Do not place it in a model name, description, public URL, or example.
 
+See the [Community Model Naming Guide](./COMMUNITY_MODEL_NAMING.md) for tips on choosing a stable model ID and clear display title.
+
 ## Register with the CLI
 
 The CLI manages text, image, and transcription model registrations. Sign in, test the endpoint, then create the model:

--- a/COMMUNITY_MODEL_NAMING.md
+++ b/COMMUNITY_MODEL_NAMING.md
@@ -1,0 +1,56 @@
+# Community Model Naming Guide
+
+Community models have three public fields: **Model ID**, **Title**, and **Description**. This guide helps you choose stable, clear values. Community models do not need to follow the stricter first-party naming convention — clarity and stability matter most.
+
+## Model ID
+
+The ID is your model's permanent public identifier: `{username}/{model-id}`. It appears in API calls, URLs, and the catalog. **It cannot change after registration.**
+
+**Keep IDs stable.** Avoid embedding mutable details:
+
+- Pricing or billing mode (`free`, `cheap`, `pay-per-token`)
+- Provider routing (`replicate-`, `openrouter-`)
+- Context size, speed, or throughput (`-128k`, `-fast`)
+- Version numbers that change frequently
+
+| Good | Avoid |
+|---|---|
+| `my-fast-coder` | `free-gpt-4-turbo-128k` |
+| `story-writer` | `replicate-flux-fast` |
+| `multimodal-lab` | `openrouter-cheap` |
+
+Custom creative names are fine — the ID just needs to stay stable and unambiguous.
+
+## Title
+
+The title is the friendly name in the Models list. It **can change freely** after registration. Use it to say what the model does in plain language.
+
+| Type | ID | Title |
+|---|---|---|
+| Direct upstream | `acme/flash-chat` | Acme Flash Chat |
+| Custom fine-tune | `data-scientist/coder-70b` | Coder 70B (Python/TS fine-tune) |
+| Router | `team/router` | Team Multi-Model Router |
+| Rebranded | `my-org/summarizer` | MyOrg Summarizer (BART-large) |
+
+## Description
+
+A short one-liner about what the model is good at. For routers and rebranded models, clearly state what the model is or what it routes to — be transparent about provenance.
+
+| ID | Description |
+|---|---|
+| `acme/flash-chat` | Low-latency chat for customer support |
+| `data-scientist/coder-70b` | Code Llama 70B fine-tuned for Python and TypeScript |
+| `team/router` | Routes to the cheapest available chat model |
+| `my-org/summarizer` | BART-large fine-tuned for meeting summaries |
+
+## Quick Reference
+
+| Field | Purpose | Can change? |
+|---|---|---|
+| **Model ID** | Permanent API identifier | No |
+| **Title** | Friendly catalog name | Yes |
+| **Description** | One-liner about capabilities | Yes |
+
+## See Also
+
+- [Publish a Model](./BRING_YOUR_OWN_MODEL.md) — full registration and pricing guide

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/model-listing-fields.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/model-listing-fields.tsx
@@ -2,6 +2,7 @@ import {
     ButtonGroup,
     CheckIcon,
     FieldStack,
+    InlineLink,
     Input,
     TabButton,
 } from "@pollinations/ui";
@@ -114,9 +115,22 @@ export function ModelListingFields({
                 <FieldStack
                     label={isAgent ? "ID" : "Model ID"}
                     helper={
-                        isAgent
-                            ? "Public ID: {username}/{id}."
-                            : "Public ID: {username}/{model-id}."
+                        isAgent ? (
+                            "Public ID: {username}/{id}."
+                        ) : (
+                            <>
+                                Public ID: {"{username}"}/{"{model-id}"}. See
+                                the{" "}
+                                <InlineLink
+                                    href="https://github.com/pollinations/pollinations/blob/main/COMMUNITY_MODEL_NAMING.md"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    naming guide
+                                </InlineLink>{" "}
+                                for tips on a stable ID and clear title.
+                            </>
+                        )
                     }
                     alignLabelRow
                 >


### PR DESCRIPTION
- Adds \COMMUNITY_MODEL_NAMING.md\ — one concise guide covering Model ID (stable, avoid mutable details), Display Title (changeable, plain language), and Description (transparent one-liner)
- Links from \BRING_YOUR_OWN_MODEL.md\ (existing publishing docs)
- Links from the Add model form's Model ID field helper text
- Community models explicitly do not need the stricter first-party convention from #13587

Fixes #12885