### PR TITLE
feat: add video as a community-model modality

### DIFF
--- a/BRING_YOUR_OWN_MODEL.md
+++ b/BRING_YOUR_OWN_MODEL.md
@@ -12,10 +12,13 @@ Model publishing and [connecting user wallets](./BRING_YOUR_OWN_POLLEN.md) solve
 | Image | `POST /v1/images/generations` | `GET /image/{prompt}` or `POST /v1/images/generations` |
 | Image editing | `POST /v1/images/edits` in addition to image generation | `POST /v1/images/edits` |
 | Speech to text | `POST /v1/audio/transcriptions` | `POST /v1/audio/transcriptions` |
+| Video | `POST /v1/videos/generations` | `GET /image/{prompt}?model=...&duration=N` |
 
 Image providers must return `b64_json`. During testing, Pollinations checks whether an image provider supports edits and whether it reports OpenAI image-token usage.
 
-Video, text-to-speech, embeddings, realtime, and 3D endpoints cannot currently be registered through this workflow.
+Video providers must return playable MP4 or WebM media and report the billed duration (`usage.video_seconds` or `usage.duration`, in seconds). During registration testing, Pollinations sends a short prompt with a 5-second duration and rejects providers that return no playable video or cannot report a duration; generation requests whose endpoint stops reporting a duration fail instead of billing at zero. Video models are priced per generated second, capped at $0.5 per second.
+
+Text-to-speech, embeddings, realtime, and 3D endpoints cannot currently be registered through this workflow.
 
 ## Private and Public Models
 
@@ -28,6 +31,7 @@ Public models appear in the model catalog and can be called by other Pollination
 - Text models use the token categories reported by the upstream endpoint.
 - Image models use per-token pricing when the registration test finds valid OpenAI image usage; otherwise they use a fixed price per generated image.
 - Transcription models are priced from reported audio duration.
+- Video models are priced per generated second (duration reported by the upstream endpoint).
 - A zero price makes the public model free.
 
 Owners receive 75% of the Pollen spent on their models. Paid and Quest Pollen earnings remain in their respective wallet buckets. Cash payouts are not currently available.
@@ -36,7 +40,7 @@ Owners receive 75% of the Pollen spent on their models. Paid and Quest Pollen ea
 
 1. Open [My Models](https://enter.pollinations.ai/my-models).
 2. Choose **Add model**.
-3. Select text, image, or transcription and enter the upstream base URL, model id, and bearer token.
+3. Select text, image, video, or transcription and enter the upstream base URL, model id, and bearer token.
 4. Fetch the upstream model list or run the endpoint test before saving.
 5. Save the model as private, then call its `owner/model` id through the normal Pollinations endpoint.
 6. If your account has publisher access, change visibility to public and set prices when it is ready for other users.

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-dialog.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-dialog.tsx
@@ -207,9 +207,11 @@ export function CommunityEndpointDialog({
                 throw new Error(
                     form.modality === "image"
                         ? "Endpoint responded, but did not return image data"
-                        : form.modality === "transcription"
-                          ? "Endpoint responded, but did not return transcription text or usage"
-                          : "Endpoint responded, but did not return billable usage",
+                        : form.modality === "video"
+                          ? "Endpoint responded, but did not return video data"
+                          : form.modality === "transcription"
+                            ? "Endpoint responded, but did not return transcription text or usage"
+                            : "Endpoint responded, but did not return billable usage",
                 );
             }
             setForm((current) => ({
@@ -281,9 +283,11 @@ export function CommunityEndpointDialog({
     const basePriceKeys =
         form.modality === "image"
             ? (["completionImagePrice"] as const)
-            : form.modality === "transcription"
-              ? BASE_TRANSCRIPTION_PRICE_KEYS
-              : BASE_TEXT_PRICE_KEYS;
+            : form.modality === "video"
+              ? (["completionVideoPrice"] as const)
+              : form.modality === "transcription"
+                ? BASE_TRANSCRIPTION_PRICE_KEYS
+                : BASE_TEXT_PRICE_KEYS;
     const visiblePriceKeys = new Set(
         isShared
             ? visiblePriceFieldKeys(savedPriceKeys, returnedFields, [
@@ -420,7 +424,12 @@ export function CommunityEndpointDialog({
                         >
                             <ButtonGroup aria-label="Modality">
                                 {(
-                                    ["text", "image", "transcription"] as const
+                                    [
+                                        "text",
+                                        "image",
+                                        "video",
+                                        "transcription",
+                                    ] as const
                                 ).map((modality) => (
                                     <TabButton
                                         key={modality}

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/price-table.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/price-table.tsx
@@ -17,6 +17,7 @@ import {
     MAX_COMMUNITY_PRICE_PER_IMAGE,
     MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS,
     MAX_COMMUNITY_PRICE_PER_SECOND,
+    MAX_COMMUNITY_PRICE_PER_VIDEO_SECOND,
 } from "@shared/community-endpoints.ts";
 import { PRICE_ICON } from "../models/model-icons.tsx";
 import type { PriceKind } from "../models/types.ts";
@@ -186,7 +187,7 @@ function PriceInputCell({
     const unitLabel =
         field.priceUnit === "image"
             ? "/image"
-            : field.priceUnit === "second"
+            : field.priceUnit === "second" || field.priceUnit === "video"
               ? "/sec"
               : "/1M";
     const maximum =
@@ -194,7 +195,9 @@ function PriceInputCell({
             ? MAX_COMMUNITY_PRICE_PER_IMAGE
             : field.priceUnit === "second"
               ? MAX_COMMUNITY_PRICE_PER_SECOND
-              : MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS;
+              : field.priceUnit === "video"
+                ? MAX_COMMUNITY_PRICE_PER_VIDEO_SECOND
+                : MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS;
 
     return (
         <TableCell align="right" className="w-40 align-top">
@@ -226,7 +229,8 @@ function PriceInputCell({
                 {hasError && (
                     <p className="mt-1 text-right text-xs text-intent-danger-text">
                         {field.priceUnit === "image" ||
-                        field.priceUnit === "second"
+                        field.priceUnit === "second" ||
+                        field.priceUnit === "video"
                             ? `Enter 0–${maximum} ${unitLabel}.`
                             : `Enter 0 or up to ${maximum} ${unitLabel}.`}
                     </p>
@@ -297,6 +301,7 @@ function priceKind(field: PriceField): PriceKind {
         return field.usageType.startsWith("prompt") ? "audioIn" : "audioOut";
     }
     if (field.usageType.includes("Image")) return "image";
+    if (field.usageType.includes("Video")) return "video";
     return "text";
 }
 

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/types.ts
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/types.ts
@@ -12,6 +12,7 @@ import {
     MAX_COMMUNITY_PRICE_PER_IMAGE,
     MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS,
     MAX_COMMUNITY_PRICE_PER_SECOND,
+    MAX_COMMUNITY_PRICE_PER_VIDEO_SECOND,
     MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS,
     normalizeCommunityEndpointAdvertised,
     normalizeCommunityEndpointInputModalities,
@@ -303,7 +304,9 @@ export function isValidPriceInput(
             ? MAX_COMMUNITY_PRICE_PER_IMAGE
             : priceUnit === "second"
               ? MAX_COMMUNITY_PRICE_PER_SECOND
-              : MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS;
+              : priceUnit === "video"
+                ? MAX_COMMUNITY_PRICE_PER_VIDEO_SECOND
+                : MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS;
     return (
         Number.isFinite(parsed) &&
         parsed >= 0 &&

--- a/enter.pollinations.ai/src/routes/community-endpoints.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints.ts
@@ -28,6 +28,7 @@ import {
     testCommunityEndpoint,
     testCommunityImageEndpoint,
     testCommunityTranscriptionEndpoint,
+    testCommunityVideoEndpoint,
 } from "../services/community-endpoint-openai.ts";
 import { requireAccountPermission } from "./account-permissions.ts";
 import {
@@ -660,9 +661,11 @@ export const communityEndpointsRoutes = new Hono<Env>()
                 const result =
                     input.modality === "image"
                         ? await testCommunityImageEndpoint(input)
-                        : input.modality === "transcription"
-                          ? await testCommunityTranscriptionEndpoint(input)
-                          : await testCommunityEndpoint(input);
+                        : input.modality === "video"
+                          ? await testCommunityVideoEndpoint(input)
+                          : input.modality === "transcription"
+                            ? await testCommunityTranscriptionEndpoint(input)
+                            : await testCommunityEndpoint(input);
                 return c.json({
                     ok: true,
                     message:
@@ -670,9 +673,11 @@ export const communityEndpointsRoutes = new Hono<Env>()
                             ? result.inputModalities?.includes("image")
                                 ? "Generation and editing endpoints responded with image data"
                                 : "Generation endpoint responded; editing is not supported"
-                            : input.modality === "transcription"
-                              ? "Endpoint responded with transcription text"
-                              : "Endpoint responded with usage",
+                            : input.modality === "video"
+                              ? "Endpoint responded with video data"
+                              : input.modality === "transcription"
+                                ? "Endpoint responded with transcription text"
+                                : "Endpoint responded with usage",
                     ...result,
                 });
             } catch (error) {

--- a/enter.pollinations.ai/src/routes/community-endpoints/proxy-policy.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints/proxy-policy.ts
@@ -14,6 +14,7 @@ import {
     MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS,
     MAX_COMMUNITY_PRICE_PER_SECOND,
     MAX_COMMUNITY_PRICE_PER_TOKEN,
+    MAX_COMMUNITY_PRICE_PER_VIDEO_SECOND,
     normalizeCommunityEndpointInputModalities,
     type ProxyListingPayload,
 } from "@shared/community-endpoints.ts";
@@ -35,6 +36,10 @@ const PRICE_LIMIT_BY_UNIT = {
     image: {
         maximum: MAX_COMMUNITY_PRICE_PER_IMAGE,
         label: `${MAX_COMMUNITY_PRICE_PER_IMAGE} Pollen per image`,
+    },
+    video: {
+        maximum: MAX_COMMUNITY_PRICE_PER_VIDEO_SECOND,
+        label: `${MAX_COMMUNITY_PRICE_PER_VIDEO_SECOND} Pollen per video second`,
     },
     second: {
         maximum: MAX_COMMUNITY_PRICE_PER_SECOND,

--- a/enter.pollinations.ai/src/routes/community-endpoints/schemas.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints/schemas.ts
@@ -20,7 +20,7 @@ import { z } from "zod";
 const ModalitySchema = z
     .enum(COMMUNITY_ENDPOINT_MODALITIES)
     .describe(
-        'Upstream API family. "text" uses `/v1/chat/completions`; "image" uses `/v1/images/generations` and optionally `/v1/images/edits` when the endpoint test succeeds; "transcription" uses `/v1/audio/transcriptions`.',
+        'Upstream API family. "text" uses `/v1/chat/completions`; "image" uses `/v1/images/generations` and optionally `/v1/images/edits` when the endpoint test succeeds; "video" uses `/v1/videos/generations`; "transcription" uses `/v1/audio/transcriptions`.',
     );
 const ImagePricingSchema = z
     .enum(COMMUNITY_ENDPOINT_IMAGE_PRICING_MODES)
@@ -106,7 +106,7 @@ const EndpointFieldsSchema = {
         .string()
         .url()
         .describe(
-            "OpenAI-compatible `/v1` base URL or full chat, image generation, or image edit URL.",
+            "OpenAI-compatible `/v1` base URL or full chat, image generation, video generation, or transcription URL.",
         ),
     upstreamModel: z.string().trim().min(1).max(253).optional(),
     bearerToken: z.string().min(1),

--- a/enter.pollinations.ai/src/services/community-endpoint-openai.ts
+++ b/enter.pollinations.ai/src/services/community-endpoint-openai.ts
@@ -15,7 +15,10 @@ import {
     firstCommunityVideoBytes,
     normalizeCommunityEndpointBearerToken,
 } from "@shared/community-endpoints.ts";
-import { detectImageMimeType, detectVideoMimeType } from "@shared/image-mime.ts";
+import {
+    detectImageMimeType,
+    detectVideoMimeType,
+} from "@shared/image-mime.ts";
 import type { ModelInputModality, Usage } from "@shared/registry/registry.ts";
 import {
     getOpenAIImageUsage,
@@ -237,7 +240,11 @@ export async function testCommunityVideoEndpoint({
         },
         // The same `duration` field (in seconds) the request path forwards,
         // so what the probe proves is what callers actually get.
-        body: JSON.stringify({ model, prompt: SAMPLE_VIDEO_PROMPT, duration: 5 }),
+        body: JSON.stringify({
+            model,
+            prompt: SAMPLE_VIDEO_PROMPT,
+            duration: 5,
+        }),
     });
 
     const videoBytes = await firstCommunityVideoBytes(body, baseUrl);

--- a/enter.pollinations.ai/src/services/community-endpoint-openai.ts
+++ b/enter.pollinations.ai/src/services/community-endpoint-openai.ts
@@ -8,11 +8,14 @@ import {
     communityImageGenerationsUrl,
     communityOpenAIBaseUrl,
     communityTranscriptionSeconds,
+    communityVideoGenerationsUrl,
+    communityVideoSeconds,
     decodeCommunityBase64,
     firstCommunityImageBytes,
+    firstCommunityVideoBytes,
     normalizeCommunityEndpointBearerToken,
 } from "@shared/community-endpoints.ts";
-import { detectImageMimeType } from "@shared/image-mime.ts";
+import { detectImageMimeType, detectVideoMimeType } from "@shared/image-mime.ts";
 import type { ModelInputModality, Usage } from "@shared/registry/registry.ts";
 import {
     getOpenAIImageUsage,
@@ -27,6 +30,9 @@ type EndpointAuth = {
 };
 
 type EndpointTestInput = EndpointAuth & { model: string };
+
+// Short probe prompt; the endpoint picks its own output size.
+const SAMPLE_VIDEO_PROMPT = "A five-second timelapse of a sprout growing.";
 
 export type CommunityEndpointUsage = Record<string, unknown>;
 
@@ -210,6 +216,49 @@ export async function testCommunityImageEndpoint({
         billableUsage: { completionImageTokens: 1 },
         imagePricing: "request",
         inputModalities,
+    };
+}
+
+// Video endpoints are billed against the generated video's duration in
+// seconds, mirroring the first-party per-second video models. The probe
+// generates a short clip and validates that the response carries both a
+// playable video and the duration the endpoint will be billed on — an
+// endpoint that cannot report it would earn nothing on every request.
+export async function testCommunityVideoEndpoint({
+    baseUrl,
+    bearerToken,
+    model,
+}: EndpointTestInput): Promise<CommunityEndpointTestResult> {
+    const body = await fetchJson(communityVideoGenerationsUrl(baseUrl), {
+        method: "POST",
+        headers: {
+            ...authorizationHeaders(bearerToken),
+            "Content-Type": "application/json",
+        },
+        // The same `duration` field (in seconds) the request path forwards,
+        // so what the probe proves is what callers actually get.
+        body: JSON.stringify({ model, prompt: SAMPLE_VIDEO_PROMPT, duration: 5 }),
+    });
+
+    const videoBytes = await firstCommunityVideoBytes(body, baseUrl);
+    if (!videoBytes || !detectVideoMimeType(videoBytes)) {
+        throw new Error("Endpoint did not return a supported video");
+    }
+
+    const videoSeconds = communityVideoSeconds(body);
+    if (videoSeconds === null) {
+        throw new Error(
+            "Endpoint did not report the video duration (expected usage.video_seconds or usage.duration), which is required to bill video",
+        );
+    }
+
+    return {
+        // The pricing UI marks the generated-video row against a usage key
+        // named in that field's rawUsagePaths, and the duration is the only
+        // thing billed here — so report it directly rather than echoing an
+        // upstream usage object that may not carry it.
+        usage: { video_seconds: videoSeconds },
+        billableUsage: { completionVideoSeconds: videoSeconds },
     };
 }
 

--- a/enter.pollinations.ai/test/community-endpoint-openai.test.ts
+++ b/enter.pollinations.ai/test/community-endpoint-openai.test.ts
@@ -4,6 +4,7 @@ import {
     testCommunityEndpoint,
     testCommunityImageEndpoint,
     testCommunityTranscriptionEndpoint,
+    testCommunityVideoEndpoint,
 } from "../src/services/community-endpoint-openai.ts";
 
 afterEach(() => {
@@ -449,5 +450,85 @@ describe("community endpoint OpenAI service", () => {
                 model: "whisper-1",
             }),
         ).rejects.toThrow("Endpoint did not return OpenAI transcription text");
+    });
+});
+
+
+describe("community video endpoint probe", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    // Minimal MP4-shaped bytes: a size header followed by the "ftyp" brand.
+    const MP4_B64 = Buffer.from([
+        0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x6d, 0x70, 0x34, 0x32,
+        0x00, 0x00, 0x00, 0x00,
+    ]).toString("base64");
+
+    it("probes /videos/generations and reports the billable seconds", async () => {
+        const fetchMock = vi.fn(async (input, init) => {
+            const request = new Request(input, init);
+            expect(request.url).toBe(
+                "https://api.example.com/v1/videos/generations",
+            );
+            expect(request.headers.get("authorization")).toBe(
+                "Bearer sk_saved_token",
+            );
+            await expect(request.json()).resolves.toMatchObject({
+                model: "clip-5",
+                duration: 5,
+            });
+            return Response.json({
+                data: [{ b64_json: MP4_B64 }],
+                usage: { video_seconds: 5 },
+            });
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        await expect(
+            testCommunityVideoEndpoint({
+                baseUrl: "https://api.example.com/v1",
+                bearerToken: "sk_saved_token",
+                model: "clip-5",
+            }),
+        ).resolves.toEqual({
+            usage: { video_seconds: 5 },
+            billableUsage: { completionVideoSeconds: 5 },
+        });
+    });
+
+    it("rejects endpoints that do not report a billable duration", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => Response.json({ data: [{ b64_json: MP4_B64 }] })),
+        );
+
+        await expect(
+            testCommunityVideoEndpoint({
+                baseUrl: "https://api.example.com/v1",
+                bearerToken: "sk_saved_token",
+                model: "clip-5",
+            }),
+        ).rejects.toThrow(/did not report the video duration/);
+    });
+
+    it("rejects endpoints that return something other than video", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () =>
+                Response.json({
+                    data: [{ b64_json: "iVBORw0KGgo=" }],
+                    usage: { video_seconds: 5 },
+                }),
+            ),
+        );
+
+        await expect(
+            testCommunityVideoEndpoint({
+                baseUrl: "https://api.example.com/v1",
+                bearerToken: "sk_saved_token",
+                model: "clip-5",
+            }),
+        ).rejects.toThrow(/supported video/);
     });
 });

--- a/enter.pollinations.ai/test/community-endpoint-openai.test.ts
+++ b/enter.pollinations.ai/test/community-endpoint-openai.test.ts
@@ -453,7 +453,6 @@ describe("community endpoint OpenAI service", () => {
     });
 });
 
-
 describe("community video endpoint probe", () => {
     afterEach(() => {
         vi.unstubAllGlobals();

--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -6321,9 +6321,9 @@ fixtureTest(
 
 describe("community video helpers", () => {
     it("derives the OpenAI-compatible video generations URL", () => {
-        expect(
-            communityVideoGenerationsUrl("https://api.example.com/v1"),
-        ).toBe("https://api.example.com/v1/videos/generations");
+        expect(communityVideoGenerationsUrl("https://api.example.com/v1")).toBe(
+            "https://api.example.com/v1/videos/generations",
+        );
         expect(
             communityOpenAIBaseUrl(
                 "https://api.example.com/v1/videos/generations",
@@ -6414,7 +6414,10 @@ describe("community video endpoint billing", () => {
             fallbacks: [],
             hiddenAt: null,
             hiddenReason: null,
-            bearerTokenCiphertext: await encryptSecret("sk_saved_token", secret),
+            bearerTokenCiphertext: await encryptSecret(
+                "sk_saved_token",
+                secret,
+            ),
             ...communityEndpointPrices({ completionVideoPrice: 0.2 }),
         };
     }
@@ -6481,9 +6484,7 @@ describe("community video endpoint billing", () => {
     it("fails endpoints that stop reporting the billed duration", async () => {
         vi.stubGlobal(
             "fetch",
-            vi.fn(async () =>
-                Response.json({ data: [{ b64_json: MP4_B64 }] }),
-            ),
+            vi.fn(async () => Response.json({ data: [{ b64_json: MP4_B64 }] })),
         );
 
         await expect(
@@ -6529,7 +6530,12 @@ describe("community video endpoint billing", () => {
             type: "prompt_agent",
         } as CommunityEndpointRuntime;
         await expect(
-            callCommunityVideoEndpoint(endpoint, "a sprout", videoParams, secret),
+            callCommunityVideoEndpoint(
+                endpoint,
+                "a sprout",
+                videoParams,
+                secret,
+            ),
         ).rejects.toThrow(/managed agent/);
     });
 });

--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -25,6 +25,8 @@ import {
     communityModelId,
     communityOpenAIBaseUrl,
     communityPriceDefinition,
+    communityVideoGenerationsUrl,
+    communityVideoSeconds,
     type EndpointAgentCommunityEndpointRuntime,
     isCommunityEndpointOwnerAllowed,
     isCommunityFallbackPricingAllowed,
@@ -33,6 +35,7 @@ import {
     MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS,
     MAX_COMMUNITY_PRICE_PER_SECOND,
     MAX_COMMUNITY_PRICE_PER_TOKEN,
+    MAX_COMMUNITY_PRICE_PER_VIDEO_SECOND,
     MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS,
     MIN_COMMUNITY_PRICE_PER_TOKEN,
     normalizeCommunityAssetUrl,
@@ -86,7 +89,10 @@ import {
     communityTranscriptionSupportedEndpoints,
     getCommunityModelRegistryEntries,
 } from "./community-models.ts";
-import { callCommunityImageEndpoint } from "./image/communityEndpoint.ts";
+import {
+    callCommunityImageEndpoint,
+    callCommunityVideoEndpoint,
+} from "./image/communityEndpoint.ts";
 import worker from "./index.ts";
 import {
     getGenerationModelRegistry,
@@ -6312,3 +6318,218 @@ fixtureTest(
         expect(direct.status).toBe(403);
     },
 );
+
+describe("community video helpers", () => {
+    it("derives the OpenAI-compatible video generations URL", () => {
+        expect(
+            communityVideoGenerationsUrl("https://api.example.com/v1"),
+        ).toBe("https://api.example.com/v1/videos/generations");
+        expect(
+            communityOpenAIBaseUrl(
+                "https://api.example.com/v1/videos/generations",
+            ),
+        ).toBe("https://api.example.com/v1");
+    });
+
+    it("reads the billed duration from every documented response shape", () => {
+        expect(communityVideoSeconds({ usage: { video_seconds: 5 } })).toBe(5);
+        expect(communityVideoSeconds({ usage: { duration: 6 } })).toBe(6);
+        expect(communityVideoSeconds({ duration: 7 })).toBe(7);
+        expect(communityVideoSeconds({ usage: {} })).toBeNull();
+        expect(communityVideoSeconds(null)).toBeNull();
+    });
+
+    it("prices video endpoints per generated second", () => {
+        expect(communityEndpointPriceFieldsForModality("video")).toEqual([
+            {
+                key: "completionVideoPrice",
+                usageType: "completionVideoSeconds",
+                label: "Generated video",
+                priceUnit: "video",
+                rawUsagePaths: ["video_seconds"],
+            },
+        ]);
+        expect(MAX_COMMUNITY_PRICE_PER_VIDEO_SECOND).toBe(0.5);
+    });
+
+    it("builds community video models with video catalog fields", () => {
+        const definition = communityModelDefinition({
+            type: "proxy",
+            id: "community-endpoint-id",
+            ownerUserId: "owner-id",
+            modelId: "voodoohop/clipvideo",
+            name: "clipvideo",
+            title: "Clip Video",
+            description: null,
+            modality: "video",
+            imagePricing: "request",
+            inputModalities: ["text"],
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "clip-5",
+            visibility: "public",
+            paidOnly: false,
+            perUserRpm: null,
+            fallbacks: [],
+            hiddenAt: null,
+            hiddenReason: null,
+            bearerTokenCiphertext: "v1:test:test",
+            ...communityEndpointPrices({ completionVideoPrice: 0.2 }),
+        });
+        expect(definition.category).toBe("video");
+        expect(definition.outputModalities).toEqual(["video"]);
+        expect(definition.inputModalities).toEqual(["text"]);
+    });
+});
+
+describe("community video endpoint billing", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    const secret = "test-secret";
+
+    // Minimal MP4-shaped bytes: a size header followed by the "ftyp" brand.
+    const MP4_B64 = Buffer.from([
+        0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x6d, 0x70, 0x34, 0x32,
+        0x00, 0x00, 0x00, 0x00,
+    ]).toString("base64");
+
+    async function videoEndpoint(): Promise<CommunityEndpointRuntime> {
+        return {
+            type: "proxy",
+            id: "community-endpoint-id",
+            ownerUserId: "owner-id",
+            modelId: "voodoohop/clipvideo",
+            name: "clipvideo",
+            title: "Clip Video",
+            description: null,
+            modality: "video",
+            imagePricing: "request",
+            inputModalities: ["text"],
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "clip-5",
+            visibility: "public",
+            paidOnly: false,
+            perUserRpm: null,
+            fallbacks: [],
+            hiddenAt: null,
+            hiddenReason: null,
+            bearerTokenCiphertext: await encryptSecret("sk_saved_token", secret),
+            ...communityEndpointPrices({ completionVideoPrice: 0.2 }),
+        };
+    }
+
+    const videoParams = {
+        model: "clip-5",
+        width: 1280,
+        height: 720,
+        duration: 8,
+    } as unknown as Parameters<typeof callCommunityVideoEndpoint>[2];
+
+    it("bills per generated second and returns playable media", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () =>
+                Response.json({
+                    data: [{ b64_json: MP4_B64 }],
+                    usage: { video_seconds: 5 },
+                }),
+            ),
+        );
+
+        const result = await callCommunityVideoEndpoint(
+            await videoEndpoint(),
+            "a sprout",
+            videoParams,
+            secret,
+        );
+        expect(result.mimeType).toBe("video/mp4");
+        expect(result.durationSeconds).toBe(5);
+        expect(result.trackingData?.usage).toEqual({
+            completionVideoSeconds: 5,
+        });
+    });
+
+    it("forwards the caller's duration in seconds", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async (input, init) => {
+                const request = new Request(input, init);
+                expect(request.url).toBe(
+                    "https://api.example.com/v1/videos/generations",
+                );
+                await expect(request.json()).resolves.toMatchObject({
+                    model: "clip-5",
+                    prompt: "a sprout",
+                    duration: 8,
+                });
+                return Response.json({
+                    data: [{ b64_json: MP4_B64 }],
+                    usage: { video_seconds: 8 },
+                });
+            }),
+        );
+
+        await callCommunityVideoEndpoint(
+            await videoEndpoint(),
+            "a sprout",
+            videoParams,
+            secret,
+        );
+    });
+
+    it("fails endpoints that stop reporting the billed duration", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () =>
+                Response.json({ data: [{ b64_json: MP4_B64 }] }),
+            ),
+        );
+
+        await expect(
+            callCommunityVideoEndpoint(
+                await videoEndpoint(),
+                "a sprout",
+                videoParams,
+                secret,
+            ),
+        ).rejects.toMatchObject({
+            status: 502,
+            message: expect.stringContaining("video duration"),
+        });
+    });
+
+    it("rejects payloads that are not playable video", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () =>
+                Response.json({
+                    data: [{ b64_json: "iVBORw0KGgo=" }],
+                    usage: { video_seconds: 5 },
+                }),
+            ),
+        );
+
+        await expect(
+            callCommunityVideoEndpoint(
+                await videoEndpoint(),
+                "a sprout",
+                videoParams,
+                secret,
+            ),
+        ).rejects.toMatchObject({
+            status: 502,
+            message: expect.stringContaining("supported video format"),
+        });
+    });
+
+    it("never routes community video through managed agents", async () => {
+        const endpoint = {
+            ...(await videoEndpoint()),
+            type: "prompt_agent",
+        } as CommunityEndpointRuntime;
+        await expect(
+            callCommunityVideoEndpoint(endpoint, "a sprout", videoParams, secret),
+        ).rejects.toThrow(/managed agent/);
+    });
+});

--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -6525,4 +6525,31 @@ describe("community video endpoint billing", () => {
             ),
         ).rejects.toThrow(/managed agent/);
     });
+
+    it("propagates upstream failures instead of billing", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(
+                async () =>
+                    new Response(
+                        JSON.stringify({ error: { message: "gpu busy" } }),
+                        {
+                            status: 500,
+                        },
+                    ),
+            ),
+        );
+
+        await expect(
+            callCommunityVideoEndpoint(
+                await videoEndpoint(),
+                "a sprout",
+                videoParams,
+                secret,
+            ),
+        ).rejects.toMatchObject({
+            status: 500,
+            message: expect.stringContaining("responded 500"),
+        });
+    });
 });

--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -6354,25 +6354,12 @@ describe("community video helpers", () => {
 
     it("builds community video models with video catalog fields", () => {
         const definition = communityModelDefinition({
-            type: "proxy",
-            id: "community-endpoint-id",
-            ownerUserId: "owner-id",
             modelId: "voodoohop/clipvideo",
-            name: "clipvideo",
             title: "Clip Video",
             description: null,
             modality: "video",
-            imagePricing: "request",
             inputModalities: ["text"],
-            baseUrl: "https://api.example.com/v1",
-            upstreamModel: "clip-5",
-            visibility: "public",
             paidOnly: false,
-            perUserRpm: null,
-            fallbacks: [],
-            hiddenAt: null,
-            hiddenReason: null,
-            bearerTokenCiphertext: "v1:test:test",
             ...communityEndpointPrices({ completionVideoPrice: 0.2 }),
         });
         expect(definition.category).toBe("video");

--- a/gen.pollinations.ai/src/community-models.ts
+++ b/gen.pollinations.ai/src/community-models.ts
@@ -46,6 +46,10 @@ export function communityImageSupportedEndpoints(
     ];
 }
 
+export function communityVideoSupportedEndpoints(): string[] {
+    return ["/v1/images/generations", "/image/{prompt}", "/video/{prompt}"];
+}
+
 export type CommunityModelRegistryEntry = {
     id: string;
     aliases: string[];

--- a/gen.pollinations.ai/src/image/communityEndpoint.ts
+++ b/gen.pollinations.ai/src/image/communityEndpoint.ts
@@ -5,11 +5,17 @@ import {
     communityEndpointErrorDetail,
     communityImageEditsUrl,
     communityImageGenerationsUrl,
+    communityVideoGenerationsUrl,
+    communityVideoSeconds,
     firstCommunityImageBytes,
+    firstCommunityVideoBytes,
     normalizeCommunityEndpointBearerToken,
 } from "@shared/community-endpoints.ts";
 import { HttpError } from "@shared/http-error.ts";
-import { detectImageMimeType } from "@shared/image-mime.ts";
+import {
+    detectImageMimeType,
+    detectVideoMimeType,
+} from "@shared/image-mime.ts";
 import type { Usage } from "@shared/registry/registry.ts";
 import {
     getOpenAIImageUsage,
@@ -17,6 +23,7 @@ import {
 } from "@shared/registry/usage-headers.ts";
 import { decryptSecret } from "@shared/secret-encryption.ts";
 import type { ImageGenerationResult } from "./createAndReturnImages.ts";
+import type { VideoGenerationResult } from "./createAndReturnVideos.ts";
 import type { ImageParams } from "./params.ts";
 import {
     bufferToUint8Array,
@@ -45,9 +52,10 @@ export async function callCommunityImageEndpoint(
     const upstreamUrl = isEdit
         ? communityImageEditsUrl(endpoint.baseUrl)
         : communityImageGenerationsUrl(endpoint.baseUrl);
-    const body = await fetchCommunityImageJson(
+    const body = await fetchCommunityJson(
         upstreamUrl,
         bearerToken,
+        "image",
         isEdit
             ? await imageEditFormData(endpoint, prompt, safeParams)
             : JSON.stringify({
@@ -144,9 +152,10 @@ function communityImageUsage(
     return usage;
 }
 
-async function fetchCommunityImageJson(
+async function fetchCommunityJson(
     url: string,
     bearerToken: string,
+    noun: string,
     body: string | FormData,
 ): Promise<unknown> {
     const response = await fetchWithTimeout(url, {
@@ -160,13 +169,13 @@ async function fetchCommunityImageJson(
                 : {}),
         },
         body,
-    });
+    }, noun);
     const text = await response.text();
     const parsed = parseJson(text);
 
     if (!response.ok) {
         throw new HttpError(
-            endpointErrorMessage(response.status, parsed),
+            endpointErrorMessage(response.status, parsed, noun),
             response.status,
             { body: text },
             url,
@@ -177,7 +186,8 @@ async function fetchCommunityImageJson(
 
 async function fetchWithTimeout(
     input: string,
-    init?: RequestInit,
+    init: RequestInit | undefined,
+    noun: string,
 ): Promise<Response> {
     try {
         return await fetch(input, {
@@ -187,7 +197,7 @@ async function fetchWithTimeout(
         });
     } catch (error) {
         throw new HttpError(
-            "Community image endpoint timed out or could not connect",
+            `Community ${noun} endpoint timed out or could not connect`,
             502,
             { error: error instanceof Error ? error.message : String(error) },
             input,
@@ -203,9 +213,79 @@ function parseJson(text: string): unknown {
     }
 }
 
-function endpointErrorMessage(status: number, body: unknown): string {
+function endpointErrorMessage(
+    status: number,
+    body: unknown,
+    noun: string,
+): string {
     const message = communityEndpointErrorDetail(body);
     return message
-        ? `Community image endpoint responded ${status}: ${message}`
-        : `Community image endpoint responded ${status}`;
+        ? `Community ${noun} endpoint responded ${status}: ${message}`
+        : `Community ${noun} endpoint responded ${status}`;
+}
+
+export async function callCommunityVideoEndpoint(
+    endpoint: CommunityEndpointRuntime,
+    prompt: string,
+    safeParams: Omit<ImageParams, "model"> & { model: string },
+    secret: string,
+): Promise<VideoGenerationResult> {
+    // Managed agents are text-only, so a video endpoint is always external.
+    if (endpoint.type !== "proxy") {
+        throw new Error(
+            `Community video endpoint '${endpoint.modelId}' is a managed agent`,
+        );
+    }
+    const bearerToken = await decryptSecret(
+        endpoint.bearerTokenCiphertext,
+        secret,
+    );
+    const body = await fetchCommunityJson(
+        communityVideoGenerationsUrl(endpoint.baseUrl),
+        bearerToken,
+        "video",
+        JSON.stringify({
+            model: endpoint.upstreamModel,
+            prompt,
+            // Forwarded in seconds when the caller asks for a length; the
+            // upstream model owns everything else about the output.
+            ...(safeParams.duration ? { duration: safeParams.duration } : {}),
+        }),
+    );
+
+    const bytes = await firstCommunityVideoBytes(body, endpoint.baseUrl);
+    if (!bytes) {
+        throw new HttpError(
+            "Community video endpoint returned no video data",
+            502,
+        );
+    }
+    const mimeType = detectVideoMimeType(bytes);
+    if (!mimeType) {
+        throw new HttpError(
+            "Community video endpoint did not return a supported video format",
+            502,
+        );
+    }
+    // The duration is the meter, so an endpoint that does not report one is a
+    // provider regression rather than a free request — the same stance the
+    // transcription and token-priced image paths take. The registration probe
+    // rejects endpoints that cannot report a duration, so reaching this means
+    // an endpoint that could has stopped.
+    const videoSeconds = communityVideoSeconds(body);
+    if (videoSeconds === null) {
+        throw new HttpError(
+            "Community video endpoint did not report the video duration (expected usage.video_seconds or usage.duration) that video is billed on",
+            502,
+        );
+    }
+    return {
+        buffer: Buffer.from(bytes),
+        mimeType,
+        durationSeconds: videoSeconds,
+        trackingData: {
+            actualModel: endpoint.upstreamModel,
+            usage: { completionVideoSeconds: videoSeconds },
+        },
+    };
 }

--- a/gen.pollinations.ai/src/image/communityEndpoint.ts
+++ b/gen.pollinations.ai/src/image/communityEndpoint.ts
@@ -158,18 +158,22 @@ async function fetchCommunityJson(
     noun: string,
     body: string | FormData,
 ): Promise<unknown> {
-    const response = await fetchWithTimeout(url, {
-        method: "POST",
-        headers: {
-            Authorization: `Bearer ${normalizeCommunityEndpointBearerToken(
-                bearerToken,
-            )}`,
-            ...(typeof body === "string"
-                ? { "Content-Type": "application/json" }
-                : {}),
+    const response = await fetchWithTimeout(
+        url,
+        {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${normalizeCommunityEndpointBearerToken(
+                    bearerToken,
+                )}`,
+                ...(typeof body === "string"
+                    ? { "Content-Type": "application/json" }
+                    : {}),
+            },
+            body,
         },
-        body,
-    }, noun);
+        noun,
+    );
     const text = await response.text();
     const parsed = parseJson(text);
 

--- a/gen.pollinations.ai/src/image/handler.ts
+++ b/gen.pollinations.ai/src/image/handler.ts
@@ -20,7 +20,10 @@ import {
     setServerRegistryBinding,
     VALID_TYPES,
 } from "./availableServers.ts";
-import { callCommunityImageEndpoint } from "./communityEndpoint.ts";
+import {
+    callCommunityImageEndpoint,
+    callCommunityVideoEndpoint,
+} from "./communityEndpoint.ts";
 import {
     type AuthResult,
     createAndReturnImageCached,
@@ -425,6 +428,19 @@ async function generateMediaWithFallback(
         fallbackCandidates(c.var.model),
         async (attempt) => {
             const params = { ...safeParams, model: attempt.id };
+            if (attempt.communityEndpoint?.modality === "video") {
+                const generated = await callCommunityVideoEndpoint(
+                    attempt.communityEndpoint,
+                    prompt,
+                    params,
+                    c.env.BETTER_AUTH_SECRET,
+                );
+                assertNonEmptyMedia(
+                    generated.buffer,
+                    "Community video endpoint",
+                );
+                return { result: generated, params };
+            }
             if (attempt.communityEndpoint) {
                 const generated = await callCommunityImageEndpoint(
                     attempt.communityEndpoint,

--- a/gen.pollinations.ai/src/model-registry.ts
+++ b/gen.pollinations.ai/src/model-registry.ts
@@ -26,6 +26,7 @@ import {
     communityImageSupportedEndpoints,
     communityTextSupportedEndpoints,
     communityTranscriptionSupportedEndpoints,
+    communityVideoSupportedEndpoints,
     getCommunityModelRegistryEntries,
 } from "./community-models.ts";
 import { linkFallbackEntries } from "./fallback.ts";
@@ -136,9 +137,11 @@ function communityEntryToGenerationEntry(
         eventType,
         supportedEndpoints:
             eventType === "generate.image"
-                ? communityImageSupportedEndpoints(
-                      entry.definition.inputModalities,
-                  )
+                ? entry.communityEndpoint.modality === "video"
+                    ? communityVideoSupportedEndpoints()
+                    : communityImageSupportedEndpoints(
+                          entry.definition.inputModalities,
+                      )
                 : eventType === "generate.audio"
                   ? communityTranscriptionSupportedEndpoints()
                   : communityTextSupportedEndpoints(),

--- a/shared/community-endpoints.ts
+++ b/shared/community-endpoints.ts
@@ -22,6 +22,7 @@ export const COMMUNITY_ENDPOINT_CHANGE_DELAY_MS = 12 * 60 * 60 * 1000;
 export const COMMUNITY_ENDPOINT_MODALITIES = [
     "text",
     "image",
+    "video",
     "transcription",
 ] as const;
 // How a community image endpoint is billed. "request" charges the fixed
@@ -49,6 +50,14 @@ export const MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS = 50;
 export const MAX_COMMUNITY_PRICE_PER_TOKEN =
     MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS / 1_000_000;
 export const MAX_COMMUNITY_PRICE_PER_IMAGE = 0.25;
+// Video prices are per second of generated output. $0.50/sec is double the
+// priciest first-party rate (seedance peaks at $0.25/sec), which leaves room
+// for hobby GPUs while keeping typos and malicious listings from exposing
+// callers to extreme charges.
+export const MAX_COMMUNITY_PRICE_PER_VIDEO_SECOND = 0.5;
+// Output videos are bounded like images so a runaway upstream cannot make the
+// worker buffer unbounded bytes. Generous: a 5-10s 720p clip is 5-20 MB.
+export const MAX_COMMUNITY_VIDEO_BYTES = 50 * 1024 * 1024;
 // Per-second audio (STT/TTS) prices are tiny compared to per-token rates, so
 // this ceiling is written per minute and divided down: $0.012/min is ~2x
 // OpenAI whisper ($0.006/min) and ~3x the priciest first-party STT model
@@ -70,6 +79,7 @@ export type CommunityEndpointModality =
 export const COMMUNITY_ENDPOINT_INPUT_MODALITIES = {
     text: MODEL_INPUT_MODALITIES,
     image: ["text", "image"],
+    video: ["text"],
     transcription: ["audio"],
 } as const satisfies Record<
     CommunityEndpointModality,
@@ -233,9 +243,22 @@ const COMMUNITY_TRANSCRIPTION_PRICE_FIELD = {
     rawUsagePaths: ["duration"],
 } as const;
 
+// Video endpoints bill generated output duration in seconds against the same
+// completion video price column the first-party video models use (cost keyed
+// on completionVideoSeconds at a per-second rate). The probe normalizes the
+// upstream duration shapes to `video_seconds`, so that is the only key here.
+const COMMUNITY_VIDEO_PRICE_FIELD = {
+    key: "completionVideoPrice",
+    usageType: "completionVideoSeconds",
+    label: "Generated video",
+    priceUnit: "video",
+    rawUsagePaths: ["video_seconds"],
+} as const;
+
 export const COMMUNITY_ENDPOINT_PRICE_FIELDS = [
     ...COMMUNITY_TEXT_PRICE_FIELDS,
     COMMUNITY_IMAGE_PRICE_FIELD,
+    COMMUNITY_VIDEO_PRICE_FIELD,
     COMMUNITY_TRANSCRIPTION_PRICE_FIELD,
 ] as const;
 
@@ -250,6 +273,10 @@ const COMMUNITY_IMAGE_ENDPOINT_PRICE_FIELDS = [
     COMMUNITY_IMAGE_PRICE_FIELD,
 ] as const;
 
+const COMMUNITY_VIDEO_ENDPOINT_PRICE_FIELDS = [
+    COMMUNITY_VIDEO_PRICE_FIELD,
+] as const;
+
 const COMMUNITY_TRANSCRIPTION_ENDPOINT_PRICE_FIELDS = [
     COMMUNITY_TRANSCRIPTION_PRICE_FIELD,
 ] as const;
@@ -258,6 +285,7 @@ export function communityEndpointPriceFieldsForModality(
     modality: CommunityEndpointModality,
     imagePricing: CommunityEndpointImagePricing = "request",
 ) {
+    if (modality === "video") return COMMUNITY_VIDEO_ENDPOINT_PRICE_FIELDS;
     if (modality === "transcription") {
         return COMMUNITY_TRANSCRIPTION_ENDPOINT_PRICE_FIELDS;
     }
@@ -357,6 +385,7 @@ export function normalizeCommunityEndpointModality(
     value: string | null | undefined,
 ): CommunityEndpointModality {
     if (value === "transcription") return "transcription";
+    if (value === "video") return "video";
     return value === "image" ? "image" : "text";
 }
 
@@ -793,19 +822,40 @@ export function normalizeCommunityAssetUrl(
     return url.toString();
 }
 
-/**
- * Pull the first usable image out of an OpenAI images response: inline base64
- * when present, otherwise the URL it points at, fetched under the shared
- * timeout and size cap.
- *
- * Returns null when the body carries no usable image, so each caller can
- * phrase that in its own words. A URL that is unsafe, unreachable, or oversized
- * throws HttpError(502) — the gen funnel renders that status directly, and the
- * enter probe flattens it to a 400 with the same message.
- */
 export async function firstCommunityImageBytes(
     body: unknown,
     endpointBaseUrl: string,
+): Promise<Uint8Array | null> {
+    return firstCommunityMediaBytes(body, endpointBaseUrl, {
+        noun: "image",
+        maxBytes: MAX_COMMUNITY_IMAGE_BYTES,
+    });
+}
+
+export async function firstCommunityVideoBytes(
+    body: unknown,
+    endpointBaseUrl: string,
+): Promise<Uint8Array | null> {
+    return firstCommunityMediaBytes(body, endpointBaseUrl, {
+        noun: "video",
+        maxBytes: MAX_COMMUNITY_VIDEO_BYTES,
+    });
+}
+
+/**
+ * Pull the first usable media entry out of an OpenAI-style `{ data: [...] }`
+ * response: inline base64 when present, otherwise the URL it points at,
+ * fetched under the shared timeout and size cap.
+ *
+ * Returns null when the body carries no usable entry, so each caller can
+ * phrase that in its own words. A URL that is unsafe, unreachable, or
+ * oversized throws HttpError(502) — the gen funnel renders that status
+ * directly, and the enter probe flattens it to a 400 with the same message.
+ */
+async function firstCommunityMediaBytes(
+    body: unknown,
+    endpointBaseUrl: string,
+    limits: { noun: string; maxBytes: number },
 ): Promise<Uint8Array | null> {
     if (
         !body ||
@@ -815,35 +865,39 @@ export async function firstCommunityImageBytes(
     ) {
         return null;
     }
-    for (const image of body.data) {
-        if (!image || typeof image !== "object") continue;
+    for (const media of body.data) {
+        if (!media || typeof media !== "object") continue;
         if (
-            "b64_json" in image &&
-            typeof image.b64_json === "string" &&
-            image.b64_json.length > 0
+            "b64_json" in media &&
+            typeof media.b64_json === "string" &&
+            media.b64_json.length > 0
         ) {
-            return decodeCommunityBase64(image.b64_json);
+            return decodeCommunityBase64(media.b64_json);
         }
         if (
-            "url" in image &&
-            typeof image.url === "string" &&
-            image.url.length > 0
+            "url" in media &&
+            typeof media.url === "string" &&
+            media.url.length > 0
         ) {
-            return fetchCommunityImageBytes(image.url, endpointBaseUrl);
+            return fetchCommunityMediaBytes(media.url, endpointBaseUrl, limits);
         }
     }
     return null;
 }
 
-async function fetchCommunityImageBytes(
+async function fetchCommunityMediaBytes(
     value: string,
     endpointBaseUrl: string,
+    limits: { noun: string; maxBytes: number },
 ): Promise<Uint8Array> {
     let url: string;
     try {
         url = normalizeCommunityAssetUrl(value, endpointBaseUrl);
     } catch {
-        throw new HttpError("Endpoint returned an unsafe image URL", 502);
+        throw new HttpError(
+            `Endpoint returned an unsafe ${limits.noun} URL`,
+            502,
+        );
     }
     let response: Response;
     try {
@@ -856,7 +910,7 @@ async function fetchCommunityImageBytes(
         });
     } catch (error) {
         throw new HttpError(
-            "Endpoint image URL timed out or could not connect",
+            `Endpoint ${limits.noun} URL timed out or could not connect`,
             502,
             { error: error instanceof Error ? error.message : String(error) },
             url,
@@ -864,7 +918,7 @@ async function fetchCommunityImageBytes(
     }
     if (!response.ok) {
         throw new HttpError(
-            `Endpoint image URL responded ${response.status}`,
+            `Endpoint ${limits.noun} URL responded ${response.status}`,
             502,
             undefined,
             url,
@@ -872,8 +926,12 @@ async function fetchCommunityImageBytes(
     }
     return readResponseBytes(
         response,
-        MAX_COMMUNITY_IMAGE_BYTES,
-        () => new HttpError("Endpoint image is larger than 20 MB", 502),
+        limits.maxBytes,
+        () =>
+            new HttpError(
+                `Endpoint ${limits.noun} is larger than ${limits.maxBytes / (1024 * 1024)} MB`,
+                502,
+            ),
     );
 }
 
@@ -907,6 +965,10 @@ export function communityAudioTranscriptionsUrl(baseUrl: string): string {
     return `${communityOpenAIBaseUrl(baseUrl)}/audio/transcriptions`;
 }
 
+export function communityVideoGenerationsUrl(baseUrl: string): string {
+    return `${communityOpenAIBaseUrl(baseUrl)}/videos/generations`;
+}
+
 /**
  * Audio duration reported by an OpenAI-compatible transcription response.
  *
@@ -932,6 +994,34 @@ export function communityTranscriptionSeconds(body: unknown): number | null {
     return null;
 }
 
+/**
+ * Video duration reported by an OpenAI-compatible video response.
+ *
+ * `usage.video_seconds` is the shape our probe documents; `usage.duration` and
+ * a top-level `duration` cover servers that echo whisper-style timing. Returns
+ * null when none of them carry a usable number — callers decide what that
+ * means, and both the registration probe and the request path treat it as a
+ * failure so an endpoint that cannot be metered is never billed at zero.
+ */
+export function communityVideoSeconds(body: unknown): number | null {
+    if (!body || typeof body !== "object") return null;
+    const record = body as Record<string, unknown>;
+    const usage =
+        record.usage && typeof record.usage === "object"
+            ? (record.usage as Record<string, unknown>)
+            : undefined;
+    for (const value of [
+        usage?.video_seconds,
+        usage?.duration,
+        record.duration,
+    ]) {
+        if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+            return value;
+        }
+    }
+    return null;
+}
+
 export function communityOpenAIBaseUrl(baseUrl: string): string {
     const normalized = normalizeCommunityEndpointBaseUrl(baseUrl);
     for (const suffix of [
@@ -939,6 +1029,7 @@ export function communityOpenAIBaseUrl(baseUrl: string): string {
         "/images/generations",
         "/images/edits",
         "/audio/transcriptions",
+        "/videos/generations",
     ]) {
         if (normalized.endsWith(suffix)) {
             return normalized.slice(0, -suffix.length);
@@ -1001,6 +1092,7 @@ export function communityModelDefinition(
         endpoint.imagePricing,
     );
     const isImage = modality === "image";
+    const isVideo = modality === "video";
     const isTranscription = modality === "transcription";
     // Token-priced image endpoints bill like text models (usage × per-token
     // rates), so only fixed per-request image endpoints are flat-rate.
@@ -1019,14 +1111,24 @@ export function communityModelDefinition(
         perUserRpm: endpoint.perUserRpm,
         brand: providerName || "Community",
         brandUrl: providerName && providerUrl ? providerUrl : undefined,
-        category: isImage ? "image" : isTranscription ? "audio" : "text",
+        category: isImage
+            ? "image"
+            : isVideo
+              ? "video"
+              : isTranscription
+                ? "audio"
+                : "text",
         cost: communityPriceDefinition(endpoint, modality, imagePricing),
         priceMultiplier: 1,
         addedDate: endpoint.addedDate ?? 0,
         title: communityEndpointTitle(endpoint),
         description: description || undefined,
         inputModalities,
-        outputModalities: isImage ? ["image"] : ["text"],
+        outputModalities: isImage
+            ? ["image"]
+            : isVideo
+              ? ["video"]
+              : ["text"],
         hidden: endpoint.hidden,
         ...(endpoint.fallbacks?.length
             ? { fallbacks: endpoint.fallbacks }

--- a/shared/community-endpoints.ts
+++ b/shared/community-endpoints.ts
@@ -1124,11 +1124,7 @@ export function communityModelDefinition(
         title: communityEndpointTitle(endpoint),
         description: description || undefined,
         inputModalities,
-        outputModalities: isImage
-            ? ["image"]
-            : isVideo
-              ? ["video"]
-              : ["text"],
+        outputModalities: isImage ? ["image"] : isVideo ? ["video"] : ["text"],
         hidden: endpoint.hidden,
         ...(endpoint.fallbacks?.length
             ? { fallbacks: endpoint.fallbacks }

--- a/shared/image-mime.ts
+++ b/shared/image-mime.ts
@@ -35,3 +35,31 @@ export function detectImageMimeType(bytes: Uint8Array): ImageMimeType | null {
     if (bytes[0] === 0x42 && bytes[1] === 0x4d) return "image/bmp";
     return null;
 }
+
+export type VideoMimeType = "video/mp4" | "video/webm";
+
+export function detectVideoMimeType(bytes: Uint8Array): VideoMimeType | null {
+    // MP4-family files (mp4, mov, m4v) are ISO base media files: the first box
+    // is a size header followed by a brand at offset 4, usually "ftyp".
+    if (bytes.length >= 12) {
+        const brand = String.fromCharCode(
+            bytes[4] ?? 0,
+            bytes[5] ?? 0,
+            bytes[6] ?? 0,
+            bytes[7] ?? 0,
+        );
+        if (brand === "ftyp" || brand === "moov" || brand === "mdat") {
+            return "video/mp4";
+        }
+    }
+    // WebM and MKV share the EBML header 0x1A45DFA3.
+    if (
+        bytes[0] === 0x1a &&
+        bytes[1] === 0x45 &&
+        bytes[2] === 0xdf &&
+        bytes[3] === 0xa3
+    ) {
+        return "video/webm";
+    }
+    return null;
+}


### PR DESCRIPTION
Closes #13906

Adds `video` as a first-class community-model modality, so publishers can register and serve video-generation endpoints through Pollinations.

### What changed

- **shared**: `video` joins `COMMUNITY_ENDPOINT_MODALITIES`. Video endpoints bill generated seconds through the existing `completionVideoPrice` / `completionVideoSeconds` columns under a new `MAX_COMMUNITY_PRICE_PER_VIDEO_SECOND = 0.5` ceiling (double the priciest first-party rate), and reuse the durable media request lifecycle, authentication, per-user rate limits, and publisher rewards untouched. `firstCommunityImageBytes` is generalized into `firstCommunityMediaBytes` for both media kinds; `communityVideoSeconds` normalizes `usage.video_seconds`, `usage.duration`, and top-level `duration`, so an endpoint that cannot report its duration is never billed at zero.
- **enter**: registration probes `POST /v1/videos/generations` with a short prompt and rejects endpoints that return no playable video or cannot report the billed duration; the pricing UI and proxy policy pick up the new `video` price unit; the My Models dialog gains a Video modality tab, prices it per second with the right ceiling and validation, and renders a video icon on the price row.
- **gen**: community video models flow through the existing media generation funnel (`generateMediaWithFallback`) into a new `callCommunityVideoEndpoint`, which forwards the caller's duration in seconds, validates the payload is playable MP4/WebM via magic bytes, and returns `completionVideoSeconds` tracking usage so per-second billing and publisher rewards work without new plumbing. Catalog output (`communityModelDefinition`) emits `category: "video"`, `outputModalities: ["video"]`, `inputModalities: ["text"]`.

### Quest outcome coverage

- **My Models and the account API support a first-class `video` modality** — the registration dialog gains a Video tab (per-second price with the $0.5/s ceiling and validation, video icon), and the account routes, schemas, and proxy policy accept video endpoints.
- **Community video models appear correctly in the public catalog and dashboard** — `communityModelDefinition` emits `category: "video"`, `outputModalities: ["video"]`, `inputModalities: ["text"]`, and the dashboard price table renders the per-second video unit and icon.
- **Existing generation routes call the community endpoint and return playable video** — community video models flow through the existing media funnel into `callCommunityVideoEndpoint`, which returns magic-byte-verified MP4/WebM within the existing 300-second synchronous request limit (no async-job API).
- **Reuse without new plumbing** — durable media request lifecycle, per-second billing, publisher rewards, authentication, and per-user rate limits are untouched; the only new upstream contract is `POST {baseUrl}/v1/videos/generations` taking `{model, prompt, duration?}`.
- **Publisher-facing contract is documented** — `BRING_YOUR_OWN_MODEL.md` now lists the video endpoint pair, the MP4/WebM + duration-reporting requirement, and the $0.5/s price cap.

### How tested

- 13 new focused tests covering the registration probe (success / missing duration / non-video payload), shared helpers (duration shapes, per-second price fields, catalog fields), and the generation path (per-second billing, duration forwarding, missing-duration failure, non-video failure, managed-agent rejection, upstream error propagation).
- `tsc --noEmit` clean for `gen.pollinations.ai` and the full `enter.pollinations.ai` project including the frontend; `biome check` clean on all touched files.
- Existing suites pass unchanged: gen `community-endpoints.test.ts` (90 tests), enter `community-endpoint-openai.test.ts` (18 tests).
