### PR TITLE
docs: add community model naming guide (Fixes #12885)

### DIFF
--- a/APIDOCS.md
+++ b/APIDOCS.md
@@ -851,15 +851,6 @@ curl -X POST "https://gen.pollinations.ai/v1/audio/transcriptions" \
   -F "model=whisper-large-v3"
 ```
 
-**Per-model `response_format` support:** The accepted formats are model-dependent and narrower than the full enum. Unsupported combinations return `400` with a message listing the formats that model accepts:
-
-| Model | Supported `response_format` values |
-|---|---|
-| `whisper-large-v3`, `whisper-1` | `json`, `text`, `verbose_json` |
-| `gpt-transcribe` | `json` |
-| `universal-2`, `universal-3.5-pro` | `json`, `text`, `srt`, `vtt`, `diarized_json` |
-| `scribe`, `grok-transcribe` | provider-dependent; check the `400` error message for the accepted list |
-
 ---
 
 #### `GET` `/audio/{text}` — Generate Audio

--- a/APIDOCS.md
+++ b/APIDOCS.md
@@ -851,6 +851,15 @@ curl -X POST "https://gen.pollinations.ai/v1/audio/transcriptions" \
   -F "model=whisper-large-v3"
 ```
 
+**Per-model `response_format` support:** The accepted formats are model-dependent and narrower than the full enum. Unsupported combinations return `400` with a message listing the formats that model accepts:
+
+| Model | Supported `response_format` values |
+|---|---|
+| `whisper-large-v3`, `whisper-1` | `json`, `text`, `verbose_json` |
+| `gpt-transcribe` | `json` |
+| `universal-2`, `universal-3.5-pro` | `json`, `text`, `srt`, `vtt`, `diarized_json` |
+| `scribe`, `grok-transcribe` | provider-dependent; check the `400` error message for the accepted list |
+
 ---
 
 #### `GET` `/audio/{text}` — Generate Audio

--- a/BRING_YOUR_OWN_MODEL.md
+++ b/BRING_YOUR_OWN_MODEL.md
@@ -43,6 +43,8 @@ Owners receive 75% of the Pollen spent on their models. Paid and Quest Pollen ea
 
 The upstream credential is used by Pollinations to proxy requests to your endpoint. Do not place it in a model name, description, public URL, or example.
 
+Choose the model ID and title carefully — the ID is public and permanent. See the [Community Model Naming Guide](./COMMUNITY_MODEL_NAMING.md) for how to pick a stable ID and a clear title, including direct, custom, router, and rebranded examples.
+
 ## Register with the CLI
 
 The CLI manages text, image, and transcription model registrations. Sign in, test the endpoint, then create the model:

--- a/COMMUNITY_MODEL_NAMING.md
+++ b/COMMUNITY_MODEL_NAMING.md
@@ -1,0 +1,68 @@
+# Community Model Naming Guide
+
+Community models expose three user-facing fields: a **stable model ID**, a **display title**, and a **description**. They answer different questions, so they should never be treated as interchangeable.
+
+| Field | Purpose | Example |
+|---|---|---|
+| Model ID (`owner/model`) | Permanent, stable identifier used in API calls and URLs. Never changes after registration. | `octocat/songpainter` |
+| Title | Short human-friendly name shown in the Models list and dashboards. | "Songpainter" |
+| Description | One line explaining what the model is, what it routes to, or what it is good at. Optional but strongly recommended for public models. | "Generates album-cover art from song titles via ImageGen-3 Turbo." |
+
+## Model ID: stable by design
+
+The model ID is `{username}/{model-id}`. It is the only value that must never change: existing links, tools, and caches may reference it. When in doubt, pick something specific to the *model's purpose*, not to the *billing, vendor, or configuration of the day*.
+
+Keep mutable details out of the ID:
+
+- **Pricing or billing mode** — do not include `free`, `paid`, `cheap`, or a token price.
+- **Provider routing** — `replicate`, `openrouter`, `claude`, `gpt` change over time or route through multiple providers.
+- **Context size, latency, or throughput** — `128k`, `fast`, `turbo` describe current limits, not the model.
+- **Frequently changing versions** — `v2` is fine when it is a deliberate version of your own model; `2026-08-27-3` will look stale next week.
+
+If the underlying upstream model changes (for example you move from one image model to another), keep the same ID and update the description and title instead. The ID is the contract; the title and description are the marketing.
+
+## Pick the right shape for your model
+
+The four common cases, with concrete examples:
+
+### 1. Direct upstream model
+
+You expose a single well-known upstream model and want users to find it by that name. Use the upstream model's own name as the `model-id`, and say what it is in the description. Do not add your username's branding to the ID.
+
+- ID: `octocat/flux-schnell` · Title: "Flux Schnell" · Description: "Runs FLUX.1-schnell (Speed category) for fast 4-step image generation."
+
+### 2. Custom model
+
+You built, fine-tuned, or wrapped something of your own that does not exist upstream. Give it a real name — product names make the best IDs. The description should sell what it does, not how it is hosted.
+
+- ID: `octocat/songpainter` · Title: "Songpainter" · Description: "Turns a song title into matching album-cover art; tuned on 1980s synth-pop covers."
+
+### 3. Router / gateway
+
+You proxy a whole class of upstream models behind one stable ID. This is the highest-risk naming case: the ID must not promise a specific provider, because routing can change. Use a category name, and let the description state the current routing.
+
+- ID: `octocat/vision-tools` · Title: "Vision Tools" · Description: "Routes to the current best image-understanding model we operate (today: ImageGen-3 Turbo)."
+
+### 4. Rebranded upstream model
+
+You run a well-known model under your own storefront name (common for white-label setups). The display title and description must be transparent about the underlying model — a hidden upstream name surprises users, breaks debugging, and can look like impersonation.
+
+- ID: `octocat/aurora` · Title: "Aurora" · Description: "Rebrand of Stable Audio 2.0 for our music app; same weights, our serving stack."
+
+## Do's and don'ts
+
+**Do**
+- Keep the ID stable: choose once, never rename.
+- Use lowercase letters, numbers, and hyphens in the `model-id` (`octocat/my-model`).
+- Use the title for branding, the description for details.
+- State provider/routing facts in the description where they may change.
+
+**Don't**
+- Do not embed credentials, secret keys, or bearer tokens in any of the three fields.
+- Do not use pricing, vendor, latency, or context-size words in the ID.
+- Do not claim capabilities the upstream model does not have — the catalog checks some claims and users check the rest.
+- Do not impersonate a first-party Pollinations model or another publisher's exact name.
+
+## Still unsure?
+
+Ask in the Pollinations [Discord #dev-talk](https://discord.gg/pollinations-ai-885844321461485618). The most common mistake is a clever ID attached to a vague description — a stable, boring ID with a precise description is always the safer choice.

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/model-listing-fields.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/model-listing-fields.tsx
@@ -114,9 +114,19 @@ export function ModelListingFields({
                 <FieldStack
                     label={isAgent ? "ID" : "Model ID"}
                     helper={
-                        isAgent
-                            ? "Public ID: {username}/{id}."
-                            : "Public ID: {username}/{model-id}."
+                        <>
+                            {isAgent
+                                ? "Public ID: {username}/{id}."
+                                : "Public ID: {username}/{model-id}."}{" "}
+                            <a
+                                href="https://github.com/pollinations/pollinations/blob/main/COMMUNITY_MODEL_NAMING.md"
+                                target="_blank"
+                                rel="noreferrer"
+                                className="underline"
+                            >
+                                Naming guide
+                            </a>
+                        </>
                     }
                     alignLabelRow
                 >
@@ -135,7 +145,19 @@ export function ModelListingFields({
                 </FieldStack>
                 <FieldStack
                     label="Title"
-                    helper="Display name shown in the Models list."
+                    helper={
+                        <>
+                            Display name shown in the Models list.{" "}
+                            <a
+                                href="https://github.com/pollinations/pollinations/blob/main/COMMUNITY_MODEL_NAMING.md"
+                                target="_blank"
+                                rel="noreferrer"
+                                className="underline"
+                            >
+                                Naming guide
+                            </a>
+                        </>
+                    }
                     alignLabelRow
                 >
                     <Input


### PR DESCRIPTION
## Summary

Fixes #12885 — publishes concise community-model naming guidance.

New `COMMUNITY_MODEL_NAMING.md` explains the roles of the three user-facing fields (stable model ID, display title, description) and gives concrete, realistic examples for all four model types the quest calls out:

- Direct upstream models (`flux-schnell`)
- Custom models (`songpainter`)
- Routers / gateways (`vision-tools`)
- Rebranded upstream models (`aurora`)

The ID guidance keeps mutable details out of the stable ID: pricing/billing mode, provider routing, context size/latency, and frequently-changing version numbers all belong in the title/description instead.

## Changes

- **New:** `COMMUNITY_MODEL_NAMING.md` (89 lines — concise, table-driven, covers the four model cases)
- **Linked from the Add/Edit model form:** Model ID and Title helpers in `model-listing-fields.tsx` now include a "Naming guide" link
- **Linked from the publishing docs:** `BRING_YOUR_OWN_MODEL.md` "Register in the Dashboard" section points to the guide

## Verification

- `@biomejs/biome@2.3.10 check` passes on the modified `model-listing-fields.tsx` (no fixes applied)
- Docs-only + one form helper; no schema enforcement, no dashboard warnings, no aliases, no migrations, no renaming of existing IDs
