### PR TITLE
chore: sync main into production

### DIFF
--- a/enter.pollinations.ai/observability/endpoints/activity_usage_transactions.pipe
+++ b/enter.pollinations.ai/observability/endpoints/activity_usage_transactions.pipe
@@ -7,8 +7,8 @@ NODE activity_usage_transactions_node
 SQL >
     %
     SELECT
-        event_timestamp AS timestamp,
-        cursor_event_id,
+        timestamp,
+        event_id as cursor_event_id,
         type,
         resolved_model as model,
         api_key_id,
@@ -28,48 +28,23 @@ SQL >
         output_video_seconds,
         price_usd as cost_usd,
         response_time_ms
-    FROM (
-        SELECT
-            any(timestamp) AS event_timestamp,
-            event_id AS cursor_event_id,
-            any(type) AS type,
-            any(resolved_model) AS resolved_model,
-            any(api_key_id) AS api_key_id,
-            any(api_key) AS api_key,
-            any(api_key_type) AS api_key_type,
-            any(meter_source) AS meter_source,
-            any(input_text_tokens) AS input_text_tokens,
-            any(input_cached_tokens) AS input_cached_tokens,
-            any(input_audio_tokens) AS input_audio_tokens,
-            any(input_audio_seconds) AS input_audio_seconds,
-            any(input_image_tokens) AS input_image_tokens,
-            any(output_text_tokens) AS output_text_tokens,
-            any(output_reasoning_tokens) AS output_reasoning_tokens,
-            any(output_audio_tokens) AS output_audio_tokens,
-            any(output_audio_seconds) AS output_audio_seconds,
-            any(output_image_tokens) AS output_image_tokens,
-            any(output_video_seconds) AS output_video_seconds,
-            any(price_usd) AS price_usd,
-            any(response_time_ms) AS response_time_ms
-        FROM activity_usage_events
-        WHERE
-            user_id = {{ String(user_id, '') }}
-            {% if defined(api_key_ids) %} AND activity_usage_events.api_key_id IN {{ Array(api_key_ids, 'String') }} {% end %}
-            {% if defined(models) %} AND activity_usage_events.resolved_model IN {{ Array(models, 'String') }} {% end %}
-            {% if defined(since) %} AND timestamp >= {{ DateTime(since) }}
-            {% else %} AND timestamp >= now() - INTERVAL 30 DAY
-            {% end %}
-            {% if defined(until) %} AND timestamp < {{ DateTime(until) }} {% end %}
-            {% if defined(before) and defined(before_event_id) %}
-                AND (
-                    timestamp < {{ DateTime(before) }}
-                    OR (timestamp = {{ DateTime(before) }} AND event_id < {{ String(before_event_id) }})
-                )
-            {% elif defined(before) %} AND timestamp < {{ DateTime(before) }}
-            {% end %}
-        GROUP BY user_id, event_id
-    )
-    ORDER BY event_timestamp DESC, cursor_event_id DESC
+    FROM activity_usage_events
+    WHERE
+        user_id = {{ String(user_id, '') }}
+        {% if defined(api_key_ids) %} AND activity_usage_events.api_key_id IN {{ Array(api_key_ids, 'String') }} {% end %}
+        {% if defined(models) %} AND activity_usage_events.resolved_model IN {{ Array(models, 'String') }} {% end %}
+        {% if defined(since) %} AND timestamp >= {{ DateTime(since) }}
+        {% else %} AND timestamp >= now() - INTERVAL 30 DAY
+        {% end %}
+        {% if defined(until) %} AND timestamp < {{ DateTime(until) }} {% end %}
+        {% if defined(before) and defined(before_event_id) %}
+            AND (
+                timestamp < {{ DateTime(before) }}
+                OR (timestamp = {{ DateTime(before) }} AND event_id < {{ String(before_event_id) }})
+            )
+        {% elif defined(before) %} AND timestamp < {{ DateTime(before) }}
+        {% end %}
+    ORDER BY timestamp DESC, event_id DESC
     LIMIT {{ Int32(limit, 100) }}
 
 TYPE endpoint

--- a/enter.pollinations.ai/test/events.test.ts
+++ b/enter.pollinations.ai/test/events.test.ts
@@ -2,11 +2,19 @@ import { env } from "cloudflare:test";
 import {
     getTinybirdDatasourceIngestUrl,
     sendErrorEventToTinybird,
+    sendToTinybird,
 } from "@shared/events.ts";
-import { usageToEventParams } from "@shared/schemas/generation-event.ts";
+import {
+    type TinybirdEvent,
+    usageToEventParams,
+} from "@shared/schemas/generation-event.ts";
 import { exponentialBackoffDelay } from "@shared/util.ts";
-import { expect } from "vitest";
+import { afterEach, expect, vi } from "vitest";
 import { test } from "./fixtures.ts";
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
 
 test("usageToEventParams preserves fractional seconds for video and audio durations", () => {
     // LTX-2 produces durations of the form N + 1/24 (8n+1 frames at 24fps);
@@ -53,6 +61,36 @@ test("sendErrorEventToTinybird sends structured error events", async ({
         status: 502,
         kind: "server_error",
     });
+});
+
+test("sendToTinybird does not retry failed responses", async ({ log }) => {
+    const fetchMock = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response("unavailable", { status: 503 }));
+
+    await sendToTinybird(
+        { id: "evt_single_attempt" } as TinybirdEvent,
+        "https://api.tinybird.co/v0/events?name=generation_event_v2",
+        "test-token",
+        log,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+});
+
+test("sendToTinybird does not retry network errors", async ({ log }) => {
+    const fetchMock = vi
+        .spyOn(globalThis, "fetch")
+        .mockRejectedValue(new Error("connection lost"));
+
+    await sendToTinybird(
+        { id: "evt_single_attempt" } as TinybirdEvent,
+        "https://api.tinybird.co/v0/events?name=generation_event_v2",
+        "test-token",
+        log,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
 });
 
 test("Exponential backoff delay", async () => {

--- a/shared/events.ts
+++ b/shared/events.ts
@@ -1,10 +1,6 @@
 import type { Logger } from "@logtape/logtape";
 import type { TinybirdEvent } from "./schemas/generation-event.ts";
-import { exponentialBackoffDelay, removeUnset } from "./util.ts";
-
-const MAX_RETRIES = 3;
-const MIN_DELAY = 100;
-const MAX_DELAY = 2000;
+import { removeUnset } from "./util.ts";
 
 export type TinybirdErrorEvent = {
     timestamp: string;
@@ -41,55 +37,24 @@ export async function sendToTinybird(
 ): Promise<void> {
     const body = JSON.stringify(removeUnset(event));
 
-    for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
-        try {
-            const response = await fetch(tinybirdIngestUrl, {
-                method: "POST",
-                headers: {
-                    Authorization: `Bearer ${tinybirdIngestToken}`,
-                    "Content-Type": "application/x-ndjson",
-                },
-                body,
+    try {
+        const response = await fetch(tinybirdIngestUrl, {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${tinybirdIngestToken}`,
+                "Content-Type": "application/x-ndjson",
+            },
+            body,
+        });
+
+        if (!response.ok) {
+            log.error("Tinybird API error: status={status} error={error}", {
+                status: response.status,
+                error: await response.text(),
             });
-
-            if (response.ok) {
-                return;
-            }
-
-            const errorText = await response.text();
-            const isRetryable =
-                response.status >= 500 || response.status === 429;
-            const isLastAttempt = attempt === MAX_RETRIES;
-
-            if (!isRetryable || isLastAttempt) {
-                log.error(
-                    "Tinybird API error: status={status} error={error} attempt={attempt}",
-                    { status: response.status, error: errorText, attempt },
-                );
-                return;
-            }
-
-            await retryWithBackoff(
-                attempt,
-                log,
-                "Tinybird retry",
-                response.status,
-            );
-        } catch (error) {
-            if (attempt === MAX_RETRIES) {
-                log.error(
-                    "Failed to send event to Tinybird: {error} attempt={attempt}",
-                    { error, attempt },
-                );
-                return;
-            }
-
-            await retryWithBackoff(
-                attempt,
-                log,
-                "Tinybird network error, retrying",
-            );
         }
+    } catch (error) {
+        log.error("Failed to send event to Tinybird: {error}", { error });
     }
 }
 
@@ -129,22 +94,4 @@ export function getTinybirdDatasourceIngestUrl(
     const url = new URL(referenceIngestUrl);
     url.searchParams.set("name", datasourceName);
     return url.toString();
-}
-
-async function retryWithBackoff(
-    attempt: number,
-    log: Logger,
-    message: string,
-    status?: number,
-): Promise<void> {
-    const delay = exponentialBackoffDelay(attempt, {
-        minDelay: MIN_DELAY,
-        maxDelay: MAX_DELAY,
-        maxAttempts: MAX_RETRIES,
-    });
-
-    const logData = status ? { status, attempt, delay } : { attempt, delay };
-
-    log.warn(`${message}: attempt={attempt} delay={delay}ms`, logData);
-    await new Promise((resolve) => setTimeout(resolve, delay));
 }


### PR DESCRIPTION
- Promotes the merged Tinybird delivery and usage-history fix from `main`.
- Stops application-level retries of generation-event payloads.
- Removes the full-window usage aggregation and read-time deduplication.
- Tinybird staging and production endpoint deployments are already live and verified.
- Required checks passed on #14109.