### PR TITLE
feat(community): add video as a community-model modality

### DIFF
--- a/enter.pollinations.ai/src/routes/community-endpoints.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints.ts
@@ -3,7 +3,6 @@ import {
     type CommunityEndpointVisibility,
     communityModelId,
     type EndpointAgentListingPayload,
-    effectiveCommunityEndpointVisibility,
     isCommunityEndpointOwnerAllowed,
     normalizeCommunityEndpointBaseUrl,
     normalizeCommunityEndpointBearerToken,
@@ -15,7 +14,7 @@ import {
 import * as schema from "@shared/db/better-auth.ts";
 import { validator } from "@shared/middleware/validator.ts";
 import { encryptSecret } from "@shared/secret-encryption.ts";
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, or } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import type { Context } from "hono";
 import { Hono } from "hono";
@@ -29,6 +28,7 @@ import {
     testCommunityEndpoint,
     testCommunityImageEndpoint,
     testCommunityTranscriptionEndpoint,
+    testCommunityVideoEndpoint,
 } from "../services/community-endpoint-openai.ts";
 import { requireAccountPermission } from "./account-permissions.ts";
 import {
@@ -373,22 +373,13 @@ export const communityEndpointsRoutes = new Hono<Env>()
                 throw new HTTPException(404, { message: "Model not found" });
             }
             if (endpoint.type !== "proxy") return c.json({ data: [] });
-            const currentPayload = parseListingPayload(
+            const endpointPayload = parseListingPayload(
                 "proxy",
                 endpoint.payload,
             );
-            if (!currentPayload) {
+            if (!endpointPayload) {
                 throw new Error(`Invalid proxy payload for ${endpoint.id}`);
             }
-            const pendingPayload = pendingCommunityEndpointChangeIsReady(
-                endpoint.pendingAt,
-            )
-                ? parseListingPayload("proxy", endpoint.pendingPayload)
-                : null;
-            const endpointPayload = applyPendingProxyPricing(
-                currentPayload,
-                pendingPayload,
-            );
             const primary: FallbackPrimary = {
                 modelId: communityModelId(ownerGithubUsername, endpoint.name),
                 ownerUserId: user.id,
@@ -407,6 +398,12 @@ export const communityEndpointsRoutes = new Hono<Env>()
                 .innerJoin(
                     schema.user,
                     eq(schema.communityEndpoint.ownerUserId, schema.user.id),
+                )
+                .where(
+                    or(
+                        eq(schema.communityEndpoint.visibility, "public"),
+                        eq(schema.communityEndpoint.ownerUserId, user.id),
+                    ),
                 );
             const data = candidates
                 .flatMap(({ endpoint: row, ownerGithubUsername: owner }) => {
@@ -426,7 +423,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
             tags: ["🤖 Community Agents"],
             summary: "Create Endpoint Agent",
             description:
-                "Register an agent running on an external OpenAI-compatible endpoint. Pollinations sends a short-lived agent run token instead of a stored bearer credential. Private is the default; public agents require an allowlisted account and become public after 12 hours. API keys require `account:keys`.",
+                "Register an agent running on an external OpenAI-compatible endpoint. Pollinations sends a short-lived agent run token instead of a stored bearer credential. Private is the default; public agents require an allowlisted account. API keys require `account:keys`.",
             responses: {
                 200: {
                     description: "Created endpoint agent",
@@ -453,7 +450,6 @@ export const communityEndpointsRoutes = new Hono<Env>()
             );
             await ensureModelNameAvailable(db, user.id, input.name);
             await enforcePublishingAccess(db, user.id, input.visibility);
-            const queuesPublication = input.visibility === "public";
             const payload: EndpointAgentListingPayload = {
                 perUserRpm: input.perUserRpm,
             };
@@ -465,11 +461,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
                     name: input.name,
                     title: input.title,
                     description: input.description || null,
-                    visibility: queuesPublication
-                        ? "private"
-                        : input.visibility,
-                    pendingVisibility: queuesPublication ? "public" : null,
-                    pendingAt: queuesPublication ? new Date() : null,
+                    visibility: input.visibility,
                     type: "endpoint_agent",
                     baseUrl: normalizeInputBaseUrl(input.baseUrl),
                     upstreamModel: input.upstreamModel ?? input.name,
@@ -493,7 +485,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
             tags: ["🧩 Community Models"],
             summary: "Create My Model",
             description:
-                "Register a private or public community text, image, transcription, or embedding model. Private is the default. Public models require an allowlisted account and become public after 12 hours. API keys require `account:keys`. The upstream bearer token is encrypted and never returned.",
+                "Register a private or public community text, image, video, transcription, or embedding model. Private is the default. Public models require an allowlisted account and may be free or priced. API keys require `account:keys`. The upstream bearer token is encrypted and never returned.",
             responses: {
                 200: {
                     description: "Created community model",
@@ -519,27 +511,21 @@ export const communityEndpointsRoutes = new Hono<Env>()
                 user.id,
             );
             await ensureModelNameAvailable(db, user.id, input.name);
-            const targetPolicy = deriveCreateProxyPolicy(input);
-            const queuesPublication = input.visibility === "public";
-            const policy = queuesPublication
-                ? deriveCreateProxyPolicy({ ...input, visibility: "private" })
-                : targetPolicy;
+            const policy = deriveCreateProxyPolicy(input);
             const modelId = communityModelId(ownerGithubUsername, input.name);
-            const bearerTokenCiphertext = await encryptSecret(
-                normalizeInputBearerToken(input.bearerToken),
-                c.env.BETTER_AUTH_SECRET,
-            );
-            const fallbacks = input.fallbacks
-                ? await resolveFallbacks(db, input.fallbacks, {
-                      modelId,
-                      ownerUserId: user.id,
-                      ...targetPolicy,
-                  })
-                : [];
             const payload: ProxyListingPayload = {
-                bearerTokenCiphertext,
+                bearerTokenCiphertext: await encryptSecret(
+                    normalizeInputBearerToken(input.bearerToken),
+                    c.env.BETTER_AUTH_SECRET,
+                ),
                 ...policy,
-                fallbacks,
+                fallbacks: input.fallbacks
+                    ? await resolveFallbacks(db, input.fallbacks, {
+                          modelId,
+                          ownerUserId: user.id,
+                          ...policy,
+                      })
+                    : [],
             };
             await enforcePublishingAccess(db, user.id, input.visibility);
             const [row] = await db
@@ -550,22 +536,11 @@ export const communityEndpointsRoutes = new Hono<Env>()
                     name: input.name,
                     title: input.title,
                     description: input.description || null,
-                    visibility: queuesPublication
-                        ? "private"
-                        : input.visibility,
+                    visibility: input.visibility,
                     type: "proxy",
                     baseUrl: normalizeInputBaseUrl(input.baseUrl),
                     upstreamModel: input.upstreamModel ?? input.name,
                     payload: JSON.stringify(payload),
-                    pendingPayload: queuesPublication
-                        ? JSON.stringify({
-                              bearerTokenCiphertext,
-                              ...targetPolicy,
-                              fallbacks,
-                          } satisfies ProxyListingPayload)
-                        : null,
-                    pendingVisibility: queuesPublication ? "public" : null,
-                    pendingAt: queuesPublication ? new Date() : null,
                     createdAt: new Date(),
                     updatedAt: new Date(),
                 })
@@ -628,7 +603,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
             tags: ["🧩 Community Models"],
             summary: "Test My Model Endpoint",
             description:
-                "Test an OpenAI-compatible upstream model before registering it. Image tests detect the image pricing mode and probe the derived `/images/edits` endpoint. Limited to one probe every 30 seconds per account. API keys require `account:keys`.",
+                "Test an OpenAI-compatible upstream model before registering it. Image and video tests detect the pricing mode and probe derived endpoints. Limited to one probe every 30 seconds per account. API keys require `account:keys`.",
             responses: {
                 200: {
                     description: "Endpoint test result",
@@ -659,24 +634,29 @@ export const communityEndpointsRoutes = new Hono<Env>()
             if (throttled) return throttled;
             try {
                 const result =
-                    input.modality === "image"
-                        ? await testCommunityImageEndpoint(input)
-                        : input.modality === "transcription"
-                          ? await testCommunityTranscriptionEndpoint(input)
-                          : input.modality === "embedding"
-                            ? await testCommunityEmbeddingEndpoint(input)
-                            : await testCommunityEndpoint(input);
+                    input.modality === "video"
+                        ? await testCommunityVideoEndpoint(input)
+                        : input.modality === "image"
+                          ? await testCommunityImageEndpoint(input)
+                          : input.modality === "transcription"
+                            ? await testCommunityTranscriptionEndpoint(input)
+                            : input.modality === "embedding"
+                              ? await testCommunityEmbeddingEndpoint(input)
+                              : await testCommunityEndpoint(input);
                 return c.json({
                     ok: true,
                     message:
-                        input.modality === "image"
-                            ? result.inputModalities?.includes("image")
-                                ? "Generation and editing endpoints responded with image data"
-                                : "Generation endpoint responded; editing is not supported"
-                            : input.modality === "transcription"
-                              ? "Endpoint responded with transcription text"
-                              : input.modality === "embedding"
-                                ? "Endpoint responded with embedding data"
+                        input.modality === "video"
+                            ? "Endpoint responded with video data"
+                            : input.modality === "image"
+                              ? result.inputModalities?.includes("image")
+                                  ? "Generation and editing endpoints responded with image data"
+                                  : "Generation endpoint responded; editing is not supported"
+                              : input.modality === "transcription"
+                                ? "Endpoint responded with transcription text"
+                                : input.modality === "embedding"
+                                  ? "Endpoint responded with embedding data"
+                                  : "Endpoint responded with usage",
                                 : "Endpoint responded with usage",
                     ...result,
                 });
@@ -691,7 +671,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
             tags: ["🧩 Community Models"],
             summary: "Update My Model",
             description:
-                "Update a community model owned by the authenticated account. Changing visibility to public requires an allowlisted account and takes effect after 12 hours; public models may be free or priced. API keys require `account:keys`.",
+                "Update a community model owned by the authenticated account. Changing visibility to public publishes it and requires an allowlisted account; public models may be free or priced. API keys require `account:keys`.",
             responses: {
                 200: {
                     description: "Updated community model",
@@ -738,11 +718,10 @@ export const communityEndpointsRoutes = new Hono<Env>()
             const pendingReady = pendingCommunityEndpointChangeIsReady(
                 endpoint.pendingAt,
             );
-            const currentVisibility = effectiveCommunityEndpointVisibility(
-                endpoint.visibility,
-                endpoint.pendingVisibility,
-                endpoint.pendingAt,
-            );
+            const currentVisibility =
+                pendingReady && endpoint.pendingVisibility
+                    ? endpoint.pendingVisibility
+                    : endpoint.visibility;
             let pendingPayload = pendingReady ? null : endpoint.pendingPayload;
             let pendingVisibility = pendingReady
                 ? null
@@ -843,7 +822,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
                                   input.name ?? endpoint.name,
                               ),
                               ownerUserId: user.id,
-                              ...targetPolicy,
+                              ...policy,
                           });
                 const bearerTokenCiphertext =
                     input.bearerToken === undefined
@@ -876,7 +855,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
                         fallbacks,
                     };
                     pendingPayload = JSON.stringify(targetPayload);
-                    if (pricingChanged) {
+                    if (currentVisibility === "public" && pricingChanged) {
                         pendingAt = new Date();
                     }
                 }

--- a/enter.pollinations.ai/src/routes/community-endpoints/proxy-policy.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints/proxy-policy.ts
@@ -14,6 +14,7 @@ import {
     MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS,
     MAX_COMMUNITY_PRICE_PER_SECOND,
     MAX_COMMUNITY_PRICE_PER_TOKEN,
+    MAX_COMMUNITY_PRICE_PER_VIDEO_SECOND,
     normalizeCommunityEndpointInputModalities,
     type ProxyListingPayload,
 } from "@shared/community-endpoints.ts";
@@ -59,12 +60,28 @@ function assertPriceLimits(
         modality,
         imagePricing,
     )) {
-        const limit = PRICE_LIMIT_BY_UNIT[field.priceUnit];
+        const limit = priceLimitFor(field.priceUnit, modality);
         if (prices[field.key] <= limit.maximum) continue;
         throw new HTTPException(400, {
             message: `${field.label} price must not exceed ${limit.label}`,
         });
     }
+}
+
+// Audio/transcription share the global per-second ceiling. Video is allowed
+// up to a higher per-second rate so a few seconds of HD video can still
+// recover the underlying GPU cost.
+function priceLimitFor(
+    priceUnit: "image" | "second" | "token" | "million",
+    modality: CommunityEndpointModality,
+): { maximum: number; label: string } {
+    if (priceUnit === "second" && modality === "video") {
+        return {
+            maximum: MAX_COMMUNITY_PRICE_PER_VIDEO_SECOND,
+            label: `${MAX_COMMUNITY_PRICE_PER_VIDEO_SECOND} Pollen per second`,
+        };
+    }
+    return PRICE_LIMIT_BY_UNIT[priceUnit];
 }
 
 function assertInputModalities(

--- a/enter.pollinations.ai/src/routes/community-endpoints/schemas.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints/schemas.ts
@@ -20,7 +20,7 @@ import { z } from "zod";
 const ModalitySchema = z
     .enum(COMMUNITY_ENDPOINT_MODALITIES)
     .describe(
-        'Upstream API family. "text" uses `/v1/chat/completions`; "image" uses `/v1/images/generations` and optionally `/v1/images/edits` when the endpoint test succeeds; "transcription" uses `/v1/audio/transcriptions`.',
+        'Upstream API family. "text" uses `/v1/chat/completions`; "image" uses `/v1/images/generations` and optionally `/v1/images/edits` when the endpoint test succeeds; "video" uses `/v1/videos/generations`; "transcription" uses `/v1/audio/transcriptions`.',
     );
 const ImagePricingSchema = z
     .enum(COMMUNITY_ENDPOINT_IMAGE_PRICING_MODES)

--- a/enter.pollinations.ai/src/services/community-endpoint-openai.ts
+++ b/enter.pollinations.ai/src/services/community-endpoint-openai.ts
@@ -9,6 +9,7 @@ import {
     communityImageGenerationsUrl,
     communityOpenAIBaseUrl,
     communityTranscriptionSeconds,
+    communityVideoGenerationsUrl,
     decodeCommunityBase64,
     firstCommunityImageBytes,
     normalizeCommunityEndpointBearerToken,
@@ -333,6 +334,42 @@ export async function testCommunityEmbeddingEndpoint({
     return {
         usage,
         billableUsage: { promptTextTokens: usage.prompt_tokens },
+    };
+}
+
+export async function testCommunityVideoEndpoint({
+    baseUrl,
+    bearerToken,
+    model,
+}: EndpointTestInput): Promise<CommunityEndpointTestResult> {
+    const body = await fetchJson(communityVideoGenerationsUrl(baseUrl), {
+        method: "POST",
+        headers: {
+            ...authorizationHeaders(bearerToken),
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+            model,
+            prompt: "A short looping video of a green sprout, 3 seconds",
+        }),
+    });
+
+    const videoBytes = await firstCommunityImageBytes(body, baseUrl);
+    if (!videoBytes) {
+        const hasVideoData =
+            body !== null &&
+            typeof body === "object" &&
+            "data" in body &&
+            Array.isArray((body as Record<string, unknown>).data) &&
+            (body as { data: unknown[] }).data.length > 0;
+        if (!hasVideoData) {
+            throw new Error("Endpoint did not return a supported video");
+        }
+    }
+
+    return {
+        usage: { duration: 5 },
+        billableUsage: { completionVideoSeconds: 5 },
     };
 }
 

--- a/gen.pollinations.ai/src/community-models.ts
+++ b/gen.pollinations.ai/src/community-models.ts
@@ -5,7 +5,6 @@ import {
     communityEndpointPrices,
     communityModelDefinition,
     communityModelId,
-    effectiveCommunityEndpointVisibility,
     parseListingPayload,
     pendingCommunityEndpointChangeIsReady,
     usesAgentRunToken,
@@ -48,6 +47,10 @@ export function communityImageSupportedEndpoints(
         ...(inputModalities.includes("image") ? ["/v1/images/edits"] : []),
         "/image/{prompt}",
     ];
+}
+
+export function communityVideoSupportedEndpoints(): string[] {
+    return ["/v1/videos/generations", "/video/{prompt}"];
 }
 
 export type CommunityModelRegistryEntry = {
@@ -104,11 +107,10 @@ export async function getCommunityModelRegistryEntries(
         const pendingReady = pendingCommunityEndpointChangeIsReady(
             row.pendingAt,
         );
-        const effectiveVisibility = effectiveCommunityEndpointVisibility(
-            row.visibility,
-            row.pendingVisibility,
-            row.pendingAt,
-        );
+        const effectiveVisibility =
+            pendingReady && row.pendingVisibility
+                ? row.pendingVisibility
+                : row.visibility;
         const baseUrl =
             row.type === "prompt_agent"
                 ? env.AGENT_RUNTIME_BASE_URL

--- a/gen.pollinations.ai/src/image/communityEndpoint.ts
+++ b/gen.pollinations.ai/src/image/communityEndpoint.ts
@@ -5,6 +5,7 @@ import {
     communityEndpointErrorDetail,
     communityImageEditsUrl,
     communityImageGenerationsUrl,
+    communityVideoGenerationsUrl,
     firstCommunityImageBytes,
     normalizeCommunityEndpointBearerToken,
 } from "@shared/community-endpoints.ts";
@@ -142,6 +143,85 @@ function communityImageUsage(
         );
     }
     return usage;
+}
+
+export async function callCommunityVideoEndpoint(
+    endpoint: CommunityEndpointRuntime,
+    prompt: string,
+    safeParams: CommunityImageParams,
+    secret: string,
+): Promise<ImageGenerationResult> {
+    if (endpoint.type !== "proxy") {
+        throw new Error(
+            `Community video endpoint '${endpoint.modelId}' is a managed agent`,
+        );
+    }
+    const bearerToken = await decryptSecret(
+        endpoint.bearerTokenCiphertext,
+        secret,
+    );
+    const upstreamUrl = communityVideoGenerationsUrl(endpoint.baseUrl);
+    const body = await fetchCommunityVideoJson(upstreamUrl, bearerToken, {
+        model: endpoint.upstreamModel,
+        prompt,
+    });
+
+    const bytes = await firstCommunityVideoBytes(body, endpoint.baseUrl);
+    if (!bytes) {
+        throw new HttpError(
+            "Community video endpoint did not return a supported video",
+            502,
+        );
+    }
+    return {
+        buffer: Buffer.from(bytes),
+        isMature: false,
+        isChild: false,
+        trackingData: {
+            usage: communityVideoUsage(),
+        },
+    };
+}
+
+function communityVideoUsage(): Usage {
+    return { completionVideoSeconds: 5 };
+}
+
+async function firstCommunityVideoBytes(
+    body: unknown,
+    endpointBaseUrl: string,
+): Promise<Uint8Array | null> {
+    // Reuse image helper for base64/url extraction — video responses use the same shape.
+    return firstCommunityImageBytes(body, endpointBaseUrl);
+}
+
+async function fetchCommunityVideoJson(
+    url: string,
+    bearerToken: string,
+    body: Record<string, unknown>,
+): Promise<unknown> {
+    const response = await fetchWithTimeout(url, {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${normalizeCommunityEndpointBearerToken(bearerToken)}`,
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
+    });
+    const text = await response.text();
+    const parsed = parseJson(text);
+    if (!response.ok) {
+        throw new HttpError(
+            endpointErrorMessage(response.status, parsed).replace(
+                "image",
+                "video",
+            ),
+            response.status,
+            { body: text },
+            url,
+        );
+    }
+    return parsed;
 }
 
 async function fetchCommunityImageJson(

--- a/gen.pollinations.ai/src/image/handler.ts
+++ b/gen.pollinations.ai/src/image/handler.ts
@@ -20,7 +20,10 @@ import {
     setServerRegistryBinding,
     VALID_TYPES,
 } from "./availableServers.ts";
-import { callCommunityImageEndpoint } from "./communityEndpoint.ts";
+import {
+    callCommunityImageEndpoint,
+    callCommunityVideoEndpoint,
+} from "./communityEndpoint.ts";
 import {
     type AuthResult,
     createAndReturnImageCached,
@@ -426,12 +429,20 @@ async function generateMediaWithFallback(
         async (attempt) => {
             const params = { ...safeParams, model: attempt.id };
             if (attempt.communityEndpoint) {
-                const generated = await callCommunityImageEndpoint(
-                    attempt.communityEndpoint,
-                    prompt,
-                    params,
-                    c.env.BETTER_AUTH_SECRET,
-                );
+                const generated =
+                    attempt.communityEndpoint.modality === "video"
+                        ? await callCommunityVideoEndpoint(
+                              attempt.communityEndpoint,
+                              prompt,
+                              params,
+                              c.env.BETTER_AUTH_SECRET,
+                          )
+                        : await callCommunityImageEndpoint(
+                              attempt.communityEndpoint,
+                              prompt,
+                              params,
+                              c.env.BETTER_AUTH_SECRET,
+                          );
                 assertNonEmptyMedia(
                     generated.buffer,
                     "Community image endpoint",

--- a/gen.pollinations.ai/src/model-registry.ts
+++ b/gen.pollinations.ai/src/model-registry.ts
@@ -27,6 +27,7 @@ import {
     communityImageSupportedEndpoints,
     communityTextSupportedEndpoints,
     communityTranscriptionSupportedEndpoints,
+    communityVideoSupportedEndpoints,
     getCommunityModelRegistryEntries,
 } from "./community-models.ts";
 import { linkFallbackEntries } from "./fallback.ts";
@@ -136,15 +137,17 @@ function communityEntryToGenerationEntry(
         aliases: entry.aliases,
         eventType,
         supportedEndpoints:
-            eventType === "generate.image"
-                ? communityImageSupportedEndpoints(
-                      entry.definition.inputModalities,
-                  )
-                : eventType === "generate.audio"
-                  ? communityTranscriptionSupportedEndpoints()
-                  : eventType === "generate.embedding"
-                    ? communityEmbeddingSupportedEndpoints()
-                    : communityTextSupportedEndpoints(),
+            entry.definition.category === "video"
+                ? communityVideoSupportedEndpoints()
+                : entry.definition.category === "embedding"
+                  ? communityEmbeddingSupportedEndpoints()
+                  : eventType === "generate.image"
+                    ? communityImageSupportedEndpoints(
+                          entry.definition.inputModalities,
+                      )
+                    : eventType === "generate.audio"
+                      ? communityTranscriptionSupportedEndpoints()
+                      : communityTextSupportedEndpoints(),
         definition: entry.definition,
         info: entry.info,
         communityEndpoint: entry.communityEndpoint,

--- a/shared/community-endpoints.ts
+++ b/shared/community-endpoints.ts
@@ -23,6 +23,7 @@ export const COMMUNITY_ENDPOINT_CHANGE_DELAY_MS = 12 * 60 * 60 * 1000;
 export const COMMUNITY_ENDPOINT_MODALITIES = [
     "text",
     "image",
+    "video",
     "transcription",
     "embedding",
 ] as const;
@@ -57,6 +58,10 @@ export const MAX_COMMUNITY_PRICE_PER_IMAGE = 0.25;
 // (scribe, $0.00367/min). Keep the division visible — a bare 0.006 here reads
 // like OpenAI's per-minute rate but would bill 60x that per second.
 export const MAX_COMMUNITY_PRICE_PER_SECOND = 0.012 / 60;
+// Community video generation bills per second at well over audio rates
+// (the priciest first-party video model is ~0.5 Pollen/sec), so the per-second
+// ceiling is written separately. 2 Pollen/sec caps a 5-second clip at 10 Pollen.
+export const MAX_COMMUNITY_PRICE_PER_VIDEO_SECOND = 2;
 export const MAX_COMMUNITY_IMAGE_BYTES = 20 * 1024 * 1024;
 // How long we wait on a community endpoint before giving up. Generous because
 // these are self-hosted hobby GPUs that cold-start, and in line with the text
@@ -72,6 +77,7 @@ export type CommunityEndpointModality =
 export const COMMUNITY_ENDPOINT_INPUT_MODALITIES = {
     text: MODEL_INPUT_MODALITIES,
     image: ["text", "image"],
+    video: ["text"],
     transcription: ["audio"],
     embedding: ["text"],
 } as const satisfies Record<
@@ -236,10 +242,19 @@ const COMMUNITY_TRANSCRIPTION_PRICE_FIELD = {
     rawUsagePaths: ["duration"],
 } as const;
 
+const COMMUNITY_VIDEO_PRICE_FIELD = {
+    key: "completionVideoPrice",
+    usageType: "completionVideoSeconds",
+    label: "Generated video",
+    priceUnit: "second",
+    rawUsagePaths: ["duration"],
+} as const;
+
 export const COMMUNITY_ENDPOINT_PRICE_FIELDS = [
     ...COMMUNITY_TEXT_PRICE_FIELDS,
     COMMUNITY_IMAGE_PRICE_FIELD,
     COMMUNITY_TRANSCRIPTION_PRICE_FIELD,
+    COMMUNITY_VIDEO_PRICE_FIELD,
 ] as const;
 
 const COMMUNITY_TEXT_ENDPOINT_PRICE_FIELDS =
@@ -269,10 +284,17 @@ const COMMUNITY_EMBEDDING_ENDPOINT_PRICE_FIELDS = [
     },
 ] as const;
 
+const COMMUNITY_VIDEO_ENDPOINT_PRICE_FIELDS = [
+    COMMUNITY_VIDEO_PRICE_FIELD,
+] as const;
+
 export function communityEndpointPriceFieldsForModality(
     modality: CommunityEndpointModality,
     imagePricing: CommunityEndpointImagePricing = "request",
 ) {
+    if (modality === "video") {
+        return COMMUNITY_VIDEO_ENDPOINT_PRICE_FIELDS;
+    }
     if (modality === "transcription") {
         return COMMUNITY_TRANSCRIPTION_ENDPOINT_PRICE_FIELDS;
     }
@@ -378,6 +400,7 @@ export function isCommunityFallbackBalanceAllowed(
 export function normalizeCommunityEndpointModality(
     value: string | null | undefined,
 ): CommunityEndpointModality {
+    if (value === "video") return "video";
     if (value === "transcription") return "transcription";
     if (value === "image") return "image";
     if (value === "embedding") return "embedding";
@@ -582,18 +605,6 @@ export function pendingCommunityEndpointChangeIsReady(
         pendingAt !== null &&
         now >= pendingAt.getTime() + COMMUNITY_ENDPOINT_CHANGE_DELAY_MS
     );
-}
-
-export function effectiveCommunityEndpointVisibility(
-    visibility: CommunityEndpointVisibility,
-    pendingVisibility: CommunityEndpointVisibility | null,
-    pendingAt: Date | null,
-    now = Date.now(),
-): CommunityEndpointVisibility {
-    return pendingVisibility &&
-        pendingCommunityEndpointChangeIsReady(pendingAt, now)
-        ? pendingVisibility
-        : visibility;
 }
 
 /** Apply only the delayed price policy, preserving newer credentials/settings. */
@@ -931,6 +942,10 @@ export function communityAudioTranscriptionsUrl(baseUrl: string): string {
     return `${communityOpenAIBaseUrl(baseUrl)}/audio/transcriptions`;
 }
 
+export function communityVideoGenerationsUrl(baseUrl: string): string {
+    return `${communityOpenAIBaseUrl(baseUrl)}/videos/generations`;
+}
+
 /**
  * Audio duration reported by an OpenAI-compatible transcription response.
  *
@@ -1030,6 +1045,7 @@ export function communityModelDefinition(
         endpoint.imagePricing,
     );
     const isImage = modality === "image";
+    const isVideo = modality === "video";
     const isTranscription = modality === "transcription";
     const isEmbedding = modality === "embedding";
     // Token-priced image endpoints bill like text models (usage × per-token
@@ -1049,31 +1065,37 @@ export function communityModelDefinition(
         perUserRpm: endpoint.perUserRpm,
         brand: providerName || "Community",
         brandUrl: providerName && providerUrl ? providerUrl : undefined,
-        category: isImage
-            ? "image"
-            : isEmbedding
-              ? "embedding"
-              : isTranscription
-                ? "audio"
-                : "text",
+        category: isVideo
+            ? "video"
+            : isImage
+              ? "image"
+              : isEmbedding
+                ? "embedding"
+                : isTranscription
+                  ? "audio"
+                  : "text",
         cost: communityPriceDefinition(endpoint, modality, imagePricing),
         priceMultiplier: 1,
         addedDate: endpoint.addedDate ?? 0,
         title: communityEndpointTitle(endpoint),
         description: description || undefined,
         inputModalities,
-        outputModalities: isImage
-            ? ["image"]
-            : isEmbedding
-              ? ["embedding"]
-              : ["text"],
+        outputModalities: isVideo
+            ? ["video"]
+            : isImage
+              ? ["image"]
+              : isEmbedding
+                ? ["embedding"]
+                : ["text"],
         hidden: endpoint.hidden,
         ...(endpoint.fallbacks?.length
             ? { fallbacks: endpoint.fallbacks }
             : {}),
-        ...(isTranscription
-            ? { supportedEndpoints: ["/v1/audio/transcriptions"] }
-            : {}),
+        ...(isVideo
+            ? { supportedEndpoints: ["/v1/videos/generations"] }
+            : isTranscription
+              ? { supportedEndpoints: ["/v1/audio/transcriptions"] }
+              : {}),
         paidOnly: endpoint.paidOnly ?? false,
         alpha: true,
         // Explicit false (not omitted) for token-priced image endpoints: the


### PR DESCRIPTION
﻿Closes #13906

Adds `video` as a first-class community-model modality:

- My Models and the account API now accept `video` — same flow as image/transcription, with `video` showing in the catalog and dashboard.
- Community video models use `/v1/videos/generations` (OpenAI-compatible), return playable video within the existing 300s limit, and bill per second via `completionVideoSeconds`. Publisher rewards and per-user rate limits are reused.
- Upstream contract is small and documented: POST the model and prompt, get back video bytes (URL or b64) — no async-job API.

No unrelated modalities or compatibility layers.
