### PR TITLE
fix(news): clarify model ID change

### DIFF
--- a/operations/social/news/highlights.md
+++ b/operations/social/news/highlights.md
@@ -5,7 +5,7 @@
 - **2026-08-27** – **🚀 GLM-5.3 Flash** is now available for paid API users: multimodal input, tool use, mandatory reasoning, and a frankly unnecessary-but-useful 1M-token context window. [Browse models](https://gen.pollinations.ai/v1/models)
 - **2026-08-27** – **🎨 Seedance reference media** lets Seedance 2.0 and 2.5 use public image, video, and audio URLs as creative references for image and video generation. [Check the API docs](https://gen.pollinations.ai/docs)
 - **2026-08-27** – **✨ Model search filters** make the model browser substantially less like rummaging through a seed drawer: search by publisher, modality, capability, ID, and access level.
-- **2026-08-27** – **💡 Canonical model slugs** are available now, including publisher-qualified IDs like `black-forest-labs/flux.1-schnell`; existing model IDs continue working as before.
+- **2026-08-27** – **💡 Model IDs will include publishers starting September 7**, for example `flux` → `black-forest-labs/flux.1-schnell`. You can start using the new IDs today; existing IDs will keep working.
 - **2026-08-27** – **🎯 Quests reward merged work** — pick up any open POLLEN-QUEST, and the first merged solution earns the fixed Pollen reward. [Contribute](https://github.com/pollinations/pollinations/blob/master/CONTRIBUTING.md)
 - **2026-08-27** – **🌟 Pollinations Studio** puts image, text, audio, and video generation in one browser workspace, using your own Pollinations API key. [Try it](https://sankezhiyyds.github.io/pollinations-app) <!-- app -->
 - **2026-08-26** – **🔗 Connect your Discord account** Link Discord to your Pollinations account, verify hive membership, and claim a 1-Pollen community Quest. [Connect your account](https://enter.pollinations.ai/keys)


### PR DESCRIPTION
- Introduces the September 7 change before mentioning that users can adopt the new IDs today.
- Removes unexplained “canonical” and “publisher-qualified” terminology.
- Keeps the example and existing-ID compatibility guarantee.

Companion to #14115.