### PR TITLE
docs: add community model naming guide (#12885)

### DIFF
--- a/BRING_YOUR_OWN_MODEL.md
+++ b/BRING_YOUR_OWN_MODEL.md
@@ -2,6 +2,8 @@
 
 Publishing a model lets you connect an OpenAI-compatible endpoint to Pollinations and call it through `gen.pollinations.ai` under an `owner/model` id. Pollinations handles authentication, Pollen billing, model discovery, and routing; the model continues to run on infrastructure you control.
 
+Before choosing a model id and title, see the [community model naming guide](./COMMUNITY_MODEL_NAMING.md).
+
 Model publishing and [connecting user wallets](./BRING_YOUR_OWN_POLLEN.md) solve different problems. Model publishing supplies a model to the Pollinations catalog. The wallet flow lets users authorize an app to spend their own Pollen. An app can use either or both.
 
 ## Supported Models

--- a/COMMUNITY_MODEL_NAMING.md
+++ b/COMMUNITY_MODEL_NAMING.md
@@ -1,0 +1,46 @@
+# Community Model Naming
+
+Community models are published under an `owner/model` id and called through Pollinations. This guide helps you choose a stable model id and clear public name for your model. It does **not** impose the stricter naming scheme used for first-party models; you are free to pick a name that fits your project.
+
+Three fields in the [Add model](https://enter.pollinations.ai/my-models) form work together:
+
+| Field | Role | Guidance |
+|---|---|---|
+| **Model id** (`owner/model`) | The stable, machine-readable identifier used in API calls. | Make it short, lowercase, hyphenated, and **fixed**. Avoid any value that is likely to change. |
+| **Title** | The short display name shown in the Models list. | Human-readable and memorable. Custom names are welcome. |
+| **Description** | One line that tells users what the model is or what it routes to. | Use it to be transparent about what the model really is. |
+
+## A stable id stays stable
+
+The id is part of the public API. Once people call `owner/my-model`, that id is effectively a contract. Prefer ids that describe the **model**, not the circumstances around it. A stable id avoids mutable details:
+
+- **Pricing** — prices change; a model named `my-model-free` or `my-model-cheap` goes stale.
+- **Provider routing** — if you switch upstream providers, a name like `my-model-openai` misleads users after the switch.
+- **Context size** — models are upgraded; `my-model-128k` becomes wrong when the limit grows.
+
+If a meaningful characteristic changes, prefer publishing a **new id** over silently reusing an old one with different behavior.
+
+## Four common cases
+
+**Direct upstream model.** You proxy an existing model with your own id. Match the upstream so the mapping is obvious.
+
+- id: `owner/flux-dev`, title: `Flux Dev`, description: `Direct proxy of BFL flux-dev.`
+
+**Custom model.** You host a fine-tune or a model built with your own tooling. The id is your name for it.
+
+- id: `owner/synth-chat`, title: `Synth Chat`, description: `My coding fine-tune of Qwen2.5-Coder.`
+
+**Router.** Your endpoint dispatches to different upstreams (by capability, content, or the request itself). Say so up front.
+
+- id: `owner/omnigate`, title: `OmniGate`, description: `Router: text generation across a pool of upstream models.`
+
+**Rebranded model.** You serve a known model under your own brand. Be transparent about what it actually is.
+
+- id: `owner/aurora`, title: `Aurora`, description: `Rebranded hosting of mistral-small-3.`
+
+## Summary
+
+- Pick a short, lowercase, hyphenated `owner/model` id that names the model, not its price, provider, or context size.
+- Give it a clear display title.
+- Use the description to say what the model is or what it routes to, especially when the id is a custom name.
+- When behavior changes materially, publish a new id instead of reusing one.

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/model-listing-fields.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/model-listing-fields.tsx
@@ -114,9 +114,19 @@ export function ModelListingFields({
                 <FieldStack
                     label={isAgent ? "ID" : "Model ID"}
                     helper={
-                        isAgent
-                            ? "Public ID: {username}/{id}."
-                            : "Public ID: {username}/{model-id}."
+                        <>
+                            {isAgent
+                                ? "Public ID: {username}/{id}."
+                                : "Public ID: {username}/{model-id}."}{" "}
+                            <a
+                                href="https://github.com/pollinations/pollinations/blob/main/COMMUNITY_MODEL_NAMING.md"
+                                className="underline underline-offset-2 transition-colors hover:text-theme-text-strong"
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                Naming guide
+                            </a>
+                        </>
                     }
                     alignLabelRow
                 >


### PR DESCRIPTION
Closes #12885

## Changes
- Adds a concise `COMMUNITY_MODEL_NAMING.md` guide for community-model naming.
- Explains the roles of the stable model id, short display title, and transparent description.
- Covers direct upstream models, custom models, routers, and rebranded models with examples.
- Advises against mutable details in ids (pricing, provider routing, context size).
- Links the guide from the Model ID field of the Add model form.
- Links it from `BRING_YOUR_OWN_MODEL.md`.
- No schema enforcement, dashboard warnings, aliases, migrations, or changes to existing ids.

## Test plan
- Docs-only change plus one ReactNode helper-text update in the Add model form.
- Biomes clears the changed TSX; no logic, API, or registry changes.