### PR TITLE
fix: route Qwen Vision Pro directly to Alibaba

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -1519,11 +1519,15 @@ exports[`effective cost and price per model — snapshot 1`] = `
   },
   "qwen-vision-pro": {
     "cost": {
+      "completionReasoningTokens": 0.000004,
       "completionTextTokens": 0.000004,
+      "promptImageTokens": 0.0000004,
       "promptTextTokens": 0.0000004,
     },
     "price": {
+      "completionReasoningTokens": 0.000004,
       "completionTextTokens": 0.000004,
+      "promptImageTokens": 0.0000004,
       "promptTextTokens": 0.0000004,
     },
   },

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -150,7 +150,7 @@ const models: ModelDefinition[] = [
     },
     {
         name: "qwen-vision-pro",
-        config: portkeyConfig["qwen/qwen3-vl-235b-a22b-thinking"],
+        config: portkeyConfig["qwen3-vl-235b-a22b-thinking"],
         // Reasoning mandatory: rejects "none" but accepts low/medium/high.
         transform: mandatoryReasoning,
     },

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -151,7 +151,7 @@ const models: ModelDefinition[] = [
     {
         name: "qwen-vision-pro",
         config: portkeyConfig["qwen3-vl-235b-a22b-thinking"],
-        // Reasoning mandatory: rejects "none" but accepts low/medium/high.
+        // Alibaba thinking-only model; strip "none" to preserve always-on reasoning.
         transform: mandatoryReasoning,
     },
     {

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -1,5 +1,6 @@
 import googleCloudAuth from "../auth/googleCloudAuth.js";
 import {
+    createAlibabaModelConfig,
     createAzureModelConfig,
     createBedrockNativeConfig,
     createDeepInfraModelConfig,
@@ -505,10 +506,10 @@ export const portkeyConfig: PortkeyConfigMap = {
         "qwen/qwen3-vl-30b-a3b-instruct",
         "alibaba",
     ),
-    "qwen/qwen3-vl-235b-a22b-thinking": createPinnedOpenRouterConfig(
-        "qwen/qwen3-vl-235b-a22b-thinking",
-        "alibaba",
-    ),
+    "qwen3-vl-235b-a22b-thinking": () =>
+        createAlibabaModelConfig({
+            model: "qwen3-vl-235b-a22b-thinking",
+        }),
 
     // -- OpenRouter (StepFun) -------------------------------------------------
     "stepfun/step-3.5-flash": () =>

--- a/gen.pollinations.ai/src/text/configs/providerConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/providerConfigs.ts
@@ -109,6 +109,18 @@ export function createOpenRouterModelConfig(
     };
 }
 
+export function createAlibabaModelConfig(
+    overrides: ModelOverride = {},
+): ProviderConfig {
+    return {
+        provider: "openai",
+        directEndpoint:
+            "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions",
+        authKey: process.env.DASHSCOPE_API_KEY,
+        ...overrides,
+    };
+}
+
 export function createVercelAIGatewayModelConfig(
     overrides: ModelOverride = {},
 ): ProviderConfig {

--- a/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
+++ b/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
@@ -267,7 +267,6 @@ describe("resolveModelConfig", () => {
     it.each([
         ["qwen-coder-large", "qwen/qwen3-coder-next", "parasail/bf16"],
         ["qwen-vision", "qwen/qwen3-vl-30b-a3b-instruct", "alibaba"],
-        ["qwen-vision-pro", "qwen/qwen3-vl-235b-a22b-thinking", "alibaba"],
         [
             "mistral-small-3.2",
             "mistralai/mistral-small-3.2-24b-instruct",
@@ -286,6 +285,20 @@ describe("resolveModelConfig", () => {
             only: [provider],
             allow_fallbacks: false,
         });
+    });
+
+    it("routes Qwen Vision Pro directly to Alibaba without fallback", () => {
+        const result = resolveModelConfig(messages, {
+            model: "qwen-vision-pro",
+        });
+
+        expect(result.options.model).toBe("qwen3-vl-235b-a22b-thinking");
+        expect(result.options.modelConfig).toMatchObject({
+            provider: "openai",
+            directEndpoint:
+                "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions",
+        });
+        expect(result.options.provider).toBeUndefined();
     });
 
     it("excludes Mistral's non-standard endpoint variants", () => {

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -2212,16 +2212,18 @@ export const TEXT_SERVICES = {
             "qwen-vl-pro",
             "qwen/qwen3-vl-235b-a22b-thinking",
         ],
-        provider: "openrouter",
+        provider: "alibaba",
         brand: "Qwen",
         addedDate: new Date("2026-05-15").getTime(),
         paidOnly: true,
         priceMultiplier: 1,
         category: "text",
         cost: {
-            // OpenRouter Alibaba endpoint, verified 2026-08-22.
+            // Alibaba Model Studio Singapore PAYG, verified 2026-08-28.
             promptTextTokens: perMillion(0.4),
+            promptImageTokens: perMillion(0.4),
             completionTextTokens: perMillion(4),
+            completionReasoningTokens: perMillion(4),
         },
         title: "Qwen3 VL 235B A22B Thinking",
         description:
@@ -2230,7 +2232,7 @@ export const TEXT_SERVICES = {
         outputModalities: ["text"],
         tools: true,
         reasoning: true,
-        contextLength: 262144,
+        contextLength: 131072,
         isSpecialized: false,
     },
     "step-flash": {


### PR DESCRIPTION
- Routes `qwen-vision-pro` directly to Alibaba Model Studio Singapore after its pinned OpenRouter endpoint became unavailable.
- Keeps the canonical name, aliases, paid-only access, multiplier `1`, and no fallback unchanged.
- Records the exact $0.40/M text or image input and $4/M text or reasoning output meters; corrects context to 131,072.
- Verifies text, image, streaming, tools, JSON, errors, aliases, permissions, cache, wallet/event billing, and a 10-request local burst (10/10 succeeded).

Alibaba schedules this exact checkpoint for retirement on October 10, 2026; its successor should be handled separately before then.