### PR TITLE
feat: add sharktide to GitHub Polli whitelist

### DIFF
--- a/.github/workflows/repo-auto-fix-polli-issues.yml
+++ b/.github/workflows/repo-auto-fix-polli-issues.yml
@@ -44,6 +44,7 @@ jobs:
               204561696, // tomdacatto
               182555207, // YoannDev90
               34513273, // fisventurous
+              189873015, // sharktide
             ]);
             const authorizedBotId = 247793354; // pollinations-ai[bot]
             const labeledBy = context.payload.sender.login;

--- a/.github/workflows/repo-polli-assistant.yml
+++ b/.github/workflows/repo-polli-assistant.yml
@@ -67,6 +67,7 @@ jobs:
               204561696, // tomdacatto
               182555207, // YoannDev90
               34513273, // fisventurous
+              189873015, // sharktide
             ]);
             const actor = context.actor;
             const actorId = context.payload.sender?.id;


### PR DESCRIPTION
- Expands GitHub Polli access from 7 to 8 authorized users across both workflows.
- Adds sharktide using immutable GitHub user ID 189873015.
- Enables access to the !polli assistant for issue and PR review/coding requests, plus automated fixes for issues labeled POLLI.