### PR TITLE
feat(polli-cli): create endpoint agents

### DIFF
--- a/packages/polli-cli/README.md
+++ b/packages/polli-cli/README.md
@@ -95,7 +95,7 @@ polli usage --daily          # daily spend
 polli earnings               # developer earnings (default 30 days, --days up to 90)
 polli quests --claimable     # only rewards ready to claim
 polli agents list            # managed prompt agents
-polli my-models list         # invite-only community text, image, and transcription models
+polli my-models list         # community models and endpoint agents
 ```
 
 Manage agents with API-shaped JSON config files plus their callable model name
@@ -106,6 +106,7 @@ polli agents get <id>
 polli agents create --config agent.json --name my-agent --title "My Agent"
 polli agents update <id> --config agent.json
 polli agents delete <id>
+polli my-models create-endpoint-agent --name my-endpoint-agent --title "My Endpoint Agent" --base-url https://agent.example.com/v1
 ```
 
 `agent.json` contains the complete configuration:
@@ -118,7 +119,7 @@ polli agents delete <id>
 }
 ```
 
-Creating an agent also creates its callable model listing. See [Publish an Agent](https://github.com/pollinations/pollinations/blob/main/BUILD_YOUR_OWN_AGENT.md) for visibility, billing, and lifecycle details.
+Creating a managed agent also creates its callable model listing. Use `my-models create-endpoint-agent` for an agent running on your own server; it receives a short-lived agent run token instead of a stored bearer credential. See [Publish an Agent](https://github.com/pollinations/pollinations/blob/main/BUILD_YOUR_OWN_AGENT.md) for visibility, billing, and lifecycle details.
 
 `polli auth login` creates a key with all account permissions Polli needs: `profile`, `usage`, and `keys`. Use `account:usage` for narrow read-only account state like usage and quests. Use `account:keys` to manage keys and, where invite-only My Models access is enabled, my-models. Quest claiming remains in the dashboard.
 

--- a/packages/polli-cli/SKILL.md
+++ b/packages/polli-cli/SKILL.md
@@ -160,6 +160,7 @@ polli quests --claimable # only rewards ready to claim
 polli my-models list
 polli my-models models --base-url https://api.example.com/v1 --bearer-token "$UPSTREAM_KEY"
 polli my-models create --name my-model --title "My Model" --base-url https://api.example.com/v1 --bearer-token "$UPSTREAM_KEY" --upstream-model gpt-4.1-mini
+polli my-models create-endpoint-agent --name my-agent --title "My Agent" --base-url https://agent.example.com/v1
 polli my-models create --name my-image --title "My Image" --modality image --image-pricing request --completion-image-price 0.01 --base-url https://api.example.com/v1 --bearer-token "$UPSTREAM_KEY" --upstream-model flux
 polli my-models update <id> --description "Updated description"
 polli my-models update <id> --paid-only            # only accept Paid Pollen; --no-paid-only reverts

--- a/packages/polli-cli/package-lock.json
+++ b/packages/polli-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pollinations/cli",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pollinations/cli",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/packages/polli-cli/package.json
+++ b/packages/polli-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollinations/cli",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "The Pollinations CLI — for humans, AI agents, and everything in between",
   "type": "module",
   "bin": {

--- a/packages/polli-cli/src/commands/my-models.test.ts
+++ b/packages/polli-cli/src/commands/my-models.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { modelBody } from "./my-models.js";
+import { endpointAgentBody, modelBody } from "./my-models.js";
 
 describe("modelBody", () => {
     it("builds image model registration fields supported by the API", () => {
@@ -74,5 +74,30 @@ describe("modelBody", () => {
                 true,
             ),
         ).toMatchObject({ modality: "transcription" });
+    });
+});
+
+describe("endpointAgentBody", () => {
+    it("builds the endpoint-agent registration body without proxy fields", () => {
+        expect(
+            endpointAgentBody({
+                name: "floret",
+                title: "Floret",
+                description: "Agent orchestration endpoint",
+                baseUrl: "https://floret.example.com/v1",
+                upstreamModel: "floret",
+                visibility: "private",
+                perUserRpm: "10",
+                bearerToken: "must-not-send",
+            }),
+        ).toEqual({
+            name: "floret",
+            title: "Floret",
+            description: "Agent orchestration endpoint",
+            baseUrl: "https://floret.example.com/v1",
+            upstreamModel: "floret",
+            visibility: "private",
+            perUserRpm: 10,
+        });
     });
 });

--- a/packages/polli-cli/src/commands/my-models.ts
+++ b/packages/polli-cli/src/commands/my-models.ts
@@ -176,6 +176,36 @@ export function modelBody(
     return body;
 }
 
+export function endpointAgentBody(opts: Record<string, unknown>) {
+    const body: Record<string, unknown> = {};
+    for (const field of [
+        "name",
+        "title",
+        "description",
+        "baseUrl",
+        "upstreamModel",
+    ] as const) {
+        if (opts[field] !== undefined) body[field] = opts[field];
+    }
+
+    if (opts.visibility !== undefined) {
+        if (opts.visibility !== "private" && opts.visibility !== "public") {
+            fail("--visibility must be 'private' or 'public'");
+        }
+        body.visibility = opts.visibility;
+    }
+
+    if (opts.perUserRpm !== undefined) {
+        const perUserRpm = Number(opts.perUserRpm);
+        if (!Number.isFinite(perUserRpm) || perUserRpm <= 0) {
+            fail("--per-user-rpm must be a positive number");
+        }
+        body.perUserRpm = perUserRpm;
+    }
+
+    return body;
+}
+
 function printModels(models: MyModel[]) {
     if (getOutputMode() === "json") {
         printResult(models);
@@ -292,6 +322,45 @@ const create = addPriceOptions(
         fail("Failed to create model", err);
     }
 });
+
+const createEndpointAgent = new Command("create-endpoint-agent")
+    .description("Register an agent running on an OpenAI-compatible endpoint")
+    .requiredOption("--name <name>", "Agent model name")
+    .requiredOption("--title <title>", "Display title shown in the catalog")
+    .requiredOption("--base-url <url>", "OpenAI-compatible base URL")
+    .option("--description <text>", "Agent description")
+    .option(
+        "--upstream-model <model>",
+        "Upstream model id (defaults to --name)",
+    )
+    .option(
+        "--visibility <visibility>",
+        "Agent visibility: private (default) or public",
+    )
+    .option(
+        "--per-user-rpm <number>",
+        "Maximum requests per minute for each Pollinations user",
+    )
+    .action(async (opts) => {
+        const key = requireKey();
+        try {
+            const created = await gen<EndpointAgentMyModel>(
+                "/account/my-models/endpoint-agents",
+                {
+                    apiKey: key,
+                    method: "POST",
+                    body: endpointAgentBody(opts),
+                },
+            );
+            if (getOutputMode() === "json") printResult(created);
+            else {
+                printSuccess(`Endpoint agent registered: ${created.modelId}`);
+                printModels([created]);
+            }
+        } catch (err) {
+            fail("Failed to create endpoint agent", err);
+        }
+    });
 
 const update = addPriceOptions(
     new Command("update")
@@ -439,11 +508,10 @@ const test = new Command("test")
     });
 
 export const myModelsCommand = new Command("my-models")
-    .description(
-        "Manage private and published community text, image, and transcription models",
-    )
+    .description("Manage community models and endpoint agents")
     .addCommand(list)
     .addCommand(create)
+    .addCommand(createEndpointAgent)
     .addCommand(update)
     .addCommand(remove)
     .addCommand(models)


### PR DESCRIPTION
- Adds `polli my-models create-endpoint-agent` for externally hosted OpenAI-compatible agents.
- Sends the strict credential-free body to `/account/my-models/endpoint-agents`.
- Supports optional upstream model, visibility, and per-user RPM.
- Documents the command in the CLI README and skill.

Related: #13781

Tests: `npm test --prefix packages/polli-cli`; `npm run build --prefix packages/polli-cli`; CLI help smoke test.