### PR TITLE
refactor: remove duplicate Replicate error logs

### DIFF
--- a/gen.pollinations.ai/src/image/models/seedance25VideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/seedance25VideoModel.ts
@@ -6,7 +6,6 @@ import { closestRatioLogSpace } from "../utils/aspectRatio.ts";
 import { fetchUpstream } from "../utils/fetchUpstream.ts";
 import { toDataUri } from "../utils/imageDownload.ts";
 import {
-    ReplicateError,
     runReplicatePrediction,
     toReplicateHttpError,
 } from "../utils/replicateClient.ts";
@@ -113,12 +112,6 @@ export async function callSeedance25API(
         });
     } catch (error) {
         logError("prediction failed", error);
-        if (error instanceof ReplicateError) {
-            logError("Replicate error", {
-                message: error.message,
-                status: error.status,
-            });
-        }
         throw toReplicateHttpError(error, "Seedance 2.5 generation failed");
     }
 

--- a/gen.pollinations.ai/src/image/models/seedanceReplicateVideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/seedanceReplicateVideoModel.ts
@@ -19,7 +19,6 @@ import { closestRatioLogSpace } from "../utils/aspectRatio.ts";
 import { fetchUpstream } from "../utils/fetchUpstream.ts";
 import { toDataUri } from "../utils/imageDownload.ts";
 import {
-    ReplicateError,
     runReplicatePrediction,
     toReplicateHttpError,
 } from "../utils/replicateClient.ts";
@@ -153,12 +152,6 @@ async function generateSeedanceVideo(
         });
     } catch (err) {
         logError(`${config.displayName} prediction call failed:`, err);
-        if (err instanceof ReplicateError) {
-            logError("Replicate raw error details:", {
-                message: err.message,
-                status: err.status,
-            });
-        }
         throw toReplicateHttpError(
             err,
             `${config.displayName} generation failed`,

--- a/gen.pollinations.ai/src/image/models/seedanceV2VideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/seedanceV2VideoModel.ts
@@ -15,7 +15,6 @@ import type { ImageParams } from "../params.ts";
 import { fetchUpstream } from "../utils/fetchUpstream.ts";
 import { toDataUri } from "../utils/imageDownload.ts";
 import {
-    ReplicateError,
     runReplicatePrediction,
     toReplicateHttpError,
 } from "../utils/replicateClient.ts";
@@ -155,12 +154,6 @@ export async function callSeedanceV2API(
         });
     } catch (err) {
         logError(`${definition.title} prediction call failed:`, err);
-        if (err instanceof ReplicateError) {
-            logError("Replicate raw error details:", {
-                message: err.message,
-                status: err.status,
-            });
-        }
         throw toReplicateHttpError(
             err,
             `${definition.title} generation failed`,


### PR DESCRIPTION
- Keeps one complete error log per failed Replicate-backed Seedance request
- Removes duplicate message/status logging and direct adapter imports
- Leaves timeout, cancellation, and error mapping behavior unchanged

Checks:
- `npm exec -- biome check` on the three changed adapters
- `npm run test --workspace pollinations-gen -- test/image/replicateClient.test.ts`
- `npm run typecheck --workspace pollinations-gen`