### PR TITLE
fix: switch qwen3.8-max provider from OpenRouter to Fireworks serverless

### DIFF
--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -135,7 +135,7 @@ const models: ModelDefinition[] = [
     },
     {
         name: "qwen3.8-max",
-        config: portkeyConfig["qwen/qwen3.8-max"],
+        config: portkeyConfig["accounts/fireworks/models/qwen3p8-max"],
     },
     {
         name: "qwen3.7-flash",

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -222,16 +222,9 @@ export const portkeyConfig: PortkeyConfigMap = {
                 },
             },
         }),
-    "qwen/qwen3.8-max": () =>
-        createOpenRouterModelConfig({
-            model: "qwen/qwen3.8-max",
-            defaultOptions: {
-                max_tokens: 64000,
-                provider: {
-                    only: ["Alibaba"],
-                    allow_fallbacks: false,
-                },
-            },
+    "accounts/fireworks/models/qwen3p8-max": () =>
+        createFireworksModelConfig({
+            model: "accounts/fireworks/models/qwen3p8-max",
         }),
     "qwen/qwen3.7-flash": () =>
         createOpenRouterModelConfig({

--- a/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
+++ b/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
@@ -138,17 +138,14 @@ describe("resolveModelConfig", () => {
         });
     });
 
-    it("routes Qwen3.8 Max to Alibaba without fallback", () => {
+    it("routes Qwen3.8 Max to Fireworks serverless", () => {
         const result = resolveModelConfig(messages, { model: "qwen3.8-max" });
 
-        expect(result.options.model).toBe("qwen/qwen3.8-max");
+        expect(result.options.model).toBe(
+            "accounts/fireworks/models/qwen3p8-max",
+        );
         expect(result.options.modelConfig).toMatchObject({
-            provider: "openrouter",
-            directEndpoint: "https://openrouter.ai/api/v1/chat/completions",
-        });
-        expect(result.options.provider).toEqual({
-            only: ["Alibaba"],
-            allow_fallbacks: false,
+            provider: "openai",
         });
     });
 

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -2081,8 +2081,8 @@ export const TEXT_SERVICES = {
         isSpecialized: false,
     },
     "qwen3.8-max": {
-        aliases: ["qwen/qwen3.8-max"],
-        provider: "openrouter",
+        aliases: ["accounts/fireworks/models/qwen3p8-max"],
+        provider: "fireworks",
         brand: "Qwen",
         category: "text",
         addedDate: new Date("2026-08-04").getTime(),


### PR DESCRIPTION
## Summary

Fixes #14093 — switches `qwen3.8-max` from OpenRouter (out-of-pocket) to Fireworks serverless (complimentary credits).

## Why

Fireworks now offers `qwen3p8-max` on serverless at the same pricing tier. The open-weight sibling `qwen3.8-2.4t-a95b` already runs on Fireworks, confirming the integration path works.

**Benefit:** Zero marginal cost while `paidOnly: true` revenue remains pure margin.

## Changes (3 files, +6/−13)

- **`shared/registry/text.ts`**: `provider: "openrouter"` → `"fireworks"`, add Fireworks alias
- **`gen.pollinations.ai/src/text/configs/modelConfigs.ts`**: Replace OpenRouter config with `createFireworksModelConfig`
- **`gen.pollinations.ai/src/text/availableModels.ts`**: Update config key reference

## Pricing

Unchanged — $2.00 input, $0.25 cached, $6.00 output per 1M tokens (same as OpenRouter).

## Impact

No user-facing behavior change — same model, same price, same `paidOnly` status. Only the backend provider changes.