### PR TITLE
feat: add GLM-5.3 Flash

### DIFF
--- a/MODEL_SLUGS.md
+++ b/MODEL_SLUGS.md
@@ -10,6 +10,8 @@ The new publisher-qualified model IDs are available now. On **September 7, 2026 
 
 Existing IDs will remain available as aliases, so current integrations do not need to change. New integrations can use the new IDs today.
 
+Models introduced during the transition may launch directly with a publisher-qualified canonical ID and no legacy alias.
+
 Only the names are changing. Model behavior and pricing stay the same.
 
 ## Alibaba
@@ -356,3 +358,4 @@ Only the names are changing. Model behavior and pricing stay the same.
 | --- | --- | --- |
 | Z.ai GLM-5.2 | `glm` | `z-ai/glm-5.2` |
 | Z.ai GLM-5.3 | `glm-5.3` | `z-ai/glm-5.3` |
+| Z.ai GLM-5.3 Flash | — | `z-ai/glm-5.3-flash` |

--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -1931,6 +1931,20 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptAudioSeconds": 0.0000452777777777778,
     },
   },
+  "z-ai/glm-5.3-flash": {
+    "cost": {
+      "completionTextTokens": 0.00000025,
+      "promptCachedTokens": 0.000000015,
+      "promptImageTokens": 0.000000075,
+      "promptTextTokens": 0.000000075,
+    },
+    "price": {
+      "completionTextTokens": 0.00000025,
+      "promptCachedTokens": 0.000000015,
+      "promptImageTokens": 0.000000075,
+      "promptTextTokens": 0.000000075,
+    },
+  },
   "zimage": {
     "cost": {
       "completionImageTokens": 0.004,

--- a/enter.pollinations.ai/test/aliases.test.ts
+++ b/enter.pollinations.ai/test/aliases.test.ts
@@ -87,8 +87,8 @@ test("every public model has one publisher-qualified ID", () => {
         const definition = getRegistryModelDefinition(model);
         if (definition.hidden) continue;
 
-        const publisherQualifiedIds = definition.aliases.filter((alias) =>
-            alias.includes("/"),
+        const publisherQualifiedIds = [model, ...definition.aliases].filter(
+            (id) => id.includes("/"),
         );
 
         expect(publisherQualifiedIds, model).toHaveLength(1);

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -421,6 +421,12 @@ const models: ModelDefinition[] = [
         transform: mandatoryReasoning,
     },
     {
+        name: "z-ai/glm-5.3-flash",
+        config: portkeyConfig["z-ai/glm-5.3-flash"],
+        // Reasoning is mandatory; off requests keep the upstream default.
+        transform: mandatoryReasoning,
+    },
+    {
         name: "minimax-m2.7",
         config: portkeyConfig["accounts/fireworks/models/minimax-m2p7"],
         // Reasoning mandatory: rejects "none"/"minimal", accepts low/medium/high.

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -172,6 +172,17 @@ export const portkeyConfig: PortkeyConfigMap = {
                 },
             },
         }),
+    "z-ai/glm-5.3-flash": () =>
+        createOpenRouterModelConfig({
+            model: "z-ai/glm-5.3-flash",
+            defaultOptions: {
+                max_tokens: 64000,
+                provider: {
+                    only: ["z-ai/fp8"],
+                    allow_fallbacks: false,
+                },
+            },
+        }),
     "xiaomi/mimo-v2.5": createPinnedOpenRouterConfig(
         "xiaomi/mimo-v2.5",
         "xiaomi/fp8",

--- a/gen.pollinations.ai/test/models-retrieve.test.ts
+++ b/gen.pollinations.ai/test/models-retrieve.test.ts
@@ -23,6 +23,20 @@ test("retrieves a model by canonical ID", async () => {
     expect(typeof body.owned_by).toBe("string");
 });
 
+test("retrieves a publisher-qualified canonical ID", async ({ paidApiKey }) => {
+    const model = "z-ai/glm-5.3-flash";
+    const response = await fetchWorker(
+        `/v1/models/${encodeURIComponent(model)}`,
+        {
+            headers: { Authorization: `Bearer ${paidApiKey}` },
+        },
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { id: string };
+    expect(body.id).toBe(model);
+});
+
 test("resolves an alias to the canonical ID with identical metadata", async () => {
     const byAlias = await fetchWorker("/v1/models/gpt-5-nano");
     expect(byAlias.status).toBe(200);

--- a/gen.pollinations.ai/test/text/transforms/createReasoningEffortTransform.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/createReasoningEffortTransform.test.ts
@@ -105,6 +105,7 @@ describe("reasoning_effort model wiring", () => {
 
     it.each([
         "glm-5.3",
+        "z-ai/glm-5.3-flash",
         "minimax-m2.7",
         "step-3.5-flash",
         "step-flash",

--- a/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
+++ b/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
@@ -248,6 +248,22 @@ describe("resolveModelConfig", () => {
         });
     });
 
+    it("pins GLM-5.3 Flash to Z.AI FP8 on OpenRouter without fallback", () => {
+        const result = resolveModelConfig(messages, {
+            model: "z-ai/glm-5.3-flash",
+        });
+
+        expect(result.options.model).toBe("z-ai/glm-5.3-flash");
+        expect(result.options.modelConfig).toMatchObject({
+            provider: "openrouter",
+            directEndpoint: "https://openrouter.ai/api/v1/chat/completions",
+        });
+        expect(result.options.provider).toEqual({
+            only: ["z-ai/fp8"],
+            allow_fallbacks: false,
+        });
+    });
+
     it.each([
         ["qwen-coder-large", "qwen/qwen3-coder-next", "parasail/bf16"],
         ["qwen-vision", "qwen/qwen3-vl-30b-a3b-instruct", "alibaba"],

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -1695,6 +1695,32 @@ export const TEXT_SERVICES = {
         contextLength: 1048576,
         isSpecialized: false,
     },
+    "z-ai/glm-5.3-flash": {
+        aliases: [],
+        provider: "openrouter",
+        brand: "Z.ai",
+        category: "text",
+        addedDate: new Date("2026-08-27").getTime(),
+        paidOnly: true,
+        priceMultiplier: 1,
+        cost: {
+            // OpenRouter Z.AI FP8 route rates (2026-08-27).
+            promptTextTokens: perMillion(0.075),
+            promptCachedTokens: perMillion(0.015),
+            promptImageTokens: perMillion(0.075),
+            completionTextTokens: perMillion(0.25),
+        },
+        title: "Z.ai GLM-5.3 Flash",
+        description:
+            "Low-cost million-token multimodal reasoning for agents and visual analysis",
+        inputModalities: ["text", "image"],
+        outputModalities: ["text"],
+        maxReferenceImages: 10,
+        tools: true,
+        reasoning: true,
+        contextLength: 1048576,
+        isSpecialized: false,
+    },
     "llama": {
         aliases: [
             "llama-3.3",


### PR DESCRIPTION
- Adds `z-ai/glm-5.3-flash` as a publisher-qualified canonical model with no aliases.
- Pins OpenRouter to the exact `z-ai/fp8` route with provider fallback disabled.
- Sets `paidOnly: true`, multiplier `1`, and verified rates: $0.075/M input and image tokens, $0.015/M cached input, and $0.25/M output.
- Advertises text and image input, tools, mandatory reasoning, 10 reference images, and a 1,048,576-token context window.
- Updates `MODEL_SLUGS.md`, pricing snapshots, canonical-ID retrieval, resolver, reasoning, alias, and billing coverage.

Verified directly and through authenticated local E2E: streaming/non-streaming, tools, JSON object mode, reasoning, 10 images, prompt caching, exact billing, paid-only access, cache hit without a second debit, invalid input, and a 5-request burst.

No Pollinations GPU and no fallback.
