### PR TITLE
feat: Try in Play button + model limits (issues #13903, #13905)

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/model-catalog.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-catalog.ts
@@ -57,6 +57,9 @@ export type ApiModelInfo = {
     tools?: boolean;
     reasoning?: boolean;
     context_length?: number;
+    min_duration?: number;
+    max_duration?: number;
+    default_duration?: number;
     voices?: string[];
     is_specialized?: boolean;
     paid_only?: boolean;
@@ -267,6 +270,10 @@ function baseModelPrice(model: ApiModelInfo): ModelPrice | null {
         outputSortPrice,
         prices: [],
         priceAdjustments: model.pricing_adjustments,
+        contextLength: model.context_length,
+        minDuration: model.min_duration,
+        maxDuration: model.max_duration,
+        defaultDuration: model.default_duration,
     };
 }
 

--- a/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
@@ -4,6 +4,7 @@ import {
     ClipboardIcon,
     CopyButton,
     cn,
+    RocketIcon,
     Surface,
     Tooltip,
 } from "@pollinations/ui";
@@ -373,6 +374,23 @@ export const ModelRow: FC<ModelRowProps> = ({ model }) => {
                             </div>
                         )}
                     </div>
+                    {model.contextLength && (
+                        <div className="mt-1 text-xs text-theme-text-muted">
+                            {model.contextLength >= 1000
+                                ? `${Math.round(model.contextLength / 1000)}K context`
+                                : `${model.contextLength} context`}
+                        </div>
+                    )}
+                    {model.minDuration != null && model.maxDuration != null && (
+                        <div className="mt-0.5 text-xs text-theme-text-muted">
+                            {model.minDuration === model.maxDuration
+                                ? `${model.minDuration}s`
+                                : `${model.minDuration}–${model.maxDuration}s`}
+                            {model.defaultDuration != null &&
+                                model.minDuration !== model.maxDuration &&
+                                ` (default ${model.defaultDuration}s)`}
+                        </div>
+                    )}
                     <div className="mt-1.5 flex min-w-0 flex-wrap items-center gap-1.5">
                         <ModelStatusChips
                             showNew={showNew}
@@ -382,6 +400,17 @@ export const ModelRow: FC<ModelRowProps> = ({ model }) => {
                             access={balanceAccess}
                             className="whitespace-nowrap"
                         />
+                        <Tooltip content="Try in Play">
+                            <a
+                                href={`/play?model=${model.name}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="inline-flex items-center justify-center rounded-md p-1 text-theme-text-muted transition-colors hover:bg-theme-bg-active hover:text-theme-text-strong"
+                                aria-label={`Try ${publicModelName} in Play`}
+                            >
+                                <RocketIcon className="h-3.5 w-3.5" />
+                            </a>
+                        </Tooltip>
                     </div>
                 </div>
             </div>

--- a/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
@@ -1,4 +1,4 @@
-import { Tooltip } from "@pollinations/ui";
+import { RocketIcon, Tooltip } from "@pollinations/ui";
 import { type FC, useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
     CAPABILITY_ICON,
@@ -268,6 +268,23 @@ const MobileModelRow: FC<MobileModelRowProps> = ({ model }) => {
                             </div>
                         )}
                     </div>
+                    {model.contextLength && (
+                        <div className="mt-1 text-xs text-theme-text-muted">
+                            {model.contextLength >= 1000
+                                ? `${Math.round(model.contextLength / 1000)}K context`
+                                : `${model.contextLength} context`}
+                        </div>
+                    )}
+                    {model.minDuration != null && model.maxDuration != null && (
+                        <div className="mt-0.5 text-xs text-theme-text-muted">
+                            {model.minDuration === model.maxDuration
+                                ? `${model.minDuration}s`
+                                : `${model.minDuration}–${model.maxDuration}s`}
+                            {model.defaultDuration != null &&
+                                model.minDuration !== model.maxDuration &&
+                                ` (default ${model.defaultDuration}s)`}
+                        </div>
+                    )}
                     <div className="mt-1.5 flex min-w-0 flex-wrap items-center gap-1.5">
                         <ModelStatusChips
                             showNew={showNew}
@@ -277,6 +294,17 @@ const MobileModelRow: FC<MobileModelRowProps> = ({ model }) => {
                             access={balanceAccess}
                             className="whitespace-nowrap"
                         />
+                        <Tooltip content="Try in Play">
+                            <a
+                                href={`/play?model=${model.name}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="inline-flex items-center justify-center rounded-md p-1 text-theme-text-muted transition-colors hover:bg-theme-bg-active hover:text-theme-text-strong"
+                                aria-label={`Try ${publicModelName} in Play`}
+                            >
+                                <RocketIcon className="h-3.5 w-3.5" />
+                            </a>
+                        </Tooltip>
                     </div>
                 </div>
             </div>

--- a/enter.pollinations.ai/frontend/src/components/models/types.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/types.ts
@@ -91,4 +91,9 @@ export type ModelPrice = {
     priceAdjustments?: ModelPriceAdjustment[];
     // Real usage data from Tinybird (rolling 7-day average)
     realAvgCost?: number;
+    // Model limits
+    contextLength?: number;
+    minDuration?: number;
+    maxDuration?: number;
+    defaultDuration?: number;
 };

--- a/pollinations.ai/src/ui/pages/PlayPage.tsx
+++ b/pollinations.ai/src/ui/pages/PlayPage.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { PLAY_PAGE } from "../../copy/content/play";
 import { LINKS } from "../../copy/content/socialLinks";
 import { useAuth } from "../../hooks/useAuth";
@@ -14,7 +15,17 @@ import { PageContainer } from "../components/ui/page-container";
 import { Body, Title } from "../components/ui/typography";
 
 function PlayPage() {
-    const [selectedModel, setSelectedModel] = useState("flux");
+    const [searchParams, setSearchParams] = useSearchParams();
+    const initialModel = searchParams.get("model") ?? "flux";
+    const [selectedModel, setSelectedModel] = useState(initialModel);
+
+    const handleModelChange = (model: string) => {
+        setSelectedModel(model);
+        setSearchParams((prev) => {
+            prev.set("model", model);
+            return prev;
+        });
+    };
     const [prompt, setPrompt] = useState("");
     const { apiKey, isLoggedIn, login } = useAuth();
     const {
@@ -103,7 +114,7 @@ function PlayPage() {
                 <ModelSelector
                     models={allModels}
                     selectedModel={selectedModel}
-                    onSelectModel={setSelectedModel}
+                    onSelectModel={handleModelChange}
                     allowedImageModelIds={allowedImageModelIds}
                     allowedTextModelIds={allowedTextModelIds}
                     allowedAudioModelIds={allowedAudioModelIds}


### PR DESCRIPTION
Combines two related Model dashboard improvements:

**Try in Play (#13903):**
- Adds a rocket icon button on each model card with 'Try in Play' tooltip
- Opens /play?model=<model-id> in a new tab
- Play page reads model from URL search params
- Works for all model types supported by Play

**Model Limits (#13905):**
- Shows context length when available (e.g. '128K context')
- Shows video duration range (e.g. '4-15s (default 5s)')
- Passes contextLength, minDuration, maxDuration, defaultDuration through catalog mapping
- Compact presentation, accessible on desktop and mobile

Fixes #13903, #13905