### PR TITLE
[QUEST] Show model limits in the Models dashboard

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/model-catalog.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-catalog.ts
@@ -57,6 +57,9 @@ export type ApiModelInfo = {
     tools?: boolean;
     reasoning?: boolean;
     context_length?: number;
+    min_duration?: number;
+    max_duration?: number;
+    default_duration?: number;
     voices?: string[];
     is_specialized?: boolean;
     paid_only?: boolean;
@@ -267,6 +270,10 @@ function baseModelPrice(model: ApiModelInfo): ModelPrice | null {
         outputSortPrice,
         prices: [],
         priceAdjustments: model.pricing_adjustments,
+        contextLength: model.context_length,
+        minDuration: model.min_duration,
+        maxDuration: model.max_duration,
+        defaultDuration: model.default_duration,
     };
 }
 

--- a/enter.pollinations.ai/frontend/src/components/models/model-info.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-info.ts
@@ -155,3 +155,39 @@ export const isPaidOnly = (model: ModelPrice): boolean =>
  * Check if a model is marked as alpha (experimental, potentially unstable)
  */
 export const isAlpha = (model: ModelPrice): boolean => model.alpha === true;
+
+/**
+ * Format a context-window size compactly: 128000 -> "128K", 1000000 -> "1M".
+ * @param tokens - context length in tokens.
+ * @returns compact label, or undefined for an absent/invalid value.
+ */
+export const formatContextLength = (tokens: number | undefined): string | undefined => {
+    if (tokens === undefined || !Number.isFinite(tokens) || tokens <= 0) return undefined;
+    if (tokens >= 1_000_000) {
+        const m = tokens / 1_000_000;
+        return `${Number.isInteger(m) ? m : m.toFixed(1)}M`;
+    }
+    if (tokens >= 1_000) {
+        const k = tokens / 1_000;
+        return `${Number.isInteger(k) ? k : k.toFixed(1)}K`;
+    }
+    return String(tokens);
+};
+
+/**
+ * Resolve the supported duration range or fixed duration for video models.
+ * @param model - model price entry with optional duration metadata.
+ * @returns compact label like "2s–30s" or "5s", or undefined when no metadata exists.
+ */
+export const getModelDurationLabel = (model: ModelPrice): string | undefined => {
+    const { minDuration, maxDuration, defaultDuration } = model;
+    if (minDuration !== undefined && maxDuration !== undefined) {
+        return minDuration === maxDuration
+            ? `${minDuration}s`
+            : `${minDuration}s–${maxDuration}s`;
+    }
+    if (defaultDuration !== undefined) return `${defaultDuration}s`;
+    if (minDuration !== undefined) return `${minDuration}s+`;
+    if (maxDuration !== undefined) return `≤${maxDuration}s`;
+    return undefined;
+};

--- a/enter.pollinations.ai/frontend/src/components/models/model-info.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-info.ts
@@ -161,8 +161,11 @@ export const isAlpha = (model: ModelPrice): boolean => model.alpha === true;
  * @param tokens - context length in tokens.
  * @returns compact label, or undefined for an absent/invalid value.
  */
-export const formatContextLength = (tokens: number | undefined): string | undefined => {
-    if (tokens === undefined || !Number.isFinite(tokens) || tokens <= 0) return undefined;
+export const formatContextLength = (
+    tokens: number | undefined,
+): string | undefined => {
+    if (tokens === undefined || !Number.isFinite(tokens) || tokens <= 0)
+        return undefined;
     if (tokens >= 1_000_000) {
         const m = tokens / 1_000_000;
         return `${Number.isInteger(m) ? m : m.toFixed(1)}M`;
@@ -179,7 +182,9 @@ export const formatContextLength = (tokens: number | undefined): string | undefi
  * @param model - model price entry with optional duration metadata.
  * @returns compact label like "2s–30s" or "5s", or undefined when no metadata exists.
  */
-export const getModelDurationLabel = (model: ModelPrice): string | undefined => {
+export const getModelDurationLabel = (
+    model: ModelPrice,
+): string | undefined => {
     const { minDuration, maxDuration, defaultDuration } = model;
     if (minDuration !== undefined && maxDuration !== undefined) {
         return minDuration === maxDuration

--- a/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
@@ -15,15 +15,15 @@ import {
     MODALITY_ICON,
 } from "./model-icons.tsx";
 import {
+    formatContextLength,
     getModelBrandLogoPath,
     getModelCapabilities,
     getModelCapabilityLabel,
     getModelDescriptionWithoutName,
     getModelDisplayName,
+    getModelDurationLabel,
     getModelInputModalities,
     getModelModalityLabel,
-    formatContextLength,
-    getModelDurationLabel,
     hasPollinationsTools,
     isAlpha,
     isNewModel,

--- a/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
@@ -22,6 +22,8 @@ import {
     getModelDisplayName,
     getModelInputModalities,
     getModelModalityLabel,
+    formatContextLength,
+    getModelDurationLabel,
     hasPollinationsTools,
     isAlpha,
     isNewModel,
@@ -184,6 +186,62 @@ export function getModelTitleTooltipContent(model: ModelPrice): ReactNode {
         </span>
     );
 }
+
+/**
+ * Compact model-limit chips: context window for text-capable models and
+ * supported duration for video models. Renders nothing when no limit metadata
+ * is available, keeping the row uncluttered.
+ */
+export const ModelLimitsChips: FC<{ model: ModelPrice }> = ({ model }) => {
+    const contextLabel = formatContextLength(model.contextLength);
+    const durationLabel = getModelDurationLabel(model);
+    if (!contextLabel && !durationLabel) return null;
+
+    return (
+        <span className="inline-flex shrink-0 items-center gap-1.5">
+            {contextLabel && (
+                <Tooltip
+                    triggerAs="span"
+                    content={
+                        <span>
+                            <strong className="font-semibold text-theme-text-strong">
+                                Context window
+                            </strong>{" "}
+                            — {contextLabel} tokens
+                        </span>
+                    }
+                    ariaLabel={`Context window ${contextLabel}`}
+                    tapEnabled
+                    displayContents
+                >
+                    <Chip intent="neutral" size="sm" className="tabular-nums">
+                        {contextLabel}
+                    </Chip>
+                </Tooltip>
+            )}
+            {durationLabel && (
+                <Tooltip
+                    triggerAs="span"
+                    content={
+                        <span>
+                            <strong className="font-semibold text-theme-text-strong">
+                                Supported duration
+                            </strong>{" "}
+                            — {durationLabel}
+                        </span>
+                    }
+                    ariaLabel={`Supported duration ${durationLabel}`}
+                    tapEnabled
+                    displayContents
+                >
+                    <Chip intent="neutral" size="sm" className="tabular-nums">
+                        {durationLabel}
+                    </Chip>
+                </Tooltip>
+            )}
+        </span>
+    );
+};
 
 export const ModelRow: FC<ModelRowProps> = ({ model }) => {
     const modelDisplayName = getModelDisplayName(model);
@@ -365,6 +423,7 @@ export const ModelRow: FC<ModelRowProps> = ({ model }) => {
                                     model={model}
                                     pricing={pricing}
                                 />
+                                <ModelLimitsChips model={model} />
                             </div>
                         )}
                         {model.perUserRpm != null && (

--- a/enter.pollinations.ai/frontend/src/components/models/types.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/types.ts
@@ -91,4 +91,9 @@ export type ModelPrice = {
     priceAdjustments?: ModelPriceAdjustment[];
     // Real usage data from Tinybird (rolling 7-day average)
     realAvgCost?: number;
+    // Model limits surfaced from the registry /models response.
+    contextLength?: number;
+    minDuration?: number;
+    maxDuration?: number;
+    defaultDuration?: number;
 };


### PR DESCRIPTION
Closes #13905

## What
Surface important model limits in the Models dashboard without making it feel more crowded.

## Changes
- **Context window**: shows a compact label (e.g. `128K`, `1M`) when `context_length` is present.
- **Video duration**: shows the supported range or fixed duration (e.g. `2s–30s`, `5s`) using the existing `min_duration` / `max_duration` / `default_duration` metadata.
- **Mapping**: the fields flow through the existing catalog-to-dashboard mapping (`ApiModelInfo` → `ModelPrice`).
- **Presentation**: two small neutral chips with tooltips, rendered only when metadata exists — nothing new when a model has no limits, so rows stay compact on desktop and mobile.

## Files
- `enter.pollinations.ai/frontend/src/components/models/types.ts` — `ModelPrice` limit fields
- `enter.pollinations.ai/frontend/src/components/models/model-catalog.ts` — API mapping passthrough
- `enter.pollinations.ai/frontend/src/components/models/model-info.ts` — formatting helpers
- `enter.pollinations.ai/frontend/src/components/models/model-row.tsx` — `ModelLimitsChips` component

## Scope
No API, registry values, pricing, sorting, filtering, or separate model-details view were changed.