### PR TITLE
fix: preserve Gemini Omni provider errors

### DIFF
--- a/gen.pollinations.ai/src/image/models/geminiOmniVideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/geminiOmniVideoModel.ts
@@ -20,6 +20,9 @@ type ModalityTokens = {
 
 type GeminiOmniResponse = {
     status?: string;
+    error?: {
+        message?: string;
+    };
     usage?: {
         input_tokens_by_modality?: ModalityTokens[];
         output_tokens_by_modality?: ModalityTokens[];
@@ -143,8 +146,10 @@ export async function callGeminiOmniAPI(
         ?.flatMap((step) => step.content ?? [])
         .find((content) => content.type === "video" && content.data);
     if (data.status !== "completed" || !video?.data) {
+        const detail =
+            data.error?.message ?? `status: ${data.status ?? "unknown"}`;
         throw new HttpError(
-            "Gemini Omni API returned no completed video",
+            `Gemini Omni API returned no completed video (${detail})`,
             502,
             undefined,
             endpoint,

--- a/gen.pollinations.ai/test/image/geminiOmniVideoModel.test.ts
+++ b/gen.pollinations.ai/test/image/geminiOmniVideoModel.test.ts
@@ -205,6 +205,25 @@ describe("geminiOmniVideoModel", () => {
         ).rejects.toMatchObject({ status: 502 });
     });
 
+    it("preserves a provider failure message for moderation classification", async () => {
+        setGoogleEnv();
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+            Response.json({
+                status: "failed",
+                error: {
+                    message: "Content policy violation detected in response.",
+                },
+            }),
+        );
+
+        await expect(
+            callGeminiOmniAPI("test", baseParams),
+        ).rejects.toMatchObject({
+            status: 502,
+            message: expect.stringContaining("Content policy violation"),
+        });
+    });
+
     it("returns 502 when Vertex omits billable video usage", async () => {
         setGoogleEnv();
         vi.spyOn(globalThis, "fetch").mockResolvedValue(


### PR DESCRIPTION
- Preserves Vertex failure details when an interaction returns no completed video.
- Allows existing content-policy handling to classify moderation refusals as 422 instead of opaque 502 errors.
- Adds a focused regression test; model and moderation suites plus typecheck pass.

Follow-up to #14083.