### PR TITLE
feat: add Gemini Omni 1.1 Flash video

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -430,6 +430,20 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.0000014,
     },
   },
+  "google/gemini-omni-1.1-flash": {
+    "cost": {
+      "completionTextTokens": 0.000009,
+      "completionVideoTokens": 0.0000175,
+      "promptImageTokens": 0.0000015,
+      "promptTextTokens": 0.0000015,
+    },
+    "price": {
+      "completionTextTokens": 0.000009,
+      "completionVideoTokens": 0.0000175,
+      "promptImageTokens": 0.0000015,
+      "promptTextTokens": 0.0000015,
+    },
+  },
   "gpt-5.4": {
     "cost": {
       "completionTextTokens": 0.000015,

--- a/enter.pollinations.ai/test/cost-variants.test.ts
+++ b/enter.pollinations.ai/test/cost-variants.test.ts
@@ -756,6 +756,14 @@ describe("registry-wide variant invariants", () => {
     it("every advertised non-default resolution selects a variant", () => {
         for (const model of getModels()) {
             const definition = getRegistryModelDefinition(model);
+            // Token-metered video routes keep one per-token rate; resolution
+            // changes the provider-reported output-token quantity instead.
+            if (
+                definition.cost.completionVideoTokens !== undefined &&
+                !definition.costVariants
+            ) {
+                continue;
+            }
             for (const resolution of definition.resolutions?.slice(1) ?? []) {
                 const variant = definition.selectCostVariant?.({
                     usage: {},

--- a/enter.pollinations.ai/test/pricing-data.test.ts
+++ b/enter.pollinations.ai/test/pricing-data.test.ts
@@ -498,6 +498,22 @@ test("reasoning token usage bills through completion text rates", () => {
     }
 });
 
+test("Gemini Omni bills exact Vertex modality usage", () => {
+    const model = "google/gemini-omni-1.1-flash";
+    const usage = {
+        promptTextTokens: 31,
+        completionVideoTokens: 5_793,
+        completionReasoningTokens: 276,
+    };
+    const cost = calculateCost(model, usage);
+
+    expect(cost.totalCost).toBeCloseTo(
+        31 * 0.0000015 + 5_793 * 0.0000175 + 276 * 0.000009,
+        10,
+    );
+    expect(calculatePrice(model, usage).totalPrice).toBe(cost.totalCost);
+});
+
 test("Claude Fable 5 is paid-only and billed at current standard rates", () => {
     const definition = getRegistryModelDefinition("claude-fable-5");
 

--- a/gen.pollinations.ai/src/image/createAndReturnVideos.ts
+++ b/gen.pollinations.ai/src/image/createAndReturnVideos.ts
@@ -7,6 +7,7 @@ import { HttpError } from "@shared/http-error.ts";
 import { getVideoModelIds, IMAGE_SERVICES } from "@shared/registry/image.ts";
 import type { ModelDefinition } from "@shared/registry/registry.ts";
 import debug from "debug";
+import { callGeminiOmniAPI } from "./models/geminiOmniVideoModel.ts";
 import { callMinimaxH3API } from "./models/minimaxH3Model.ts";
 import { callNovaReelAPI } from "./models/novaReelModel.ts";
 import {
@@ -64,6 +65,9 @@ export async function createAndReturnVideo(
 
     let result: VideoGenerationResult;
     switch (safeParams.model) {
+        case "google/gemini-omni-1.1-flash":
+            result = await callGeminiOmniAPI(prompt, safeParams);
+            break;
         case "veo":
             result = await callVeoAPI(prompt, safeParams);
             break;

--- a/gen.pollinations.ai/src/image/models/geminiOmniVideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/geminiOmniVideoModel.ts
@@ -1,0 +1,196 @@
+import { HttpError } from "@shared/http-error.ts";
+import debug from "debug";
+import googleCloudAuth from "@/text/auth/googleCloudAuth.ts";
+import { getImageEnv } from "../env.ts";
+import type { ImageParams } from "../params.ts";
+import { fetchUpstream } from "../utils/fetchUpstream.ts";
+import { downloadUserImage } from "../utils/imageDownload.ts";
+import type { VideoGenerationResult } from "./veoVideoModel.ts";
+
+const logOps = debug("pollinations:gemini-omni:ops");
+
+const MODEL_ID = "gemini-omni-1.1-flash-preview";
+const PUBLIC_MODEL_ID = "google/gemini-omni-1.1-flash";
+const RESOLUTIONS = ["360p", "720p", "1080p", "4k"] as const;
+
+type ModalityTokens = {
+    modality?: "text" | "image" | "audio" | "video" | "document";
+    tokens?: number;
+};
+
+type GeminiOmniResponse = {
+    status?: string;
+    usage?: {
+        input_tokens_by_modality?: ModalityTokens[];
+        output_tokens_by_modality?: ModalityTokens[];
+        total_thought_tokens?: number;
+        total_tokens?: number;
+    };
+    steps?: Array<{
+        content?: Array<{
+            type?: string;
+            data?: string;
+            mime_type?: string;
+        }>;
+    }>;
+};
+
+function tokensFor(
+    rows: ModalityTokens[] | undefined,
+    modality: ModalityTokens["modality"],
+): number | undefined {
+    const total = rows
+        ?.filter((row) => row.modality === modality)
+        .reduce((sum, row) => sum + (row.tokens ?? 0), 0);
+    return total && total > 0 ? total : undefined;
+}
+
+async function imageInput(url: string) {
+    const { buffer, mimeType } = await downloadUserImage(url);
+    return {
+        type: "image" as const,
+        data: buffer.toString("base64"),
+        mime_type: mimeType,
+    };
+}
+
+export async function callGeminiOmniAPI(
+    prompt: string,
+    safeParams: ImageParams,
+): Promise<VideoGenerationResult> {
+    const duration = safeParams.duration ?? 5;
+    if (!Number.isInteger(duration) || duration < 3 || duration > 10) {
+        throw new HttpError(
+            "Gemini Omni 1.1 Flash supports whole-second durations from 3 to 10.",
+            400,
+        );
+    }
+    if (safeParams.fps !== undefined && safeParams.fps !== 24) {
+        throw new HttpError(
+            "Gemini Omni 1.1 Flash outputs video at 24 FPS.",
+            400,
+        );
+    }
+
+    const requestedResolution = safeParams.resolution ?? "720p";
+    if (
+        !RESOLUTIONS.includes(
+            requestedResolution as (typeof RESOLUTIONS)[number],
+        )
+    ) {
+        throw new HttpError(
+            `Gemini Omni 1.1 Flash does not support ${requestedResolution} resolution.`,
+            400,
+        );
+    }
+    const resolution = requestedResolution as (typeof RESOLUTIONS)[number];
+    const aspectRatio =
+        safeParams.aspectRatio === "16:9" || safeParams.aspectRatio === "9:16"
+            ? safeParams.aspectRatio
+            : safeParams.dimensionsExplicit &&
+                safeParams.height > safeParams.width
+              ? "9:16"
+              : "16:9";
+
+    const projectId = getImageEnv("GOOGLE_PROJECT_ID");
+    if (!projectId) {
+        throw new HttpError(
+            "GOOGLE_PROJECT_ID environment variable is required",
+            500,
+        );
+    }
+    const accessToken = await googleCloudAuth.getAccessToken();
+    if (!accessToken) {
+        throw new HttpError("Failed to get Google Cloud access token", 500);
+    }
+
+    const input = [
+        { type: "text" as const, text: prompt },
+        ...(await Promise.all(safeParams.image.map(imageInput))),
+    ];
+    const endpoint = `https://aiplatform.googleapis.com/v1beta1/projects/${projectId}/locations/global/interactions`;
+    const response = await fetchUpstream(endpoint, {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${accessToken}`,
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+            model: MODEL_ID,
+            store: false,
+            input,
+            response_format: [
+                {
+                    type: "video",
+                    aspect_ratio: aspectRatio,
+                    resolution,
+                    duration: `${duration}s`,
+                },
+            ],
+            generation_config: {
+                video_config: {
+                    task:
+                        safeParams.image.length > 0
+                            ? "image_to_video"
+                            : "text_to_video",
+                },
+            },
+        }),
+        errorLabel: "Gemini Omni API request failed",
+    });
+    const data = (await response.json()) as GeminiOmniResponse;
+    const video = data.steps
+        ?.flatMap((step) => step.content ?? [])
+        .find((content) => content.type === "video" && content.data);
+    if (data.status !== "completed" || !video?.data) {
+        throw new HttpError(
+            "Gemini Omni API returned no completed video",
+            502,
+            undefined,
+            endpoint,
+        );
+    }
+
+    const inputUsage = data.usage?.input_tokens_by_modality;
+    const outputUsage = data.usage?.output_tokens_by_modality;
+    const promptTextTokens = tokensFor(inputUsage, "text");
+    const promptImageTokens = tokensFor(inputUsage, "image");
+    const completionTextTokens = tokensFor(outputUsage, "text");
+    const completionVideoTokens = tokensFor(outputUsage, "video");
+    const completionReasoningTokens = data.usage?.total_thought_tokens;
+    if (!completionVideoTokens) {
+        throw new HttpError(
+            "Gemini Omni API returned no billable video usage",
+            502,
+            undefined,
+            endpoint,
+        );
+    }
+    const usage = {
+        ...(promptTextTokens ? { promptTextTokens } : {}),
+        ...(promptImageTokens ? { promptImageTokens } : {}),
+        ...(completionTextTokens ? { completionTextTokens } : {}),
+        completionVideoTokens,
+        ...(completionReasoningTokens ? { completionReasoningTokens } : {}),
+        ...(data.usage?.total_tokens
+            ? { totalTokenCount: data.usage.total_tokens }
+            : {}),
+    };
+
+    logOps("Gemini Omni generation complete", {
+        duration,
+        resolution,
+        aspectRatio,
+        usage,
+    });
+
+    return {
+        buffer: Buffer.from(video.data, "base64"),
+        mimeType: video.mime_type ?? "video/mp4",
+        durationSeconds: duration,
+        trackingData: {
+            actualModel: PUBLIC_MODEL_ID,
+            usage,
+        },
+    };
+}

--- a/gen.pollinations.ai/src/image/models/veoVideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/veoVideoModel.ts
@@ -1,4 +1,5 @@
 import { HttpError } from "@shared/http-error.ts";
+import type { Usage } from "@shared/registry/registry.ts";
 import debug from "debug";
 import googleCloudAuth from "@/text/auth/googleCloudAuth.ts";
 import { getImageEnv } from "../env.ts";
@@ -44,12 +45,7 @@ export interface VideoGenerationResult {
     durationSeconds: number;
     trackingData: {
         actualModel: string;
-        usage: {
-            completionVideoSeconds?: number; // For Veo, Wan (billed by seconds)
-            completionVideoTokens?: number; // For Seedance (billed by tokens)
-            completionAudioSeconds?: number; // Output audio billed by seconds
-            totalTokenCount?: number;
-        };
+        usage: Usage & { totalTokenCount?: number };
     };
 }
 

--- a/gen.pollinations.ai/src/image/params.ts
+++ b/gen.pollinations.ai/src/image/params.ts
@@ -115,7 +115,7 @@ export const ImageParamsSchema = z
         duration: z.coerce.number().optional(),
         fps: z.coerce.number().optional(),
         resolution: z
-            .enum(["1k", "2k", "480p", "720p", "768p", "1080p"])
+            .enum(["1k", "2k", "360p", "480p", "720p", "768p", "1080p", "4k"])
             .optional(),
         aspectRatio: z
             .enum([
@@ -201,6 +201,27 @@ export const ImageParamsSchema = z
                     code: z.ZodIssueCode.custom,
                     path: ["fps"],
                     message: "minimax-h3 outputs 24 FPS.",
+                });
+            }
+        }
+        if (data.model === "google/gemini-omni-1.1-flash") {
+            if (
+                data.aspectRatio !== undefined &&
+                !["16:9", "9:16"].includes(data.aspectRatio)
+            ) {
+                ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: ["aspectRatio"],
+                    message:
+                        "google/gemini-omni-1.1-flash supports 16:9 or 9:16.",
+                });
+            }
+            if (data.fps !== undefined && data.fps !== 24) {
+                ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: ["fps"],
+                    message:
+                        "google/gemini-omni-1.1-flash outputs video at 24 FPS.",
                 });
             }
         }

--- a/gen.pollinations.ai/src/schemas/image.ts
+++ b/gen.pollinations.ai/src/schemas/image.ts
@@ -132,7 +132,7 @@ const GenerateImageRequestQueryParamsBaseSchema = z.object({
 
     // Video-specific params
     resolution: z
-        .enum(["1k", "2k", "480p", "720p", "768p", "1080p"])
+        .enum(["1k", "2k", "360p", "480p", "720p", "768p", "1080p", "4k"])
         .optional()
         .meta({
             description:
@@ -140,15 +140,15 @@ const GenerateImageRequestQueryParamsBaseSchema = z.object({
         }),
     duration: z.coerce.number().int().min(1).max(120).optional().meta({
         description:
-            "Video duration in seconds. Only applies to video models. `veo`: 4, 6, or 8s. `seedance-pro`: 2-10s. `seedance-2.0`: 4-15s; Mini: 4-10s; Fast: 4-5s. `seedance-2.5`: exactly 4s. `minimax-h3`: exactly 5s. `wan`: 2-15s. `wan-3.0`: exactly 5s. `nova-reel`: 6-120s (multiples of 6).",
+            "Video duration in seconds. Only applies to video models. `google/gemini-omni-1.1-flash`: 3-10s. `veo`: 4, 6, or 8s. `seedance-pro`: 2-10s. `seedance-2.0`: 4-15s; Mini: 4-10s; Fast: 4-5s. `seedance-2.5`: exactly 4s. `minimax-h3`: exactly 5s. `wan`: 2-15s. `wan-3.0`: exactly 5s. `nova-reel`: 6-120s (multiples of 6).",
     }),
     aspectRatio: z.string().optional().meta({
         description:
-            "Video aspect ratio (`16:9` or `9:16`). Only applies to video models. If not set, determined by explicit width/height; `seedance-2.5` otherwise defaults to `16:9`. `minimax-h3` supports only `16:9`.",
+            "Video aspect ratio (`16:9` or `9:16`). Only applies to video models. If not set, determined by explicit width/height; `google/gemini-omni-1.1-flash` and `seedance-2.5` otherwise default to `16:9`. `minimax-h3` supports only `16:9`.",
     }),
     audio: z.coerce.boolean().optional().default(false).meta({
         description:
-            "Generate audio for the video. Only applies to video models. `wan` and `minimax-h3` always generate audio regardless of this flag. For `veo` and `wan-3.0`, set to `true` to enable audio.",
+            "Generate audio for the video. Only applies to video models. `google/gemini-omni-1.1-flash`, `wan`, and `minimax-h3` always generate audio regardless of this flag. For `veo` and `wan-3.0`, set to `true` to enable audio.",
     }),
 });
 

--- a/gen.pollinations.ai/test/image/geminiOmniVideoModel.test.ts
+++ b/gen.pollinations.ai/test/image/geminiOmniVideoModel.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { syncImageEnv } from "../../src/image/env.ts";
+import { callGeminiOmniAPI } from "../../src/image/models/geminiOmniVideoModel.ts";
+import type { ImageParams } from "../../src/image/params.ts";
+import googleCloudAuth from "../../src/text/auth/googleCloudAuth.ts";
+
+const FIRST_FRAME_URL = "https://image.example.com/first.png";
+const LAST_FRAME_URL = "https://image.example.com/last.png";
+const PNG_BYTES = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
+const VIDEO_BYTES = Buffer.from("gemini-omni-video");
+
+const baseParams: ImageParams = {
+    model: "google/gemini-omni-1.1-flash",
+    width: 1024,
+    height: 1024,
+    dimensionsExplicit: false,
+    seed: 42,
+    safe: false,
+    quality: "medium",
+    image: [],
+    transparent: false,
+    reasoning: "balanced",
+    audio: false,
+    duration: 5,
+};
+
+function setGoogleEnv() {
+    syncImageEnv({ GOOGLE_PROJECT_ID: "test-project" } as CloudflareBindings, [
+        "GOOGLE_PROJECT_ID",
+    ]);
+    vi.spyOn(googleCloudAuth, "getAccessToken").mockResolvedValue("test-token");
+}
+
+function mockGeminiOmniFetch(requests: Array<Record<string, unknown>>) {
+    return vi
+        .spyOn(globalThis, "fetch")
+        .mockImplementation(async (url, init) => {
+            const href = typeof url === "string" ? url : url.toString();
+            if (href === FIRST_FRAME_URL || href === LAST_FRAME_URL) {
+                return new Response(PNG_BYTES, {
+                    headers: { "Content-Type": "image/png" },
+                });
+            }
+            if (href.endsWith("/locations/global/interactions")) {
+                requests.push(
+                    JSON.parse(init?.body as string) as Record<string, unknown>,
+                );
+                return Response.json({
+                    status: "completed",
+                    usage: {
+                        total_tokens: 10_100,
+                        input_tokens_by_modality: [
+                            { modality: "text", tokens: 20 },
+                            { modality: "image", tokens: 2_240 },
+                        ],
+                        output_tokens_by_modality: [
+                            { modality: "video", tokens: 9_655 },
+                        ],
+                        total_thought_tokens: 425,
+                    },
+                    steps: [
+                        {
+                            type: "model_output",
+                            content: [
+                                {
+                                    type: "video",
+                                    mime_type: "video/mp4",
+                                    data: VIDEO_BYTES.toString("base64"),
+                                },
+                            ],
+                        },
+                    ],
+                });
+            }
+            return new Response("unexpected URL", { status: 404 });
+        });
+}
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe("geminiOmniVideoModel", () => {
+    it.each([
+        [undefined, "720p"],
+        ["360p", "360p"],
+        ["720p", "720p"],
+        ["1080p", "1080p"],
+        ["4k", "4k"],
+    ] as const)("forwards resolution %s as %s", async (requested, expected) => {
+        setGoogleEnv();
+        const requests: Array<Record<string, unknown>> = [];
+        mockGeminiOmniFetch(requests);
+
+        const result = await callGeminiOmniAPI("a calm ocean", {
+            ...baseParams,
+            resolution: requested,
+        });
+
+        expect(requests[0]).toMatchObject({
+            model: "gemini-omni-1.1-flash-preview",
+            store: false,
+            generation_config: {
+                video_config: { task: "text_to_video" },
+            },
+            response_format: [
+                {
+                    type: "video",
+                    aspect_ratio: "16:9",
+                    resolution: expected,
+                    duration: "5s",
+                },
+            ],
+        });
+        expect(result.buffer).toEqual(VIDEO_BYTES);
+        expect(result.trackingData).toEqual({
+            actualModel: "google/gemini-omni-1.1-flash",
+            usage: {
+                promptTextTokens: 20,
+                promptImageTokens: 2240,
+                completionVideoTokens: 9655,
+                completionReasoningTokens: 425,
+                totalTokenCount: 10100,
+            },
+        });
+    });
+
+    it("sends two frame images in order and honors portrait output", async () => {
+        setGoogleEnv();
+        const requests: Array<Record<string, unknown>> = [];
+        mockGeminiOmniFetch(requests);
+
+        await callGeminiOmniAPI("transition between these frames", {
+            ...baseParams,
+            image: [FIRST_FRAME_URL, LAST_FRAME_URL],
+            aspectRatio: "9:16",
+        });
+
+        expect(requests[0]).toMatchObject({
+            input: [
+                { type: "text", text: "transition between these frames" },
+                {
+                    type: "image",
+                    data: Buffer.from(PNG_BYTES).toString("base64"),
+                    mime_type: "image/png",
+                },
+                {
+                    type: "image",
+                    data: Buffer.from(PNG_BYTES).toString("base64"),
+                    mime_type: "image/png",
+                },
+            ],
+            generation_config: {
+                video_config: { task: "image_to_video" },
+            },
+            response_format: [{ aspect_ratio: "9:16" }],
+        });
+    });
+
+    it.each([
+        [1024, 1024, "16:9"],
+        [1280, 720, "16:9"],
+        [720, 1280, "9:16"],
+    ] as const)("maps explicit %sx%s dimensions to %s", async (width, height, aspectRatio) => {
+        setGoogleEnv();
+        const requests: Array<Record<string, unknown>> = [];
+        mockGeminiOmniFetch(requests);
+
+        await callGeminiOmniAPI("test", {
+            ...baseParams,
+            width,
+            height,
+            dimensionsExplicit: true,
+        });
+
+        expect(requests[0]).toMatchObject({
+            response_format: [{ aspect_ratio: aspectRatio }],
+        });
+    });
+
+    it("rejects unsupported duration and FPS before calling Vertex", async () => {
+        setGoogleEnv();
+        const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+        for (const params of [
+            { duration: 2 },
+            { duration: 3.5 },
+            { fps: 30 },
+        ]) {
+            await expect(
+                callGeminiOmniAPI("test", { ...baseParams, ...params }),
+            ).rejects.toMatchObject({ status: 400 });
+        }
+        expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("returns 502 when Vertex completes without video data", async () => {
+        setGoogleEnv();
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+            Response.json({ status: "completed", steps: [] }),
+        );
+
+        await expect(
+            callGeminiOmniAPI("test", baseParams),
+        ).rejects.toMatchObject({ status: 502 });
+    });
+
+    it("returns 502 when Vertex omits billable video usage", async () => {
+        setGoogleEnv();
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+            Response.json({
+                status: "completed",
+                steps: [
+                    {
+                        content: [
+                            {
+                                type: "video",
+                                mime_type: "video/mp4",
+                                data: VIDEO_BYTES.toString("base64"),
+                            },
+                        ],
+                    },
+                ],
+            }),
+        );
+
+        await expect(
+            callGeminiOmniAPI("test", baseParams),
+        ).rejects.toMatchObject({ status: 502 });
+    });
+});

--- a/gen.pollinations.ai/test/image/params.test.ts
+++ b/gen.pollinations.ai/test/image/params.test.ts
@@ -113,6 +113,25 @@ describe("ImageParamsSchema", () => {
         ).toBe(false);
     });
 
+    it("enforces the public Gemini Omni 1.1 Flash contract", () => {
+        for (const resolution of ["360p", "720p", "1080p", "4k"] as const) {
+            expect(
+                ImageParamsSchema.safeParse({
+                    model: "google/gemini-omni-1.1-flash",
+                    resolution,
+                }).success,
+            ).toBe(true);
+        }
+        for (const params of [{ aspectRatio: "1:1" }, { fps: 30 }]) {
+            expect(
+                ImageParamsSchema.safeParse({
+                    model: "google/gemini-omni-1.1-flash",
+                    ...params,
+                }).success,
+            ).toBe(false);
+        }
+    });
+
     it("rejects unsupported Grok Imagine Image 2.0 quality", () => {
         const result = ImageParamsSchema.safeParse({
             model: "grok-imagine-image-2.0",

--- a/gen.pollinations.ai/test/image/videoFrameValidation.test.ts
+++ b/gen.pollinations.ai/test/image/videoFrameValidation.test.ts
@@ -12,6 +12,7 @@ import {
 import type { ImageParams } from "../../src/image/params.ts";
 
 const VIDEO_FRAME_LIMITS = [
+    ["google/gemini-omni-1.1-flash", 2],
     ["veo", 2],
     ["seedance-pro", 1],
     ["seedance-2.0", 2],

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -428,6 +428,34 @@ const IMAGE_BASE_SERVICES = {
         defaultDuration: 4,
         allowedDurations: [4, 6, 8],
     },
+    "google/gemini-omni-1.1-flash": {
+        aliases: [],
+        provider: "google",
+        brand: "Google",
+        category: "video",
+        addedDate: new Date("2026-08-28").getTime(),
+        paidOnly: true,
+        priceMultiplier: 1,
+        // Vertex AI pricing verified 2026-08-28:
+        // https://cloud.google.com/vertex-ai/generative-ai/pricing
+        cost: {
+            promptTextTokens: perMillion(1.5),
+            promptImageTokens: perMillion(1.5),
+            completionTextTokens: perMillion(9),
+            completionVideoTokens: perMillion(17.5),
+        },
+        resolutions: ["720p", "360p", "1080p", "4k"],
+        title: "Gemini Omni 1.1 Flash",
+        description:
+            "Cinematic video from text or keyframes with synchronized audio at up to 4K",
+        inputModalities: ["text", "image"],
+        outputModalities: ["video"],
+        videoCapabilities: ["start_frame", "end_frame", "audio_output"],
+        maxReferenceImages: 2,
+        minDuration: 3,
+        maxDuration: 10,
+        defaultDuration: 5,
+    },
     "seedance-pro": {
         aliases: ["bytedance/seedance-1-pro-fast"],
         provider: "replicate",

--- a/shared/schemas/openai.ts
+++ b/shared/schemas/openai.ts
@@ -592,7 +592,7 @@ const imageQualityField = z
             "Image quality. OpenAI 'standard'/'hd' mapped to Pollinations equivalents",
     });
 const imageResolutionField = z
-    .enum(["1k", "2k", "480p", "720p", "768p", "1080p"])
+    .enum(["1k", "2k", "360p", "480p", "720p", "768p", "1080p", "4k"])
     .optional()
     .meta({
         description:


### PR DESCRIPTION
- Adds paid-only canonical `google/gemini-omni-1.1-flash` with no aliases, fallback, or Pollinations GPU.
- Uses Vertex global Interactions route `gemini-omni-1.1-flash-preview` with exact provider-reported modality-token billing at $1.50/M input, $9/M text/thought output, and $17.50/M video output.
- Supports text or two keyframes, synchronized audio, 3–10 seconds, 24 FPS, 16:9/9:16, and 360p/720p/1080p/4K.
- Verifies direct provider calls and full local E2E across every resolution, URL/base64 formats, cache, paid-only/error paths, one-upstream burst deduplication, and three concurrent unique requests.

Sources: [Vertex model docs](https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/omni) · [Vertex pricing](https://cloud.google.com/vertex-ai/generative-ai/pricing)