### PR TITLE
refactor: separate image support from input limits

### DIFF
--- a/apps/playground/src/Playground.tsx
+++ b/apps/playground/src/Playground.tsx
@@ -154,11 +154,6 @@ function isTextToAudioModel(model: ModelInfo | undefined): boolean {
     );
 }
 
-function referenceImageLimit(model: ModelInfo | undefined): number {
-    if (!model?.input_modalities?.includes("image")) return 0;
-    return model.max_reference_images ?? 0;
-}
-
 function pluralizeImages(count: number): string {
     return count === 1 ? "1 image" : `${count} images`;
 }
@@ -369,16 +364,16 @@ export function Playground({
         };
     }, [result]);
 
-    const maxReferenceImages = referenceImageLimit(currentModel);
-    const supportsReferenceImages = maxReferenceImages > 0;
+    const supportsReferenceImages =
+        currentModel?.input_modalities?.includes("image") ?? false;
+    const maxReferenceImages = currentModel?.max_reference_images;
     const isVideoReferenceMode =
         currentModel?.category === "video" && supportsReferenceImages;
     const isReferenceImageListMode =
         supportsReferenceImages && !isVideoReferenceMode;
     const supportsLastFrame =
         isVideoReferenceMode &&
-        (currentModel?.video_capabilities?.includes("end_frame") ?? false) &&
-        maxReferenceImages >= 2;
+        (currentModel?.video_capabilities?.includes("end_frame") ?? false);
     const firstFrameFiles = referenceImages[0] ? [referenceImages[0]] : [];
     const lastFrameFiles = referenceImages[1] ? [referenceImages[1]] : [];
     const isAudioTranscription = isAudioTranscriptionModel(currentModel);
@@ -390,10 +385,16 @@ export function Playground({
 
     useEffect(() => {
         setReferenceImages((current) => {
-            if (current.length <= maxReferenceImages) return current;
+            if (!supportsReferenceImages) return [];
+            if (
+                maxReferenceImages === undefined ||
+                current.length <= maxReferenceImages
+            ) {
+                return current;
+            }
             return current.slice(0, maxReferenceImages);
         });
-    }, [maxReferenceImages]);
+    }, [maxReferenceImages, supportsReferenceImages]);
 
     function selectCategory(category: ModelCategory) {
         setActiveCategory(category);
@@ -653,28 +654,39 @@ export function Playground({
                         {isReferenceImageListMode && (
                             <FieldStack
                                 label={
-                                    <>
-                                        Reference images (up to{" "}
-                                        {pluralizeImages(maxReferenceImages)})
-                                    </>
+                                    maxReferenceImages === undefined
+                                        ? "Reference images"
+                                        : `Reference images (up to ${pluralizeImages(maxReferenceImages)})`
                                 }
                             >
                                 <FileUpload
                                     value={referenceImages}
                                     onChange={setReferenceImages}
-                                    maxFiles={maxReferenceImages}
+                                    maxFiles={
+                                        maxReferenceImages ??
+                                        Number.POSITIVE_INFINITY
+                                    }
                                     maxSizeBytes={5 * 1024 * 1024}
                                     label={
-                                        <>
-                                            Drag up to{" "}
-                                            {pluralizeImages(
-                                                maxReferenceImages,
-                                            )}{" "}
-                                            here or{" "}
-                                            <span className="polli:underline">
-                                                browse
-                                            </span>
-                                        </>
+                                        maxReferenceImages === undefined ? (
+                                            <>
+                                                Drag images here or{" "}
+                                                <span className="polli:underline">
+                                                    browse
+                                                </span>
+                                            </>
+                                        ) : (
+                                            <>
+                                                Drag up to{" "}
+                                                {pluralizeImages(
+                                                    maxReferenceImages,
+                                                )}{" "}
+                                                here or{" "}
+                                                <span className="polli:underline">
+                                                    browse
+                                                </span>
+                                            </>
+                                        )
                                     }
                                     onReject={(rejected) => {
                                         const reason = rejected[0]?.reason;
@@ -682,7 +694,10 @@ export function Playground({
                                             setError(
                                                 "Images must be under 5 MB each.",
                                             );
-                                        } else if (reason === "count") {
+                                        } else if (
+                                            reason === "count" &&
+                                            maxReferenceImages !== undefined
+                                        ) {
                                             setError(
                                                 `Use up to ${pluralizeImages(
                                                     maxReferenceImages,

--- a/packages/ui/src/compositions/FileUpload.tsx
+++ b/packages/ui/src/compositions/FileUpload.tsx
@@ -333,7 +333,7 @@ export function FileUpload({
                             )}
                         </ul>
 
-                        {maxFiles > 1 && (
+                        {Number.isFinite(maxFiles) && maxFiles > 1 && (
                             <span className="polli:text-xs polli:text-theme-text-muted">
                                 {value.length} / {maxFiles} files
                             </span>

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -431,7 +431,6 @@ export const TEXT_SERVICES = {
             "Follows instructions reliably and calls functions well, at low cost",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
-        maxReferenceImages: 10, // OpenRouter/Mistral image count varies by provider/model; Pollinations cap.
         tools: true,
         contextLength: 128000,
         isSpecialized: false,
@@ -709,7 +708,6 @@ export const TEXT_SERVICES = {
             "Efficient open-source chat with image understanding; modest on hard problems",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
-        maxReferenceImages: 10, // OpenRouter image count varies by provider/model; Pollinations cap.
         tools: true,
         reasoning: true,
         contextLength: 262144,
@@ -788,7 +786,6 @@ export const TEXT_SERVICES = {
         description: "Multimodal chat and tool calling with optional reasoning",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
-        maxReferenceImages: 100, // xAI publishes no hard image-count limit; Pollinations cap.
         tools: true,
         reasoning: true,
         contextLength: 262144,
@@ -812,7 +809,6 @@ export const TEXT_SERVICES = {
             "Strong multimodal reasoning with a huge context window at a friendly price",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
-        maxReferenceImages: 100, // xAI publishes no hard image-count limit; Pollinations cap.
         tools: true,
         reasoning: true,
         // The selected Azure deployment caps prompts at 200K; xAI direct's 1M
@@ -1655,7 +1651,6 @@ export const TEXT_SERVICES = {
             "Open-source chat that understands images, with a huge context window",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
-        maxReferenceImages: 10, // Azure-hosted Llama vision route has no public fixed image count; Pollinations cap.
         tools: true,
         contextLength: 1048576,
         isSpecialized: false,
@@ -1775,7 +1770,6 @@ export const TEXT_SERVICES = {
         description: "Agentic coding and tool-use model with 1M context",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
-        maxReferenceImages: 10, // Vercel/Meta publish vision support but no fixed image-count limit.
         tools: true,
         reasoning: true,
         contextLength: 1048576,
@@ -1798,7 +1792,6 @@ export const TEXT_SERVICES = {
             "Polished multilingual writing and reasoning with image understanding",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
-        maxReferenceImages: 10, // Mistral image count varies by model/token budget; Pollinations cap.
         tools: true,
         reasoning: true,
         contextLength: 256000,
@@ -2075,7 +2068,6 @@ export const TEXT_SERVICES = {
             "Fast image understanding — describes, reads and analyzes what it sees",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
-        maxReferenceImages: 10, // OpenRouter image count varies by provider/model; Pollinations cap.
         tools: true,
         reasoning: false,
         contextLength: 131072,
@@ -2104,7 +2096,6 @@ export const TEXT_SERVICES = {
             "Careful visual reasoning for charts, documents and complex scenes",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
-        maxReferenceImages: 10, // OpenRouter image count varies by provider/model; Pollinations cap.
         tools: true,
         reasoning: true,
         contextLength: 262144,
@@ -2130,7 +2121,6 @@ export const TEXT_SERVICES = {
             "Speedy reasoning over text and images for everyday questions",
         inputModalities: ["text", "image"],
         outputModalities: ["text"],
-        maxReferenceImages: 10, // OpenRouter image count varies by provider/model; Pollinations cap.
         tools: true,
         // Emits a chain-of-thought `reasoning` field (verified live); reasoning
         // tokens are billed within completion_tokens at the completionText rate.


### PR DESCRIPTION
- Uses input modalities to decide whether Play accepts images
- Treats a missing reference-image limit as unknown instead of unsupported
- Removes guessed text-model limits while retaining documented provider limits

Checks:
- `npm exec -- biome check apps/playground/src/Playground.tsx packages/ui/src/compositions/FileUpload.tsx shared/registry/text.ts`
- `npm run typecheck --prefix packages/ui`
- `npm run typecheck --prefix apps/playground`
- `npm run build:app --prefix apps/playground`