### PR TITLE
feat: add compact Quest leaderboard to Community

### DIFF
--- a/enter.pollinations.ai/src/routes/quests.ts
+++ b/enter.pollinations.ai/src/routes/quests.ts
@@ -409,8 +409,7 @@ async function buildQuestLeaderboard(
         totals: {
             contributors: contributors.length,
             completedQuests: contributors.reduce(
-                (total, contributor) =>
-                    total + contributor.completedQuests,
+                (total, contributor) => total + contributor.completedQuests,
                 0,
             ),
             totalPollen: roundPollenLedgerAmount(

--- a/enter.pollinations.ai/src/routes/quests.ts
+++ b/enter.pollinations.ai/src/routes/quests.ts
@@ -1,7 +1,8 @@
+import { roundPollenLedgerAmount } from "@shared/billing/precision.ts";
 import { claimReward } from "@shared/billing/rewards.ts";
 import * as schema from "@shared/db/better-auth.ts";
 import { rewards as rewardsTable } from "@shared/db/better-auth.ts";
-import { desc, eq } from "drizzle-orm";
+import { and, desc, eq, isNotNull, like, sql } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
@@ -22,6 +23,9 @@ import { requireAccountPermission } from "./account-permissions.ts";
 const CACHE_KEY = "quests:catalog:v29";
 const CACHE_TTL = 60;
 const QUEST_CHECK_THROTTLE_SECONDS = 60;
+const LEADERBOARD_CACHE_KEY = "quests:leaderboard:v1";
+const LEADERBOARD_CACHE_TTL = 60;
+const LEADERBOARD_SIZE = 10;
 
 export type QuestCatalogResponse = {
     quests: QuestCard[];
@@ -47,6 +51,25 @@ const questCatalogItemSchema = z.object({
 const questCatalogResponseSchema = z.object({
     quests: z.array(questCatalogItemSchema),
 });
+
+const leaderboardEntrySchema = z.object({
+    githubUsername: z.string(),
+    completedQuests: z.number().int().nonnegative(),
+    totalPollen: z.number().nonnegative(),
+});
+
+const questLeaderboardResponseSchema = z.object({
+    leaderboard: z.array(leaderboardEntrySchema),
+    totals: z.object({
+        contributors: z.number().int().nonnegative(),
+        completedQuests: z.number().int().nonnegative(),
+        totalPollen: z.number().nonnegative(),
+    }),
+});
+
+export type QuestLeaderboardResponse = z.infer<
+    typeof questLeaderboardResponseSchema
+>;
 
 const rewardSchema = z.object({
     id: z.string(),
@@ -118,6 +141,41 @@ export const questsRoutes = new Hono<Env>()
                 expirationTtl: CACHE_TTL,
             });
             return c.json(catalog);
+        },
+    )
+    .get(
+        "/leaderboard",
+        describeRoute({
+            tags: ["✨ Quests"],
+            summary: "Get Quest Leaderboard",
+            security: [],
+            description:
+                "Returns a public aggregate of contributors who earned Pollen from completed GitHub POLLEN-QUEST issues.",
+            responses: {
+                200: {
+                    description: "Quest leaderboard",
+                    content: {
+                        "application/json": {
+                            schema: resolver(questLeaderboardResponseSchema),
+                        },
+                    },
+                },
+            },
+        }),
+        async (c) => {
+            const cached = await c.env.KV.get<QuestLeaderboardResponse>(
+                LEADERBOARD_CACHE_KEY,
+                "json",
+            );
+            if (cached) return c.json(cached);
+
+            const leaderboard = await buildQuestLeaderboard(c.env);
+            await c.env.KV.put(
+                LEADERBOARD_CACHE_KEY,
+                JSON.stringify(leaderboard),
+                { expirationTtl: LEADERBOARD_CACHE_TTL },
+            );
+            return c.json(leaderboard);
         },
     )
     .post(
@@ -303,6 +361,66 @@ async function readCached(
     kv: KVNamespace,
 ): Promise<QuestCatalogResponse | null> {
     return await kv.get<QuestCatalogResponse>(CACHE_KEY, "json");
+}
+
+async function buildQuestLeaderboard(
+    env: CloudflareBindings,
+): Promise<QuestLeaderboardResponse> {
+    const db = drizzle(env.DB, { schema });
+    const githubUsername = sql<string>`lower(${schema.user.githubUsername})`;
+    const rows = await db
+        .select({
+            githubUsername,
+            completedQuests:
+                sql<number>`count(distinct ${rewardsTable.questId})`.mapWith(
+                    Number,
+                ),
+            totalPollen:
+                sql<number>`coalesce(sum(${rewardsTable.pollenAmount}), 0)`.mapWith(
+                    Number,
+                ),
+        })
+        .from(rewardsTable)
+        .innerJoin(schema.user, eq(rewardsTable.userId, schema.user.id))
+        .where(
+            and(
+                like(rewardsTable.questId, "github:issue:%"),
+                isNotNull(schema.user.githubUsername),
+            ),
+        )
+        .groupBy(githubUsername);
+
+    const contributors = rows
+        .filter((row) => row.githubUsername)
+        .map((row) => ({
+            githubUsername: row.githubUsername,
+            completedQuests: row.completedQuests,
+            totalPollen: roundPollenLedgerAmount(row.totalPollen),
+        }))
+        .sort(
+            (a, b) =>
+                b.totalPollen - a.totalPollen ||
+                b.completedQuests - a.completedQuests ||
+                a.githubUsername.localeCompare(b.githubUsername),
+        );
+
+    return {
+        leaderboard: contributors.slice(0, LEADERBOARD_SIZE),
+        totals: {
+            contributors: contributors.length,
+            completedQuests: contributors.reduce(
+                (total, contributor) =>
+                    total + contributor.completedQuests,
+                0,
+            ),
+            totalPollen: roundPollenLedgerAmount(
+                contributors.reduce(
+                    (total, contributor) => total + contributor.totalPollen,
+                    0,
+                ),
+            ),
+        },
+    };
 }
 
 async function buildQuestCatalog(

--- a/enter.pollinations.ai/test/quest-leaderboard.test.ts
+++ b/enter.pollinations.ai/test/quest-leaderboard.test.ts
@@ -1,0 +1,148 @@
+import { env, SELF } from "cloudflare:test";
+import * as schema from "@shared/db/better-auth.ts";
+import { drizzle } from "drizzle-orm/d1";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { expect } from "vitest";
+import { COMMUNITY_PAGE } from "../../pollinations.ai/src/copy/content/community";
+import {
+    QuestLeaderboardContent,
+    type QuestLeaderboardData,
+} from "../../pollinations.ai/src/ui/components/QuestLeaderboard";
+import { test } from "./fixtures.ts";
+
+const CACHE_KEY = "quests:leaderboard:v1";
+
+test("quest leaderboard aggregates only public GitHub issue rewards", async () => {
+    const db = drizzle(env.DB, { schema });
+    await env.KV.delete(CACHE_KEY);
+
+    await db.insert(schema.user).values([
+        {
+            id: "quest-board-alice",
+            name: "Alice",
+            email: "quest-board-alice@example.com",
+            githubId: 81_001,
+            githubUsername: "Alice",
+        },
+        {
+            id: "quest-board-alice-alias",
+            name: "Alice alias",
+            email: "quest-board-alice-alias@example.com",
+            githubId: 81_002,
+            githubUsername: "alice",
+        },
+        {
+            id: "quest-board-bob",
+            name: "Bob",
+            email: "quest-board-bob@example.com",
+            githubId: 81_003,
+            githubUsername: "bob",
+        },
+        {
+            id: "quest-board-private",
+            name: "Private",
+            email: "quest-board-private@example.com",
+            githubId: 81_004,
+            githubUsername: null,
+        },
+    ]);
+
+    await db.insert(schema.rewards).values([
+        {
+            id: "quest-board-alice-a",
+            idempotencyKey: "quest:github:issue:81001",
+            userId: "quest-board-alice",
+            questId: "github:issue:81001",
+            title: "Alice quest A",
+            pollenAmount: 0.1,
+            balanceBucket: "tier",
+        },
+        {
+            id: "quest-board-alice-b",
+            idempotencyKey: "quest:github:issue:81002",
+            userId: "quest-board-alice-alias",
+            questId: "github:issue:81002",
+            title: "Alice quest B",
+            pollenAmount: 0.2,
+            balanceBucket: "tier",
+        },
+        {
+            id: "quest-board-bob",
+            idempotencyKey: "quest:github:issue:81003",
+            userId: "quest-board-bob",
+            questId: "github:issue:81003",
+            title: "Bob quest",
+            pollenAmount: 1,
+            balanceBucket: "tier",
+        },
+        {
+            id: "quest-board-product",
+            idempotencyKey: "quest:first_top_up:quest-board-bob",
+            userId: "quest-board-bob",
+            questId: "first_top_up",
+            title: "Product quest",
+            pollenAmount: 100,
+            balanceBucket: "tier",
+        },
+        {
+            id: "quest-board-private-reward",
+            idempotencyKey: "quest:github:issue:81004",
+            userId: "quest-board-private",
+            questId: "github:issue:81004",
+            title: "Private quest",
+            pollenAmount: 99,
+            balanceBucket: "tier",
+        },
+    ]);
+
+    const response = await SELF.fetch(
+        "http://localhost:3000/api/quests/leaderboard",
+    );
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+        leaderboard: [
+            { githubUsername: "bob", completedQuests: 1, totalPollen: 1 },
+            {
+                githubUsername: "alice",
+                completedQuests: 2,
+                totalPollen: 0.3,
+            },
+        ],
+        totals: {
+            contributors: 2,
+            completedQuests: 3,
+            totalPollen: 1.3,
+        },
+    });
+});
+
+test("quest leaderboard renders GitHub identity, totals, and quest CTA", () => {
+    const data: QuestLeaderboardData = {
+        leaderboard: [
+            { githubUsername: "alice", completedQuests: 2, totalPollen: 7 },
+            { githubUsername: "bob", completedQuests: 1, totalPollen: 5 },
+        ],
+        totals: {
+            contributors: 2,
+            completedQuests: 3,
+            totalPollen: 12,
+        },
+    };
+
+    const html = renderToStaticMarkup(
+        createElement(QuestLeaderboardContent, {
+            data,
+            copy: COMMUNITY_PAGE,
+        }),
+    );
+
+    expect(html).toContain("Quest leaderboard");
+    expect(html).toContain("@alice");
+    expect(html).toContain("2 quests");
+    expect(html).toContain("7 Pollen");
+    expect(html).toContain("2</strong> builders");
+    expect(html).toContain("3</strong> completed");
+    expect(html).toContain('href="https://github.com/alice"');
+    expect(html).toContain('href="https://enter.pollinations.ai/quests"');
+});

--- a/pollinations.ai/src/copy/content/community.ts
+++ b/pollinations.ai/src/copy/content/community.ts
@@ -85,6 +85,17 @@ export const COMMUNITY_PAGE = {
         },
     ],
 
+    // Quest leaderboard
+    questLeaderboardTitle: "Quest leaderboard",
+    questLeaderboardDescription:
+        "Builders completing public GitHub POLLEN-QUEST issues.",
+    questLeaderboardCta: "Join the quests",
+    questLeaderboardQuestLabel: "quest",
+    questLeaderboardQuestsLabel: "quests",
+    questLeaderboardPollenLabel: "Pollen",
+    questLeaderboardBuildersLabel: "builders",
+    questLeaderboardCompletedLabel: "completed",
+
     // Top Contributors
     topContributorsTitle: "Most active contributors",
     topContributorsDescription:

--- a/pollinations.ai/src/ui/components/QuestLeaderboard.tsx
+++ b/pollinations.ai/src/ui/components/QuestLeaderboard.tsx
@@ -2,8 +2,6 @@ import { useEffect, useState } from "react";
 import { COMMUNITY_PAGE } from "../../copy/content/community";
 import { LINKS } from "../../copy/content/socialLinks";
 import { usePageCopy } from "../../hooks/usePageCopy";
-import { Divider } from "./ui/divider";
-import { Body, Heading } from "./ui/typography";
 
 export type QuestLeaderboardEntry = {
     githubUsername: string;
@@ -37,16 +35,15 @@ export function QuestLeaderboardContent({
             >
                 <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
                     <div>
-                        <Heading
+                        <h2
                             id="quest-leaderboard-heading"
-                            variant="section"
-                            spacing="tight"
+                            className="mb-2 border-l-4 border-dark pl-4 font-headline text-2xl font-black uppercase tracking-widest text-dark md:text-3xl"
                         >
                             {copy.questLeaderboardTitle}
-                        </Heading>
-                        <Body size="sm" spacing="none">
+                        </h2>
+                        <p className="font-body text-sm leading-relaxed text-dark">
                             {copy.questLeaderboardDescription}
-                        </Body>
+                        </p>
                     </div>
                     <a
                         href={`${LINKS.enter}/quests`}
@@ -105,7 +102,7 @@ export function QuestLeaderboardContent({
                     ))}
                 </ol>
             </section>
-            <Divider />
+            <hr className="my-12 border-t-2 border-white" />
         </>
     );
 }

--- a/pollinations.ai/src/ui/components/QuestLeaderboard.tsx
+++ b/pollinations.ai/src/ui/components/QuestLeaderboard.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useState } from "react";
+import { COMMUNITY_PAGE } from "../../copy/content/community";
+import { LINKS } from "../../copy/content/socialLinks";
+import { usePageCopy } from "../../hooks/usePageCopy";
+import { Divider } from "./ui/divider";
+import { Body, Heading } from "./ui/typography";
+
+export type QuestLeaderboardEntry = {
+    githubUsername: string;
+    completedQuests: number;
+    totalPollen: number;
+};
+
+export type QuestLeaderboardData = {
+    leaderboard: QuestLeaderboardEntry[];
+    totals: {
+        contributors: number;
+        completedQuests: number;
+        totalPollen: number;
+    };
+};
+
+const LEADERBOARD_API = "https://enter.pollinations.ai/api/quests/leaderboard";
+
+export function QuestLeaderboardContent({
+    data,
+    copy,
+}: {
+    data: QuestLeaderboardData;
+    copy: typeof COMMUNITY_PAGE;
+}) {
+    return (
+        <>
+            <section
+                className="mb-12"
+                aria-labelledby="quest-leaderboard-heading"
+            >
+                <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+                    <div>
+                        <Heading
+                            id="quest-leaderboard-heading"
+                            variant="section"
+                            spacing="tight"
+                        >
+                            {copy.questLeaderboardTitle}
+                        </Heading>
+                        <Body size="sm" spacing="none">
+                            {copy.questLeaderboardDescription}
+                        </Body>
+                    </div>
+                    <a
+                        href={`${LINKS.enter}/quests`}
+                        className="w-fit bg-accent-strong px-2 py-1 font-headline text-xs font-black text-dark hover:underline"
+                    >
+                        {copy.questLeaderboardCta}
+                    </a>
+                </div>
+
+                <div className="mb-4 font-body text-xs text-subtle">
+                    <strong className="text-dark">
+                        {data.totals.contributors}
+                    </strong>{" "}
+                    {copy.questLeaderboardBuildersLabel}
+                    <span className="mx-2">·</span>
+                    <strong className="text-dark">
+                        {data.totals.completedQuests}
+                    </strong>{" "}
+                    {copy.questLeaderboardCompletedLabel}
+                    <span className="mx-2">·</span>
+                    <strong className="text-dark">
+                        {data.totals.totalPollen}
+                    </strong>{" "}
+                    {copy.questLeaderboardPollenLabel}
+                </div>
+
+                <ol className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                    {data.leaderboard.map((entry, index) => (
+                        <li key={entry.githubUsername}>
+                            <a
+                                href={`https://github.com/${encodeURIComponent(entry.githubUsername)}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="flex items-center gap-3 rounded-sub-card border border-border-subtle bg-white/60 px-3 py-3 transition hover:translate-x-[1px] hover:translate-y-[1px]"
+                            >
+                                <span className="w-6 shrink-0 text-center font-headline text-xs font-black text-muted">
+                                    {index + 1}
+                                </span>
+                                <span className="min-w-0 flex-1">
+                                    <span className="block truncate font-headline text-xs font-black text-dark">
+                                        @{entry.githubUsername}
+                                    </span>
+                                    <span className="block font-body text-xs text-subtle">
+                                        {entry.completedQuests}{" "}
+                                        {entry.completedQuests === 1
+                                            ? copy.questLeaderboardQuestLabel
+                                            : copy.questLeaderboardQuestsLabel}
+                                    </span>
+                                </span>
+                                <strong className="shrink-0 font-headline text-xs font-black text-dark">
+                                    {entry.totalPollen}{" "}
+                                    {copy.questLeaderboardPollenLabel}
+                                </strong>
+                            </a>
+                        </li>
+                    ))}
+                </ol>
+            </section>
+            <Divider />
+        </>
+    );
+}
+
+export function QuestLeaderboard() {
+    const { copy } = usePageCopy(COMMUNITY_PAGE);
+    const [data, setData] = useState<QuestLeaderboardData | null>(null);
+
+    useEffect(() => {
+        let active = true;
+
+        fetch(LEADERBOARD_API)
+            .then((response) => {
+                if (!response.ok) throw new Error("Leaderboard request failed");
+                return response.json() as Promise<QuestLeaderboardData>;
+            })
+            .then((result) => {
+                if (active && result.leaderboard.length > 0) setData(result);
+            })
+            .catch(() => {
+                // Keep the Community page useful if the optional board is unavailable.
+            });
+
+        return () => {
+            active = false;
+        };
+    }, []);
+
+    return data ? <QuestLeaderboardContent data={data} copy={copy} /> : null;
+}

--- a/pollinations.ai/src/ui/components/TopContributors.tsx
+++ b/pollinations.ai/src/ui/components/TopContributors.tsx
@@ -118,11 +118,11 @@ export function TopContributors() {
     }, []);
 
     if (loadingContributors && contributors.length === 0) {
-        return null;
+        return <QuestLeaderboard />;
     }
 
     if (!loadingContributors && contributors.length === 0) {
-        return null;
+        return <QuestLeaderboard />;
     }
 
     return (

--- a/pollinations.ai/src/ui/components/TopContributors.tsx
+++ b/pollinations.ai/src/ui/components/TopContributors.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { COMMUNITY_PAGE } from "../../copy/content/community";
 import { usePageCopy } from "../../hooks/usePageCopy";
 import { ExternalLinkIcon } from "../assets/ExternalLinkIcon";
+import { QuestLeaderboard } from "./QuestLeaderboard";
 import { Divider } from "./ui/divider";
 import { Body, Heading } from "./ui/typography";
 
@@ -116,74 +117,78 @@ export function TopContributors() {
         fetchTopContributors365();
     }, []);
 
-    if (loadingContributors && contributors.length === 0) {
-        return null;
-    }
-
-    if (!loadingContributors && contributors.length === 0) {
-        return null;
-    }
-
     return (
         <>
-            <div className="mb-12">
-                <Heading variant="section">{copy.topContributorsTitle}</Heading>
-                <Body size="sm" spacing="comfortable">
-                    {copy.topContributorsDescription}
-                    <br />
-                    {copy.topContributorsCta}{" "}
-                    <a
-                        href="https://github.com/pollinations/pollinations"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="font-headline text-xs font-black hover:underline inline-flex items-center gap-1 text-dark bg-accent-strong px-2 py-0.5"
-                    >
-                        {copy.githubRepositoryLink}
-                        <ExternalLinkIcon className="w-3 h-3" strokeWidth="4" />
-                    </a>{" "}
-                    {copy.overThePastYear}
-                </Body>
-                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-                    {contributors.map((contributor) => {
-                        const colors = [
-                            "border-primary-strong",
-                            "border-secondary-strong",
-                            "border-tertiary-strong",
-                        ];
-                        const colorClass =
-                            colors[
-                                contributor.login.charCodeAt(0) % colors.length
-                            ];
-                        return (
+            <QuestLeaderboard />
+            {contributors.length > 0 && (
+                <>
+                    <div className="mb-12">
+                        <Heading variant="section">
+                            {copy.topContributorsTitle}
+                        </Heading>
+                        <Body size="sm" spacing="comfortable">
+                            {copy.topContributorsDescription}
+                            <br />
+                            {copy.topContributorsCta}{" "}
                             <a
-                                key={contributor.login}
-                                href={contributor.profile_url}
+                                href="https://github.com/pollinations/pollinations"
                                 target="_blank"
                                 rel="noopener noreferrer"
-                                className="group flex flex-col items-center text-center transition hover:translate-x-[2px] hover:translate-y-[2px]"
+                                className="font-headline text-xs font-black hover:underline inline-flex items-center gap-1 text-dark bg-accent-strong px-2 py-0.5"
                             >
-                                <div
-                                    className={`w-16 h-16 mb-2 overflow-hidden rounded-full border-2 border-r-4 border-b-4 ${colorClass} shadow-[3px_3px_0_rgb(17_5_24_/_0.15)] group-hover:shadow-none transition`}
-                                >
-                                    <img
-                                        src={contributor.avatar_url}
-                                        alt={contributor.login}
-                                        className="w-full h-full object-cover"
-                                        loading="lazy"
-                                        decoding="async"
-                                        width={64}
-                                        height={64}
-                                    />
-                                </div>
-                                <p className="font-headline text-[10px] font-black text-dark mb-1">
-                                    {contributor.login}
-                                </p>
-                            </a>
-                        );
-                    })}
-                </div>
-            </div>
-            <Divider />
+                                {copy.githubRepositoryLink}
+                                <ExternalLinkIcon
+                                    className="w-3 h-3"
+                                    strokeWidth="4"
+                                />
+                            </a>{" "}
+                            {copy.overThePastYear}
+                        </Body>
+                        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+                            {contributors.map((contributor) => {
+                                const colors = [
+                                    "border-primary-strong",
+                                    "border-secondary-strong",
+                                    "border-tertiary-strong",
+                                ];
+                                const colorClass =
+                                    colors[
+                                        contributor.login.charCodeAt(0) %
+                                            colors.length
+                                    ];
+                                return (
+                                    <a
+                                        key={contributor.login}
+                                        href={contributor.profile_url}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="group flex flex-col items-center text-center transition hover:translate-x-[2px] hover:translate-y-[2px]"
+                                    >
+                                        <div
+                                            className={`w-16 h-16 mb-2 overflow-hidden rounded-full border-2 border-r-4 border-b-4 ${colorClass} shadow-[3px_3px_0_rgb(17_5_24_/_0.15)] group-hover:shadow-none transition`}
+                                        >
+                                            <img
+                                                src={contributor.avatar_url}
+                                                alt={contributor.login}
+                                                className="w-full h-full object-cover"
+                                                loading="lazy"
+                                                decoding="async"
+                                                width={64}
+                                                height={64}
+                                            />
+                                        </div>
+                                        <p className="font-headline text-[10px] font-black text-dark mb-1">
+                                            {contributor.login}
+                                        </p>
+                                    </a>
+                                );
+                            })}
+                        </div>
+                    </div>
+                    <Divider />
+                </>
+            )}
+            {loadingContributors && null}
         </>
     );
 }

--- a/pollinations.ai/src/ui/components/TopContributors.tsx
+++ b/pollinations.ai/src/ui/components/TopContributors.tsx
@@ -117,78 +117,75 @@ export function TopContributors() {
         fetchTopContributors365();
     }, []);
 
+    if (loadingContributors && contributors.length === 0) {
+        return null;
+    }
+
+    if (!loadingContributors && contributors.length === 0) {
+        return null;
+    }
+
     return (
         <>
             <QuestLeaderboard />
-            {contributors.length > 0 && (
-                <>
-                    <div className="mb-12">
-                        <Heading variant="section">
-                            {copy.topContributorsTitle}
-                        </Heading>
-                        <Body size="sm" spacing="comfortable">
-                            {copy.topContributorsDescription}
-                            <br />
-                            {copy.topContributorsCta}{" "}
+            <div className="mb-12">
+                <Heading variant="section">{copy.topContributorsTitle}</Heading>
+                <Body size="sm" spacing="comfortable">
+                    {copy.topContributorsDescription}
+                    <br />
+                    {copy.topContributorsCta}{" "}
+                    <a
+                        href="https://github.com/pollinations/pollinations"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="font-headline text-xs font-black hover:underline inline-flex items-center gap-1 text-dark bg-accent-strong px-2 py-0.5"
+                    >
+                        {copy.githubRepositoryLink}
+                        <ExternalLinkIcon className="w-3 h-3" strokeWidth="4" />
+                    </a>{" "}
+                    {copy.overThePastYear}
+                </Body>
+                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+                    {contributors.map((contributor) => {
+                        const colors = [
+                            "border-primary-strong",
+                            "border-secondary-strong",
+                            "border-tertiary-strong",
+                        ];
+                        const colorClass =
+                            colors[
+                                contributor.login.charCodeAt(0) % colors.length
+                            ];
+                        return (
                             <a
-                                href="https://github.com/pollinations/pollinations"
+                                key={contributor.login}
+                                href={contributor.profile_url}
                                 target="_blank"
                                 rel="noopener noreferrer"
-                                className="font-headline text-xs font-black hover:underline inline-flex items-center gap-1 text-dark bg-accent-strong px-2 py-0.5"
+                                className="group flex flex-col items-center text-center transition hover:translate-x-[2px] hover:translate-y-[2px]"
                             >
-                                {copy.githubRepositoryLink}
-                                <ExternalLinkIcon
-                                    className="w-3 h-3"
-                                    strokeWidth="4"
-                                />
-                            </a>{" "}
-                            {copy.overThePastYear}
-                        </Body>
-                        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-                            {contributors.map((contributor) => {
-                                const colors = [
-                                    "border-primary-strong",
-                                    "border-secondary-strong",
-                                    "border-tertiary-strong",
-                                ];
-                                const colorClass =
-                                    colors[
-                                        contributor.login.charCodeAt(0) %
-                                            colors.length
-                                    ];
-                                return (
-                                    <a
-                                        key={contributor.login}
-                                        href={contributor.profile_url}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        className="group flex flex-col items-center text-center transition hover:translate-x-[2px] hover:translate-y-[2px]"
-                                    >
-                                        <div
-                                            className={`w-16 h-16 mb-2 overflow-hidden rounded-full border-2 border-r-4 border-b-4 ${colorClass} shadow-[3px_3px_0_rgb(17_5_24_/_0.15)] group-hover:shadow-none transition`}
-                                        >
-                                            <img
-                                                src={contributor.avatar_url}
-                                                alt={contributor.login}
-                                                className="w-full h-full object-cover"
-                                                loading="lazy"
-                                                decoding="async"
-                                                width={64}
-                                                height={64}
-                                            />
-                                        </div>
-                                        <p className="font-headline text-[10px] font-black text-dark mb-1">
-                                            {contributor.login}
-                                        </p>
-                                    </a>
-                                );
-                            })}
-                        </div>
-                    </div>
-                    <Divider />
-                </>
-            )}
-            {loadingContributors && null}
+                                <div
+                                    className={`w-16 h-16 mb-2 overflow-hidden rounded-full border-2 border-r-4 border-b-4 ${colorClass} shadow-[3px_3px_0_rgb(17_5_24_/_0.15)] group-hover:shadow-none transition`}
+                                >
+                                    <img
+                                        src={contributor.avatar_url}
+                                        alt={contributor.login}
+                                        className="w-full h-full object-cover"
+                                        loading="lazy"
+                                        decoding="async"
+                                        width={64}
+                                        height={64}
+                                    />
+                                </div>
+                                <p className="font-headline text-[10px] font-black text-dark mb-1">
+                                    {contributor.login}
+                                </p>
+                            </a>
+                        );
+                    })}
+                </div>
+            </div>
+            <Divider />
         </>
     );
 }


### PR DESCRIPTION
Closes #13909

## Summary

Adds a compact Quest leaderboard to the existing Community contributor area, backed only by the current reward ledger.

- Adds public `GET /api/quests/leaderboard` to the existing Quest routes.
- Counts only `github:issue:*` rewards and public linked GitHub usernames.
- Merges GitHub usernames case-insensitively, rounds Pollen with the shared ledger precision helper, and ranks by total Quest Pollen with deterministic tie-breaks.
- Returns a top-10 board plus global contributor / completed-quest / Quest-Pollen totals.
- Adds a small Community leaderboard with GitHub identity, completed quest count, Pollen earned, and a direct Quests CTA.
- Reuses the existing server KV cache and adds no browser cache, new tables, Tinybird, GitHub scraping, or general leaderboard framework.
- Adds focused aggregate and rendered-output coverage.

## Validation

The focused tests are included in the branch. I could not run the repository test suite locally from this environment, so CI should verify the implementation.

## AI assistance disclosure

ChatGPT assisted with repository inspection, implementation design, code preparation, and GitHub operations. The contribution is being submitted intentionally with that assistance disclosed.