### PR TITLE
[QUEST] Publish concise community-model naming guidance

### DIFF
--- a/BRING_YOUR_OWN_MODEL.md
+++ b/BRING_YOUR_OWN_MODEL.md
@@ -2,6 +2,8 @@
 
 Publishing a model lets you connect an OpenAI-compatible endpoint to Pollinations and call it through `gen.pollinations.ai` under an `owner/model` id. Pollinations handles authentication, Pollen billing, model discovery, and routing; the model continues to run on infrastructure you control.
 
+Before choosing a model ID, title, and description, read the [community model naming guidance](./COMMUNITY_MODEL_NAMING.md) — it helps you pick a stable ID and a clear public name.
+
 Model publishing and [connecting user wallets](./BRING_YOUR_OWN_POLLEN.md) solve different problems. Model publishing supplies a model to the Pollinations catalog. The wallet flow lets users authorize an app to spend their own Pollen. An app can use either or both.
 
 ## Supported Models

--- a/COMMUNITY_MODEL_NAMING.md
+++ b/COMMUNITY_MODEL_NAMING.md
@@ -1,0 +1,88 @@
+# Community Model Naming
+
+A short guide for publishing community models with stable model IDs and clear public names. First-party models follow a stricter canonical scheme ([`MODEL_SLUGS.md`](./MODEL_SLUGS.md)); community models do not need to. Use the guidance here instead.
+
+## The three fields
+
+Every published model has three public-facing names, each with a different job:
+
+| Field | Role | Example |
+| --- | --- | --- |
+| **Model ID** | Stable identifier used in API calls (`owner/model-id`). Never changes once users depend on it. | `alice/fast-llama` |
+| **Title** | Short display name shown in the Models list. Human-friendly, can be a brand or nickname. | `Fast Llama` |
+| **Description** | One line that says what the model actually is, what it routes to, or what it is good at. | `Qwen-style 8B fine-tune for chat, routed to acme-gateway` |
+
+The ID is the contract; the title is the face; the description is the honesty.
+
+## Choosing a stable model ID
+
+Keep the ID stable. Users write it into code, configs, and integrations, so changing it breaks them.
+
+IDs should avoid **mutable details**:
+
+- **Pricing** — a price change would force an ID rename.
+- **Provider routing** — the upstream provider may change without the model changing.
+- **Context size** — context windows grow over time.
+- **Version churn** — avoid `-v1`, `-v2`, `-final`, `-new` in the ID unless the version is genuinely part of the model identity.
+
+Prefer short, lowercase, hyphen-separated names that describe the model itself.
+
+| Avoid | Prefer | Why |
+| --- | --- | --- |
+| `alice/cheap-llama` | `alice/fast-llama` | Price is mutable; speed is the model's character |
+| `alice/llama-openrouter` | `alice/llama-chat` | The router can change; the purpose should not |
+| `alice/qwen-128k` | `alice/qwen-chat` | Context size may grow |
+| `alice/my-model-final-v2` | `alice/assistant` | Version churn in an ID is a trap |
+
+## Clear titles and honest descriptions
+
+Custom names are welcome. The title can be a brand, a pun, or anything memorable — the description is where the model is explained.
+
+The description should make it clear what the model is or what it routes to:
+
+- **Direct upstream model**: `DeepSeek-V3 served from our own cluster`
+- **Custom model**: `Our LoRA fine-tune of Llama-3.3 for medical Q&A`
+- **Router**: `Routes between gpt-5-mini and claude-opus based on prompt length`
+- **Rebranded model**: `Whisper-large-v3, rebranded as "Echo" for our API`
+
+If a title is a brand or nickname that does not obviously describe the model, the description must say what the model actually is.
+
+## Examples by model kind
+
+**Direct upstream model**
+
+```text
+Model ID:     alice/mistral-7b
+Title:        Mistral 7B
+Description:  Mistral-7B-instruct served directly from our endpoint
+```
+
+**Custom model**
+
+```text
+Model ID:     alice/summarizer
+Title:        DocSum
+Description:  Fine-tune of Qwen-2.5-14B for long-document summarization
+```
+
+**Router**
+
+```text
+Model ID:     alice/chat-router
+Title:        Smart Chat
+Description:  Routes to gpt-5.1 for short prompts and claude-opus for long ones
+```
+
+**Rebranded model**
+
+```text
+Model ID:     alice/echo-tts
+Title:        Echo
+Description:  ElevenLabs multi-speaker TTS under our brand
+```
+
+## Summary
+
+- The model ID is stable; the title is short; the description is transparent.
+- Do not bake pricing, routing, or context size into the ID.
+- Custom and rebranded names are fine as long as the description says what the model is.

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/model-listing-fields.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/model-listing-fields.tsx
@@ -2,6 +2,7 @@ import {
     ButtonGroup,
     CheckIcon,
     FieldStack,
+    InlineLink,
     Input,
     TabButton,
 } from "@pollinations/ui";
@@ -114,9 +115,17 @@ export function ModelListingFields({
                 <FieldStack
                     label={isAgent ? "ID" : "Model ID"}
                     helper={
-                        isAgent
-                            ? "Public ID: {username}/{id}."
-                            : "Public ID: {username}/{model-id}."
+                        <>
+                            {isAgent
+                                ? "Public ID: {username}/{id}."
+                                : "Public ID: {username}/{model-id}."}{" "}
+                            <InlineLink
+                                href="https://github.com/pollinations/pollinations/blob/main/COMMUNITY_MODEL_NAMING.md"
+                                showIcon={false}
+                            >
+                                naming guidance
+                            </InlineLink>
+                        </>
                     }
                     alignLabelRow
                 >


### PR DESCRIPTION
Closes #12885

## What
Adds a concise Markdown guide for community-model naming, linked from the Add model form and the existing model-publishing documentation.

## Changes
- **`COMMUNITY_MODEL_NAMING.md`** (new): explains the roles of the stable model ID, short display title, and transparent description; covers direct upstream models, custom models, routers, and rebranded models with examples; advises against mutable details in IDs (pricing, provider routing, context size).
- **`BRING_YOUR_OWN_MODEL.md`**: links the guide near the top of the publishing doc.
- **`model-listing-fields.tsx`**: adds a "naming guidance" link in the helper text of the Model ID field in the Add model form.

## Scope
No schema enforcement, dashboard warnings, aliases, migrations, automatic renaming, compatibility layers, or changes to existing model IDs.