### PR TITLE
fix: reward merged quest PR authors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Before you start, please refer to the main `README.md` file of the `pollinations
 
 Look for issues that interest you and feel free to tackle them!
 
-Issues labeled `POLLEN-QUEST` are open to multiple solutions; you do not need to claim the issue or wait for assignment before starting. Link your PR with `Fixes #N`. Maintainers compare completed approaches and assign the selected contributor before merge so they can claim the stated reward.
+Issues labeled `POLLEN-QUEST` are open to multiple solutions; you do not need to claim the issue or wait for assignment before starting. Link your PR with `Fixes #N`. Maintainers compare completed approaches, and the author of the selected merged PR can claim the stated reward.
 
 ### 2. Understand the Issue and Build an MVP
 

--- a/enter.pollinations.ai/POLLEN_FAQ.md
+++ b/enter.pollinations.ai/POLLEN_FAQ.md
@@ -34,7 +34,7 @@ Quests reward eligible account activity and community contributions.
 
 - Browse the dashboard for current requirements, progress, and rewards.
 - Claim completed rewards from the dashboard; past qualifying activity may count.
-- Contribution quests are labeled GitHub issues with a stated reward. Multiple contributors may submit solutions without claiming the issue first. Maintainers select and assign the best completed approach before merge; the selected contributor can claim the reward afterward.
+- Contribution quests are labeled GitHub issues with a stated reward. Multiple contributors may submit solutions without claiming the issue first. The author of the selected merged PR can claim the reward afterward.
 
 Quest availability and reward amounts can change, so the dashboard and the linked issue are the source of truth.
 

--- a/enter.pollinations.ai/src/services/quests/groups/github-contributions.ts
+++ b/enter.pollinations.ai/src/services/quests/groups/github-contributions.ts
@@ -44,7 +44,7 @@ const solveGithubIssueQuest: QuestDefinition = {
     id: "solve_github_issue",
     title: "Solve a quest issue in GitHub",
     description:
-        "Pick an open POLLEN-QUEST issue and submit a focused PR. Multiple contributors may submit; maintainers select and assign the best solution before merge.",
+        "Pick an open POLLEN-QUEST issue and submit a focused PR. Multiple contributors may submit; the author of the selected merged PR earns the reward.",
     category: CONTRIBUTION_CATEGORY,
     scope: "perUser",
     rewardAmount: 0,
@@ -61,12 +61,10 @@ type DerivedQuestIssue = {
     rewardAmount: number | null;
     // "available" = open bounty; "completed" = closed by a merged PR.
     state: "available" | "completed";
-    assigneeGithubId: number | null;
-    completedByPrNumber: number | null;
+    completedByGithubId: number | null;
 };
 
 type GitHubUser = {
-    login?: string;
     databaseId?: number;
 };
 
@@ -76,10 +74,13 @@ type GitHubIssueNode = {
     title: string;
     url: string;
     body: string | null;
-    assignees: { nodes: GitHubUser[] };
     labels: { nodes: { name: string }[] };
     closedByPullRequestsReferences: {
-        nodes: { number: number; mergedAt: string | null }[];
+        nodes: {
+            number: number;
+            mergedAt: string | null;
+            author: GitHubUser | null;
+        }[];
     };
 };
 
@@ -100,9 +101,10 @@ query($query:String!){
     nodes{
       ... on Issue{
         number state title url body
-        assignees(first:10){ nodes{ login ... on User{ databaseId } } }
         labels(first:100){ nodes{ name } }
-        closedByPullRequestsReferences(first:10){ nodes{ number mergedAt } }
+        closedByPullRequestsReferences(first:10){
+          nodes{ number mergedAt author{ ... on User{ databaseId } } }
+        }
       }
     }
   }
@@ -165,20 +167,21 @@ function hasQuestLabel(labels: { name: string }[]): boolean {
     return labels.some((label) => label.name === QUEST_LABEL);
 }
 
-function firstMergedCloser(issue: GitHubIssueNode): number | null {
-    const merged = issue.closedByPullRequestsReferences.nodes
-        .filter((pr) => pr.mergedAt !== null)
-        .map((pr) => pr.number)
-        .sort((a, b) => a - b);
-    return merged[0] ?? null;
+function firstMergedCloser(issue: GitHubIssueNode) {
+    return (
+        issue.closedByPullRequestsReferences.nodes
+            .flatMap((pr) =>
+                pr.mergedAt === null ? [] : [{ ...pr, mergedAt: pr.mergedAt }],
+            )
+            .sort((a, b) => a.mergedAt.localeCompare(b.mergedAt))[0] ?? null
+    );
 }
 
 function toDerivedQuestIssue(issue: GitHubIssueNode): DerivedQuestIssue {
     const body = issue.body ?? "";
-    const completedByPrNumber = firstMergedCloser(issue);
+    const completedBy = firstMergedCloser(issue);
     const state: DerivedQuestIssue["state"] =
-        completedByPrNumber !== null ? "completed" : "available";
-    const firstAssignee = issue.assignees.nodes[0];
+        completedBy !== null ? "completed" : "available";
     return {
         issueNumber: issue.number,
         title: issue.title,
@@ -186,8 +189,7 @@ function toDerivedQuestIssue(issue: GitHubIssueNode): DerivedQuestIssue {
         url: issue.url,
         rewardAmount: parseReward(body),
         state,
-        assigneeGithubId: firstAssignee?.databaseId ?? null,
-        completedByPrNumber,
+        completedByGithubId: completedBy?.author?.databaseId ?? null,
     };
 }
 
@@ -208,16 +210,8 @@ async function loadQuestIssues(token: string): Promise<DerivedQuestIssue[]> {
         .filter((issue) => issue.rewardAmount !== null);
 }
 
-// State is a two-state BOARD concept: "available" = an open bounty
-// anyone can take; "completed" = off the open board. Only a genuinely open
-// issue (not completed, nobody assigned) is shown; the moment a maintainer
-// selects and assigns the winning contributor, or the issue is completed, it
-// leaves the board. It reappears only for the user who earned it, via their
-// reward (see the frontend). So selected and completed both map to "completed"
-// (off-board).
 function issueState(issue: DerivedQuestIssue): QuestState {
-    const open = issue.state === "available" && issue.assigneeGithubId === null;
-    return open ? "available" : "completed";
+    return issue.state;
 }
 
 function toIssueQuestDefinition(issue: DerivedQuestIssue): QuestDefinition {
@@ -273,14 +267,13 @@ export async function evaluateUser(
         hasMergedPr(token, user),
     ]);
 
-    // Payable issue bounties: completed by a merged PR, with a positive reward
-    // and assigned to the current user's linked GitHub account.
+    // Payable issue bounties: completed by a merged PR authored by the current
+    // user's linked GitHub account, with a positive reward.
     const issueProposals = issues
         .filter(
             (issue) =>
                 issue.state === "completed" &&
-                issue.completedByPrNumber !== null &&
-                issue.assigneeGithubId === user.githubId &&
+                issue.completedByGithubId === user.githubId &&
                 (issue.rewardAmount ?? 0) > 0,
         )
         .map((issue) => ({

--- a/enter.pollinations.ai/test/mocks/github.ts
+++ b/enter.pollinations.ai/test/mocks/github.ts
@@ -29,6 +29,7 @@ export type MockGithubState = {
         closedByPullRequestsReferences?: Array<{
             number: number;
             mergedAt: string | null;
+            author: { databaseId?: number | null } | null;
         }>;
     }>;
     mergedPullRequests: Array<{

--- a/enter.pollinations.ai/test/quests.test.ts
+++ b/enter.pollinations.ai/test/quests.test.ts
@@ -59,6 +59,8 @@ type SeedQuestIssue = {
     closed?: boolean;
     // When set, a merged PR closes the issue (→ "completed" / payable).
     completedByPrNumber?: number | null;
+    completedByGithubId?: number | null;
+    completedByLogin?: string | null;
     createdAt?: Date;
     updatedAt?: Date;
 };
@@ -69,6 +71,8 @@ function seedQuestIssue(github: MockGithubState, issue: SeedQuestIssue): void {
     const assigneeGithubId = issue.assigneeGithubId ?? null;
     const assigneeLogin = issue.assigneeLogin ?? null;
     const completedBy = issue.completedByPrNumber ?? null;
+    const completedByGithubId = issue.completedByGithubId ?? null;
+    const completedByLogin = issue.completedByLogin ?? null;
     const created = issue.createdAt ?? new Date("2026-06-01T00:00:00Z");
     const updated = issue.updatedAt ?? new Date("2026-06-02T00:00:00Z");
 
@@ -89,14 +93,20 @@ function seedQuestIssue(github: MockGithubState, issue: SeedQuestIssue): void {
         labels: [{ name: "POLLEN-QUEST" }],
         closedByPullRequestsReferences:
             completedBy !== null
-                ? [{ number: completedBy, mergedAt: updated.toISOString() }]
+                ? [
+                      {
+                          number: completedBy,
+                          mergedAt: updated.toISOString(),
+                          author: { databaseId: completedByGithubId },
+                      },
+                  ]
                 : [],
     });
 
-    if (completedBy !== null && assigneeLogin) {
+    if (completedBy !== null && completedByLogin) {
         github.mergedPullRequests.push({
             number: completedBy,
-            authorLogin: assigneeLogin,
+            authorLogin: completedByLogin,
             mergedAt: updated.toISOString(),
         });
     }
@@ -462,6 +472,8 @@ test("catalog excludes closed GitHub quest issues without merged PRs", async ({
         title: "Open bounty",
         goal: "Still available.",
         reward: 3,
+        assigneeGithubId: 123456,
+        assigneeLogin: "interested-contributor",
     });
     seedQuestIssue(mocks.github.state, {
         issueNumber: 802,
@@ -1476,7 +1488,7 @@ test("quest check records elixpo intern easter egg once", async ({
     });
 });
 
-test("quest check records completed GitHub quest issue rewards through shared path", async ({
+test("quest check rewards the merged quest PR author, not the issue assignee", async ({
     mocks,
     sessionToken: _sessionToken,
 }) => {
@@ -1488,21 +1500,8 @@ test("quest check records completed GitHub quest issue rewards through shared pa
     const issueNumber = 777;
     const issueQuestId = `github:issue:${issueNumber}`;
     const issueTitle = "Ship a focused fix";
-
-    seedQuestIssue(mocks.github.state, {
-        issueNumber,
-        title: issueTitle,
-        goal: "Merge the quest PR.",
-        reward: 17,
-        assigneeGithubId: user.githubId,
-        assigneeLogin: user.githubUsername,
-        completedByPrNumber: 888,
-    });
-
-    const first = await checkQuestsForUser(env, user.id);
-    expect(first.recorded).toBeGreaterThanOrEqual(1);
-
     const otherGithubId = 987654;
+
     await db.insert(schema.user).values({
         id: "github-quest-other-user",
         name: "Other Dev",
@@ -1516,12 +1515,21 @@ test("quest check records completed GitHub quest issue rewards through shared pa
         tierBalance: 0,
         packBalance: 0,
     });
-    const mockedIssue = mocks.github.state.questIssues.find(
-        (issue) => issue.number === issueNumber,
-    );
-    if (!mockedIssue) throw new Error("Expected mocked quest issue");
-    mockedIssue.assignees = [{ login: "other-dev", databaseId: otherGithubId }];
-    mockedIssue.updated_at = "2026-06-13T00:00:00Z";
+
+    seedQuestIssue(mocks.github.state, {
+        issueNumber,
+        title: issueTitle,
+        goal: "Merge the quest PR.",
+        reward: 17,
+        assigneeGithubId: otherGithubId,
+        assigneeLogin: "other-dev",
+        completedByPrNumber: 888,
+        completedByGithubId: user.githubId,
+        completedByLogin: user.githubUsername,
+    });
+
+    const first = await checkQuestsForUser(env, user.id);
+    expect(first.recorded).toBeGreaterThanOrEqual(1);
 
     const second = await checkQuestsForUser(env, "github-quest-other-user");
     expect(second.recorded).toBe(0);
@@ -1551,7 +1559,7 @@ test("quest check records completed GitHub quest issue rewards through shared pa
         .where(eq(schema.rewards.questId, issueQuestId));
 
     // scope:"once" idempotency: exactly one reward, keyed WITHOUT a userId, owned
-    // by the original assignee who triggered the first recording.
+    // by the merged PR author who triggered the first recording.
     expect(rewards).toHaveLength(1);
     expect(rewards[0]).toMatchObject({
         idempotencyKey: `quest:github:issue:${issueNumber}`,
@@ -1592,14 +1600,14 @@ test("two lazy GitHub issue bounties each record independently", async ({
     const issues = [
         {
             issueNumber: 901,
-            assigneeGithubId: user.githubId,
-            assigneeLogin: user.githubUsername,
+            authorGithubId: user.githubId,
+            authorLogin: user.githubUsername,
             reward: 11,
         },
         {
             issueNumber: 902,
-            assigneeGithubId: secondGithubId,
-            assigneeLogin: "second-dev",
+            authorGithubId: secondGithubId,
+            authorLogin: "second-dev",
             reward: 13,
         },
     ];
@@ -1609,9 +1617,9 @@ test("two lazy GitHub issue bounties each record independently", async ({
             title: `Community bounty #${issue.issueNumber}`,
             goal: "Merge the linked PR.",
             reward: issue.reward,
-            assigneeGithubId: issue.assigneeGithubId,
-            assigneeLogin: issue.assigneeLogin,
             completedByPrNumber: issue.issueNumber + 1000,
+            completedByGithubId: issue.authorGithubId,
+            completedByLogin: issue.authorLogin,
         });
     }
 
@@ -1641,7 +1649,7 @@ test("two lazy GitHub issue bounties each record independently", async ({
         "quest:github:issue:901",
         "quest:github:issue:902",
     ]);
-    // Both assignees have their own issue's reward (901→user, 902→other).
+    // Both PR authors have their own issue's reward (901→user, 902→other).
     expect(
         issueRewards.find((g) => g.userId === user.id)?.pollenAmount,
     ).toBeCloseTo(11);

--- a/operations/social/prompts/brand/about.md
+++ b/operations/social/prompts/brand/about.md
@@ -34,5 +34,5 @@ Think: the tone of a well-written README, a CCC talk abstract, or a Phrack artic
 
 Earn Pollen by completing useful actions — onboarding, using models, growing an app, GitHub contributions.
 - complete a Quest, claim the reward, Pollen lands in your wallet
-- Contribute quests may receive multiple PRs; maintainers select and assign the best solution before merge, then the selected contributor claims the fixed reward
+- Contribute quests may receive multiple PRs; the author of the selected merged PR claims the fixed reward
 - in alpha — rewards and availability evolve


### PR DESCRIPTION
- Rewards the author of the first merged PR that closes a POLLEN-QUEST issue
- Removes issue assignment from eligibility and keeps open quests available to multiple contributors
- Updates contributor guidance and focused quest reward tests

Tests:
- `npm run typecheck --workspace pollinations-enter`
- `npx vitest run test/quests.test.ts`
- `npx biome check ...`