### PR TITLE
[QUEST] Open a model directly in Play

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-row.tsx
@@ -4,9 +4,11 @@ import {
     ClipboardIcon,
     CopyButton,
     cn,
+    RocketIcon,
     Surface,
     Tooltip,
 } from "@pollinations/ui";
+import { PUBLIC_URLS } from "@shared/public-urls.ts";
 import type { FC, ReactNode } from "react";
 import { calculatePerPollen } from "./calculations.ts";
 import {
@@ -185,6 +187,40 @@ export function getModelTitleTooltipContent(model: ModelPrice): ReactNode {
     );
 }
 
+/**
+ * Compact "Try in Play" action: opens the Play page with this model preselected.
+ * Rendered as a small icon link with a tooltip and accessible label.
+ */
+export const TryInPlayLink: FC<{ modelId: string }> = ({ modelId }) => {
+    const playUrl = `${PUBLIC_URLS.root}/play?model=${encodeURIComponent(modelId)}`;
+    return (
+        <Tooltip
+            triggerAs="span"
+            content={
+                <span>
+                    <strong className="font-semibold text-theme-text-strong">
+                        Try in Play
+                    </strong>{" "}
+                    — open this model in the Play page
+                </span>
+            }
+            ariaLabel="Try in Play"
+            tapEnabled
+            displayContents
+        >
+            <a
+                href={playUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={`Try ${modelId} in Play`}
+                className="inline-flex shrink-0 items-center justify-center rounded p-1 text-theme-text-muted transition-colors hover:bg-theme-bg-hover hover:text-theme-text-strong"
+            >
+                <RocketIcon className="h-4 w-4" />
+            </a>
+        </Tooltip>
+    );
+};
+
 export const ModelRow: FC<ModelRowProps> = ({ model }) => {
     const modelDisplayName = getModelDisplayName(model);
     const brandLogoPath = getModelBrandLogoPath(model);
@@ -275,7 +311,10 @@ export const ModelRow: FC<ModelRowProps> = ({ model }) => {
                             </span>
                         )}
                     </div>
-                    <ModelId name={model.name} />
+                    <div className="flex min-w-0 items-center gap-2">
+                        <ModelId name={model.name} />
+                        <TryInPlayLink modelId={model.name} />
+                    </div>
                     {model.brandUrl && model.brand && (
                         <a
                             href={model.brandUrl}

--- a/pollinations.ai/src/ui/pages/PlayPage.tsx
+++ b/pollinations.ai/src/ui/pages/PlayPage.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { PLAY_PAGE } from "../../copy/content/play";
 import { LINKS } from "../../copy/content/socialLinks";
 import { useAuth } from "../../hooks/useAuth";
@@ -14,6 +15,7 @@ import { PageContainer } from "../components/ui/page-container";
 import { Body, Title } from "../components/ui/typography";
 
 function PlayPage() {
+    const [searchParams] = useSearchParams();
     const [selectedModel, setSelectedModel] = useState("flux");
     const [prompt, setPrompt] = useState("");
     const { apiKey, isLoggedIn, login } = useAuth();
@@ -49,6 +51,18 @@ function PlayPage() {
                 (typeOrder[effectiveType(b)] ?? 99),
         );
     }, [registryModels]);
+
+    // Preselect the model named by ?model=<id> once the catalog has loaded.
+    // Only apply when the requested id is actually supported by Play, so an
+    // unknown or mistyped id falls back to the default without clobbering a
+    // user's in-page selection.
+    const modelFromUrl = searchParams.get("model");
+    useEffect(() => {
+        if (modelFromUrl && !isLoadingModels) {
+            const supported = allModels.some((m) => m.id === modelFromUrl);
+            if (supported) setSelectedModel(modelFromUrl);
+        }
+    }, [modelFromUrl, isLoadingModels, allModels]);
 
     const currentModel = allModels.find((m) => m.id === selectedModel);
     const isVideoModel = !!currentModel?.hasVideoOutput;


### PR DESCRIPTION
Closes #13903

## What
Let users open any supported model from the model catalog and try it immediately in the existing Play page.

## Changes
- **Model cards** (enter dashboard): each row gets a compact rocket-icon action with a "Try in Play" tooltip and accessible label (`Try in Play`).
- **Link target**: the action opens `{PUBLIC_URLS.root}/play?model=<model-id>` (public site Play page).
- **Play page**: reads `?model=<id>` and preselects that model once the catalog has loaded — only when the id is actually supported by Play, so unknown/mistyped ids fall back to the default and a user in-page selection is never clobbered.
- **Model category**: image/video/audio/text behavior is derived from the selected model as before, so placeholders and styling follow the preselected model automatically.

## Files
- `enter.pollinations.ai/frontend/src/components/models/model-row.tsx` — `TryInPlayLink` icon action on each model card
- `pollinations.ai/src/ui/pages/PlayPage.tsx` — URL param preselection

## Scope
No new playground, no backend changes, no broader Play redesign. Minimal diff: 2 files, ~55 insertions.