### PR TITLE
feat(polli-cli): add modular coding harness setup

### DIFF
--- a/gen.pollinations.ai/src/docs/coding-harnesses.md
+++ b/gen.pollinations.ai/src/docs/coding-harnesses.md
@@ -1,0 +1,25 @@
+# Coding harnesses
+
+Use the Polli CLI to configure supported coding harnesses with Pollinations:
+
+```bash
+npm install -g @pollinations/cli
+polli harness --help
+polli harness opencode on
+polli harness opencode status
+polli harness opencode off
+```
+
+## OpenCode
+
+`on` first checks for the `opencode` executable. When it is missing, Polli runs OpenCode's official npm installation command:
+
+```bash
+npm install --global opencode-ai@latest
+```
+
+After installation, the adapter adds the community-maintained [`opencode-pollinations-plugin`](https://github.com/fkom13/opencode-pollinations-plugin) package to the global `opencode.json` plugin list. It preserves existing configuration and does not store an API key. If installation fails, Polli leaves the OpenCode configuration unchanged.
+
+Restart OpenCode after setup, then run `/poll login` to connect your Pollinations account. `OPENCODE_CONFIG_DIR` is respected when OpenCode uses a custom configuration directory.
+
+Each harness has `on`, `off`, and `status` commands and defaults to `on` when the command is omitted. `off` disables the Pollinations integration; it does not uninstall the harness. Each integration is an isolated Polli CLI adapter, so additional harnesses do not change the shared command.

--- a/gen.pollinations.ai/src/routes/docs.ts
+++ b/gen.pollinations.ai/src/routes/docs.ts
@@ -41,6 +41,7 @@ import MODEL3D_GENERATION_MD from "../docs/3d-generation.md?raw";
 import ACCOUNT_MD from "../docs/account.md?raw";
 import AUDIO_GENERATION_MD from "../docs/audio-generation.md?raw";
 import AUTHENTICATION_MD from "../docs/authentication.md?raw";
+import CODING_HARNESSES_MD from "../docs/coding-harnesses.md?raw";
 import EMBEDDINGS_MD from "../docs/embeddings.md?raw";
 import ERRORS_MD from "../docs/errors.md?raw";
 import IMAGE_GENERATION_MD from "../docs/image-generation.md?raw";
@@ -63,6 +64,7 @@ const DOC_TAGS = {
     communityModels: "Community Models",
     publishAgent: "Publish an Agent",
     communityAgents: "Community Agents",
+    codingHarnesses: "Coding Harnesses",
     cli: "CLI",
     mcpServer: "MCP Server",
     errors: "Errors",
@@ -134,6 +136,9 @@ const DOC_TAG_ICON_HTML: Record<string, string> = {
     [DOC_TAGS.cli]: docsIcon(
         '<polyline points="4 8 8 12 4 16" /><line x1="12" y1="20" x2="20" y2="20" />',
     ),
+    [DOC_TAGS.codingHarnesses]: docsIcon(
+        '<path d="M4 7h16" /><path d="M4 17h16" /><circle cx="9" cy="7" r="2" fill="currentColor" /><circle cx="15" cy="17" r="2" fill="currentColor" />',
+    ),
     [DOC_TAGS.mcpServer]: docsIcon(
         '<rect x="2" y="7" width="8" height="10" rx="1.5" /><rect x="14" y="7" width="8" height="10" rx="1.5" /><path d="M10 12h4" />',
     ),
@@ -188,7 +193,6 @@ const DOC_TAG_NAV_ICON_HTML: Record<string, string> = Object.fromEntries(
 );
 
 const CLI_DOCS = CLI_README.replace(/^# .*\n+/, "").trim();
-
 const MCP_DOCS = MCP_README.replace(/^# .*\n+/, "").trim();
 
 // Strip the leading H1/H2 heading line so the markdown can be embedded under
@@ -196,6 +200,7 @@ const MCP_DOCS = MCP_README.replace(/^# .*\n+/, "").trim();
 const stripLeadingHeading = (md: string) =>
     md.replace(/^#{1,2}\s.*\n+/, "").trim();
 
+const CODING_HARNESSES_DOCS = stripLeadingHeading(CODING_HARNESSES_MD.trim());
 const USER_WALLETS_DOCS = stripLeadingHeading(BYOP_MD.trim());
 const PUBLISH_MODEL_DOCS = stripLeadingHeading(COMMUNITY_MODELS_MD.trim());
 const PUBLISH_AGENT_DOCS = stripLeadingHeading(AGENTS_MD.trim());
@@ -352,6 +357,7 @@ const USER_WALLETS_SECTION = `## Connect User Wallets\n\n${USER_WALLETS_DOCS}`;
 const PUBLISH_MODEL_SECTION = `## Publish a Model\n\n${PUBLISH_MODEL_DOCS}`;
 const PUBLISH_AGENT_SECTION = `## Publish an Agent\n\n${PUBLISH_AGENT_DOCS}`;
 const CLI_SECTION = `## CLI\n\n${CLI_DOCS}`;
+const CODING_HARNESSES_SECTION = `## Coding Harnesses\n\n${CODING_HARNESSES_DOCS}`;
 const MCP_SECTION = `## MCP Server\n\n${MCP_DOCS}`;
 
 const LLM_DOC_TEXT = [
@@ -360,6 +366,7 @@ const LLM_DOC_TEXT = [
     PUBLISH_MODEL_SECTION,
     PUBLISH_AGENT_SECTION,
     CLI_SECTION,
+    CODING_HARNESSES_SECTION,
     MCP_SECTION,
 ].join("\n\n");
 
@@ -369,6 +376,7 @@ const LLM_DOC_SECTIONS: Record<string, string> = {
     "publish-a-model": PUBLISH_MODEL_SECTION,
     "publish-an-agent": PUBLISH_AGENT_SECTION,
     cli: CLI_SECTION,
+    "coding-harnesses": CODING_HARNESSES_SECTION,
     mcp: MCP_SECTION,
 };
 
@@ -490,8 +498,9 @@ function generationDocumentation(): OpenApiSchema {
                     DOC_TAGS.userWallets,
                     DOC_TAGS.publishModel,
                     DOC_TAGS.publishAgent,
-                    DOC_TAGS.mcpServer,
                     DOC_TAGS.cli,
+                    DOC_TAGS.codingHarnesses,
+                    DOC_TAGS.mcpServer,
                 ],
             },
             {
@@ -555,6 +564,10 @@ function generationDocumentation(): OpenApiSchema {
             {
                 name: DOC_TAGS.cli,
                 description: CLI_DOCS,
+            },
+            {
+                name: DOC_TAGS.codingHarnesses,
+                description: CODING_HARNESSES_DOCS,
             },
             {
                 name: DOC_TAGS.mcpServer,

--- a/gen.pollinations.ai/test/docs.test.ts
+++ b/gen.pollinations.ai/test/docs.test.ts
@@ -237,6 +237,7 @@ describe("docs routes", () => {
         expect(resources?.tags).not.toContain("Publish a Model");
         expect(integrations?.tags).toContain("Publish an Agent");
         expect(integrations?.tags).not.toContain("Community Agents");
+        expect(integrations?.tags).toContain("Coding Harnesses");
         expect(resources?.tags).toContain("Community Agents");
         expect(resources?.tags).not.toContain("Publish an Agent");
         expect(schema.tags.map((tag) => tag.name)).toContain(
@@ -253,6 +254,17 @@ describe("docs routes", () => {
             "Community Agents",
         );
         expect(schema.tags.map((tag) => tag.name)).toContain("CLI");
+        expect(schema.tags.map((tag) => tag.name)).toContain(
+            "Coding Harnesses",
+        );
+        expect(
+            schema.tags.find((tag) => tag.name === "Coding Harnesses")
+                ?.description,
+        ).toContain("polli harness opencode on");
+        expect(
+            schema.tags.find((tag) => tag.name === "Coding Harnesses")
+                ?.description,
+        ).toContain("npm install --global opencode-ai@latest");
         expect(schema.tags.map((tag) => tag.name)).toContain("MCP Server");
         expect(schema.tags.map((tag) => tag.name)).toContain("Quests");
         expect(schema.tags.map((tag) => tag.name)).toContain("Media Storage");
@@ -533,6 +545,18 @@ describe("docs routes", () => {
         const agentsBody = await agentsRes.text();
         expect(agentsBody).toContain("## Publish an Agent");
         expect(agentsBody).toContain("/account/agents");
+
+        const harnessesRes = await worker.fetch(
+            new Request(
+                "https://gen.pollinations.ai/docs/llm.txt?section=coding-harnesses",
+            ),
+            envWithEnterSchema({}),
+            ctx,
+        );
+        expect(harnessesRes.status).toBe(200);
+        const harnessesBody = await harnessesRes.text();
+        expect(harnessesBody).toContain("## Coding Harnesses");
+        expect(harnessesBody).toContain("polli harness opencode on");
 
         const badRes = await worker.fetch(
             new Request("https://gen.pollinations.ai/docs/llm.txt?section=bad"),

--- a/packages/polli-cli/README.md
+++ b/packages/polli-cli/README.md
@@ -68,6 +68,8 @@ polli docs /image            # one endpoint
 polli docs --open            # open in browser
 polli quests                 # public quest catalog
 polli quests --claimed       # already-completed and earned quest status
+polli harness --help         # supported coding harnesses
+polli harness opencode on    # install OpenCode if needed, then enable Pollinations
 ```
 
 ## Account

--- a/packages/polli-cli/SKILL.md
+++ b/packages/polli-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: polli
-description: Generate images, text, audio, video, and transcribe speech via the Pollinations API using the polli CLI. Use when asked to generate media, call pollinations.ai, check pollen balance, list models, manage API keys, inspect quests, manage agents or my-models, or run polli commands.
+description: Generate images, text, audio, video, and transcribe speech via the Pollinations API using the polli CLI. Use when asked to generate media, call pollinations.ai, check pollen balance, list models, manage API keys, inspect quests, configure coding harnesses, manage agents or my-models, or run polli commands.
 allowed-tools: Bash(polli *)
 ---
 
@@ -41,6 +41,7 @@ Install: `npm i -g @pollinations/cli@latest` (provides the `polli` binary).
 | Check balance | `polli usage` |
 | Developer earnings | `polli earnings` (`--days <n>`, max 90) |
 | List your quests + claim state | `polli quests` (filters: `--open --claimable --claimed --coming-soon`) |
+| Configure a coding harness | `polli harness opencode on` |
 | Manage prompt agents | `polli agents list` |
 | Manage invite-only community models | `polli my-models list` |
 | Machine-readable output | append `--json` to any command |
@@ -51,6 +52,8 @@ One-time: `polli auth login` (device-flow; creates a key with `profile`, `usage`
 `printf '%s' "$POLLINATIONS_API_KEY" | polli auth login --with-token`. Verify
 with `polli auth status`.
 Override the stored key for a single command with `--key <key>`.
+
+Coding harness setup does not require Polli authentication. Run `polli harness --help` for available adapters, then use `polli harness <id> on|off|status`. `on` installs a missing harness with its official installer before configuring it. The OpenCode adapter installs `opencode-ai@latest` through npm when needed, enables `opencode-pollinations-plugin`, then asks the user to restart OpenCode and run `/poll login`.
 
 ## Recipes
 

--- a/packages/polli-cli/src/commands/harness.ts
+++ b/packages/polli-cli/src/commands/harness.ts
@@ -1,0 +1,42 @@
+import { Command } from "commander";
+import { listHarnesses } from "../harnesses/index.js";
+import type { HarnessAdapter } from "../harnesses/types.js";
+import { fail, printResult } from "../lib/output.js";
+
+type HarnessAction = "on" | "off" | "status";
+
+const run = async (harness: HarnessAdapter, action: HarnessAction) => {
+    try {
+        printResult(await harness[action]());
+    } catch (error) {
+        fail(`Could not run ${harness.id} ${action}`, error);
+    }
+};
+
+const createHarnessCommand = (harness: HarnessAdapter): Command =>
+    new Command(harness.id)
+        .description(harness.description)
+        .action(() => run(harness, "on"))
+        .addCommand(
+            new Command("on")
+                .description(`Enable ${harness.name}`)
+                .action(() => run(harness, "on")),
+        )
+        .addCommand(
+            new Command("off")
+                .description(`Disable ${harness.name}`)
+                .action(() => run(harness, "off")),
+        )
+        .addCommand(
+            new Command("status")
+                .description(`Show ${harness.name} status`)
+                .action(() => run(harness, "status")),
+        );
+
+export const harnessesCommand = new Command("harness").description(
+    "Configure coding harnesses to use Pollinations",
+);
+
+for (const harness of listHarnesses()) {
+    harnessesCommand.addCommand(createHarnessCommand(harness));
+}

--- a/packages/polli-cli/src/harnesses/atomic-write.ts
+++ b/packages/polli-cli/src/harnesses/atomic-write.ts
@@ -1,0 +1,34 @@
+import { randomBytes } from "node:crypto";
+import { mkdir, rename, stat, unlink, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+
+const fileMode = async (path: string): Promise<number> => {
+    try {
+        return (await stat(path)).mode & 0o777;
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") return 0o600;
+        throw error;
+    }
+};
+
+export const writeJsonAtomic = async (
+    path: string,
+    value: Record<string, unknown>,
+): Promise<void> => {
+    await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+    const temporaryPath = join(
+        dirname(path),
+        `.${basename(path)}.${randomBytes(6).toString("hex")}.tmp`,
+    );
+
+    try {
+        await writeFile(temporaryPath, `${JSON.stringify(value, null, 2)}\n`, {
+            encoding: "utf-8",
+            mode: await fileMode(path),
+        });
+        await rename(temporaryPath, path);
+    } catch (error) {
+        await unlink(temporaryPath).catch(() => undefined);
+        throw error;
+    }
+};

--- a/packages/polli-cli/src/harnesses/index.ts
+++ b/packages/polli-cli/src/harnesses/index.ts
@@ -1,0 +1,6 @@
+import { opencodeHarness } from "./opencode.js";
+import type { HarnessAdapter } from "./types.js";
+
+const harnesses: HarnessAdapter[] = [opencodeHarness];
+
+export const listHarnesses = (): HarnessAdapter[] => [...harnesses];

--- a/packages/polli-cli/src/harnesses/opencode.test.ts
+++ b/packages/polli-cli/src/harnesses/opencode.test.ts
@@ -1,0 +1,154 @@
+import { spawnSync } from "node:child_process";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { opencodeHarness } from "./opencode.js";
+
+vi.mock("node:child_process", () => ({ spawnSync: vi.fn() }));
+
+const temporaryDirectories: string[] = [];
+const spawnSyncMock = vi.mocked(spawnSync);
+
+const testContext = async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "polli-opencode-"));
+    temporaryDirectories.push(homeDir);
+    return { env: {}, homeDir };
+};
+
+beforeEach(() => {
+    spawnSyncMock.mockReset();
+    spawnSyncMock.mockReturnValue({ status: 0 } as ReturnType<
+        typeof spawnSync
+    >);
+});
+
+afterEach(async () => {
+    await Promise.all(
+        temporaryDirectories
+            .splice(0)
+            .map((path) => rm(path, { recursive: true, force: true })),
+    );
+});
+
+describe("OpenCode harness", () => {
+    it("adds the Pollinations plugin without replacing existing plugins", async () => {
+        const context = await testContext();
+        const configPath = join(
+            context.homeDir,
+            ".config",
+            "opencode",
+            "opencode.json",
+        );
+        await mkdir(join(context.homeDir, ".config", "opencode"), {
+            recursive: true,
+        });
+        await writeFile(
+            configPath,
+            JSON.stringify({ plugin: ["existing-plugin"], theme: "dark" }),
+        );
+
+        const enabled = await opencodeHarness.on(context);
+        const config = JSON.parse(await readFile(configPath, "utf-8"));
+
+        expect(enabled).toMatchObject({ configured: true, changed: true });
+        expect(config).toEqual({
+            plugin: ["existing-plugin", "opencode-pollinations-plugin"],
+            theme: "dark",
+        });
+    });
+
+    it("is idempotent and reports the configured status", async () => {
+        const context = await testContext();
+
+        expect(await opencodeHarness.status(context)).toMatchObject({
+            configured: false,
+        });
+        await opencodeHarness.on(context);
+        expect(await opencodeHarness.on(context)).toMatchObject({
+            configured: true,
+            changed: false,
+        });
+        expect(await opencodeHarness.status(context)).toMatchObject({
+            configured: true,
+        });
+    });
+
+    it("removes only the Pollinations plugin", async () => {
+        const context = await testContext();
+        await opencodeHarness.on(context);
+        const configPath = join(
+            context.homeDir,
+            ".config",
+            "opencode",
+            "opencode.json",
+        );
+        const config = JSON.parse(await readFile(configPath, "utf-8"));
+        config.plugin.push("another-plugin");
+        config.theme = "dark";
+        await writeFile(configPath, JSON.stringify(config));
+
+        expect(await opencodeHarness.off(context)).toMatchObject({
+            configured: false,
+            changed: true,
+        });
+        expect(JSON.parse(await readFile(configPath, "utf-8"))).toEqual({
+            plugin: ["another-plugin"],
+            theme: "dark",
+        });
+    });
+
+    it("honors OPENCODE_CONFIG_DIR", async () => {
+        const context = await testContext();
+        const customDir = join(context.homeDir, "custom-opencode");
+
+        const enabled = await opencodeHarness.on({
+            ...context,
+            env: { OPENCODE_CONFIG_DIR: customDir },
+        });
+
+        expect(enabled.configPath).toBe(join(customDir, "opencode.json"));
+    });
+
+    it("installs OpenCode before configuring a missing harness", async () => {
+        const context = await testContext();
+        spawnSyncMock
+            .mockReturnValueOnce({ status: 1 } as ReturnType<typeof spawnSync>)
+            .mockReturnValueOnce({ status: 0 } as ReturnType<typeof spawnSync>)
+            .mockReturnValueOnce({ status: 0 } as ReturnType<typeof spawnSync>);
+
+        const enabled = await opencodeHarness.on(context);
+
+        expect(spawnSyncMock).toHaveBeenNthCalledWith(
+            2,
+            "npm",
+            ["install", "--global", "opencode-ai@latest"],
+            { stdio: ["inherit", process.stderr, process.stderr] },
+        );
+        expect(enabled).toMatchObject({
+            installed: true,
+            configured: true,
+        });
+    });
+
+    it("does not write config when the official installer fails", async () => {
+        const context = await testContext();
+        const configPath = join(
+            context.homeDir,
+            ".config",
+            "opencode",
+            "opencode.json",
+        );
+
+        spawnSyncMock
+            .mockReturnValueOnce({ status: 1 } as ReturnType<typeof spawnSync>)
+            .mockReturnValueOnce({ status: 1 } as ReturnType<typeof spawnSync>);
+
+        await expect(opencodeHarness.on(context)).rejects.toThrow(
+            "Official OpenCode installer exited with status 1",
+        );
+        await expect(readFile(configPath, "utf-8")).rejects.toMatchObject({
+            code: "ENOENT",
+        });
+    });
+});

--- a/packages/polli-cli/src/harnesses/opencode.ts
+++ b/packages/polli-cli/src/harnesses/opencode.ts
@@ -1,0 +1,183 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { printInfo } from "../lib/output.js";
+import { writeJsonAtomic } from "./atomic-write.js";
+import type {
+    HarnessAdapter,
+    HarnessContext,
+    HarnessResult,
+} from "./types.js";
+
+const PLUGIN_PACKAGE = "opencode-pollinations-plugin";
+const OPENCODE_PACKAGE = "opencode-ai@latest";
+
+type OpenCodeConfig = Record<string, unknown> & {
+    plugin?: unknown;
+    plugins?: unknown;
+};
+
+const defaultContext = (): HarnessContext => ({
+    env: process.env,
+    homeDir: homedir(),
+});
+
+const executable = (command: string): string =>
+    process.platform === "win32" ? `${command}.cmd` : command;
+
+const hasOpenCode = (): boolean =>
+    spawnSync(executable("opencode"), ["--version"], {
+        stdio: "ignore",
+    }).status === 0;
+
+const installOpenCode = (): void => {
+    printInfo(`OpenCode not found. Installing ${OPENCODE_PACKAGE}...`);
+    const install = spawnSync(
+        executable("npm"),
+        ["install", "--global", OPENCODE_PACKAGE],
+        { stdio: ["inherit", process.stderr, process.stderr] },
+    );
+    if (install.error) throw install.error;
+    if (install.status !== 0) {
+        throw new Error(`Official OpenCode installer exited with status ${install.status}`);
+    }
+    if (!hasOpenCode()) {
+        throw new Error(
+            "OpenCode was installed but is not on PATH. Open a new terminal and run this command again.",
+        );
+    }
+};
+
+const configPath = (context: HarnessContext): string => {
+    const configDir = context.env.OPENCODE_CONFIG_DIR;
+    return join(
+        configDir
+            ? resolve(configDir)
+            : join(context.homeDir, ".config", "opencode"),
+        "opencode.json",
+    );
+};
+
+const pluginName = (entry: unknown): string => {
+    if (typeof entry === "string") return entry;
+    if (!entry || typeof entry !== "object") return "";
+
+    const value = entry as Record<string, unknown>;
+    const name = value.package ?? value.id ?? value.name;
+    return typeof name === "string" ? name : "";
+};
+
+const isPollinationsPlugin = (entry: unknown): boolean => {
+    const name = pluginName(entry);
+    return name === PLUGIN_PACKAGE || name.startsWith(`${PLUGIN_PACKAGE}@`);
+};
+
+const readConfig = async (path: string): Promise<OpenCodeConfig> => {
+    if (!existsSync(path)) return {};
+
+    let config: unknown;
+    try {
+        config = JSON.parse(await readFile(path, "utf-8"));
+    } catch (error) {
+        const message = error instanceof Error ? error.message : "invalid JSON";
+        throw new Error(`Could not read ${path}: ${message}`);
+    }
+
+    if (!config || typeof config !== "object" || Array.isArray(config)) {
+        throw new Error(`Could not read ${path}: expected a JSON object`);
+    }
+    return config as OpenCodeConfig;
+};
+
+const pluginEntries = (config: OpenCodeConfig): unknown[] => {
+    if (config.plugin !== undefined && !Array.isArray(config.plugin)) {
+        throw new Error('OpenCode config field "plugin" must be an array');
+    }
+    if (config.plugins !== undefined && !Array.isArray(config.plugins)) {
+        throw new Error('OpenCode config field "plugins" must be an array');
+    }
+    return Array.isArray(config.plugin)
+        ? config.plugin
+        : Array.isArray(config.plugins)
+          ? config.plugins
+          : [];
+};
+
+const isConfigured = (config: OpenCodeConfig): boolean =>
+    pluginEntries(config).some(isPollinationsPlugin);
+
+const result = (
+    path: string,
+    installed: boolean,
+    configured: boolean,
+    changed?: boolean,
+): HarnessResult => ({
+    harness: "opencode",
+    installed,
+    configured,
+    ...(changed === undefined ? {} : { changed }),
+    configPath: path,
+    next:
+        configured && changed
+            ? "Restart OpenCode, then run /poll login"
+            : undefined,
+});
+
+export const opencodeHarness: HarnessAdapter = {
+    id: "opencode",
+    name: "OpenCode",
+    description: "Manage the Pollinations OpenCode plugin",
+
+    async on(context = defaultContext()) {
+        const installed = hasOpenCode();
+        if (!installed) installOpenCode();
+
+        const path = configPath(context);
+        const config = await readConfig(path);
+        const entries = pluginEntries(config);
+
+        if (isConfigured(config)) {
+            return result(path, true, true, false);
+        }
+
+        const key = Array.isArray(config.plugin)
+            ? "plugin"
+            : Array.isArray(config.plugins)
+              ? "plugins"
+              : "plugin";
+        config[key] = [...entries, PLUGIN_PACKAGE];
+
+        await writeJsonAtomic(path, config);
+        return result(path, true, true, true);
+    },
+
+    async off(context = defaultContext()) {
+        const path = configPath(context);
+        const config = await readConfig(path);
+        const entries = pluginEntries(config);
+
+        if (!entries.some(isPollinationsPlugin)) {
+            return result(path, hasOpenCode(), false, false);
+        }
+
+        const key = Array.isArray(config.plugin) ? "plugin" : "plugins";
+        const remaining = entries.filter(
+            (entry) => !isPollinationsPlugin(entry),
+        );
+        if (remaining.length === 0) {
+            delete config[key];
+        } else {
+            config[key] = remaining;
+        }
+        await writeJsonAtomic(path, config);
+        return result(path, hasOpenCode(), false, true);
+    },
+
+    async status(context = defaultContext()) {
+        const path = configPath(context);
+        const config = await readConfig(path);
+        return result(path, hasOpenCode(), isConfigured(config));
+    },
+};

--- a/packages/polli-cli/src/harnesses/types.ts
+++ b/packages/polli-cli/src/harnesses/types.ts
@@ -1,0 +1,22 @@
+export interface HarnessContext {
+    env: NodeJS.ProcessEnv;
+    homeDir: string;
+}
+
+export interface HarnessResult {
+    harness: string;
+    installed: boolean;
+    configured: boolean;
+    changed?: boolean;
+    configPath: string;
+    next?: string;
+}
+
+export interface HarnessAdapter {
+    id: string;
+    name: string;
+    description: string;
+    on(context?: HarnessContext): Promise<HarnessResult>;
+    off(context?: HarnessContext): Promise<HarnessResult>;
+    status(context?: HarnessContext): Promise<HarnessResult>;
+}

--- a/packages/polli-cli/src/index.ts
+++ b/packages/polli-cli/src/index.ts
@@ -7,6 +7,7 @@ import { authCommand } from "./commands/auth.js";
 import { docsCommand } from "./commands/docs.js";
 import { earningsCommand } from "./commands/earnings.js";
 import { createGenCommand } from "./commands/gen/index.js";
+import { harnessesCommand } from "./commands/harness.js";
 import { keysCommand } from "./commands/keys.js";
 import { modelsCommand } from "./commands/models.js";
 import { myModelsCommand } from "./commands/my-models.js";
@@ -68,6 +69,9 @@ program.addCommand(earningsCommand);
 program.addCommand(questsCommand);
 program.addCommand(agentsCommand);
 program.addCommand(myModelsCommand);
+
+// Coding harness integrations
+program.addCommand(harnessesCommand);
 
 // Generation
 program.addCommand(createGenCommand());


### PR DESCRIPTION
- Adds `polli harness <id> on|off|status` with registry-backed adapters.
- Adds OpenCode as the reference adapter and installs `opencode-ai@latest` when the harness is missing.
- Preserves unrelated OpenCode settings with atomic writes and ownership-safe disable behavior.
- Adds Polli CLI and Scalar documentation plus focused tests.
- Tests: `npm test`, `npm run build`, command smoke checks.