### PR TITLE
feat: add metadata and filters to Models search (issue #13907)

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/model-search-parser.test.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-search-parser.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { matchesQuery, parseQuery } from "./model-search-parser.ts";
+import type { ModelPrice } from "./types.ts";
+
+const makeModel = (overrides: Partial<ModelPrice> = {}): ModelPrice => ({
+    name: "test-model",
+    type: "text",
+    capabilities: [],
+    paidOnly: false,
+    prices: [],
+    ...overrides,
+});
+
+describe("parseQuery", () => {
+    it("splits free-text terms", () => {
+        expect(parseQuery("hello world")).toEqual({
+            terms: ["hello", "world"],
+            filters: new Map(),
+        });
+    });
+
+    it("parses key:value filters", () => {
+        const result = parseQuery("type:text access:paid");
+        expect(result.terms).toEqual([]);
+        expect(result.filters.get("type")).toBe("text");
+        expect(result.filters.get("access")).toBe("paid");
+        expect(result.filters.size).toBe(2);
+    });
+
+    it("parses quoted values", () => {
+        const result = parseQuery('owner:"openai"');
+        expect(result.terms).toEqual([]);
+        expect(result.filters.get("owner")).toBe("openai");
+    });
+
+    it("combines free-text and filters", () => {
+        const result = parseQuery("flux type:image");
+        expect(result.terms).toEqual(["flux"]);
+        expect(result.filters.get("type")).toBe("image");
+        expect(result.filters.size).toBe(1);
+    });
+
+    it("normalizes to lowercase when called from matchesQuery", () => {
+        const model = makeModel({ name: "flux", type: "image" });
+        expect(matchesQuery(model, "Flux TYPE:Image")).toBe(true);
+    });
+});
+
+describe("matchesQuery", () => {
+    it("matches free text against name, brand, description, baseModel, modalities, capabilities", () => {
+        const model = makeModel({
+            name: "gpt-4",
+            brand: "OpenAI",
+            description: "Fast coding model",
+            baseModel: "gpt-4-turbo",
+            inputModalities: ["text", "image"],
+            capabilities: ["tool_calling"],
+        });
+
+        expect(matchesQuery(model, "gpt-4")).toBe(true);
+        expect(matchesQuery(model, "openai")).toBe(true);
+        expect(matchesQuery(model, "coding")).toBe(true);
+        expect(matchesQuery(model, "turbo")).toBe(true);
+        expect(matchesQuery(model, "tool_calling")).toBe(true);
+        expect(matchesQuery(model, "image")).toBe(true);
+        expect(matchesQuery(model, "nonexistent")).toBe(false);
+    });
+
+    it("filters by type", () => {
+        expect(matchesQuery(makeModel({ type: "image" }), "type:image")).toBe(true);
+        expect(matchesQuery(makeModel({ type: "text" }), "type:image")).toBe(false);
+    });
+
+    it("filters by access:paid", () => {
+        expect(matchesQuery(makeModel({ paidOnly: true }), "access:paid")).toBe(true);
+        expect(matchesQuery(makeModel({ paidOnly: false }), "access:paid")).toBe(false);
+    });
+
+    it("filters by access:free", () => {
+        expect(matchesQuery(makeModel({ paidOnly: false }), "access:free")).toBe(true);
+        expect(matchesQuery(makeModel({ paidOnly: true }), "access:free")).toBe(false);
+    });
+
+    it("filters by owner", () => {
+        const model = makeModel({ community: true, brand: "OpenAI" });
+        expect(matchesQuery(model, "owner:openai")).toBe(true);
+        expect(matchesQuery(model, "owner:anthropic")).toBe(false);
+    });
+
+    it("filters by id", () => {
+        const model = makeModel({ name: "gpt-4-turbo", brand: "openai" });
+        expect(matchesQuery(model, "id:gpt-4")).toBe(true);
+        expect(matchesQuery(model, "id:openai/gpt-4")).toBe(true);
+    });
+
+    it("filters by capability", () => {
+        const model = makeModel({ capabilities: ["tool_calling", "reasoning"] });
+        expect(matchesQuery(model, "capability:tool_calling")).toBe(true);
+        expect(matchesQuery(model, "capability:reasoning")).toBe(true);
+        expect(matchesQuery(model, "capability:web_search")).toBe(false);
+    });
+
+    it("combines filters and free text", () => {
+        const model = makeModel({
+            name: "gpt-4",
+            brand: "OpenAI",
+            type: "text",
+            paidOnly: true,
+        });
+        expect(matchesQuery(model, "gpt type:text access:paid")).toBe(true);
+        expect(matchesQuery(model, "gpt type:image")).toBe(false);
+        expect(matchesQuery(model, "gpt access:free")).toBe(false);
+    });
+
+    it("returns true for empty query", () => {
+        expect(matchesQuery(makeModel(), "")).toBe(true);
+    });
+});

--- a/enter.pollinations.ai/frontend/src/components/models/model-search-parser.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-search-parser.ts
@@ -1,0 +1,116 @@
+import { getModelDisplayName } from "./model-info.ts";
+import type { ModelPrice } from "./types.ts";
+
+type ParsedQuery = {
+    terms: string[];
+    filters: Map<string, string>;
+};
+
+export function parseQuery(query: string): ParsedQuery {
+    const terms: string[] = [];
+    const filters = new Map<string, string>();
+
+    // Match key:value pairs (supports quoted values for multi-word matches)
+    const tokenRegex = /(\w+):(?:"([^"]*)"|(\S+))/g;
+    let lastIndex = 0;
+
+    for (const match of query.matchAll(tokenRegex)) {
+        // Add any text before this filter as a free-text term
+        const before = query.slice(lastIndex, match.index).trim();
+        if (before) {
+            for (const term of before.split(/\s+/)) {
+                if (term) terms.push(term);
+            }
+        }
+        const key = match[1].toLowerCase();
+        const value = (match[2] ?? match[3]).toLowerCase();
+        filters.set(key, value);
+        lastIndex = (match.index ?? 0) + match[0].length;
+    }
+
+    // Add remaining text as free-text terms
+    const remaining = query.slice(lastIndex).trim();
+    if (remaining) {
+        for (const term of remaining.split(/\s+/)) {
+            if (term) terms.push(term);
+        }
+    }
+
+    return { terms, filters };
+}
+
+function modelId(model: ModelPrice): string {
+    return `${model.brand ? `${model.brand.toLowerCase()}/` : ""}${model.name.toLowerCase()}`;
+}
+
+function matchesFilters(
+    model: ModelPrice,
+    filters: Map<string, string>,
+): boolean {
+    for (const [key, value] of filters) {
+        switch (key) {
+            case "access":
+                if (value === "paid" && !model.paidOnly) return false;
+                if (value === "free" && model.paidOnly) return false;
+                if (value === "quest" && model.paidOnly) return false;
+                if (value === "quest" && !model.free && !model.paidOnly)
+                    return false;
+                break;
+            case "owner":
+                if (!model.community) return false;
+                if (model.brand?.toLowerCase() !== value) return false;
+                break;
+            case "id":
+                if (
+                    !modelId(model).includes(value) &&
+                    !model.name.toLowerCase().includes(value)
+                )
+                    return false;
+                break;
+            case "type":
+                if (model.type !== value) return false;
+                break;
+            case "capability":
+                if (
+                    !model.capabilities.includes(
+                        value as ModelPrice["capabilities"][number],
+                    )
+                )
+                    return false;
+                break;
+            default:
+                // Unknown filter — ignore it (no rejection)
+                break;
+        }
+    }
+    return true;
+}
+
+function matchesFreeText(model: ModelPrice, terms: string[]): boolean {
+    if (terms.length === 0) return true;
+
+    const displayName = getModelDisplayName(model) ?? "";
+    const haystack = [
+        displayName,
+        model.name,
+        model.brand ?? "",
+        model.description ?? "",
+        model.baseModel ?? "",
+        ...(model.inputModalities ?? []),
+        ...(model.outputModalities ?? []),
+        ...model.capabilities,
+    ]
+        .join(" ")
+        .toLowerCase();
+
+    return terms.every((term) => haystack.includes(term));
+}
+
+export function matchesQuery(model: ModelPrice, query: string): boolean {
+    if (!query) return true;
+    const parsed = parseQuery(query.toLowerCase());
+    return (
+        matchesFilters(model, parsed.filters) &&
+        matchesFreeText(model, parsed.terms)
+    );
+}

--- a/enter.pollinations.ai/frontend/src/components/models/models.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/models.tsx
@@ -34,8 +34,8 @@ import {
     fetchModelCatalog,
     getModelPricesFromCatalog,
 } from "./model-catalog.ts";
-import { getModelDisplayName } from "./model-info.ts";
 import type { ModelScope, ModelSort } from "./model-search.ts";
+import { matchesQuery } from "./model-search-parser.ts";
 import { sortModels } from "./model-sort.ts";
 import {
     type SectionType,
@@ -115,13 +115,6 @@ const SEARCH_LABELS: Record<SectionType, string> = {
     embedding: "embedding",
     agent: "agent",
 };
-
-function matchesQuery(model: ModelPrice, query: string): boolean {
-    if (!query) return true;
-    const displayName = getModelDisplayName(model) ?? "";
-    const haystack = `${displayName} ${model.brand ?? ""}`.toLowerCase();
-    return haystack.includes(query);
-}
 
 function categorizeModels(
     models: ModelPrice[],


### PR DESCRIPTION
Adds key:value filter syntax (type, access, owner, id, capability) and expands free text to search name, brand, description, baseModel, modalities, and capabilities. Filters and free text combine with AND logic. Adds 14 focused tests. Fixes #13907