### PR TITLE
Promote main to production

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-card.tsx
@@ -6,6 +6,7 @@ import {
     Chip,
     ClipboardIcon,
     CopyButton,
+    currentPeriod,
     ExternalLinkIcon,
     GlobeIcon,
     IconButton,
@@ -17,6 +18,7 @@ import {
     XIcon,
 } from "@pollinations/ui";
 import { communityEndpointPriceFieldsForModality } from "@shared/community-endpoints.ts";
+import { Link } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 import { PriceBadge, type PriceBadgeConfig } from "../models/price-badge.tsx";
 import type { PriceKind } from "../models/types.ts";
@@ -172,6 +174,23 @@ export function CommunityEndpointCard({
                         value={<CommunityPriceBadges group={group} />}
                     />
                 ))}
+            </div>
+            <div className="mt-3">
+                <Link
+                    to="/activity"
+                    search={{
+                        ...currentPeriod(),
+                        earningsModels: [endpoint.modelId],
+                        usageMetric: undefined,
+                        usageKeys: undefined,
+                        usageModels: undefined,
+                        earningsMetric: undefined,
+                        earningsApps: undefined,
+                    }}
+                    className="inline-flex items-center gap-1.5 text-xs font-medium text-theme-text-muted underline underline-offset-2 transition-colors hover:text-theme-text-strong"
+                >
+                    View activity
+                </Link>
             </div>
         </Surface>
     );

--- a/enter.pollinations.ai/frontend/src/components/models/model-query.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-query.ts
@@ -16,6 +16,13 @@ export type ParsedModelQuery = {
 };
 
 const ACCESS_VALUES: readonly ModelAccess[] = ["paid", "quest", "free"];
+const FILTER_KEYS = [
+    "access",
+    "publisher",
+    "id",
+    "type",
+    "capability",
+] as const;
 
 const isModelAccess = (value: string): value is ModelAccess =>
     ACCESS_VALUES.includes(value as ModelAccess);
@@ -78,17 +85,70 @@ function getSearchableCapabilities(model: ModelPrice): string[] {
     );
 }
 
+function getModelPublisher(model: ModelPrice): string | null {
+    if (model.community) {
+        const separator = model.name.indexOf("/");
+        return separator > 0
+            ? model.name.slice(0, separator).toLowerCase()
+            : null;
+    }
+    return model.brand?.trim().toLowerCase().replace(/\s+/g, "-") ?? null;
+}
+
+function getFilterValues(key: string, models: ModelPrice[]): string[] {
+    switch (key) {
+        case "access":
+            return [...ACCESS_VALUES];
+        case "publisher":
+            return models
+                .map(getModelPublisher)
+                .filter((value): value is string => Boolean(value));
+        case "id":
+            return models.map((model) => model.name.toLowerCase());
+        case "type":
+            return models.map((model) => (model.agent ? "agent" : model.type));
+        case "capability":
+            return models
+                .flatMap(getSearchableCapabilities)
+                .map((value) => value.replaceAll("_", "-"));
+        default:
+            return [];
+    }
+}
+
+/** Complete the filter token currently being typed. */
+export function getModelQuerySuggestions(
+    query: string,
+    models: ModelPrice[],
+): string[] {
+    const tokenStart = query.lastIndexOf(" ") + 1;
+    const prefix = query.slice(0, tokenStart);
+    const token = query.slice(tokenStart).toLowerCase();
+    const separator = token.indexOf(":");
+
+    const suggestions =
+        separator === -1
+            ? FILTER_KEYS.filter((key) => key.startsWith(token)).map(
+                  (key) => `${key}:`,
+              )
+            : getFilterValues(token.slice(0, separator), models)
+                  .filter((value) =>
+                      value.startsWith(token.slice(separator + 1)),
+                  )
+                  .map((value) => `${token.slice(0, separator)}:${value} `);
+
+    return [...new Set(suggestions)]
+        .sort()
+        .slice(0, 20)
+        .map((suggestion) => `${prefix}${suggestion}`);
+}
+
 function matchesFilter(model: ModelPrice, filter: ModelQueryFilter): boolean {
     switch (filter.key) {
         case "access":
             return getModelAccess(model) === filter.value;
         case "publisher": {
-            if (!model.community) return false;
-            const separator = model.name.indexOf("/");
-            return (
-                separator > 0 &&
-                model.name.slice(0, separator).toLowerCase() === filter.value
-            );
+            return getModelPublisher(model) === filter.value;
         }
         case "id":
             return model.name.toLowerCase() === filter.value;

--- a/enter.pollinations.ai/frontend/src/components/models/models.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/models.tsx
@@ -7,10 +7,10 @@ import {
     ClockIcon,
     Dropdown,
     DropdownItem,
+    EditableCombobox,
     ExternalLinkButton,
     GitHubIcon,
     InlineLink,
-    Input,
     SearchIcon,
     Section,
     SparklesIcon,
@@ -34,7 +34,11 @@ import {
     fetchModelCatalog,
     getModelPricesFromCatalog,
 } from "./model-catalog.ts";
-import { matchesModelQuery, parseModelQuery } from "./model-query.ts";
+import {
+    getModelQuerySuggestions,
+    matchesModelQuery,
+    parseModelQuery,
+} from "./model-query.ts";
 import type { ModelScope, ModelSort } from "./model-search.ts";
 import { sortModels } from "./model-sort.ts";
 import {
@@ -176,6 +180,8 @@ export const Models: FC = () => {
     const activeSort = modelSearch.sort ?? "newest";
     const urlSearch = modelSearch.q ?? "";
     const [search, setSearch] = useState(urlSearch);
+    const [searchFocused, setSearchFocused] = useState(false);
+    const [searchOpen, setSearchOpen] = useState(false);
     const lastPushedSearchRef = useRef(urlSearch);
     const [catalogModels, setCatalogModels] = useState<ApiModelInfo[]>([]);
     const [catalogError, setCatalogError] = useState<string | null>(null);
@@ -203,6 +209,14 @@ export const Models: FC = () => {
                 : scopedModels,
         [parsedQuery, query, scopedModels],
     );
+    const searchOptions = useMemo(
+        () => getModelQuerySuggestions(search, scopedModels),
+        [search, scopedModels],
+    );
+
+    useEffect(() => {
+        setSearchOpen(searchFocused && searchOptions.length > 0);
+    }, [searchFocused, searchOptions]);
 
     const loadModelCatalog = useCallback(
         () =>
@@ -400,34 +414,29 @@ export const Models: FC = () => {
                             })}
                         </div>
                     </div>
-                    <div className="flex w-full flex-wrap items-start justify-between gap-2">
+                    <div className="flex w-full flex-wrap items-center justify-between gap-2">
                         <div className="min-w-0 max-w-md flex-1 basis-[240px]">
                             <div className="relative">
-                                <SearchIcon className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-theme-text-muted" />
-                                <Input
-                                    type="search"
+                                <SearchIcon className="pointer-events-none absolute left-3 top-1/2 z-10 h-4 w-4 -translate-y-1/2 text-theme-text-muted" />
+                                <EditableCombobox
                                     value={search}
-                                    onChange={(event) =>
-                                        setSearch(event.target.value)
-                                    }
+                                    options={searchOptions}
+                                    onChange={setSearch}
+                                    open={searchOpen}
+                                    onOpenChange={setSearchOpen}
+                                    onFocus={() => setSearchFocused(true)}
                                     onBlur={() => {
+                                        setSearchFocused(false);
                                         const normalizedSearch = search.trim();
                                         setSearch(normalizedSearch);
                                         pushSearch(normalizedSearch);
                                     }}
                                     placeholder={`Search ${searchTarget}…`}
                                     aria-label={`Search ${searchTarget}`}
-                                    aria-describedby="model-search-filter-help"
-                                    className="w-full pl-9"
+                                    autoComplete="off"
+                                    className="pl-9"
                                 />
                             </div>
-                            <p
-                                id="model-search-filter-help"
-                                className="mt-1 text-xs text-theme-text-muted"
-                            >
-                                Filters: access:, publisher:, id:, type:,
-                                capability:
-                            </p>
                         </div>
                         <Dropdown
                             align="end"

--- a/enter.pollinations.ai/test/model-query.test.ts
+++ b/enter.pollinations.ai/test/model-query.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+    getModelQuerySuggestions,
     matchesModelQuery,
     parseModelQuery,
 } from "../frontend/src/components/models/model-query.ts";
@@ -89,7 +90,7 @@ describe("matchesModelQuery", () => {
         expect(matches(model(overrides), query)).toBe(expected);
     });
 
-    it("matches an exact public publisher login for community models only", () => {
+    it("matches official publishers and public community owners", () => {
         const community = model({
             name: "PublicOwner/image-model",
             community: true,
@@ -99,11 +100,11 @@ describe("matchesModelQuery", () => {
         expect(matches(community, "publisher:publicowner")).toBe(true);
         expect(matches(community, "publisher:public")).toBe(false);
         expect(
-            matches(
-                model({ name: "PublicOwner/image-model" }),
-                "publisher:publicowner",
-            ),
-        ).toBe(false);
+            matches(model({ brand: "Moonshot AI" }), "publisher:moonshot-ai"),
+        ).toBe(true);
+        expect(matches(model({ brand: "NVIDIA" }), "publisher:nvidia")).toBe(
+            true,
+        );
     });
 
     it("matches an exact canonical ID case-insensitively", () => {
@@ -155,5 +156,50 @@ describe("matchesModelQuery", () => {
 
     it("matches an empty query", () => {
         expect(matches(model(), "   ")).toBe(true);
+    });
+});
+
+describe("getModelQuerySuggestions", () => {
+    const models = [
+        model({ name: "openai/gpt", type: "text", brand: "OpenAI" }),
+        model({
+            name: "Alice/quick-coder",
+            community: true,
+            agent: true,
+            capabilities: ["tool_calling"],
+        }),
+        model({ name: "bob/painter", community: true, type: "image" }),
+    ];
+
+    it("suggests filter names and their values", () => {
+        expect(getModelQuerySuggestions("", models)).toEqual([
+            "access:",
+            "capability:",
+            "id:",
+            "publisher:",
+            "type:",
+        ]);
+        expect(getModelQuerySuggestions("access:", models)).toEqual([
+            "access:free ",
+            "access:paid ",
+            "access:quest ",
+        ]);
+        expect(getModelQuerySuggestions("publisher:a", models)).toEqual([
+            "publisher:alice ",
+        ]);
+        expect(getModelQuerySuggestions("publisher:o", models)).toEqual([
+            "publisher:openai ",
+        ]);
+    });
+
+    it("completes only the current token", () => {
+        expect(getModelQuerySuggestions("fast capability:t", models)).toEqual([
+            "fast capability:tool-calling ",
+        ]);
+        expect(getModelQuerySuggestions("type:", models)).toEqual([
+            "type:agent ",
+            "type:image ",
+            "type:text ",
+        ]);
     });
 });

--- a/packages/ui/src/compositions/EditableCombobox.tsx
+++ b/packages/ui/src/compositions/EditableCombobox.tsx
@@ -53,6 +53,7 @@ export function EditableCombobox({
         <Combobox.Root
             collection={collection}
             inputValue={value}
+            value={[]}
             allowCustomValue
             openOnClick={hasOptions}
             openOnChange={() => hasOptions}


### PR DESCRIPTION
- Adds a direct earnings activity link to each My Models card
- Restores GitHub-style model filter autocomplete
- Fixes selected filters disappearing and official publisher filtering

Promotion only; no secrets, database migrations, or Tinybird changes.