### PR TITLE
feat: route GLM-5.3 through Fireworks

### DIFF
--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -416,9 +416,9 @@ const models: ModelDefinition[] = [
     },
     {
         name: "glm-5.3",
-        config: portkeyConfig["z-ai/glm-5.3"],
+        config: portkeyConfig["accounts/fireworks/models/glm-5p3"],
         // Reasoning is mandatory; off requests keep the upstream default.
-        transform: mandatoryReasoning,
+        transform: pipe(stripCacheControl, mandatoryReasoning),
     },
     {
         name: "z-ai/glm-5.3-flash",

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -159,20 +159,6 @@ export const portkeyConfig: PortkeyConfigMap = {
                 },
             },
         }),
-    // GLM-5.3 is a mandatory-reasoning model (see registry entry), making it
-    // just as exposed to the blank-answer/billed-tokens bug as the Qwen
-    // models above if z-ai/fp8's own max_tokens default is ever too low.
-    "z-ai/glm-5.3": () =>
-        createOpenRouterModelConfig({
-            model: "z-ai/glm-5.3",
-            defaultOptions: {
-                max_tokens: 64000,
-                provider: {
-                    only: ["z-ai/fp8"],
-                    allow_fallbacks: false,
-                },
-            },
-        }),
     "z-ai/glm-5.3-flash": () =>
         createOpenRouterModelConfig({
             model: "z-ai/glm-5.3-flash",
@@ -453,6 +439,11 @@ export const portkeyConfig: PortkeyConfigMap = {
     "accounts/fireworks/models/glm-5p2": () =>
         createFireworksModelConfig({
             model: "accounts/fireworks/models/glm-5p2",
+        }),
+    "accounts/fireworks/models/glm-5p3": () =>
+        createFireworksModelConfig({
+            model: "accounts/fireworks/models/glm-5p3",
+            defaultOptions: { max_tokens: 64000 },
         }),
     "accounts/fireworks/models/minimax-m2p7": () =>
         createFireworksModelConfig({

--- a/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
+++ b/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
@@ -234,18 +234,16 @@ describe("resolveModelConfig", () => {
         });
     });
 
-    it("pins GLM-5.3 to Z.AI FP8 on OpenRouter without fallback", () => {
+    it("routes GLM-5.3 directly to Fireworks without fallback", () => {
         const result = resolveModelConfig(messages, { model: "glm-5.3" });
 
-        expect(result.options.model).toBe("z-ai/glm-5.3");
+        expect(result.options.model).toBe("accounts/fireworks/models/glm-5p3");
         expect(result.options.modelConfig).toMatchObject({
-            provider: "openrouter",
-            directEndpoint: "https://openrouter.ai/api/v1/chat/completions",
+            provider: "openai",
+            "custom-host": "https://api.fireworks.ai/inference/v1",
         });
-        expect(result.options.provider).toEqual({
-            only: ["z-ai/fp8"],
-            allow_fallbacks: false,
-        });
+        expect(result.options.provider).toBeUndefined();
+        expect(result.options.max_tokens).toBe(64000);
     });
 
     it("pins GLM-5.3 Flash to Z.AI FP8 on OpenRouter without fallback", () => {

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -1676,12 +1676,13 @@ export const TEXT_SERVICES = {
     },
     "glm-5.3": {
         aliases: ["z-ai/glm-5.3"],
-        provider: "openrouter",
+        provider: "fireworks",
         brand: "Z.ai",
         category: "text",
         addedDate: new Date("2026-08-19").getTime(),
-        paidOnly: true,
+        paidOnly: false,
         priceMultiplier: 1,
+        // Fireworks standard serverless rates (2026-08-29).
         cost: {
             promptTextTokens: perMillion(1.4),
             promptCachedTokens: perMillion(0.26),


### PR DESCRIPTION
- Routes canonical GLM-5.3 and its existing alias directly to Fireworks serverless accounts/fireworks/models/glm-5p3.
- Sets paidOnly to false; preserves the $1.40/$0.26/$4.40 per-million cost sheet, multiplier 1, 1,048,576 context, mandatory reasoning, and no fallback.
- Strips unsupported cache-control annotations before the Fireworks request.
- Verified direct reasoning, JSON, tools, streaming, cached usage, and 10/10 burst; full local E2E passed both wallet paths, cache, errors, aliases, catalog, and 10/10 burst. Tinybird reconciled provider, meters, units, and exact settlement.

Pricing: https://fireworks.ai/models/fireworks/glm-5p3