### PR TITLE
fix: remove leaked key incident banner

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/keys/api-key-list.tsx
+++ b/enter.pollinations.ai/frontend/src/components/keys/api-key-list.tsx
@@ -1,5 +1,4 @@
 import {
-    Alert,
     AppIcon,
     Chip,
     GlobeIcon,
@@ -47,17 +46,6 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
     const now = Date.now();
     const visibleKeys = apiKeys.filter(
         (k) => !k.expiresAt || new Date(k.expiresAt).getTime() > now,
-    );
-    const leakedPublishableKeys = visibleKeys.filter(
-        (key) =>
-            isPublishableKey(key) &&
-            key.metadata?.directUseDisabledDueToLeak === true,
-    );
-    const disabledPublishableKeys = leakedPublishableKeys.filter(
-        (key) => !isAppKey(key) && key.enabled === false,
-    );
-    const protectedAppKeys = leakedPublishableKeys.filter(
-        (key) => isAppKey(key) && key.enabled !== false,
     );
     const sortedKeys = [...visibleKeys].sort(
         (a, b) =>
@@ -240,48 +228,6 @@ export const ApiKeyList: FC<ApiKeyManagerProps> = ({
     return (
         <>
             <div className="flex flex-col gap-6">
-                {(disabledPublishableKeys.length > 0 ||
-                    protectedAppKeys.length > 0) && (
-                    <Alert intent="warning">
-                        {disabledPublishableKeys.length > 0 && (
-                            <p className="font-medium">
-                                We disabled {disabledPublishableKeys.length}{" "}
-                                publishable{" "}
-                                {disabledPublishableKeys.length === 1
-                                    ? "key"
-                                    : "keys"}{" "}
-                                after detecting suspicious direct use:{" "}
-                                {disabledPublishableKeys
-                                    .map((key) => key.name || "Unnamed key")
-                                    .join(", ")}
-                                .
-                            </p>
-                        )}
-                        {protectedAppKeys.length > 0 && (
-                            <p className="font-medium">
-                                We blocked direct Pollen spending on{" "}
-                                {protectedAppKeys.length} app{" "}
-                                {protectedAppKeys.length === 1 ? "key" : "keys"}{" "}
-                                after detecting suspicious direct use:{" "}
-                                {protectedAppKeys
-                                    .map((key) => key.name || "Unnamed key")
-                                    .join(", ")}
-                                . Connect User Wallets remains available.
-                            </p>
-                        )}
-                        <p className="mt-1 text-sm">
-                            Raw publishable keys (<code>pk_</code>) are legacy
-                            for direct API requests. Use Connect User Wallets,
-                            where users sign in and spend their own Pollen.{" "}
-                            <InlineLink
-                                href={genDocsUrl("#tag/connect-user-wallets")}
-                            >
-                                Read the migration guide
-                            </InlineLink>
-                            .
-                        </p>
-                    </Alert>
-                )}
                 <Section
                     title="API"
                     framed


### PR DESCRIPTION
- Removes the historical leaked-key warning from the Keys page
- Removes filtering logic used only by that banner
- Keeps publishable-key budget and direct-spending enforcement unchanged

Checks:
- `npx biome check --write enter.pollinations.ai/frontend/src/components/keys/api-key-list.tsx`
- `npm run typecheck --workspace enter.pollinations.ai`
- `npm run build:frontend --workspace enter.pollinations.ai`

Follow-up to #13338.