### PR TITLE
docs: record DreamShaper Vast replacement

### DIFF
--- a/operations/infrastructure/gpu/GPU_INSTANCES.md
+++ b/operations/infrastructure/gpu/GPU_INSTANCES.md
@@ -1,6 +1,6 @@
 # GPU Instances
 
-Last updated: 2026-08-19
+Last updated: 2026-08-29
 
 ## Capacity Summary
 
@@ -9,14 +9,14 @@ Last updated: 2026-08-19
 | Flux (FP4) | 2 | 2x RTX PRO 4000 Blackwell | Vast.ai | $0.460000/hr all-in | **ACTIVE — two production, Vast-only** |
 | Z-Image | 1 | RTX 5090 | Vast.ai | $0.351111/hr all-in | **ACTIVE — one production with Fal spillover** |
 | Klein 4B | 1 | RTX 3090 | Vast.ai | $0.150000/hr all-in | **ACTIVE — Vast production** |
-| DreamShaper 8 LCM (`dreamshaper`, alias `sana`) | 2 | 2x RTX 4070 | Vast.ai | $0.196889/hr all-in | **ACTIVE — production** |
+| DreamShaper 8 LCM (`dreamshaper`, alias `sana`) | 2 | RTX 4070 + RTX 3060 | Vast.ai | $0.169444/hr all-in | **ACTIVE — production** |
 | LTX-2 + ACE-Step | 0 active routes | GH200 (historical) | Lambda Labs | Verify provider account | **RETIRED from production** |
 
-At capture time, the six running Vast instances cost **$1.158000/hr** in total
-(**$833.76 per 30-day month**).
+At capture time, the six running Vast instances cost **$1.130556/hr** in total
+(**$814.00 per 30-day month**).
 All six are production workers; there is no isolated canary left running.
 
-Live verification on 2026-08-19 confirmed that all six instances are in both
+Live verification on 2026-08-29 confirmed that all six instances are in both
 `actual_status=running` and `intended_status=running`, every model server and
 named tunnel is healthy, and the registry contains both Flux hostnames, the
 shared Z-Image hostname, and both DreamShaper hostnames. Klein is not in the
@@ -37,7 +37,7 @@ exists after the routing change deploys.
 
 | Worker | Vast instance | Machine / region | GPU | All-in rate | Status |
 |--------|---------------|------------------|-----|-------------|--------|
-| dreamshaper-vast-01 | 48108043 | 94288 / New Zealand | RTX 4070 | $0.103000/hr | ACTIVE — named tunnel `dreamshaper-canary-46600159.myceli.ai` |
+| dreamshaper-vast-01 | 49063196 | 143507 / Mexico, MX | RTX 3060 | $0.075556/hr | ACTIVE — named tunnel `dreamshaper-canary-49063196.myceli.ai` |
 | dreamshaper-vast-02 | 47789794 | 100803 / Romania, RO | RTX 4070 | $0.093889/hr | ACTIVE — named tunnel `dreamshaper-canary-47789794.myceli.ai` |
 
 Config: `Lykon/dreamshaper-8` + fused `lcm-lora-sdv1-5`, `LCMScheduler`, TAESD
@@ -51,20 +51,24 @@ gen retries the other registered DreamShaper hostname. With three processes,
 each GPU admits at most six in-flight requests instead of accumulating an
 unbounded local backlog.
 
-Instance `48108043` replaced `46607014` on 2026-08-19 and reduced the slot from
-`$0.150000/hr` to `$0.103000/hr`, saving **$0.047000/hr** or **$33.84 per
-30-day month** in Vast credits. The New Zealand host had Vast reliability
-`0.9977049` when rented and preserves machine and regional diversity from the
-Romania replica.
+Instance `49063196` replaced `48108043` on 2026-08-29 and reduced the slot from
+`$0.103000/hr` to `$0.075556/hr`, saving **$0.027444/hr** or **$19.76 per
+30-day month** in Vast credits. The Mexico host had Vast reliability
+`0.9968025` when promoted and preserves machine and regional diversity from
+the Romania replica.
 
-Qualification passed authentication, fixed-seed byte parity, 512x512 and
-clamped dimension limits, output quality, queue shedding, and restart
-recovery. At 200 RPM the RTX 4070 served 60/60 requests after restart. At 300
-RPM it served 60/60 before restart and 29/30 in a later short probe, shedding
-the remaining request for cross-worker retry. In the final post-cutover window
-it served 58 production requests with zero backend errors at **0.23s mean**
-and **0.40s p95** generation time; five queue-full responses were retried on
-the other DreamShaper worker.
+Qualification passed authentication rejection, a public Cloudflare health
+check and 512x512 render, restart recovery, queue shedding, and sustained
+load. The RTX 3060 served 60/60 requests at concurrency 3 and sustained
+**4.42 img/s**. During cutover it served 265 attributed production requests;
+the final one-minute fleet window after the old host drained recorded 270
+successful requests, one client 4xx, zero 5xx, and **0.98s p95** latency. The
+old instance was removed from the registry before destruction, and Vast then
+reported only the two intended DreamShaper instances with no retained storage
+for `48108043`.
+
+Instance `48108043` had previously replaced `46607014` on 2026-08-19, reducing
+that slot from `$0.150000/hr` to `$0.103000/hr` before its own replacement.
 
 The canary exposed two reusable deployment requirements. Prefer the smaller
 `nvidia/cuda:12.8.1-cudnn-runtime-ubuntu24.04` image; the previous Vast


### PR DESCRIPTION
- Replaces DreamShaper instance `48108043` with production instance `49063196` in the fleet inventory.
- Records the RTX 3060 qualification, production cutover evidence, and completed old-instance cleanup.
- Updates DreamShaper spend to `$0.169444/hr` and total Vast fleet burn to `$1.130556/hr` (`$814.00/30d`).
- Documents `$19.76/30d` in Vast-credit savings.

Validation: live Vast inventory, production registry, public canary render, worker logs, and model monitor.