### PR TITLE
chore: promote main to production

### DIFF
--- a/MODEL_SLUGS.md
+++ b/MODEL_SLUGS.md
@@ -6,11 +6,9 @@
 
 # Model ID changes
 
-The new publisher-qualified model IDs are available now. On **September 7, 2026 at 14:00 UTC**, they will become the canonical IDs.
+On **September 7, 2026 at 14:00 UTC**, we're standardizing model IDs. They will use the publisher and official model name.
 
-Existing IDs will remain available as aliases, so current integrations do not need to change. New integrations can use the new IDs today.
-
-Models introduced during the transition may launch directly with a publisher-qualified canonical ID and no legacy alias.
+You can use the new IDs now. Existing IDs will keep working, so current integrations do not need to change.
 
 Only the names are changing. Model behavior and pricing stay the same.
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@
 </div>
 
 > [!IMPORTANT]
-> **New model IDs are available now**
+> **We're standardizing model IDs on September 7**
 >
-> Publisher-qualified IDs such as `black-forest-labs/flux.1-schnell` work today and become canonical on September 7. Existing IDs will keep working.
+> Model IDs will use the publisher and official model name—for example, `flux` → `black-forest-labs/flux.1-schnell`. You can use the new IDs now. Existing IDs will keep working.
 >
 > [View all model ID changes →](MODEL_SLUGS.md)
 
@@ -65,7 +65,7 @@ We've launched **https://gen.pollinations.ai** — a single endpoint for all you
 - **2026-08-27** – **🚀 GLM-5.3 Flash** is now available for paid API users: multimodal input, tool use, mandatory reasoning, and a frankly unnecessary-but-useful 1M-token context window. [Browse models](https://gen.pollinations.ai/v1/models)
 - **2026-08-27** – **🎨 Seedance reference media** lets Seedance 2.0 and 2.5 use public image, video, and audio URLs as creative references for image and video generation. [Check the API docs](https://gen.pollinations.ai/docs)
 - **2026-08-27** – **✨ Model search filters** make the model browser substantially less like rummaging through a seed drawer: search by publisher, modality, capability, ID, and access level.
-- **2026-08-27** – **💡 Canonical model slugs** are available now, including publisher-qualified IDs like `black-forest-labs/flux.1-schnell`; existing model IDs continue working as before.
+- **2026-08-27** – **💡 We're standardizing model IDs on September 7.** Existing IDs will keep working. [View the changes →](MODEL_SLUGS.md)
 - **2026-08-27** – **🎯 Quests reward merged work** — pick up any open POLLEN-QUEST, and the first merged solution earns the fixed Pollen reward. [Contribute](https://github.com/pollinations/pollinations/blob/master/CONTRIBUTING.md)
 - **2026-08-27** – **🌟 Pollinations Studio** puts image, text, audio, and video generation in one browser workspace, using your own Pollinations API key. [Try it](https://sankezhiyyds.github.io/pollinations-app) <!-- app -->
 ---

--- a/enter.pollinations.ai/frontend/src/components/models/models.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/models.tsx
@@ -69,7 +69,6 @@ const COMMUNITY_SECTION_ORDER: SectionType[] = [
 ];
 const SCOPE_ORDER: ModelScope[] = ["pollinations", "community"];
 
-const MODEL_SLUG_ANNOUNCEMENT_URL = "/news#canonical-model-slugs";
 const MODEL_SLUG_LIST_URL =
     "https://github.com/pollinations/pollinations/blob/main/MODEL_SLUGS.md";
 
@@ -371,17 +370,17 @@ export const Models: FC = () => {
                     </div>
                     <div className="mb-1.5 flex items-center gap-2 text-base font-bold text-theme-text-strong">
                         <BeakerIcon className="h-4 w-4 shrink-0" />
-                        <span>Publisher-qualified IDs are available now</span>
+                        <span>
+                            We're standardizing model IDs on September 7
+                        </span>
                     </div>
-                    You can adopt them today. On September 7,
-                    publisher-qualified IDs become the canonical model IDs, and
-                    current IDs become aliases.{" "}
-                    <a
-                        href={MODEL_SLUG_ANNOUNCEMENT_URL}
-                        className="font-semibold text-theme-text-soft hover:text-theme-text-strong hover:underline"
-                    >
-                        Learn more →
-                    </a>
+                    Model IDs will use the publisher and official model name—for
+                    example, <code className="font-semibold">flux</code> →{" "}
+                    <code className="font-semibold">
+                        black-forest-labs/flux.1-schnell
+                    </code>
+                    . You can use the new IDs now. Existing IDs will keep
+                    working.
                     <a
                         href={MODEL_SLUG_LIST_URL}
                         className="mt-2 flex w-fit items-center gap-1.5 font-semibold text-theme-text-soft hover:text-theme-text-strong hover:underline"

--- a/enter.pollinations.ai/frontend/src/components/news-faq/news-banner.tsx
+++ b/enter.pollinations.ai/frontend/src/components/news-faq/news-banner.tsx
@@ -1,4 +1,4 @@
-import { ArrowRightIcon, cn, Surface } from "@pollinations/ui";
+import { cn, Surface } from "@pollinations/ui";
 import { type FC, type ReactNode, useEffect, useState } from "react";
 
 const HIGHLIGHTS_RAW_URL =
@@ -154,47 +154,22 @@ const CanonicalModelSlugAnnouncement: FC = () => (
             <span aria-hidden="true" className="shrink-0">
                 🧪
             </span>
-            <span>New model IDs are available now</span>
+            <span>We're standardizing model IDs</span>
         </div>
         <p className="mt-1 text-sm text-ink-700">
-            The new publisher-qualified IDs work today. On September 7, they
-            will become canonical. Existing IDs will remain available as
-            aliases.
+            Model IDs will use the publisher and official model name—for
+            example, <code>flux</code> →{" "}
+            <code>black-forest-labs/flux.1-schnell</code>. You can use the new
+            IDs now. Existing IDs will keep working.
         </p>
-
-        <div className="mt-4 border-y border-divider py-4">
-            <div className="text-[11px] font-semibold uppercase tracking-wider text-theme-text-muted">
-                Example
-            </div>
-            <div className="mt-2 flex flex-col items-start gap-3 min-[480px]:flex-row min-[480px]:items-end">
-                <div className="flex flex-col items-start gap-1">
-                    <div className="mb-1 text-xs font-medium text-theme-text-muted">
-                        Existing ID
-                    </div>
-                    <span className="font-mono text-sm font-semibold text-intent-danger-text">
-                        flux
-                    </span>
-                </div>
-                <ArrowRightIcon className="h-5 w-5 self-center text-theme-text-strong rotate-90 min-[480px]:mb-1 min-[480px]:self-auto min-[480px]:rotate-0" />
-                <div className="flex min-w-0 flex-col items-start gap-1">
-                    <div className="mb-1 text-xs font-medium text-theme-text-muted">
-                        New ID
-                    </div>
-                    <span className="max-w-full break-all font-mono text-sm font-semibold text-intent-free-text">
-                        black-forest-labs/flux.1-schnell
-                    </span>
-                </div>
-            </div>
-        </div>
-
-        <ul className="mt-4 list-disc space-y-2 pl-5 text-sm text-theme-text-muted marker:text-theme-text-soft">
-            <li>Existing IDs will keep working.</li>
-            <li>
-                {renderWithLinks(
-                    "[View all model ID changes](https://github.com/pollinations/pollinations/blob/main/MODEL_SLUGS.md)",
-                )}
-            </li>
-        </ul>
+        <a
+            href="https://github.com/pollinations/pollinations/blob/main/MODEL_SLUGS.md"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-3 block w-fit text-sm font-semibold text-theme-text-soft hover:text-theme-text-strong hover:underline"
+        >
+            View all model ID changes →
+        </a>
     </Surface>
 );
 


### PR DESCRIPTION
- Promotes #14115 to production.
- Simplifies the model ID announcement across Enter and repository docs.
- Keeps existing model IDs working and links to the full mapping.

No secret synchronization.