### PR TITLE
feat(cli): add OpenCode harness profile

### DIFF
--- a/packages/polli-cli/README.md
+++ b/packages/polli-cli/README.md
@@ -67,7 +67,7 @@ polli docs                   # full API reference in the terminal
 polli docs /image            # one endpoint
 polli docs --open            # open in browser
 polli quests                 # public quest catalog
-polli quests mine            # your completed and earned quest status
+polli quests --claimed       # already-completed and earned quest status
 ```
 
 ## Account
@@ -92,11 +92,55 @@ Keys can't be edited — to change a name, budget, or model list, revoke and rec
 polli usage                  # pollen balance
 polli usage --history        # recent requests
 polli usage --daily          # daily spend
-polli quests mine --completed # completed and earned quests
-polli my-models list         # invite-only community text models
+polli earnings               # developer earnings (default 30 days, --days up to 90)
+polli quests --claimable     # only rewards ready to claim
+polli agents list            # managed prompt agents
+polli my-models list         # invite-only community text, image, and transcription models
 ```
 
+Manage agents with API-shaped JSON config files plus their callable model name
+and catalog title:
+
+```bash
+polli agents get <id>
+polli agents create --config agent.json --name my-agent --title "My Agent"
+polli agents update <id> --config agent.json
+polli agents delete <id>
+```
+
+`agent.json` contains the complete configuration:
+
+```json
+{
+  "systemPrompt": "You are a concise research assistant.",
+  "baseModel": "openai",
+  "mcpServers": ["pollinations"]
+}
+```
+
+Creating an agent also creates its callable model listing. See [Publish an Agent](https://github.com/pollinations/pollinations/blob/main/BUILD_YOUR_OWN_AGENT.md) for visibility, billing, and lifecycle details.
+
 `polli auth login` creates a key with all account permissions Polli needs: `profile`, `usage`, and `keys`. Use `account:usage` for narrow read-only account state like usage and quests. Use `account:keys` to manage keys and, where invite-only My Models access is enabled, my-models. Quest claiming remains in the dashboard.
+
+## Coding harnesses
+
+Point an agentic coding tool at Pollinations. `on` logs in if needed, mints a
+key for the harness, backs up its config, and writes the provider; `off`
+restores the backup.
+
+```bash
+polli harness --help            # supported harnesses
+polli harness dsh on            # DeepSeek Harness → Pollinations (default model: deepseek)
+polli harness dsh on --model kimi
+polli harness dsh on --no-mcp   # skip MCP tool configuration
+polli harness dsh status
+polli harness dsh off
+```
+
+The DSH adapter configures the Pollinations provider, hosted Pollinations MCP,
+and Polli CLI skill globally under `$DSH_HOME` (default `~/.dsh`).
+
+See [Coding Harnesses](https://github.com/pollinations/pollinations/blob/main/CODING_HARNESSES.md) for what each profile changes and how to add one.
 
 ## Links
 

--- a/packages/polli-cli/README.md
+++ b/packages/polli-cli/README.md
@@ -129,16 +129,33 @@ key for the harness, backs up its config, and writes the provider; `off`
 restores the backup.
 
 ```bash
-polli harness --help            # supported harnesses
-polli harness dsh on            # DeepSeek Harness → Pollinations (default model: deepseek)
+polli harness --help                      # supported harnesses
+
+# DeepSeek Harness
+polli harness dsh on                      # DeepSeek Harness → Pollinations (default model: deepseek)
 polli harness dsh on --model kimi
-polli harness dsh on --no-mcp   # skip MCP tool configuration
+polli harness dsh on --no-mcp            # skip MCP tool configuration
 polli harness dsh status
 polli harness dsh off
+
+# OpenCode
+polli harness opencode on                 # OpenCode → Pollinations (default model: openai)
+polli harness opencode on --model gemini  # choose a different tool-calling text model
+polli harness opencode on --no-mcp       # add provider only, skip the Pollinations plugin
+polli harness opencode status
+polli harness opencode off
 ```
 
 The DSH adapter configures the Pollinations provider, hosted Pollinations MCP,
 and Polli CLI skill globally under `$DSH_HOME` (default `~/.dsh`).
+
+The OpenCode adapter writes to `~/.config/opencode/opencode.json` (or
+`$OPENCODE_CONFIG_DIR/opencode.json`). It registers the Pollinations
+OpenAI-compatible provider, adds a dedicated API key (no second login needed
+inside OpenCode), lists all current tool-calling text models, and enables the
+`opencode-pollinations-plugin` for media generation, usage tracking, and quest
+capabilities. If OpenCode is not installed, the adapter prints the install
+command and continues writing the config so it is ready when OpenCode is added.
 
 See [Coding Harnesses](https://github.com/pollinations/pollinations/blob/main/CODING_HARNESSES.md) for what each profile changes and how to add one.
 

--- a/packages/polli-cli/SKILL.md
+++ b/packages/polli-cli/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: polli
-description: Generate images, text, audio, video, and transcribe speech via the Pollinations API using the polli CLI. Use when asked to generate media, call pollinations.ai, check pollen balance, list models, manage API keys, inspect quests, manage my-models, or run polli commands.
+description: Generate images, text, audio, video, and transcribe speech via the Pollinations API using the polli CLI. Use when asked to generate media, call pollinations.ai, check pollen balance, list models, manage API keys, inspect quests, manage agents or my-models, or run polli commands.
 allowed-tools: Bash(polli *)
 ---
 
 # polli — Pollinations CLI
 
-Thin wrapper around `gen.pollinations.ai`. Generates images, text, audio, video; transcribes speech; manages API keys, usage, quests, and invite-only my-models.
+Thin wrapper around `gen.pollinations.ai`. Generates images, text, audio, video; transcribes speech; manages API keys, usage, quests, agents, and invite-only my-models.
 
-Install: `npm i -g @pollinations/cli@latest` (provides the `polli` binary).
+If `polli` is not installed, run `npm i -g @pollinations/cli@latest` (provides the `polli` binary).
 
 ## When to use this skill
 
@@ -18,6 +18,7 @@ Install: `npm i -g @pollinations/cli@latest` (provides the `polli` binary).
 - User asks about their **pollen balance, usage, or API keys**
 - User wants to **browse or filter available models**
 - User wants to inspect **quests** or manage invite-only **my-models**
+- User wants to create or update a hosted prompt **agent**
 
 ## Quick reference
 
@@ -38,8 +39,11 @@ Install: `npm i -g @pollinations/cli@latest` (provides the `polli` binary).
 | Filter models by type | `polli models --type image` |
 | Model health + latency | `polli models --stats` (default 60m, `--window <min>`) |
 | Check balance | `polli usage` |
+| Developer earnings | `polli earnings` (`--days <n>`, max 90) |
 | List your quests + claim state | `polli quests` (filters: `--open --claimable --claimed --coming-soon`) |
+| Manage prompt agents | `polli agents list` |
 | Manage invite-only community models | `polli my-models list` |
+| Connect a coding harness to Pollinations | `polli harness dsh on` (available adapters: `polli harness --help`) |
 | Machine-readable output | append `--json` to any command |
 
 ## Setup
@@ -145,6 +149,8 @@ Use `--stats` before choosing a model. **Caveat**: the `err%` column counts **5x
 polli usage              # current pollen balance
 polli usage --history    # recent individual requests
 polli usage --daily      # daily cost summary
+polli earnings           # developer earnings total + per-entity breakdown (default 30d)
+polli earnings --days 7  # rolling window, max 90
 polli quests             # your quests + claim state (open/claimable/claimed/coming)
 polli quests --claimable # only rewards ready to claim
 ```
@@ -155,10 +161,38 @@ polli quests --claimable # only rewards ready to claim
 polli my-models list
 polli my-models models --base-url https://api.example.com/v1 --bearer-token "$UPSTREAM_KEY"
 polli my-models create --name my-model --title "My Model" --base-url https://api.example.com/v1 --bearer-token "$UPSTREAM_KEY" --upstream-model gpt-4.1-mini
+polli my-models create --name my-image --title "My Image" --modality image --image-pricing request --completion-image-price 0.01 --base-url https://api.example.com/v1 --bearer-token "$UPSTREAM_KEY" --upstream-model flux
 polli my-models update <id> --description "Updated description"
+polli my-models update <id> --paid-only            # only accept Paid Pollen; --no-paid-only reverts
 polli my-models delete <id>
 ```
-`my-models` manages owned community text models for invite-only accounts. It requires `communityEndpointsAllowed: true` plus a key with `account:keys`, or an authenticated dashboard session through the API. Use `account:usage` for narrow read-only usage and `polli quests`; use both permissions when a client needs both read-only account state and admin operations. Quest claiming is dashboard-only; `polli quests` is read-only and account-aware.
+`my-models` manages owned community text, image, and transcription models. Any account can create private models; `communityEndpointsAllowed: true` is required only to publish them. API keys require `account:keys`. Use `account:usage` for narrow read-only usage and `polli quests`; use both permissions when a client needs both read-only account state and admin operations. Quest claiming is dashboard-only; `polli quests` is read-only and account-aware.
+
+### Register an image my-model
+```bash
+polli my-models test --modality image --base-url https://api.example.com/v1 --bearer-token "$UPSTREAM_KEY" --model image-v1
+polli my-models create --name my-image --title "My Image" --modality image --image-pricing request --completion-image-price 0.01 --input-modalities text,image --base-url https://api.example.com/v1 --bearer-token "$UPSTREAM_KEY" --upstream-model image-v1
+```
+Test before creating. The probe reports the pricing mode it detected and the input modalities it found, including whether the endpoint accepts image edits; pass those back as `--input-modalities text,image` to advertise edit support. `polli my-models list` shows them in the `inputs` column.
+
+Two billing modes: `--image-pricing request` charges `--completion-image-price` per generated image, while `--image-pricing tokens` bills returned token usage per 1M through `--prompt-text-price`, `--prompt-image-price`, and `--completion-image-price`.
+
+Prices only apply to `--visibility public` models. A private model is owner-only and always free, so every price flag above is stored as `0` until you publish — and making a published model private clears its prices again.
+
+`--modality` is fixed at creation — `update` cannot change it.
+
+### Manage agents
+
+```bash
+polli agents list
+polli agents get <id>
+polli agents create --config agent.json --name my-agent --title "My Agent"
+polli agents update <id> --config agent.json
+polli agents delete <id>
+```
+The config file contains `systemPrompt`, `baseModel`, and optional `mcpServers`; create also requires `--name` and `--title` for the callable model listing. The only supported server ID is currently `"pollinations"`. Updates replace the complete agent configuration.
+
+Creating an agent also creates its callable model listing. Managed agents are text-only and free, with no fallbacks or per-user RPM. Deleting the agent also deletes its model listing. See [Publish an Agent](https://github.com/pollinations/pollinations/blob/main/BUILD_YOUR_OWN_AGENT.md).
 
 ### Manage API keys
 ```bash
@@ -169,6 +203,16 @@ polli keys create --name "my-app" --type publishable --redirect-uri https://app.
 polli keys revoke <id>                                             # id comes from `keys list --json`
 ```
 `--permissions <perms...>` scopes what the new key can do on the account (e.g. `profile usage` lets it call `polli --key <new> usage`). **Without `--permissions`, new scoped keys can generate media but cannot read account state** — `polli --key <new> usage` will 403. `"keys"` is auto-stripped from the list so a scoped key can never mint further keys. Existing keys with `account:keys` can manage my-models where that invite-only feature is enabled, but still need `account:usage` for read-only account state. Publishable app keys default developer earnings off; pass `--earnings` to enable them. To inspect a specific key other than the current one, use `polli keys list --json | jq '.[] | select(.id == "<id>")'`. `keys info` is intentionally scoped to the caller's own key.
+
+### Connect a coding harness
+```bash
+polli harness --help                # supported harnesses
+polli harness dsh on                # login if needed, mint key "polli-harness-dsh", write provider + default model
+polli harness dsh on --model kimi   # any tool-calling text model from `polli models`
+polli harness dsh on --no-mcp       # configure the provider and skill without MCP tools
+polli harness dsh off               # restore the config backed up before "on"
+```
+The DSH adapter globally configures the Pollinations provider, hosted Pollinations MCP, and this skill under `$DSH_HOME` (default `~/.dsh`). It stores one dedicated child key in `$DSH_HOME/.env` for the provider and MCP, plus a private snapshot under `~/.pollinations/harnesses/`. Reruns reuse a valid key already in the harness config. Other adapters may use their harness's official plugin or installer instead. Guide: `polli docs` section "Coding Harnesses".
 
 ### Read API docs
 ```bash

--- a/packages/polli-cli/SKILL.md
+++ b/packages/polli-cli/SKILL.md
@@ -43,7 +43,7 @@ If `polli` is not installed, run `npm i -g @pollinations/cli@latest` (provides t
 | List your quests + claim state | `polli quests` (filters: `--open --claimable --claimed --coming-soon`) |
 | Manage prompt agents | `polli agents list` |
 | Manage invite-only community models | `polli my-models list` |
-| Connect a coding harness to Pollinations | `polli harness dsh on` (available adapters: `polli harness --help`) |
+| Connect a coding harness to Pollinations | `polli harness dsh on` or `polli harness opencode on` (available adapters: `polli harness --help`) |
 | Machine-readable output | append `--json` to any command |
 
 ## Setup
@@ -206,13 +206,21 @@ polli keys revoke <id>                                             # id comes fr
 
 ### Connect a coding harness
 ```bash
-polli harness --help                # supported harnesses
-polli harness dsh on                # login if needed, mint key "polli-harness-dsh", write provider + default model
-polli harness dsh on --model kimi   # any tool-calling text model from `polli models`
-polli harness dsh on --no-mcp       # configure the provider and skill without MCP tools
-polli harness dsh off               # restore the config backed up before "on"
+polli harness --help                      # supported harnesses
+polli harness dsh on                      # login if needed, mint key "polli-harness-dsh", write provider + default model
+polli harness dsh on --model kimi         # any tool-calling text model from `polli models`
+polli harness dsh on --no-mcp            # configure the provider and skill without MCP tools
+polli harness dsh off                     # restore the config backed up before "on"
+
+polli harness opencode on                 # login if needed, mint key, write provider + plugin to ~/.config/opencode/opencode.json
+polli harness opencode on --model gemini  # choose a default tool-calling text model
+polli harness opencode on --no-mcp       # add provider only, skip the opencode-pollinations-plugin entry
+polli harness opencode status            # show whether OpenCode is connected to Pollinations
+polli harness opencode off               # restore the config backed up before "on"
 ```
-The DSH adapter globally configures the Pollinations provider, hosted Pollinations MCP, and this skill under `$DSH_HOME` (default `~/.dsh`). It stores one dedicated child key in `$DSH_HOME/.env` for the provider and MCP, plus a private snapshot under `~/.pollinations/harnesses/`. Reruns reuse a valid key already in the harness config. Other adapters may use their harness's official plugin or installer instead. Guide: `polli docs` section "Coding Harnesses".
+The DSH adapter globally configures the Pollinations provider, hosted Pollinations MCP, and this skill under `$DSH_HOME` (default `~/.dsh`). It stores one dedicated child key in `$DSH_HOME/.env` for the provider and MCP, plus a private snapshot under `~/.pollinations/harnesses/`. Reruns reuse a valid key already in the harness config.
+
+The OpenCode adapter writes to `~/.config/opencode/opencode.json` (or `$OPENCODE_CONFIG_DIR/opencode.json`). It adds a `provider.pollinations` block (OpenAI-compatible, pointing to `gen.pollinations.ai/v1`) and the `opencode-pollinations-plugin` entry. The plugin reads the API key from the provider block, so no second login is needed inside OpenCode. Other adapters may use their harness's official plugin or installer instead. Guide: `polli docs` section "Coding Harnesses".
 
 ### Read API docs
 ```bash

--- a/packages/polli-cli/package-lock.json
+++ b/packages/polli-cli/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "@pollinations/cli",
-  "version": "0.1.7",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pollinations/cli",
-      "version": "0.1.7",
+      "version": "0.1.11",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",
         "commander": "^14.0.3",
-        "open": "^11.0.0"
+        "open": "^11.0.0",
+        "yaml": "^2.9.0"
       },
       "bin": {
         "polli": "bin/polli.js"
@@ -2241,6 +2242,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     }
   }

--- a/packages/polli-cli/package.json
+++ b/packages/polli-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollinations/cli",
-  "version": "0.1.7",
+  "version": "0.1.11",
   "description": "The Pollinations CLI — for humans, AI agents, and everything in between",
   "type": "module",
   "bin": {
@@ -62,7 +62,8 @@
   "dependencies": {
     "chalk": "^5.4.1",
     "commander": "^14.0.3",
-    "open": "^11.0.0"
+    "open": "^11.0.0",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@types/node": "^22.20.1",

--- a/packages/polli-cli/src/commands/agents.test.ts
+++ b/packages/polli-cli/src/commands/agents.test.ts
@@ -1,0 +1,37 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { agentBody } from "./agents.js";
+
+describe("agentBody", () => {
+    it("combines prompt config with listing fields", () => {
+        const directory = mkdtempSync(join(tmpdir(), "polli-agent-"));
+        const config = join(directory, "agent.json");
+        writeFileSync(
+            config,
+            JSON.stringify({
+                systemPrompt: "Answer briefly.",
+                baseModel: "openai-fast",
+                mcpServers: ["pollinations"],
+            }),
+        );
+
+        expect(
+            agentBody(config, {
+                name: "brief-agent",
+                title: "Brief Agent",
+                description: "Concise answers",
+                visibility: "private",
+            }),
+        ).toEqual({
+            systemPrompt: "Answer briefly.",
+            baseModel: "openai-fast",
+            mcpServers: ["pollinations"],
+            name: "brief-agent",
+            title: "Brief Agent",
+            description: "Concise answers",
+            visibility: "private",
+        });
+    });
+});

--- a/packages/polli-cli/src/commands/agents.ts
+++ b/packages/polli-cli/src/commands/agents.ts
@@ -1,0 +1,220 @@
+import { readFileSync } from "node:fs";
+import chalk from "chalk";
+import { Command } from "commander";
+import { gen, requireKey } from "../lib/api.js";
+import {
+    getOutputMode,
+    printError,
+    printResult,
+    printSuccess,
+    printTable,
+} from "../lib/output.js";
+
+type Agent = {
+    id: string;
+    name: string;
+    title: string;
+    description: string | null;
+    visibility: "private" | "public";
+    baseUrl: string;
+    upstreamModel: string;
+    systemPrompt: string;
+    baseModel: string;
+    mcpServers: string[];
+    createdAt: string;
+    updatedAt: string;
+};
+
+function readConfig(path: string): Record<string, unknown> {
+    try {
+        const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
+        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+            throw new Error("config must be a JSON object");
+        }
+        return parsed as Record<string, unknown>;
+    } catch (error) {
+        printError(
+            `Failed to read agent config: ${error instanceof Error ? error.message : "unknown"}`,
+        );
+        process.exit(1);
+    }
+}
+
+export function agentBody(
+    configPath: string,
+    opts: Record<string, unknown>,
+): Record<string, unknown> {
+    if (
+        opts.visibility !== undefined &&
+        opts.visibility !== "private" &&
+        opts.visibility !== "public"
+    ) {
+        printError("--visibility must be 'private' or 'public'");
+        process.exit(1);
+    }
+    return {
+        ...readConfig(configPath),
+        ...(opts.name !== undefined && { name: opts.name }),
+        ...(opts.title !== undefined && { title: opts.title }),
+        ...(opts.description !== undefined && {
+            description: opts.description,
+        }),
+        ...(opts.visibility !== undefined && {
+            visibility: opts.visibility,
+        }),
+    };
+}
+
+function printAgents(agents: Agent[]): void {
+    if (getOutputMode() === "json") {
+        printResult(agents);
+        return;
+    }
+    printTable(
+        agents.map((agent) => ({
+            id: chalk.dim(agent.id),
+            name: agent.name,
+            base_model: agent.baseModel,
+            visibility: agent.visibility,
+            pollinations_tools: agent.mcpServers.includes("pollinations")
+                ? "yes"
+                : "no",
+        })),
+        ["id", "name", "base_model", "visibility", "pollinations_tools"],
+    );
+}
+
+const list = new Command("list")
+    .description("List agents owned by your account")
+    .action(async () => {
+        const key = requireKey();
+        try {
+            const response = await gen<{ data: Agent[] }>("/account/agents", {
+                apiKey: key,
+            });
+            printAgents(response.data ?? []);
+        } catch (error) {
+            printError(
+                `Failed to list agents: ${error instanceof Error ? error.message : "unknown"}`,
+            );
+            process.exit(1);
+        }
+    });
+
+const get = new Command("get")
+    .description("Get an agent owned by your account")
+    .argument("<id>", "Agent id")
+    .action(async (id) => {
+        const key = requireKey();
+        try {
+            const agent = await gen<Agent>(
+                `/account/agents/${encodeURIComponent(id)}`,
+                { apiKey: key },
+            );
+            if (getOutputMode() === "json") printResult(agent);
+            else printAgents([agent]);
+        } catch (error) {
+            printError(
+                `Failed to get agent: ${error instanceof Error ? error.message : "unknown"}`,
+            );
+            process.exit(1);
+        }
+    });
+
+const create = new Command("create")
+    .description("Create a prompt agent")
+    .requiredOption(
+        "--config <file>",
+        "JSON agent config file sent directly to the API",
+    )
+    .requiredOption("--name <name>", "Callable model name")
+    .requiredOption("--title <title>", "Display title shown in the catalog")
+    .option("--description <text>", "Agent description", "")
+    .option(
+        "--visibility <visibility>",
+        "Agent visibility: private (default) or public",
+        "private",
+    )
+    .action(async (opts) => {
+        const key = requireKey();
+        try {
+            const agent = await gen<Agent>("/account/agents", {
+                apiKey: key,
+                method: "POST",
+                body: agentBody(opts.config, opts),
+            });
+            if (getOutputMode() === "json") printResult(agent);
+            else {
+                printSuccess(`Agent created: ${agent.id}`);
+                printAgents([agent]);
+            }
+        } catch (error) {
+            printError(
+                `Failed to create agent: ${error instanceof Error ? error.message : "unknown"}`,
+            );
+            process.exit(1);
+        }
+    });
+
+const update = new Command("update")
+    .description("Update an agent")
+    .argument("<id>", "Agent id")
+    .requiredOption(
+        "--config <file>",
+        "JSON agent config file sent directly to the API",
+    )
+    .option("--name <name>", "Callable model name")
+    .option("--title <title>", "Display title shown in the catalog")
+    .option("--description <text>", "Agent description; empty clears it")
+    .option("--visibility <visibility>", "Agent visibility: private or public")
+    .action(async (id, opts) => {
+        const key = requireKey();
+        try {
+            const agent = await gen<Agent>(
+                `/account/agents/${encodeURIComponent(id)}`,
+                {
+                    apiKey: key,
+                    method: "PATCH",
+                    body: agentBody(opts.config, opts),
+                },
+            );
+            if (getOutputMode() === "json") printResult(agent);
+            else {
+                printSuccess(`Agent updated: ${agent.id}`);
+                printAgents([agent]);
+            }
+        } catch (error) {
+            printError(
+                `Failed to update agent: ${error instanceof Error ? error.message : "unknown"}`,
+            );
+            process.exit(1);
+        }
+    });
+
+const remove = new Command("delete")
+    .description("Delete an agent and its model registration")
+    .argument("<id>", "Agent id")
+    .action(async (id) => {
+        const key = requireKey();
+        try {
+            await gen<{ id: string }>(
+                `/account/agents/${encodeURIComponent(id)}`,
+                { apiKey: key, method: "DELETE" },
+            );
+            printSuccess(`Agent deleted: ${id}`);
+            if (getOutputMode() === "json") printResult({ id });
+        } catch (error) {
+            printError(
+                `Failed to delete agent: ${error instanceof Error ? error.message : "unknown"}`,
+            );
+            process.exit(1);
+        }
+    });
+
+export const agentsCommand = new Command("agents")
+    .description("Manage prompt agents")
+    .addCommand(list)
+    .addCommand(get)
+    .addCommand(create)
+    .addCommand(update)
+    .addCommand(remove);

--- a/packages/polli-cli/src/commands/auth.ts
+++ b/packages/polli-cli/src/commands/auth.ts
@@ -126,6 +126,88 @@ async function fetchProfileLabel(key: string): Promise<string | null> {
     return `Logged in as ${profile.githubUsername ?? "unknown"}`;
 }
 
+/** Run the browser device flow, store the resulting key, and return it. */
+export async function loginWithDeviceFlow(
+    opts: { browser?: boolean } = {},
+): Promise<string> {
+    printInfo("Requesting device code...");
+
+    const res = await fetch(`${ENTER_URL}/api/device/code`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+            client_id: "pk_VZF38YW4tQX36SEn",
+            scope: "generate profile usage keys",
+        }),
+    }).catch((err) => {
+        printError(
+            `Failed to start device flow: ${err instanceof Error ? err.message : err}`,
+        );
+        printInfo(
+            "Fallback: printf '%s' '<your-key>' | polli auth login --with-token",
+        );
+        printInfo("Get your key at: https://enter.pollinations.ai/keys");
+        process.exit(1);
+    });
+
+    if (!res.ok) {
+        printError(
+            `Failed to start device flow: ${res.status} ${await res.text()}`,
+        );
+        process.exit(1);
+    }
+
+    const deviceResp = (await res.json()) as DeviceCodeResponse;
+
+    printInfo(`\nYour code: ${deviceResp.user_code}\n`);
+
+    const url = deviceResp.verification_uri_complete;
+    printInfo(`Open this URL in your browser:\n  ${url}`);
+
+    if (opts.browser !== false) {
+        const open = (await import("open")).default;
+        await open(url).catch(() =>
+            printInfo("Could not open browser automatically."),
+        );
+    }
+
+    printInfo("Waiting for approval...");
+    const tokenResp = await pollForToken(
+        deviceResp.device_code,
+        deviceResp.interval,
+        deviceResp.expires_in,
+    );
+
+    if (!tokenResp.access_token) {
+        let errMsg: string;
+        switch (tokenResp.error) {
+            case "access_denied":
+                errMsg = "Access denied. You declined the authorization.";
+                break;
+            case "expired_token":
+                errMsg = "Code expired. Run `polli auth login` to try again.";
+                break;
+            default:
+                errMsg = `Login failed: ${tokenResp.error_description ?? tokenResp.error}`;
+        }
+        printError(errMsg);
+        process.exit(1);
+    }
+
+    const key = tokenResp.access_token;
+    storeKey(key);
+    printSuccess("Authenticated!");
+
+    const label = await fetchProfileLabel(key);
+    if (label) {
+        printSuccess(label);
+    } else {
+        printInfo("Key stored. Could not fetch profile, but auth is complete.");
+    }
+    printInfo(flavor.login);
+    return key;
+}
+
 const login = new Command("login")
     .description("Authenticate with Pollinations")
     .addOption(
@@ -148,84 +230,7 @@ const login = new Command("login")
             return;
         }
 
-        printInfo("Requesting device code...");
-
-        const res = await fetch(`${ENTER_URL}/api/device/code`, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-                client_id: "pk_VZF38YW4tQX36SEn",
-                scope: "generate profile usage keys",
-            }),
-        }).catch((err) => {
-            printError(
-                `Failed to start device flow: ${err instanceof Error ? err.message : err}`,
-            );
-            printInfo(
-                "Fallback: printf '%s' '<your-key>' | polli auth login --with-token",
-            );
-            printInfo("Get your key at: https://enter.pollinations.ai/keys");
-            process.exit(1);
-        });
-
-        if (!res.ok) {
-            printError(
-                `Failed to start device flow: ${res.status} ${await res.text()}`,
-            );
-            process.exit(1);
-        }
-
-        const deviceResp = (await res.json()) as DeviceCodeResponse;
-
-        printInfo(`\nYour code: ${deviceResp.user_code}\n`);
-
-        const url = deviceResp.verification_uri_complete;
-        printInfo(`Open this URL in your browser:\n  ${url}`);
-
-        if (opts.browser !== false) {
-            const open = (await import("open")).default;
-            await open(url).catch(() =>
-                printInfo("Could not open browser automatically."),
-            );
-        }
-
-        printInfo("Waiting for approval...");
-        const tokenResp = await pollForToken(
-            deviceResp.device_code,
-            deviceResp.interval,
-            deviceResp.expires_in,
-        );
-
-        if (!tokenResp.access_token) {
-            let errMsg: string;
-            switch (tokenResp.error) {
-                case "access_denied":
-                    errMsg = "Access denied. You declined the authorization.";
-                    break;
-                case "expired_token":
-                    errMsg =
-                        "Code expired. Run `polli auth login` to try again.";
-                    break;
-                default:
-                    errMsg = `Login failed: ${tokenResp.error_description ?? tokenResp.error}`;
-            }
-            printError(errMsg);
-            process.exit(1);
-        }
-
-        const key = tokenResp.access_token;
-        storeKey(key);
-        printSuccess("Authenticated!");
-
-        const label = await fetchProfileLabel(key);
-        if (label) {
-            printSuccess(label);
-        } else {
-            printInfo(
-                "Key stored. Could not fetch profile, but auth is complete.",
-            );
-        }
-        printInfo(flavor.login);
+        await loginWithDeviceFlow({ browser: opts.browser });
     });
 
 const logout = new Command("logout")

--- a/packages/polli-cli/src/commands/docs.ts
+++ b/packages/polli-cli/src/commands/docs.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 import open from "open";
 import { BASE_URL } from "../lib/config.js";
 import {
+    fail,
     getOutputMode,
     printError,
     printInfo,
@@ -72,10 +73,7 @@ export const docsCommand = new Command("docs")
                     process.stdout.write("\n");
                 }
             } catch (err) {
-                printError(
-                    `Failed to fetch docs: ${err instanceof Error ? err.message : "unknown"}`,
-                );
-                process.exit(1);
+                fail("Failed to fetch docs", err);
             }
             return;
         }

--- a/packages/polli-cli/src/commands/earnings.test.ts
+++ b/packages/polli-cli/src/commands/earnings.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+    type EarningsRow,
+    MAX_EARNINGS_DAYS,
+    parseDaysWindow,
+    totalPollenEarned,
+} from "./earnings.js";
+
+const row = (overrides: Partial<EarningsRow> = {}): EarningsRow => ({
+    date: "",
+    entity_id: "app_1",
+    entity_name: "My App",
+    source: "byop_markup",
+    requests: 10,
+    baseline_price: 0.5,
+    pollen_earned: 0.1,
+    paid_earned: 0.08,
+    tier_earned: 0.02,
+    cost_usd: 0.5,
+    reward_rate: 0.2,
+    ...overrides,
+});
+
+describe("parseDaysWindow", () => {
+    it("accepts a plain day count", () => {
+        expect(parseDaysWindow("30")).toBe(30);
+    });
+
+    it("rejects zero, negatives and non-integers", () => {
+        expect(() => parseDaysWindow("0")).toThrow(
+            "--days must be a positive integer",
+        );
+        expect(() => parseDaysWindow("-5")).toThrow(
+            "--days must be a positive integer",
+        );
+        expect(() => parseDaysWindow("1.5")).toThrow(
+            "--days must be a positive integer",
+        );
+        expect(() => parseDaysWindow("abc")).toThrow(
+            "--days must be a positive integer",
+        );
+    });
+
+    it("rejects windows beyond the API maximum", () => {
+        expect(() => parseDaysWindow(String(MAX_EARNINGS_DAYS + 1))).toThrow(
+            `--days must be ${MAX_EARNINGS_DAYS} or less`,
+        );
+        expect(parseDaysWindow(String(MAX_EARNINGS_DAYS))).toBe(
+            MAX_EARNINGS_DAYS,
+        );
+    });
+});
+
+describe("totalPollenEarned", () => {
+    it("sums pollen across entities", () => {
+        const perEntity = [
+            row({ pollen_earned: 0.1 }),
+            row({ pollen_earned: 2.5 }),
+        ];
+        expect(totalPollenEarned(perEntity)).toBeCloseTo(2.6);
+    });
+
+    it("returns 0 for an empty rollup", () => {
+        expect(totalPollenEarned([])).toBe(0);
+    });
+});

--- a/packages/polli-cli/src/commands/earnings.ts
+++ b/packages/polli-cli/src/commands/earnings.ts
@@ -1,0 +1,100 @@
+import { Command } from "commander";
+import { gen, requireKey } from "../lib/api.js";
+import {
+    fail,
+    getOutputMode,
+    printError,
+    printInfo,
+    printResult,
+    printTable,
+} from "../lib/output.js";
+
+interface EarningsRow {
+    date: string;
+    entity_id: string;
+    entity_name: string;
+    source: string;
+    requests: number;
+    baseline_price: number;
+    pollen_earned: number;
+    paid_earned: number;
+    tier_earned: number;
+    cost_usd: number;
+    reward_rate: number;
+}
+
+interface EarningsResponse {
+    daily: EarningsRow[];
+    perEntity: EarningsRow[];
+}
+
+export type { EarningsRow };
+
+/** The API accepts a rolling window of at most 90 days. */
+export const MAX_EARNINGS_DAYS = 90;
+
+export function parseDaysWindow(value: string): number {
+    const days = Number(value);
+    if (!Number.isInteger(days) || days < 1) {
+        throw new Error("--days must be a positive integer");
+    }
+    if (days > MAX_EARNINGS_DAYS) {
+        throw new Error(`--days must be ${MAX_EARNINGS_DAYS} or less`);
+    }
+    return days;
+}
+
+export function totalPollenEarned(perEntity: EarningsRow[]): number {
+    return perEntity.reduce((sum, row) => sum + row.pollen_earned, 0);
+}
+
+export const earningsCommand = new Command("earnings")
+    .description("Show developer earnings from BYOP apps and community models")
+    .option("--days <n>", "Rolling window in days, max 90", "30")
+    .action(async (opts) => {
+        const key = requireKey();
+
+        let days: number;
+        try {
+            days = parseDaysWindow(opts.days);
+        } catch (err) {
+            printError(
+                err instanceof Error ? err.message : "Invalid --days value",
+            );
+            process.exit(1);
+        }
+
+        try {
+            const data = await gen<EarningsResponse>(
+                `/account/earnings?days=${days}`,
+                { apiKey: key },
+            );
+
+            if (getOutputMode() !== "human") {
+                printResult({ daily: data.daily, perEntity: data.perEntity });
+                return;
+            }
+
+            if (data.perEntity.length === 0) {
+                printInfo(`No earnings in the last ${days} days.`);
+                return;
+            }
+
+            const total = totalPollenEarned(data.perEntity);
+            printResult({
+                total_pollen: total.toFixed(4),
+                window_days: days,
+            });
+            printTable(
+                data.perEntity.map((row) => ({
+                    entity: row.entity_name,
+                    source: row.source,
+                    requests: row.requests,
+                    pollen: row.pollen_earned.toFixed(4),
+                    volume: `$${row.cost_usd.toFixed(2)}`,
+                })),
+            );
+        } catch (err) {
+            fail("Failed to fetch earnings", err);
+        }
+    });

--- a/packages/polli-cli/src/commands/gen/audio.ts
+++ b/packages/polli-cli/src/commands/gen/audio.ts
@@ -1,8 +1,6 @@
 import { writeFileSync } from "node:fs";
 import { Command } from "commander";
-import { requireKey } from "../../lib/api.js";
-import { BASE_URL } from "../../lib/config.js";
-import { budgetHint } from "../../lib/errors.js";
+import { exitWithError, fetchGen } from "../../lib/errors.js";
 import {
     getOutputMode,
     printError,
@@ -33,7 +31,6 @@ export function createAudioCommand() {
         .option("--output <path>", "Save to file", "speech.mp3")
         .option("--play", "Play the audio after saving (platform player)")
         .action(async (textArg, opts) => {
-            const key = requireKey();
             const isHuman = getOutputMode() === "human";
             const inputText = textArg || (await readStdin());
             if (!inputText) {
@@ -53,25 +50,12 @@ export function createAudioCommand() {
             if (opts.seed) params.set("seed", opts.seed);
 
             const encodedText = encodeURIComponent(inputText);
-            const url = `${BASE_URL}/audio/${encodedText}?${params}`;
+            const path = `/audio/${encodedText}?${params}`;
 
             if (isHuman) printInfo("Generating audio...");
 
             try {
-                const res = await fetch(url, {
-                    headers: { Authorization: `Bearer ${key}` },
-                });
-                if (!res.ok) {
-                    const errText = await res.text().catch(() => "");
-                    const hint = await budgetHint(res.status, errText);
-                    if (hint) {
-                        printError(hint);
-                        process.exit(1);
-                    }
-                    throw new Error(
-                        `${res.status} ${res.statusText}: ${errText}`,
-                    );
-                }
+                const res = await fetchGen(path);
 
                 const buffer = Buffer.from(await res.arrayBuffer());
                 writeFileSync(opts.output, buffer);
@@ -86,11 +70,8 @@ export function createAudioCommand() {
                     const ok = await playAudio(opts.output);
                     if (!ok) printWarn(playerMissingHint());
                 }
-            } catch (err) {
-                printError(
-                    err instanceof Error ? err.message : "unknown error",
-                );
-                process.exit(1);
+            } catch (error) {
+                exitWithError(error);
             }
         });
 }

--- a/packages/polli-cli/src/commands/gen/image.ts
+++ b/packages/polli-cli/src/commands/gen/image.ts
@@ -1,8 +1,6 @@
 import { writeFileSync } from "node:fs";
 import { Command } from "commander";
-import { requireKey } from "../../lib/api.js";
-import { BASE_URL } from "../../lib/config.js";
-import { budgetHint } from "../../lib/errors.js";
+import { exitWithError, fetchGen } from "../../lib/errors.js";
 import {
     getOutputMode,
     printError,
@@ -26,7 +24,6 @@ export function createImageCommand() {
         )
         .option("--output <path>", "Save to file", "image.png")
         .action(async (prompt, opts) => {
-            const key = requireKey();
             const isHuman = getOutputMode() === "human";
 
             const params = new URLSearchParams({
@@ -51,23 +48,12 @@ export function createImageCommand() {
             }
 
             const encodedPrompt = encodeURIComponent(prompt);
-            const url = `${BASE_URL}/image/${encodedPrompt}?${params}`;
+            const path = `/image/${encodedPrompt}?${params}`;
 
             if (isHuman) printInfo("Generating image...");
 
             try {
-                const res = await fetch(url, {
-                    headers: { Authorization: `Bearer ${key}` },
-                });
-                if (!res.ok) {
-                    const text = await res.text().catch(() => "");
-                    const hint = await budgetHint(res.status, text);
-                    if (hint) {
-                        printError(hint);
-                        process.exit(1);
-                    }
-                    throw new Error(`${res.status} ${res.statusText}: ${text}`);
-                }
+                const res = await fetchGen(path);
 
                 const buffer = Buffer.from(await res.arrayBuffer());
                 writeFileSync(opts.output, buffer);
@@ -77,11 +63,8 @@ export function createImageCommand() {
                     size: buffer.length,
                     model: opts.model,
                 });
-            } catch (err) {
-                printError(
-                    err instanceof Error ? err.message : "unknown error",
-                );
-                process.exit(1);
+            } catch (error) {
+                exitWithError(error);
             }
         });
 }

--- a/packages/polli-cli/src/commands/gen/text.ts
+++ b/packages/polli-cli/src/commands/gen/text.ts
@@ -1,9 +1,7 @@
 import { writeFileSync } from "node:fs";
 import chalk from "chalk";
 import { Command } from "commander";
-import { requireKey } from "../../lib/api.js";
-import { BASE_URL } from "../../lib/config.js";
-import { budgetHint } from "../../lib/errors.js";
+import { exitWithError, fetchGen } from "../../lib/errors.js";
 import {
     getOutputMode,
     printError,
@@ -49,7 +47,6 @@ export function createTextCommand() {
             "Wait for full response instead of streaming tokens",
         )
         .action(async (promptArg, opts) => {
-            const key = requireKey();
             const stdinText = await readStdin();
             const prompt = promptArg || stdinText;
 
@@ -122,26 +119,13 @@ export function createTextCommand() {
             if (isHuman && !useStream) printInfo("Generating...");
 
             try {
-                const res = await fetch(`${BASE_URL}/v1/chat/completions`, {
+                const res = await fetchGen("/v1/chat/completions", {
                     method: "POST",
                     headers: {
                         "Content-Type": "application/json",
-                        Authorization: `Bearer ${key}`,
                     },
                     body: JSON.stringify(body),
                 });
-
-                if (!res.ok) {
-                    const errText = await res.text().catch(() => "");
-                    const hint = await budgetHint(res.status, errText);
-                    if (hint) {
-                        printError(hint);
-                        process.exit(1);
-                    }
-                    throw new Error(
-                        `${res.status} ${res.statusText}: ${errText}`,
-                    );
-                }
 
                 if (useStream) {
                     // Dim the model's streamed output in TTY mode so it's
@@ -180,11 +164,8 @@ export function createTextCommand() {
                         : content;
                     process.stdout.write(`${out}\n`);
                 }
-            } catch (err) {
-                printError(
-                    err instanceof Error ? err.message : "unknown error",
-                );
-                process.exit(1);
+            } catch (error) {
+                exitWithError(error);
             }
         });
 }

--- a/packages/polli-cli/src/commands/gen/transcribe.ts
+++ b/packages/polli-cli/src/commands/gen/transcribe.ts
@@ -1,15 +1,8 @@
 import { readFileSync } from "node:fs";
 import { basename } from "node:path";
 import { Command } from "commander";
-import { requireKey } from "../../lib/api.js";
-import { BASE_URL } from "../../lib/config.js";
-import { budgetHint } from "../../lib/errors.js";
-import {
-    getOutputMode,
-    printError,
-    printInfo,
-    printResult,
-} from "../../lib/output.js";
+import { exitWithError, fetchGen } from "../../lib/errors.js";
+import { getOutputMode, printInfo, printResult } from "../../lib/output.js";
 
 export function createTranscribeCommand() {
     return new Command("transcribe")
@@ -22,7 +15,6 @@ export function createTranscribeCommand() {
         )
         .option("--language <lang>", "Language hint (ISO code)")
         .action(async (file, opts) => {
-            const key = requireKey();
             const isHuman = getOutputMode() === "human";
             if (isHuman) printInfo("Transcribing...");
 
@@ -35,21 +27,10 @@ export function createTranscribeCommand() {
                 formData.append("model", opts.model);
                 if (opts.language) formData.append("language", opts.language);
 
-                const res = await fetch(`${BASE_URL}/v1/audio/transcriptions`, {
+                const res = await fetchGen("/v1/audio/transcriptions", {
                     method: "POST",
-                    headers: { Authorization: `Bearer ${key}` },
                     body: formData,
                 });
-
-                if (!res.ok) {
-                    const text = await res.text().catch(() => "");
-                    const hint = await budgetHint(res.status, text);
-                    if (hint) {
-                        printError(hint);
-                        process.exit(1);
-                    }
-                    throw new Error(`${res.status}: ${text}`);
-                }
 
                 const data = (await res.json()) as { text: string };
 
@@ -58,11 +39,8 @@ export function createTranscribeCommand() {
                 } else {
                     process.stdout.write(`${data.text}\n`);
                 }
-            } catch (err) {
-                printError(
-                    err instanceof Error ? err.message : "unknown error",
-                );
-                process.exit(1);
+            } catch (error) {
+                exitWithError(error);
             }
         });
 }

--- a/packages/polli-cli/src/commands/gen/video.ts
+++ b/packages/polli-cli/src/commands/gen/video.ts
@@ -1,8 +1,6 @@
 import { writeFileSync } from "node:fs";
 import { Command } from "commander";
-import { requireKey } from "../../lib/api.js";
-import { BASE_URL } from "../../lib/config.js";
-import { budgetHint } from "../../lib/errors.js";
+import { exitWithError, fetchGen } from "../../lib/errors.js";
 import {
     getOutputMode,
     printError,
@@ -27,7 +25,6 @@ export function createVideoCommand() {
         .option("--image <url>", "Reference frame URL")
         .option("--output <path>", "Save to file", "video.mp4")
         .action(async (prompt, opts) => {
-            const key = requireKey();
             const isHuman = getOutputMode() === "human";
 
             const params = new URLSearchParams({
@@ -50,24 +47,13 @@ export function createVideoCommand() {
             }
 
             const encodedPrompt = encodeURIComponent(prompt);
-            const url = `${BASE_URL}/video/${encodedPrompt}?${params}`;
+            const path = `/video/${encodedPrompt}?${params}`;
 
             if (isHuman)
                 printInfo("Generating video (this can take up to 60s)...");
 
             try {
-                const res = await fetch(url, {
-                    headers: { Authorization: `Bearer ${key}` },
-                });
-                if (!res.ok) {
-                    const text = await res.text().catch(() => "");
-                    const hint = await budgetHint(res.status, text);
-                    if (hint) {
-                        printError(hint);
-                        process.exit(1);
-                    }
-                    throw new Error(`${res.status} ${res.statusText}: ${text}`);
-                }
+                const res = await fetchGen(path);
 
                 const buffer = Buffer.from(await res.arrayBuffer());
                 writeFileSync(opts.output, buffer);
@@ -76,11 +62,8 @@ export function createVideoCommand() {
                     size: buffer.length,
                     model: opts.model,
                 });
-            } catch (err) {
-                printError(
-                    err instanceof Error ? err.message : "unknown error",
-                );
-                process.exit(1);
+            } catch (error) {
+                exitWithError(error);
             }
         });
 }

--- a/packages/polli-cli/src/commands/harness.ts
+++ b/packages/polli-cli/src/commands/harness.ts
@@ -1,0 +1,92 @@
+import { homedir } from "node:os";
+import { Command } from "commander";
+import { HARNESSES } from "../harnesses/index.js";
+import type {
+    HarnessAdapter,
+    HarnessContext,
+    HarnessOnOptions,
+} from "../harnesses/types.js";
+import { fail, printInfo, printResult, printSuccess } from "../lib/output.js";
+
+const context = (): HarnessContext => ({ home: homedir(), env: process.env });
+
+const OFF_MESSAGES = {
+    restored: "original config restored.",
+    stripped: "Pollinations entries removed.",
+    unchanged: "was not connected; nothing changed.",
+};
+
+const runOn = async (harness: HarnessAdapter, options: HarnessOnOptions) => {
+    try {
+        const result = await harness.on(context(), options);
+        const model = result.model ? ` (model: ${result.model})` : "";
+        printSuccess(`${harness.label} now uses Pollinations${model}.`);
+        printInfo(harness.restartHint);
+        printResult(result);
+    } catch (error) {
+        fail(`Failed to connect ${harness.label}`, error);
+    }
+};
+
+const runOff = async (harness: HarnessAdapter) => {
+    try {
+        const result = await harness.off(context());
+        const outcome = result.outcome ?? "unchanged";
+        printSuccess(`${harness.label}: ${OFF_MESSAGES[outcome]}`);
+        if (outcome !== "unchanged") printInfo(harness.restartHint);
+        printResult(result);
+    } catch (error) {
+        fail(`Failed to disconnect ${harness.label}`, error);
+    }
+};
+
+const runStatus = async (harness: HarnessAdapter) => {
+    try {
+        printResult(await harness.status(context()));
+    } catch (error) {
+        fail(`Failed to inspect ${harness.label}`, error);
+    }
+};
+
+const withOnOptions = (command: Command) =>
+    command
+        .option("--model <id>", "Default model for the harness")
+        .option("--no-mcp", "Skip MCP tool configuration")
+        .option(
+            "--no-browser",
+            "Print the login URL instead of opening a browser",
+        );
+
+const harnessSubcommand = (harness: HarnessAdapter) => {
+    const command = withOnOptions(
+        new Command(harness.id).description(harness.description),
+    ).action((options: HarnessOnOptions) => runOn(harness, options));
+
+    command.addCommand(
+        new Command("on")
+            .description(`Connect ${harness.label} to Pollinations`)
+            .action(() => runOn(harness, command.opts<HarnessOnOptions>())),
+    );
+    command.addCommand(
+        new Command("off")
+            .description(`Restore ${harness.label}'s previous configuration`)
+            .action(() => runOff(harness)),
+    );
+    command.addCommand(
+        new Command("status")
+            .description(`Show ${harness.label}'s Pollinations status`)
+            .action(() => runStatus(harness)),
+    );
+    return command;
+};
+
+export const harnessCommand = new Command("harness")
+    .description("Configure coding harnesses to use Pollinations")
+    .addHelpText(
+        "after",
+        "\nGuide: https://gen.pollinations.ai/docs#tag/coding-harnesses\n",
+    );
+
+for (const harness of HARNESSES) {
+    harnessCommand.addCommand(harnessSubcommand(harness));
+}

--- a/packages/polli-cli/src/commands/keys.ts
+++ b/packages/polli-cli/src/commands/keys.ts
@@ -2,8 +2,8 @@ import chalk from "chalk";
 import { Command } from "commander";
 import { gen, requireKey } from "../lib/api.js";
 import {
+    fail,
     getOutputMode,
-    printError,
     printInfo,
     printResult,
     printSuccess,
@@ -117,10 +117,7 @@ const list = new Command("list")
                 : ["name", "prefix", "balance", "expires", "permissions"];
             printTable(rows, cols);
         } catch (err) {
-            printError(
-                `Failed to list keys: ${err instanceof Error ? err.message : "unknown"}`,
-            );
-            process.exit(1);
+            fail("Failed to list keys", err);
         }
     });
 
@@ -150,10 +147,7 @@ const info = new Command("info")
                     keyInfo.permissions?.account?.join(", ") ?? "none",
             });
         } catch (err) {
-            printError(
-                `Failed to fetch key info: ${err instanceof Error ? err.message : "unknown"}`,
-            );
-            process.exit(1);
+            fail("Failed to fetch key info", err);
         }
     });
 
@@ -197,12 +191,10 @@ Examples:
                 type: opts.type,
             };
             if (opts.redirectUri && opts.type !== "publishable") {
-                printError("--redirect-uri requires --type publishable");
-                process.exit(1);
+                fail("--redirect-uri requires --type publishable");
             }
             if (opts.earnings === true && opts.type !== "publishable") {
-                printError("--earnings requires --type publishable");
-                process.exit(1);
+                fail("--earnings requires --type publishable");
             }
             if (opts.expiresIn !== undefined)
                 body.expiresIn = Number(opts.expiresIn);
@@ -210,8 +202,7 @@ Examples:
             if (opts.budget !== undefined) {
                 const budget = Number(opts.budget);
                 if (!Number.isFinite(budget) || budget < 0) {
-                    printError("--budget must be a non-negative number");
-                    process.exit(1);
+                    fail("--budget must be a non-negative number");
                 }
                 body.pollenBudget = budget;
             }
@@ -244,10 +235,7 @@ Examples:
                 earnings: created.metadata?.earningsEnabled,
             });
         } catch (err) {
-            printError(
-                `Failed to create key: ${err instanceof Error ? err.message : "unknown"}`,
-            );
-            process.exit(1);
+            fail("Failed to create key", err);
         }
     });
 
@@ -265,10 +253,7 @@ const revoke = new Command("revoke")
 
             printSuccess(`Key ${id} revoked.`);
         } catch (err) {
-            printError(
-                `Failed to revoke key: ${err instanceof Error ? err.message : "unknown"}`,
-            );
-            process.exit(1);
+            fail("Failed to revoke key", err);
         }
     });
 

--- a/packages/polli-cli/src/commands/models.ts
+++ b/packages/polli-cli/src/commands/models.ts
@@ -1,12 +1,7 @@
 import chalk from "chalk";
 import { Command } from "commander";
 import { gen } from "../lib/api.js";
-import {
-    getOutputMode,
-    printError,
-    printResult,
-    printTable,
-} from "../lib/output.js";
+import { fail, getOutputMode, printResult, printTable } from "../lib/output.js";
 import { fetchModelStats } from "./stats.js";
 
 const MAX_STATS_WINDOW_MINUTES = 7 * 24 * 60;
@@ -90,10 +85,9 @@ export const modelsCommand = new Command("models")
                     windowMinutes < 1 ||
                     windowMinutes > MAX_STATS_WINDOW_MINUTES
                 ) {
-                    printError(
+                    fail(
                         `--window must be an integer between 1 and ${MAX_STATS_WINDOW_MINUTES}`,
                     );
-                    process.exit(1);
                 }
 
                 const rows = await fetchModelStats(windowMinutes);
@@ -133,10 +127,7 @@ export const modelsCommand = new Command("models")
                     printTable(curated);
                 }
             } catch (err) {
-                printError(
-                    `Failed to fetch stats: ${err instanceof Error ? err.message : "unknown"}`,
-                );
-                process.exit(1);
+                fail("Failed to fetch stats", err);
             }
             return;
         }
@@ -193,9 +184,6 @@ export const modelsCommand = new Command("models")
                 : ["name", "type", "capabilities", "description"];
             printTable(rows, cols);
         } catch (err) {
-            printError(
-                `Failed to fetch models: ${err instanceof Error ? err.message : "unknown"}`,
-            );
-            process.exit(1);
+            fail("Failed to fetch models", err);
         }
     });

--- a/packages/polli-cli/src/commands/my-models.test.ts
+++ b/packages/polli-cli/src/commands/my-models.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { modelBody } from "./my-models.js";
+
+describe("modelBody", () => {
+    it("builds image model registration fields supported by the API", () => {
+        expect(
+            modelBody(
+                {
+                    name: "image-provider",
+                    title: "Image Provider",
+                    baseUrl: "https://example.com/v1",
+                    bearerToken: "upstream-token",
+                    modality: "image",
+                    imagePricing: "request",
+                    inputModalities: "text,image",
+                    fallbacks: "owner/backup, owner/secondary",
+                    completionImagePrice: "0.01",
+                },
+                true,
+            ),
+        ).toEqual({
+            name: "image-provider",
+            title: "Image Provider",
+            baseUrl: "https://example.com/v1",
+            bearerToken: "upstream-token",
+            modality: "image",
+            imagePricing: "request",
+            inputModalities: ["text", "image"],
+            fallbacks: ["owner/backup", "owner/secondary"],
+            completionImagePrice: 0.01,
+        });
+    });
+
+    it("sends the paid-only choice only when the flag is given", () => {
+        expect(modelBody({ visibility: "public" }, false)).toEqual({
+            visibility: "public",
+        });
+        expect(modelBody({ paidOnly: true }, false)).toEqual({
+            paidOnly: true,
+        });
+        expect(modelBody({ paidOnly: false }, false)).toEqual({
+            paidOnly: false,
+        });
+    });
+
+    it("keeps modality out of updates while allowing image pricing changes", () => {
+        expect(
+            modelBody(
+                {
+                    imagePricing: "tokens",
+                    promptImagePrice: "0.000001",
+                    completionImagePrice: "0.02",
+                    modality: "image",
+                },
+                false,
+            ),
+        ).toEqual({
+            imagePricing: "tokens",
+            promptImagePrice: 0.000001,
+            completionImagePrice: 0.02,
+        });
+    });
+
+    it("supports transcription model registration", () => {
+        expect(
+            modelBody(
+                {
+                    name: "speech-provider",
+                    title: "Speech Provider",
+                    baseUrl: "https://example.com/v1",
+                    bearerToken: "upstream-token",
+                    modality: "transcription",
+                },
+                true,
+            ),
+        ).toMatchObject({ modality: "transcription" });
+    });
+});

--- a/packages/polli-cli/src/commands/my-models.ts
+++ b/packages/polli-cli/src/commands/my-models.ts
@@ -2,8 +2,8 @@ import chalk from "chalk";
 import { Command } from "commander";
 import { gen, requireKey } from "../lib/api.js";
 import {
+    fail,
     getOutputMode,
-    printError,
     printResult,
     printSuccess,
     printTable,
@@ -21,6 +21,10 @@ const PRICE_FLAGS = [
         "Completion reasoning token price",
     ],
     ["--completion-audio-price <number>", "Completion audio token price"],
+    [
+        "--completion-image-price <number>",
+        "Generated-image price (per image when --image-pricing request; per token when --image-pricing tokens)",
+    ],
 ] as const;
 
 const PRICE_OPTION_KEYS = [
@@ -32,11 +36,12 @@ const PRICE_OPTION_KEYS = [
     "completionTextPrice",
     "completionReasoningPrice",
     "completionAudioPrice",
+    "completionImagePrice",
 ] as const;
 
 type PriceOptionKey = (typeof PRICE_OPTION_KEYS)[number];
 
-interface MyModel {
+interface MyModelBase {
     id: string;
     modelId: string;
     name: string;
@@ -49,6 +54,28 @@ interface MyModel {
     updatedAt: string;
     [key: string]: unknown;
 }
+
+interface ProxyMyModel extends MyModelBase {
+    type: "proxy";
+    paidOnly: boolean;
+    modality: "text" | "image" | "transcription";
+    imagePricing: "request" | "tokens";
+    completionImagePrice: number;
+    // /account/my-models/test detects edit support from endpoint probes.
+    inputModalities: string[];
+    fallbacks: string[];
+}
+
+interface PromptAgentMyModel extends MyModelBase {
+    type: "prompt_agent";
+}
+
+interface EndpointAgentMyModel extends MyModelBase {
+    type: "endpoint_agent";
+    perUserRpm: number | null;
+}
+
+type MyModel = ProxyMyModel | PromptAgentMyModel | EndpointAgentMyModel;
 
 function addPriceOptions(command: Command): Command {
     for (const [flag, description] of PRICE_FLAGS) {
@@ -63,20 +90,20 @@ function readPriceOptions(opts: Record<string, unknown>) {
         if (opts[key] === undefined) continue;
         const value = Number(opts[key]);
         if (!Number.isFinite(value) || value < 0) {
-            printError(
+            fail(
                 `--${key.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`)} must be a non-negative number`,
             );
-            process.exit(1);
         }
         prices[key] = value;
     }
     return prices;
 }
 
-function modelBody(opts: Record<string, unknown>, includeRequired: boolean) {
-    const body: Record<string, unknown> = {
-        ...readPriceOptions(opts),
-    };
+export function modelBody(
+    opts: Record<string, unknown>,
+    includeRequired: boolean,
+) {
+    const body: Record<string, unknown> = readPriceOptions(opts);
     const fields = [
         ["name", "name"],
         ["title", "title"],
@@ -84,6 +111,7 @@ function modelBody(opts: Record<string, unknown>, includeRequired: boolean) {
         ["baseUrl", "baseUrl"],
         ["upstreamModel", "upstreamModel"],
         ["bearerToken", "bearerToken"],
+        ["paidOnly", "paidOnly"],
     ] as const;
 
     for (const [optionKey, bodyKey] of fields) {
@@ -92,21 +120,57 @@ function modelBody(opts: Record<string, unknown>, includeRequired: boolean) {
 
     if (opts.visibility !== undefined) {
         if (opts.visibility !== "private" && opts.visibility !== "public") {
-            printError("--visibility must be 'private' or 'public'");
-            process.exit(1);
+            fail("--visibility must be 'private' or 'public'");
         }
         body.visibility = opts.visibility;
     }
 
+    // Create only. UpdateEndpointSchema has no modality — a model's family
+    // is fixed at registration, so update must not send this field.
+    if (includeRequired && opts.modality !== undefined) {
+        if (
+            opts.modality !== "text" &&
+            opts.modality !== "image" &&
+            opts.modality !== "transcription"
+        ) {
+            fail("--modality must be 'text', 'image', or 'transcription'");
+        }
+        body.modality = opts.modality;
+    }
+
+    if (opts.imagePricing !== undefined) {
+        if (opts.imagePricing !== "request" && opts.imagePricing !== "tokens") {
+            fail("--image-pricing must be 'request' or 'tokens'");
+        }
+        body.imagePricing = opts.imagePricing;
+    }
+
+    // An empty string clears the list, which is why this checks for the flag
+    // being present rather than for a truthy value.
+    if (opts.fallbacks !== undefined) {
+        body.fallbacks = String(opts.fallbacks)
+            .split(",")
+            .map((id) => id.trim())
+            .filter((id) => id.length > 0);
+    }
+
+    if (opts.inputModalities !== undefined) {
+        body.inputModalities = String(opts.inputModalities)
+            .split(",")
+            .map((modality) => modality.trim())
+            .filter((modality) => modality.length > 0);
+    }
+
     if (includeRequired) {
-        for (const required of ["name", "title", "baseUrl", "bearerToken"]) {
+        for (const required of ["name", "title"]) {
             if (!body[required]) {
-                printError(
+                fail(
                     `--${required.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`)} is required`,
                 );
-                process.exit(1);
             }
         }
+        if (!body.baseUrl) fail("--base-url is required");
+        if (!body.bearerToken) fail("--bearer-token is required");
     }
 
     return body;
@@ -122,18 +186,42 @@ function printModels(models: MyModel[]) {
             id: chalk.dim(model.id),
             model: chalk.hex("#a78bfa").bold(model.modelId),
             title: model.title,
-            visibility: model.visibility,
+            type: model.type,
+            modality: model.type === "proxy" ? model.modality : "text",
+            // Price and billing mode read as one unit, so they share a cell
+            // rather than widening an already wide table by two columns.
+            image_price:
+                model.type === "proxy" && model.modality === "image"
+                    ? `${model.completionImagePrice}/${model.imagePricing === "tokens" ? "token" : "req"}`
+                    : "-",
+            inputs:
+                model.type === "proxy"
+                    ? model.inputModalities?.join(", ") || "-"
+                    : "-",
+            visibility:
+                model.type === "proxy" && model.paidOnly
+                    ? `${model.visibility} (paid only)`
+                    : model.visibility,
             upstream: model.upstreamModel,
             base_url: model.baseUrl,
+            fallbacks:
+                model.type === "proxy"
+                    ? model.fallbacks?.join(", ") || "-"
+                    : "-",
             description: model.description ?? "-",
         })),
         [
             "id",
             "model",
             "title",
+            "type",
+            "modality",
+            "image_price",
+            "inputs",
             "visibility",
             "upstream",
             "base_url",
+            "fallbacks",
             "description",
         ],
     );
@@ -149,10 +237,7 @@ const list = new Command("list")
             });
             printModels(res.data ?? []);
         } catch (err) {
-            printError(
-                `Failed to list my models: ${err instanceof Error ? err.message : "unknown"}`,
-            );
-            process.exit(1);
+            fail("Failed to list my models", err);
         }
     });
 
@@ -162,12 +247,33 @@ const create = addPriceOptions(
         .requiredOption("--name <name>", "Model name")
         .requiredOption("--title <title>", "Display title shown in the catalog")
         .option("--description <text>", "Model description")
-        .requiredOption("--base-url <url>", "OpenAI-compatible base URL")
+        .option("--base-url <url>", "OpenAI-compatible base URL")
         .option("--upstream-model <model>", "Upstream model id")
-        .requiredOption("--bearer-token <token>", "Upstream bearer token")
+        .option("--bearer-token <token>", "Upstream bearer token")
         .option(
             "--visibility <visibility>",
             "Model visibility: private (default) or public",
+        )
+        .option(
+            "--paid-only",
+            "Only accept Paid Pollen, for a pay-as-you-go upstream whose cost free Quest Pollen would not cover",
+        )
+        .option("--no-paid-only", "Accept Quest or Paid Pollen (default)")
+        .option(
+            "--fallbacks <ids>",
+            "Comma-separated community model ids tried in order when this model's upstream fails; empty string clears them",
+        )
+        .option(
+            "--input-modalities <types>",
+            "Comma-separated accepted inputs: text,image,audio,video",
+        )
+        .option(
+            "--modality <modality>",
+            "Model family: text (default), image, or transcription",
+        )
+        .option(
+            "--image-pricing <mode>",
+            "Image billing: request (per image, default) or tokens",
         ),
 ).action(async (opts) => {
     const key = requireKey();
@@ -183,10 +289,7 @@ const create = addPriceOptions(
             printModels([created]);
         }
     } catch (err) {
-        printError(
-            `Failed to create model: ${err instanceof Error ? err.message : "unknown"}`,
-        );
-        process.exit(1);
+        fail("Failed to create model", err);
     }
 });
 
@@ -203,6 +306,25 @@ const update = addPriceOptions(
         .option(
             "--visibility <visibility>",
             "Model visibility: private or public",
+        )
+        .option(
+            "--paid-only",
+            "Only accept Paid Pollen, for a pay-as-you-go upstream whose cost free Quest Pollen would not cover",
+        )
+        .option("--no-paid-only", "Accept Quest or Paid Pollen")
+        .option(
+            "--fallbacks <ids>",
+            "Comma-separated community model ids tried in order when this model's upstream fails; empty string clears them",
+        )
+        .option(
+            "--input-modalities <types>",
+            "Comma-separated accepted inputs: text,image,audio,video",
+        )
+        // No --modality here on purpose: UpdateEndpointSchema has no modality
+        // field, so a registered model's family is fixed at creation.
+        .option(
+            "--image-pricing <mode>",
+            "Image billing: request (per image) or tokens",
         ),
 ).action(async (id, opts) => {
     const key = requireKey();
@@ -221,10 +343,7 @@ const update = addPriceOptions(
             printModels([updated]);
         }
     } catch (err) {
-        printError(
-            `Failed to update model: ${err instanceof Error ? err.message : "unknown"}`,
-        );
-        process.exit(1);
+        fail("Failed to update model", err);
     }
 });
 
@@ -244,10 +363,7 @@ const remove = new Command("delete")
             printSuccess(`Model deleted: ${id}`);
             if (getOutputMode() === "json") printResult({ id });
         } catch (err) {
-            printError(
-                `Failed to delete model: ${err instanceof Error ? err.message : "unknown"}`,
-            );
-            process.exit(1);
+            fail("Failed to delete model", err);
         }
     });
 
@@ -277,10 +393,7 @@ const models = new Command("models")
                     ["model"],
                 );
         } catch (err) {
-            printError(
-                `Failed to fetch upstream models: ${err instanceof Error ? err.message : "unknown"}`,
-            );
-            process.exit(1);
+            fail("Failed to fetch upstream models", err);
         }
     });
 
@@ -289,8 +402,20 @@ const test = new Command("test")
     .requiredOption("--base-url <url>", "OpenAI-compatible base URL")
     .requiredOption("--bearer-token <token>", "Upstream bearer token")
     .requiredOption("--model <model>", "Upstream model id")
+    .option(
+        "--modality <modality>",
+        "Model family: text (default), image, or transcription",
+    )
     .action(async (opts) => {
         const key = requireKey();
+        if (
+            opts.modality !== undefined &&
+            opts.modality !== "text" &&
+            opts.modality !== "image" &&
+            opts.modality !== "transcription"
+        ) {
+            fail("--modality must be 'text', 'image', or 'transcription'");
+        }
         try {
             const res = await gen<Record<string, unknown>>(
                 "/account/my-models/test",
@@ -301,20 +426,22 @@ const test = new Command("test")
                         baseUrl: opts.baseUrl,
                         bearerToken: opts.bearerToken,
                         model: opts.model,
+                        ...(opts.modality !== undefined && {
+                            modality: opts.modality,
+                        }),
                     },
                 },
             );
             printResult(res);
         } catch (err) {
-            printError(
-                `Failed to test model: ${err instanceof Error ? err.message : "unknown"}`,
-            );
-            process.exit(1);
+            fail("Failed to test model", err);
         }
     });
 
 export const myModelsCommand = new Command("my-models")
-    .description("Manage private and published community text models")
+    .description(
+        "Manage private and published community text, image, and transcription models",
+    )
     .addCommand(list)
     .addCommand(create)
     .addCommand(update)

--- a/packages/polli-cli/src/commands/quests.ts
+++ b/packages/polli-cli/src/commands/quests.ts
@@ -3,8 +3,8 @@ import { Command } from "commander";
 import { gen, requireKey } from "../lib/api.js";
 import { ENTER_URL } from "../lib/config.js";
 import {
+    fail,
     getOutputMode,
-    printError,
     printInfo,
     printResult,
     printTable,
@@ -143,9 +143,6 @@ export const questsCommand = new Command("quests")
 
             renderQuests(filterQuests(all, opts));
         } catch (err) {
-            printError(
-                `Failed to fetch quests: ${err instanceof Error ? err.message : "unknown"}`,
-            );
-            process.exit(1);
+            fail("Failed to fetch quests", err);
         }
     });

--- a/packages/polli-cli/src/commands/upload.ts
+++ b/packages/polli-cli/src/commands/upload.ts
@@ -3,7 +3,7 @@ import { basename, extname } from "node:path";
 import { Command } from "commander";
 import { requireKey } from "../lib/api.js";
 import { MEDIA_URL } from "../lib/config.js";
-import { getOutputMode, printError, printMeta } from "../lib/output.js";
+import { fail, getOutputMode, printMeta } from "../lib/output.js";
 
 const MIME_BY_EXT: Record<string, string> = {
     ".jpg": "image/jpeg",
@@ -41,8 +41,7 @@ export const uploadCommand = new Command("upload")
         const isHuman = getOutputMode() === "human";
 
         if (!existsSync(file)) {
-            printError(`File not found: ${file}`);
-            process.exit(1);
+            fail(`File not found: ${file}`);
         }
 
         const mime =
@@ -63,8 +62,7 @@ export const uploadCommand = new Command("upload")
 
         if (!res.ok) {
             const text = await res.text().catch(() => "");
-            printError(`${res.status} ${res.statusText}: ${text}`);
-            process.exit(1);
+            fail(`${res.status} ${res.statusText}: ${text}`);
         }
 
         const data = (await res.json()) as UploadResponse;

--- a/packages/polli-cli/src/harnesses/dsh.test.ts
+++ b/packages/polli-cli/src/harnesses/dsh.test.ts
@@ -1,0 +1,257 @@
+import {
+    existsSync,
+    mkdirSync,
+    mkdtempSync,
+    readdirSync,
+    readFileSync,
+    rmSync,
+    statSync,
+    unlinkSync,
+    writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseEnv } from "node:util";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { parse, stringify } from "yaml";
+import { configureDsh, disableDsh, dsh } from "./dsh.js";
+import type { HarnessContext } from "./types.js";
+
+const models = [
+    { id: "deepseek", contextWindow: 1048576, input: ["text"] },
+    { id: "kimi", contextWindow: 262000, input: ["text", "image"] },
+];
+const settings = { apiKey: "sk_test_key", model: "deepseek", models };
+
+let home: string;
+let ctx: HarnessContext;
+
+beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "polli-harness-"));
+    ctx = { home, env: {} };
+});
+
+afterEach(() => rmSync(home, { recursive: true, force: true }));
+
+const settingsFile = () => join(home, ".dsh", "settings.yaml");
+const envFile = () => join(home, ".dsh", ".env");
+const patchFile = () => join(home, ".dsh", "cordis.patch.yml");
+const skillFile = () => join(home, ".dsh", "skills", "polli", "SKILL.md");
+const snapshotFiles = () => {
+    const dir = join(home, ".pollinations", "harnesses");
+    return existsSync(dir)
+        ? readdirSync(dir).filter((f) => f.startsWith("dsh."))
+        : [];
+};
+const read = (path: string) => readFileSync(path, "utf-8");
+
+describe("dsh harness", () => {
+    it("writes the provider, MCP, skill, and credential from scratch", () => {
+        const result = configureDsh(ctx, settings);
+        expect(result).toMatchObject({
+            harness: "dsh",
+            configured: true,
+            model: "deepseek",
+            mcp: true,
+        });
+
+        const doc = parse(read(settingsFile()));
+        expect(doc["agent-default-model"]).toEqual({
+            provider: "pollinations",
+            model: "deepseek",
+        });
+        const provider = doc["llm-pi-ai"].providers.pollinations;
+        expect(provider).toMatchObject({
+            api: "openai-completions",
+            apiKeyEnv: "POLLI_DSH_API_KEY",
+            baseURL: "https://gen.pollinations.ai/v1",
+        });
+        expect(provider.models.map((m: { id: string }) => m.id)).toEqual([
+            "deepseek",
+            "kimi",
+        ]);
+
+        expect(parseEnv(read(envFile())).POLLI_DSH_API_KEY).toBe("sk_test_key");
+        const patch = read(patchFile());
+        expect(patch).toContain("id: mcp-pollinations");
+        expect(patch).toContain('name: "@deepseek-ai/dsh-mcp-client"');
+        expect(patch).toContain("serverName: pollinations");
+        expect(patch).toContain("transport: streamable-http");
+        expect(patch).toContain(
+            "url: https://gen.pollinations.ai/mcp/pollinations",
+        );
+        expect(patch).toContain(
+            "!!js '`Bearer ${process.env.POLLI_DSH_API_KEY}`'",
+        );
+        expect(read(skillFile())).toContain("name: polli");
+        expect(statSync(settingsFile()).mode & 0o777).toBe(0o600);
+        expect(statSync(envFile()).mode & 0o777).toBe(0o600);
+        expect(statSync(patchFile()).mode & 0o777).toBe(0o600);
+        expect(statSync(skillFile()).mode & 0o777).toBe(0o600);
+        expect(statSync(join(home, ".dsh")).mode & 0o777).toBe(0o700);
+        expect(dsh.status(ctx)).toMatchObject({
+            configured: true,
+            model: "deepseek",
+        });
+    });
+
+    it("keeps existing settings, comments, environment, and MCP entries", () => {
+        mkdirSync(join(home, ".dsh"), { recursive: true });
+        writeFileSync(
+            settingsFile(),
+            "# my notes\nui-onboarding:\n  welcomeNoticeVersion: 1\nagent-default-model:\n  provider: deepseek\n  model: deepseek-chat\n",
+        );
+        writeFileSync(envFile(), "# local env\nDEEPSEEK_API_KEY=ds-secret\n", {
+            mode: 0o644,
+        });
+        writeFileSync(
+            patchFile(),
+            "# my plugins\n- insert:\n    - id: mcp-local\n      name: local-mcp\n",
+        );
+
+        configureDsh(ctx, settings);
+
+        const text = read(settingsFile());
+        expect(text).toContain("# my notes");
+        expect(parse(text)["ui-onboarding"]).toEqual({
+            welcomeNoticeVersion: 1,
+        });
+        expect(read(envFile())).toContain("# local env");
+        expect(parseEnv(read(envFile()))).toMatchObject({
+            DEEPSEEK_API_KEY: "ds-secret",
+            POLLI_DSH_API_KEY: "sk_test_key",
+        });
+        expect(read(patchFile())).toContain("# my plugins");
+        expect(read(patchFile())).toContain("id: mcp-local");
+        expect(statSync(settingsFile()).mode & 0o777).toBe(0o600);
+        expect(statSync(envFile()).mode & 0o777).toBe(0o600);
+    });
+
+    it("restores the original files byte-for-byte on off", () => {
+        mkdirSync(join(home, ".dsh"), { recursive: true });
+        const original =
+            "agent-default-model: {provider: deepseek, model: deepseek-chat}\n";
+        writeFileSync(settingsFile(), original);
+
+        configureDsh(ctx, settings);
+        expect(snapshotFiles()).toHaveLength(1);
+        const result = disableDsh(ctx);
+
+        expect(result.outcome).toBe("restored");
+        expect(read(settingsFile())).toBe(original);
+        expect(existsSync(envFile())).toBe(false);
+        expect(existsSync(patchFile())).toBe(false);
+        expect(existsSync(skillFile())).toBe(false);
+        expect(snapshotFiles()).toHaveLength(0);
+        expect(dsh.status(ctx).configured).toBe(false);
+    });
+
+    it("only strips the Pollinations entries when the config changed since on", () => {
+        configureDsh(ctx, settings);
+        const edited = parse(read(settingsFile()));
+        edited["agent-presets"] = { default: "mine" };
+        writeFileSync(settingsFile(), stringify(edited));
+
+        const result = disableDsh(ctx);
+
+        expect(result.outcome).toBe("stripped");
+        const doc = parse(read(settingsFile()));
+        expect(doc["agent-presets"]).toEqual({ default: "mine" });
+        expect(doc["agent-default-model"]).toBeUndefined();
+        expect(doc["llm-pi-ai"].providers.pollinations).toBeUndefined();
+        expect(parseEnv(read(envFile())).POLLI_DSH_API_KEY).toBeUndefined();
+        expect(read(patchFile())).not.toContain("mcp-pollinations");
+        expect(existsSync(skillFile())).toBe(false);
+        expect(snapshotFiles()).toHaveLength(0);
+    });
+
+    it("reports unchanged when off runs on a harness that was never on", () => {
+        expect(disableDsh(ctx).outcome).toBe("unchanged");
+    });
+
+    it("can skip MCP configuration", () => {
+        const result = configureDsh(ctx, { ...settings, mcp: false });
+
+        expect(result).toMatchObject({ configured: true, mcp: false });
+        expect(existsSync(patchFile())).toBe(false);
+        expect(existsSync(skillFile())).toBe(true);
+    });
+
+    it("keeps one backup per harness home", () => {
+        configureDsh(ctx, settings);
+        const moved = { home, env: { DSH_HOME: join(home, "moved") } };
+        configureDsh(moved, settings);
+        expect(snapshotFiles()).toHaveLength(2);
+
+        expect(disableDsh(moved).outcome).toBe("restored");
+        expect(existsSync(join(home, "moved", "settings.yaml"))).toBe(false);
+        // The original location is untouched and still has its own backup.
+        expect(dsh.status(ctx).configured).toBe(true);
+        expect(snapshotFiles()).toHaveLength(1);
+    });
+
+    it("re-running on switches the model and keeps the pre-on backup", () => {
+        configureDsh(ctx, settings);
+        configureDsh(ctx, { ...settings, model: "kimi" });
+        expect(dsh.status(ctx).model).toBe("kimi");
+
+        disableDsh(ctx);
+        expect(existsSync(settingsFile())).toBe(false);
+    });
+
+    it("honors DSH_HOME", () => {
+        const custom = join(home, "custom-dsh");
+        configureDsh({ home, env: { DSH_HOME: custom } }, settings);
+        expect(existsSync(join(custom, "settings.yaml"))).toBe(true);
+        expect(existsSync(settingsFile())).toBe(false);
+    });
+
+    it("treats an empty DSH_HOME as unset", () => {
+        configureDsh({ home, env: { DSH_HOME: "  " } }, settings);
+        expect(existsSync(settingsFile())).toBe(true);
+    });
+
+    it("expands a tilde in DSH_HOME", () => {
+        configureDsh({ home, env: { DSH_HOME: "~/custom-dsh" } }, settings);
+        expect(existsSync(join(home, "custom-dsh", "settings.yaml"))).toBe(
+            true,
+        );
+    });
+
+    it("reports unconfigured when the credential is missing", () => {
+        configureDsh(ctx, settings);
+        unlinkSync(envFile());
+        expect(dsh.status(ctx).configured).toBe(false);
+    });
+
+    it("preserves a corrupt snapshot and refuses to disable", () => {
+        configureDsh(ctx, settings);
+        const snapshot = join(
+            home,
+            ".pollinations",
+            "harnesses",
+            snapshotFiles()[0],
+        );
+        writeFileSync(snapshot, "{");
+
+        expect(() => disableDsh(ctx)).toThrow();
+        expect(snapshotFiles()).toHaveLength(1);
+        expect(dsh.status(ctx).configured).toBe(true);
+    });
+
+    it("rolls back earlier files when the MCP config is invalid", () => {
+        mkdirSync(join(home, ".dsh"), { recursive: true });
+        const original =
+            "agent-default-model: {provider: deepseek, model: deepseek-chat}\n";
+        writeFileSync(settingsFile(), original);
+        const invalidPatch = "{}\n";
+        writeFileSync(patchFile(), invalidPatch, { mode: 0o600 });
+
+        expect(() => configureDsh(ctx, settings)).toThrow();
+
+        expect(read(settingsFile())).toBe(original);
+        expect(existsSync(envFile())).toBe(false);
+        expect(read(patchFile())).toBe(invalidPatch);
+        expect(snapshotFiles()).toHaveLength(0);
+    });
+});

--- a/packages/polli-cli/src/harnesses/dsh.ts
+++ b/packages/polli-cli/src/harnesses/dsh.ts
@@ -1,0 +1,314 @@
+import { join, resolve } from "node:path";
+import { parseEnv } from "node:util";
+import { isMap, isSeq, parseDocument, Scalar } from "yaml";
+import polliSkill from "../../SKILL.md?raw";
+import { BASE_URL } from "../lib/config.js";
+import { readTextIfExists, removeIfExists, writeTextAtomic } from "./fs.js";
+import { resolveHarnessKey } from "./keys.js";
+import { fetchHarnessModels } from "./models.js";
+import {
+    applyWithSnapshot,
+    clearSnapshot,
+    restoreSnapshot,
+} from "./snapshot.js";
+import type {
+    HarnessAdapter,
+    HarnessContext,
+    HarnessModel,
+    HarnessResult,
+} from "./types.js";
+
+const ID = "dsh";
+const LABEL = "DeepSeek Harness";
+const PROVIDER = "pollinations";
+const DEFAULT_MODEL = "deepseek";
+const KEY_ENV = "POLLI_DSH_API_KEY";
+const MCP_ID = "mcp-pollinations";
+const MCP_URL = `${BASE_URL}/mcp/pollinations`;
+const PROVIDER_PATH = ["llm-pi-ai", "providers", PROVIDER];
+const DEFAULT_MODEL_PATH = ["agent-default-model"];
+// Never fold long scalars (the API key) across lines.
+const YAML_OUT = { lineWidth: 0 };
+const JS_TAG = {
+    tag: "tag:yaml.org,2002:js",
+    resolve: (value: string) => value,
+};
+
+export const dshHome = (ctx: HarnessContext) => {
+    const configured = ctx.env.DSH_HOME;
+    if (!configured?.trim()) return join(ctx.home, ".dsh");
+    const expanded =
+        configured === "~"
+            ? ctx.home
+            : configured.startsWith("~/") || configured.startsWith("~\\")
+              ? join(ctx.home, configured.slice(2))
+              : configured;
+    return resolve(expanded);
+};
+const settingsPath = (ctx: HarnessContext) =>
+    join(dshHome(ctx), "settings.yaml");
+const envPath = (ctx: HarnessContext) => join(dshHome(ctx), ".env");
+const patchPath = (ctx: HarnessContext) =>
+    join(dshHome(ctx), "cordis.patch.yml");
+const skillPath = (ctx: HarnessContext) =>
+    join(dshHome(ctx), "skills", "polli", "SKILL.md");
+
+// parseDocument keeps comments and untouched entries intact on rewrite.
+const loadYaml = (path: string) =>
+    parseDocument(readTextIfExists(path) ?? "", { customTags: [JS_TAG] });
+
+const files = (ctx: HarnessContext) => [
+    settingsPath(ctx),
+    envPath(ctx),
+    patchPath(ctx),
+    skillPath(ctx),
+];
+
+const readKey = (ctx: HarnessContext) => {
+    const text = readTextIfExists(envPath(ctx));
+    if (text === null) return null;
+    const key = parseEnv(text)[KEY_ENV];
+    return key || null;
+};
+
+const envLine = (key: string) => `${KEY_ENV}=${JSON.stringify(key)}`;
+const keyLine = new RegExp(`^\\s*(?:export\\s+)?${KEY_ENV}\\s*=`, "u");
+
+const setEnvKey = (ctx: HarnessContext, key: string) => {
+    const lines = (readTextIfExists(envPath(ctx)) ?? "").split("\n");
+    const index = lines.findIndex((line) => keyLine.test(line));
+    const filtered = lines.filter(
+        (line, i) => i === index || !keyLine.test(line),
+    );
+    if (index === -1) {
+        const insertAt =
+            filtered.at(-1) === "" ? filtered.length - 1 : filtered.length;
+        filtered.splice(insertAt, 0, envLine(key));
+    } else filtered[index] = envLine(key);
+    writeTextAtomic(envPath(ctx), filtered.join("\n"), 0o600);
+};
+
+const deleteEnvKey = (ctx: HarnessContext) => {
+    const text = readTextIfExists(envPath(ctx));
+    if (text === null) return false;
+    const lines = text.split("\n");
+    const filtered = lines.filter((line) => !keyLine.test(line));
+    if (filtered.length === lines.length) return false;
+    writeTextAtomic(envPath(ctx), filtered.join("\n"), 0o600);
+    return true;
+};
+
+const stripMcpEntry = (doc: ReturnType<typeof loadYaml>) => {
+    if (!isSeq(doc.contents)) return false;
+    let changed = false;
+    for (let i = doc.contents.items.length - 1; i >= 0; i--) {
+        const patch = doc.contents.items[i];
+        if (!isMap(patch)) continue;
+        const inserted = patch.get("insert", true);
+        if (!isSeq(inserted)) continue;
+        const before = inserted.items.length;
+        inserted.items = inserted.items.filter(
+            (entry) => !isMap(entry) || entry.get("id") !== MCP_ID,
+        );
+        changed ||= inserted.items.length !== before;
+        if (inserted.items.length === 0 && patch.items.length === 1) {
+            doc.contents.items.splice(i, 1);
+        }
+    }
+    return changed;
+};
+
+const removeMcpEntry = (ctx: HarnessContext) => {
+    const doc = loadYaml(patchPath(ctx));
+    if (!stripMcpEntry(doc)) return false;
+    writeTextAtomic(patchPath(ctx), doc.toString(YAML_OUT), 0o600);
+    return true;
+};
+
+const writeMcpEntry = (ctx: HarnessContext) => {
+    const doc = loadYaml(patchPath(ctx));
+    if (doc.contents === null) doc.contents = doc.createNode([]);
+    if (!isSeq(doc.contents)) {
+        throw new Error(`${patchPath(ctx)} must contain a YAML list`);
+    }
+    stripMcpEntry(doc);
+    const authorization = doc.createNode(
+        `\`Bearer \${process.env.${KEY_ENV}}\``,
+    );
+    authorization.tag = "tag:yaml.org,2002:js";
+    authorization.type = Scalar.QUOTE_SINGLE;
+    doc.add({
+        insert: [
+            {
+                id: MCP_ID,
+                name: "@deepseek-ai/dsh-mcp-client",
+                config: {
+                    serverName: "pollinations",
+                    transport: "streamable-http",
+                    url: MCP_URL,
+                    headers: { Authorization: authorization },
+                },
+            },
+        ],
+    });
+    writeTextAtomic(patchPath(ctx), doc.toString(YAML_OUT), 0o600);
+};
+
+const hasMcpEntry = (ctx: HarnessContext) => {
+    const doc = loadYaml(patchPath(ctx));
+    if (!isSeq(doc.contents)) return false;
+    return doc.contents.items.some((patch) => {
+        if (!isMap(patch)) return false;
+        const inserted = patch.get("insert", true);
+        return (
+            isSeq(inserted) &&
+            inserted.items.some(
+                (entry) =>
+                    isMap(entry) &&
+                    entry.get("id") === MCP_ID &&
+                    entry.getIn(["config", "url"]) === MCP_URL,
+            )
+        );
+    });
+};
+
+// Provider block in the pi-ai schema dsh shares with Pi and Prime Agent. The
+// compat flags match what gen.pollinations.ai/v1 accepts.
+const providerConfig = (models: HarnessModel[]) => ({
+    displayName: "Pollinations.ai",
+    apiKeyEnv: KEY_ENV,
+    api: "openai-completions",
+    baseURL: `${BASE_URL}/v1`,
+    compat: {
+        supportsStore: false,
+        supportsDeveloperRole: false,
+        supportsReasoningEffort: true,
+        supportsUsageInStreaming: true,
+        supportsStrictMode: false,
+        maxTokensField: "max_tokens",
+    },
+    models: models.map((model) => ({
+        id: model.id,
+        name: model.id,
+        contextWindow: model.contextWindow,
+        input: model.input,
+        reasoningEfforts: false,
+    })),
+});
+
+interface DshSettings {
+    apiKey: string;
+    model: string;
+    models: HarnessModel[];
+    mcp?: boolean;
+}
+
+const writeConfig = (ctx: HarnessContext, settings: DshSettings) => {
+    const doc = loadYaml(settingsPath(ctx));
+    doc.setIn(PROVIDER_PATH, doc.createNode(providerConfig(settings.models)));
+    doc.setIn(
+        DEFAULT_MODEL_PATH,
+        doc.createNode({ provider: PROVIDER, model: settings.model }),
+    );
+    writeTextAtomic(settingsPath(ctx), doc.toString(YAML_OUT), 0o600);
+    // DSH's provider and MCP loader both read its user environment layer.
+    setEnvKey(ctx, settings.apiKey);
+    if (settings.mcp === false) removeMcpEntry(ctx);
+    else writeMcpEntry(ctx);
+    if (readTextIfExists(skillPath(ctx)) === null) {
+        writeTextAtomic(skillPath(ctx), polliSkill, 0o600);
+    }
+};
+
+const stripConfig = (ctx: HarnessContext) => {
+    const doc = loadYaml(settingsPath(ctx));
+    let changed = false;
+    if (doc.hasIn(PROVIDER_PATH)) {
+        doc.deleteIn(PROVIDER_PATH);
+        changed = true;
+    }
+    if (doc.getIn([...DEFAULT_MODEL_PATH, "provider"]) === PROVIDER) {
+        doc.deleteIn(DEFAULT_MODEL_PATH);
+        changed = true;
+    }
+    if (changed)
+        writeTextAtomic(settingsPath(ctx), doc.toString(YAML_OUT), 0o600);
+
+    changed = deleteEnvKey(ctx) || changed;
+    changed = removeMcpEntry(ctx) || changed;
+    if (readTextIfExists(skillPath(ctx)) === polliSkill) {
+        removeIfExists(skillPath(ctx));
+        changed = true;
+    }
+    return changed;
+};
+
+const result = (ctx: HarnessContext): HarnessResult => {
+    const doc = loadYaml(settingsPath(ctx));
+    const model = doc.getIn([...DEFAULT_MODEL_PATH, "model"]);
+    return {
+        harness: ID,
+        label: LABEL,
+        configured:
+            doc.getIn([...PROVIDER_PATH, "apiKeyEnv"]) === KEY_ENV &&
+            doc.getIn([...PROVIDER_PATH, "api"]) === "openai-completions" &&
+            doc.getIn([...PROVIDER_PATH, "baseURL"]) === `${BASE_URL}/v1` &&
+            doc.getIn([...DEFAULT_MODEL_PATH, "provider"]) === PROVIDER &&
+            typeof model === "string" &&
+            readKey(ctx) !== null &&
+            readTextIfExists(skillPath(ctx)) !== null,
+        model: typeof model === "string" ? model : undefined,
+        mcp: hasMcpEntry(ctx),
+        files: files(ctx),
+    };
+};
+
+export const configureDsh = (
+    ctx: HarnessContext,
+    settings: DshSettings,
+): HarnessResult => {
+    applyWithSnapshot(ctx, ID, files(ctx), () => writeConfig(ctx, settings));
+    return result(ctx);
+};
+
+export const disableDsh = (ctx: HarnessContext): HarnessResult => {
+    const managedFiles = files(ctx);
+    let outcome: HarnessResult["outcome"] = "restored";
+    if (restoreSnapshot(ctx, ID, managedFiles) !== "restored") {
+        outcome = stripConfig(ctx) ? "stripped" : "unchanged";
+        clearSnapshot(ctx, ID, managedFiles);
+    }
+    return { ...result(ctx), configured: false, outcome };
+};
+
+export const dsh: HarnessAdapter = {
+    id: ID,
+    label: LABEL,
+    description: "Configure DeepSeek Harness as a Pollinations provider",
+    restartHint:
+        "Changes apply on the next request. Start DeepSeek Harness with: npx @deepseek-ai/dsh web",
+
+    async on(ctx, options) {
+        const model = options.model ?? DEFAULT_MODEL;
+        const models = await fetchHarnessModels();
+        if (!models.some((candidate) => candidate.id === model)) {
+            throw new Error(
+                `Model "${model}" is not a tool-calling text model. Run: polli models`,
+            );
+        }
+
+        const apiKey = await resolveHarnessKey(
+            { id: ID, label: LABEL, existingKey: readKey(ctx) },
+            { browser: options.browser },
+        );
+        return configureDsh(ctx, {
+            apiKey,
+            model,
+            models,
+            mcp: options.mcp,
+        });
+    },
+
+    off: disableDsh,
+    status: result,
+};

--- a/packages/polli-cli/src/harnesses/fs.ts
+++ b/packages/polli-cli/src/harnesses/fs.ts
@@ -1,0 +1,27 @@
+import {
+    existsSync,
+    mkdirSync,
+    readFileSync,
+    renameSync,
+    statSync,
+    unlinkSync,
+    writeFileSync,
+} from "node:fs";
+import { basename, dirname, join } from "node:path";
+
+export const readTextIfExists = (path: string): string | null =>
+    existsSync(path) ? readFileSync(path, "utf-8") : null;
+
+/** Write via temp file + rename so a crash never leaves a half-written config. */
+export const writeTextAtomic = (path: string, text: string, mode?: number) => {
+    mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+    const fileMode =
+        mode ?? (existsSync(path) ? statSync(path).mode & 0o777 : 0o600);
+    const tmp = join(dirname(path), `.${basename(path)}.${process.pid}.tmp`);
+    writeFileSync(tmp, text, { encoding: "utf-8", mode: fileMode });
+    renameSync(tmp, path);
+};
+
+export const removeIfExists = (path: string) => {
+    if (existsSync(path)) unlinkSync(path);
+};

--- a/packages/polli-cli/src/harnesses/index.ts
+++ b/packages/polli-cli/src/harnesses/index.ts
@@ -1,4 +1,5 @@
 import { dsh } from "./dsh.js";
+import { opencode } from "./opencode.js";
 import type { HarnessAdapter } from "./types.js";
 
-export const HARNESSES: HarnessAdapter[] = [dsh];
+export const HARNESSES: HarnessAdapter[] = [dsh, opencode];

--- a/packages/polli-cli/src/harnesses/index.ts
+++ b/packages/polli-cli/src/harnesses/index.ts
@@ -1,0 +1,4 @@
+import { dsh } from "./dsh.js";
+import type { HarnessAdapter } from "./types.js";
+
+export const HARNESSES: HarnessAdapter[] = [dsh];

--- a/packages/polli-cli/src/harnesses/keys.test.ts
+++ b/packages/polli-cli/src/harnesses/keys.test.ts
@@ -1,0 +1,47 @@
+import { createServer, type Server } from "node:http";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+let server: Server;
+let resolveHarnessKey: typeof import("./keys.js").resolveHarnessKey;
+const requests: string[] = [];
+const previousBaseUrl = process.env.POLLINATIONS_BASE_URL;
+
+beforeAll(async () => {
+    server = createServer((request, response) => {
+        requests.push(`${request.method} ${request.url}`);
+        response.writeHead(503, { "Content-Type": "application/json" });
+        response.end('{"error":"temporarily unavailable"}');
+    });
+    await new Promise<void>((resolve) =>
+        server.listen(0, "127.0.0.1", resolve),
+    );
+    const address = server.address();
+    if (!address || typeof address === "string")
+        throw new Error("No test port");
+    process.env.POLLINATIONS_BASE_URL = `http://127.0.0.1:${address.port}`;
+    ({ resolveHarnessKey } = await import("./keys.js"));
+});
+
+afterAll(async () => {
+    if (previousBaseUrl === undefined) delete process.env.POLLINATIONS_BASE_URL;
+    else process.env.POLLINATIONS_BASE_URL = previousBaseUrl;
+    await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+    );
+});
+
+describe("harness keys", () => {
+    it("does not mint a replacement when validation is unavailable", async () => {
+        await expect(
+            resolveHarnessKey(
+                {
+                    id: "dsh",
+                    label: "DeepSeek Harness",
+                    existingKey: "sk_existing",
+                },
+                {},
+            ),
+        ).rejects.toMatchObject({ status: 503 });
+        expect(requests).toEqual(["GET /account/key"]);
+    });
+});

--- a/packages/polli-cli/src/harnesses/keys.ts
+++ b/packages/polli-cli/src/harnesses/keys.ts
@@ -1,0 +1,48 @@
+import { loginWithDeviceFlow } from "../commands/auth.js";
+import { ApiError, gen } from "../lib/api.js";
+import { resolveApiKey } from "../lib/config.js";
+import { printInfo, printSuccess } from "../lib/output.js";
+
+// gen's response cache can answer an unauthenticated prompt, so a chat
+// completion proves nothing — check the key itself.
+const keyIsValid = async (key: string) => {
+    try {
+        const info = await gen<{ valid: boolean }>("/account/key", {
+            apiKey: key,
+        });
+        return info.valid === true;
+    } catch (error) {
+        if (error instanceof ApiError && error.status === 401) return false;
+        throw error;
+    }
+};
+
+/**
+ * Key the harness will call gen with: the one already in its config if still
+ * valid, otherwise a child key named after the harness, minted from the polli
+ * login (logging in first if needed).
+ */
+export const resolveHarnessKey = async (
+    harness: { id: string; label: string; existingKey: string | null },
+    options: { browser?: boolean },
+): Promise<string> => {
+    const existing = harness.existingKey;
+    if (existing && (await keyIsValid(existing))) {
+        printInfo(
+            `Reusing the Pollinations key already stored for ${harness.label}.`,
+        );
+        return existing;
+    }
+
+    const accountKey =
+        resolveApiKey() ??
+        (await loginWithDeviceFlow({ browser: options.browser }));
+    const name = `polli-harness-${harness.id}`;
+    const created = await gen<{ key: string }>("/account/keys", {
+        method: "POST",
+        apiKey: accountKey,
+        body: { name, type: "secret" },
+    });
+    printSuccess(`Created API key "${name}" for ${harness.label}.`);
+    return created.key;
+};

--- a/packages/polli-cli/src/harnesses/models.ts
+++ b/packages/polli-cli/src/harnesses/models.ts
@@ -1,0 +1,36 @@
+import { gen } from "../lib/api.js";
+import type { HarnessModel } from "./types.js";
+
+interface CatalogModel {
+    id: string;
+    input_modalities?: string[];
+    output_modalities?: string[];
+    tools?: boolean;
+    context_length?: number;
+    agent?: unknown;
+}
+
+/**
+ * First-party text models with tool calling — what an agentic harness can
+ * drive. Community models (`owner/name`) and published agents are left out:
+ * they come and go, and they would triple the list.
+ */
+export const fetchHarnessModels = async (): Promise<HarnessModel[]> => {
+    const { data } = await gen<{ data: CatalogModel[] }>("/v1/models");
+    return data
+        .filter(
+            (m) =>
+                m.tools === true &&
+                m.output_modalities?.includes("text") &&
+                m.context_length &&
+                !m.agent &&
+                !m.id.includes("/"),
+        )
+        .map((m) => ({
+            id: m.id,
+            contextWindow: m.context_length as number,
+            input: (m.input_modalities ?? ["text"]).filter(
+                (modality) => modality === "text" || modality === "image",
+            ),
+        }));
+};

--- a/packages/polli-cli/src/harnesses/opencode.test.ts
+++ b/packages/polli-cli/src/harnesses/opencode.test.ts
@@ -1,0 +1,227 @@
+import {
+    existsSync,
+    mkdirSync,
+    mkdtempSync,
+    readdirSync,
+    readFileSync,
+    rmSync,
+    writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+    configureOpenCode,
+    disableOpenCode,
+    openCodeConfigDir,
+    opencode,
+} from "./opencode.js";
+import type { HarnessContext } from "./types.js";
+
+const models = [
+    { id: "openai", contextWindow: 128000, input: ["text"] },
+    { id: "openai-vision", contextWindow: 128000, input: ["text", "image"] },
+];
+const settings = { apiKey: "sk_test_key", model: "openai", models };
+
+let home: string;
+let ctx: HarnessContext;
+
+beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "polli-opencode-"));
+    ctx = { home, env: {} };
+});
+
+afterEach(() => rmSync(home, { recursive: true, force: true }));
+
+const ocConfig = () => join(home, ".config", "opencode", "opencode.json");
+const snapshotFiles = () => {
+    const dir = join(home, ".pollinations", "harnesses");
+    return existsSync(dir)
+        ? readdirSync(dir).filter((f) => f.startsWith("opencode."))
+        : [];
+};
+const read = (path: string) => readFileSync(path, "utf-8");
+const readJson = (path: string) => JSON.parse(read(path));
+
+describe("opencode harness", () => {
+    it("writes provider, plugin, and model from scratch", () => {
+        const r = configureOpenCode(ctx, settings);
+        expect(r).toMatchObject({
+            harness: "opencode",
+            configured: true,
+            model: "openai",
+            mcp: true,
+        });
+
+        const cfg = readJson(ocConfig());
+        expect(cfg.model).toBe("pollinations/openai");
+        expect(cfg.provider.pollinations).toMatchObject({
+            npm: "@ai-sdk/openai-compatible",
+            name: "Pollinations.ai",
+            options: {
+                baseURL: "https://gen.pollinations.ai/v1",
+                apiKey: "sk_test_key",
+            },
+        });
+        expect(cfg.provider.pollinations.models.openai).toMatchObject({
+            name: "openai",
+            limit: { context: 128000 },
+            tool_call: true,
+        });
+        expect(cfg.provider.pollinations.models["openai-vision"]).toMatchObject(
+            {
+                attachment: true,
+            },
+        );
+        expect(cfg.plugin).toContain("opencode-pollinations-plugin");
+        expect(opencode.status(ctx)).toMatchObject({
+            configured: true,
+            model: "openai",
+        });
+    });
+
+    it("preserves existing config keys and other providers", () => {
+        mkdirSync(join(home, ".config", "opencode"), { recursive: true });
+        writeFileSync(
+            ocConfig(),
+            JSON.stringify(
+                {
+                    $schema: "https://opencode.ai/config.json",
+                    theme: "dark",
+                    provider: { anthropic: { options: { timeout: 60000 } } },
+                    plugin: ["another-plugin"],
+                },
+                null,
+                2,
+            ),
+        );
+
+        configureOpenCode(ctx, settings);
+
+        const cfg = readJson(ocConfig());
+        expect(cfg.$schema).toBe("https://opencode.ai/config.json");
+        expect(cfg.theme).toBe("dark");
+        expect(cfg.provider.anthropic).toMatchObject({
+            options: { timeout: 60000 },
+        });
+        expect(cfg.provider.pollinations).toBeDefined();
+        expect(cfg.plugin).toContain("another-plugin");
+        expect(cfg.plugin).toContain("opencode-pollinations-plugin");
+    });
+
+    it("restores the original file byte-for-byte on off", () => {
+        mkdirSync(join(home, ".config", "opencode"), { recursive: true });
+        const original = `${JSON.stringify({ theme: "dark" }, null, 2)}\n`;
+        writeFileSync(ocConfig(), original);
+
+        configureOpenCode(ctx, settings);
+        expect(snapshotFiles()).toHaveLength(1);
+        const r = disableOpenCode(ctx);
+
+        expect(r.outcome).toBe("restored");
+        expect(read(ocConfig())).toBe(original);
+        expect(snapshotFiles()).toHaveLength(0);
+        expect(opencode.status(ctx).configured).toBe(false);
+    });
+
+    it("only strips Pollinations entries when the config changed since on", () => {
+        configureOpenCode(ctx, settings);
+
+        const cfg = readJson(ocConfig());
+        cfg["editor-theme"] = "monokai";
+        writeFileSync(ocConfig(), `${JSON.stringify(cfg, null, 2)}\n`);
+
+        const r = disableOpenCode(ctx);
+
+        expect(r.outcome).toBe("stripped");
+        const after = readJson(ocConfig());
+        expect(after["editor-theme"]).toBe("monokai");
+        expect(after.provider?.pollinations).toBeUndefined();
+        expect(after.model).toBeUndefined();
+        expect(
+            (after.plugin ?? []).some((p: string) =>
+                p.includes("opencode-pollinations-plugin"),
+            ),
+        ).toBe(false);
+        expect(snapshotFiles()).toHaveLength(0);
+    });
+
+    it("reports unchanged when off on a harness that was never on", () => {
+        expect(disableOpenCode(ctx).outcome).toBe("unchanged");
+    });
+
+    it("can skip plugin with --no-mcp", () => {
+        const r = configureOpenCode(ctx, { ...settings, mcp: false });
+
+        expect(r).toMatchObject({ configured: true, mcp: false });
+        const cfg = readJson(ocConfig());
+        expect(cfg.plugin ?? []).not.toContain("opencode-pollinations-plugin");
+        expect(cfg.provider.pollinations).toBeDefined();
+    });
+
+    it("re-running on updates model and keeps the pre-on backup", () => {
+        configureOpenCode(ctx, settings);
+        configureOpenCode(ctx, { ...settings, model: "openai-vision" });
+        expect(opencode.status(ctx).model).toBe("openai-vision");
+
+        disableOpenCode(ctx);
+        expect(existsSync(ocConfig())).toBe(false);
+    });
+
+    it("honors OPENCODE_CONFIG_DIR", () => {
+        const custom = join(home, "my-opencode");
+        configureOpenCode(
+            { home, env: { OPENCODE_CONFIG_DIR: custom } },
+            settings,
+        );
+        expect(existsSync(join(custom, "opencode.json"))).toBe(true);
+        expect(existsSync(ocConfig())).toBe(false);
+    });
+
+    it("treats an empty OPENCODE_CONFIG_DIR as unset", () => {
+        configureOpenCode(
+            { home, env: { OPENCODE_CONFIG_DIR: "  " } },
+            settings,
+        );
+        expect(existsSync(ocConfig())).toBe(true);
+    });
+
+    it("reports unconfigured when no config file exists", () => {
+        expect(opencode.status(ctx).configured).toBe(false);
+    });
+
+    it("does not add duplicate plugin entries on re-run", () => {
+        configureOpenCode(ctx, settings);
+        configureOpenCode(ctx, settings);
+        const cfg = readJson(ocConfig());
+        const count = (cfg.plugin as string[]).filter((p) =>
+            p.includes("opencode-pollinations-plugin"),
+        ).length;
+        expect(count).toBe(1);
+    });
+
+    it("openCodeConfigDir returns correct path from env", () => {
+        const custom = join(home, "custom");
+        expect(
+            openCodeConfigDir({ home, env: { OPENCODE_CONFIG_DIR: custom } }),
+        ).toBe(custom);
+    });
+
+    it("openCodeConfigDir defaults to ~/.config/opencode", () => {
+        expect(openCodeConfigDir({ home, env: {} })).toBe(
+            join(home, ".config", "opencode"),
+        );
+    });
+
+    it("keeps one backup per config location", () => {
+        configureOpenCode(ctx, settings);
+        const moved = { home, env: { OPENCODE_CONFIG_DIR: join(home, "alt") } };
+        configureOpenCode(moved, settings);
+        expect(snapshotFiles()).toHaveLength(2);
+
+        disableOpenCode(moved);
+        expect(snapshotFiles()).toHaveLength(1);
+        expect(opencode.status(ctx).configured).toBe(true);
+    });
+});

--- a/packages/polli-cli/src/harnesses/opencode.ts
+++ b/packages/polli-cli/src/harnesses/opencode.ts
@@ -1,0 +1,255 @@
+import { existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { BASE_URL } from "../lib/config.js";
+import { printInfo } from "../lib/output.js";
+import { readTextIfExists, writeTextAtomic } from "./fs.js";
+import { resolveHarnessKey } from "./keys.js";
+import { fetchHarnessModels } from "./models.js";
+import {
+    applyWithSnapshot,
+    clearSnapshot,
+    restoreSnapshot,
+} from "./snapshot.js";
+import type {
+    HarnessAdapter,
+    HarnessContext,
+    HarnessModel,
+    HarnessResult,
+} from "./types.js";
+
+const ID = "opencode";
+const LABEL = "OpenCode";
+const PROVIDER = "pollinations";
+const DEFAULT_MODEL = "openai";
+const PLUGIN_SPEC = "opencode-pollinations-plugin";
+const INSTALL_URL = "https://opencode.ai/";
+
+export const openCodeConfigDir = (ctx: HarnessContext): string => {
+    const custom = ctx.env.OPENCODE_CONFIG_DIR;
+    if (!custom?.trim()) return join(ctx.home, ".config", "opencode");
+    return resolve(custom);
+};
+
+const configPath = (ctx: HarnessContext) =>
+    join(openCodeConfigDir(ctx), "opencode.json");
+
+const files = (ctx: HarnessContext) => [configPath(ctx)];
+
+const loadJson = (ctx: HarnessContext): Record<string, unknown> => {
+    const text = readTextIfExists(configPath(ctx));
+    if (!text?.trim()) return {};
+    try {
+        return JSON.parse(text) as Record<string, unknown>;
+    } catch {
+        return {};
+    }
+};
+
+const saveJson = (ctx: HarnessContext, cfg: Record<string, unknown>) => {
+    writeTextAtomic(configPath(ctx), `${JSON.stringify(cfg, null, 2)}\n`);
+};
+
+const providerBlock = (apiKey: string, models: HarnessModel[]) => ({
+    npm: "@ai-sdk/openai-compatible",
+    name: "Pollinations.ai",
+    options: {
+        baseURL: `${BASE_URL}/v1`,
+        apiKey,
+    },
+    models: Object.fromEntries(
+        models.map((m) => [
+            m.id,
+            {
+                name: m.id,
+                limit: { context: m.contextWindow },
+                ...(m.input.includes("image") ? { attachment: true } : {}),
+                tool_call: true,
+            },
+        ]),
+    ),
+});
+
+const addPlugin = (plugins: unknown): string[] => {
+    const list = Array.isArray(plugins) ? [...(plugins as string[])] : [];
+    if (!list.some((p) => typeof p === "string" && p.includes(PLUGIN_SPEC)))
+        list.push(PLUGIN_SPEC);
+    return list;
+};
+
+const removePlugin = (
+    plugins: unknown,
+): { list: string[]; changed: boolean } => {
+    if (!Array.isArray(plugins)) return { list: [], changed: false };
+    const before = plugins as string[];
+    const list = before.filter(
+        (p) => typeof p !== "string" || !p.includes(PLUGIN_SPEC),
+    );
+    return { list, changed: list.length !== before.length };
+};
+
+interface OcSettings {
+    apiKey: string;
+    model: string;
+    models: HarnessModel[];
+    mcp?: boolean;
+}
+
+const writeConfig = (ctx: HarnessContext, s: OcSettings) => {
+    const cfg = loadJson(ctx);
+    const existing =
+        typeof cfg.provider === "object" && cfg.provider !== null
+            ? (cfg.provider as Record<string, unknown>)
+            : {};
+    cfg.provider = {
+        ...existing,
+        [PROVIDER]: providerBlock(s.apiKey, s.models),
+    };
+    if (s.mcp !== false) cfg.plugin = addPlugin(cfg.plugin);
+    cfg.model = `${PROVIDER}/${s.model}`;
+    saveJson(ctx, cfg);
+};
+
+const stripConfig = (ctx: HarnessContext): boolean => {
+    const cfg = loadJson(ctx);
+    let changed = false;
+
+    if (typeof cfg.provider === "object" && cfg.provider !== null) {
+        const providers = cfg.provider as Record<string, unknown>;
+        if (PROVIDER in providers) {
+            const { [PROVIDER]: _, ...rest } = providers;
+            cfg.provider = Object.keys(rest).length > 0 ? rest : undefined;
+            changed = true;
+        }
+    }
+
+    const { list, changed: pc } = removePlugin(cfg.plugin);
+    if (pc) {
+        cfg.plugin = list.length > 0 ? list : undefined;
+        changed = true;
+    }
+
+    if (typeof cfg.model === "string" && cfg.model.startsWith(`${PROVIDER}/`)) {
+        cfg.model = undefined;
+        changed = true;
+    }
+
+    if (changed) {
+        const clean = Object.fromEntries(
+            Object.entries(cfg).filter(([, v]) => v !== undefined),
+        );
+        saveJson(ctx, clean);
+    }
+    return changed;
+};
+
+const readKey = (ctx: HarnessContext): string | null => {
+    const cfg = loadJson(ctx);
+    const provider = (cfg.provider as Record<string, unknown>)?.[PROVIDER] as
+        | Record<string, unknown>
+        | undefined;
+    const options = provider?.options as Record<string, unknown> | undefined;
+    const key = options?.apiKey;
+    return typeof key === "string" && key.length > 5 ? key : null;
+};
+
+const hasPlugin = (ctx: HarnessContext): boolean => {
+    const cfg = loadJson(ctx);
+    return (
+        Array.isArray(cfg.plugin) &&
+        (cfg.plugin as string[]).some(
+            (p) => typeof p === "string" && p.includes(PLUGIN_SPEC),
+        )
+    );
+};
+
+const result = (ctx: HarnessContext): HarnessResult => {
+    const cfg = loadJson(ctx);
+    const provider = (cfg.provider as Record<string, unknown>)?.[PROVIDER] as
+        | Record<string, unknown>
+        | undefined;
+    const options = provider?.options as Record<string, unknown> | undefined;
+    const configured =
+        typeof options?.baseURL === "string" &&
+        options.baseURL === `${BASE_URL}/v1` &&
+        typeof options.apiKey === "string" &&
+        (options.apiKey as string).length > 5;
+    const prefix = `${PROVIDER}/`;
+    const model =
+        typeof cfg.model === "string" && cfg.model.startsWith(prefix)
+            ? cfg.model.slice(prefix.length)
+            : undefined;
+    return {
+        harness: ID,
+        label: LABEL,
+        configured,
+        model,
+        mcp: hasPlugin(ctx),
+        files: files(ctx),
+    };
+};
+
+// Check PATH without spawning a shell.
+const isInstalled = (): boolean => {
+    const pathEnv = process.env.PATH ?? "";
+    const dirs = pathEnv.split(process.platform === "win32" ? ";" : ":");
+    const exts = process.platform === "win32" ? [".cmd", ".exe", ""] : [""];
+    return dirs.some((dir) =>
+        exts.some((ext) => existsSync(join(dir, `opencode${ext}`))),
+    );
+};
+
+export const configureOpenCode = (
+    ctx: HarnessContext,
+    settings: OcSettings,
+): HarnessResult => {
+    applyWithSnapshot(ctx, ID, files(ctx), () => writeConfig(ctx, settings));
+    return result(ctx);
+};
+
+export const disableOpenCode = (ctx: HarnessContext): HarnessResult => {
+    const managedFiles = files(ctx);
+    let outcome: HarnessResult["outcome"] = "restored";
+    if (restoreSnapshot(ctx, ID, managedFiles) !== "restored") {
+        outcome = stripConfig(ctx) ? "stripped" : "unchanged";
+        clearSnapshot(ctx, ID, managedFiles);
+    }
+    return { ...result(ctx), configured: false, outcome };
+};
+
+export const opencode: HarnessAdapter = {
+    id: ID,
+    label: LABEL,
+    description: "Configure OpenCode as a Pollinations provider",
+    restartHint: "Restart OpenCode for the changes to take effect.",
+
+    async on(ctx, options) {
+        const model = options.model ?? DEFAULT_MODEL;
+        const models = await fetchHarnessModels();
+        if (!models.some((m) => m.id === model)) {
+            throw new Error(
+                `Model "${model}" is not a tool-calling text model. Run: polli models`,
+            );
+        }
+
+        if (!isInstalled()) {
+            printInfo(
+                `OpenCode not found. Install it with: npm install -g opencode-ai`,
+            );
+            printInfo(`Or visit ${INSTALL_URL} for other install options.`);
+        }
+
+        const apiKey = await resolveHarnessKey(
+            { id: ID, label: LABEL, existingKey: readKey(ctx) },
+            { browser: options.browser },
+        );
+        return configureOpenCode(ctx, {
+            apiKey,
+            model,
+            models,
+            mcp: options.mcp,
+        });
+    },
+
+    off: disableOpenCode,
+    status: result,
+};

--- a/packages/polli-cli/src/harnesses/snapshot.ts
+++ b/packages/polli-cli/src/harnesses/snapshot.ts
@@ -1,0 +1,144 @@
+import { createHash } from "node:crypto";
+import { join } from "node:path";
+import { readTextIfExists, removeIfExists, writeTextAtomic } from "./fs.js";
+import type { HarnessContext } from "./types.js";
+
+interface FileSnapshot {
+    /** Content before the first `on`; null when the file did not exist. */
+    before: string | null;
+    /** Digest after the last `on`, used to detect edits without copying secrets. */
+    afterHash: string | null;
+}
+
+interface Snapshot {
+    complete: boolean;
+    files: Record<string, FileSnapshot>;
+}
+
+type RestoreOutcome = "restored" | "modified" | "missing";
+
+const sha256 = (content: string) =>
+    createHash("sha256").update(content).digest("hex");
+
+// Keyed by the file set, so `off` after moving the harness home (e.g. a
+// different DSH_HOME) never restores a backup taken for other files.
+const snapshotPath = (ctx: HarnessContext, id: string, paths: string[]) => {
+    const key = sha256(paths.join("\n")).slice(0, 12);
+    return join(ctx.home, ".pollinations", "harnesses", `${id}.${key}.json`);
+};
+
+const contentHash = (content: string | null) =>
+    content === null ? null : sha256(content);
+
+const writeSnapshot = (
+    ctx: HarnessContext,
+    id: string,
+    paths: string[],
+    snapshot: Snapshot,
+) =>
+    writeTextAtomic(
+        snapshotPath(ctx, id, paths),
+        JSON.stringify(snapshot, null, 2),
+        0o600,
+    );
+
+const captureFiles = (paths: string[]) =>
+    Object.fromEntries(
+        paths.map((path) => [
+            path,
+            { before: readTextIfExists(path), afterHash: null },
+        ]),
+    );
+
+const restoreFiles = (files: Record<string, FileSnapshot>) => {
+    for (const [path, file] of Object.entries(files)) {
+        if (file.before === null) removeIfExists(path);
+        else writeTextAtomic(path, file.before);
+    }
+};
+
+const loadSnapshot = (
+    ctx: HarnessContext,
+    id: string,
+    paths: string[],
+): Snapshot | null => {
+    const text = readTextIfExists(snapshotPath(ctx, id, paths));
+    if (!text) return null;
+    return JSON.parse(text) as Snapshot;
+};
+
+/**
+ * Apply a config update with a persisted pre-change snapshot. A failed update
+ * is rolled back immediately; a successful update stays reversible with `off`.
+ */
+export const applyWithSnapshot = (
+    ctx: HarnessContext,
+    id: string,
+    paths: string[],
+    apply: () => void,
+): void => {
+    const existing = loadSnapshot(ctx, id, paths);
+    const rollback = captureFiles(paths);
+    const snapshot = existing ?? {
+        complete: false,
+        files: rollback,
+    };
+
+    if (!existing) writeSnapshot(ctx, id, paths, snapshot);
+
+    try {
+        apply();
+    } catch (error) {
+        try {
+            restoreFiles(rollback);
+            if (!existing) clearSnapshot(ctx, id, paths);
+        } catch (rollbackError) {
+            throw new AggregateError(
+                [error, rollbackError],
+                "Harness setup failed and its config could not be restored",
+            );
+        }
+        throw error;
+    }
+
+    for (const path of paths) {
+        snapshot.files[path].afterHash = contentHash(readTextIfExists(path));
+    }
+    snapshot.complete = true;
+    writeSnapshot(ctx, id, paths, snapshot);
+};
+
+/** Put the files back byte-for-byte, unless something else edited them since `on`. */
+export const restoreSnapshot = (
+    ctx: HarnessContext,
+    id: string,
+    paths: string[],
+): RestoreOutcome => {
+    const snapshot = loadSnapshot(ctx, id, paths);
+    if (!snapshot) return "missing";
+
+    if (!snapshot.complete) {
+        restoreFiles(snapshot.files);
+        removeIfExists(snapshotPath(ctx, id, paths));
+        return "restored";
+    }
+
+    const entries = Object.entries(snapshot.files);
+    if (
+        entries.some(
+            ([path, file]) =>
+                contentHash(readTextIfExists(path)) !== file.afterHash,
+        )
+    ) {
+        return "modified";
+    }
+    restoreFiles(snapshot.files);
+    removeIfExists(snapshotPath(ctx, id, paths));
+    return "restored";
+};
+
+export const clearSnapshot = (
+    ctx: HarnessContext,
+    id: string,
+    paths: string[],
+) => removeIfExists(snapshotPath(ctx, id, paths));

--- a/packages/polli-cli/src/harnesses/types.ts
+++ b/packages/polli-cli/src/harnesses/types.ts
@@ -1,0 +1,41 @@
+export interface HarnessContext {
+    /** Home directory harness configs are resolved against. */
+    home: string;
+    env: NodeJS.ProcessEnv;
+}
+
+export interface HarnessOnOptions {
+    model?: string;
+    browser?: boolean;
+    mcp?: boolean;
+}
+
+export interface HarnessModel {
+    id: string;
+    contextWindow: number;
+    /** Input modalities the model accepts, e.g. ["text", "image"]. */
+    input: string[];
+}
+
+export type OffOutcome = "restored" | "stripped" | "unchanged";
+
+export interface HarnessResult {
+    harness: string;
+    label: string;
+    configured: boolean;
+    model?: string;
+    mcp?: boolean;
+    files: string[];
+    outcome?: OffOutcome;
+}
+
+/** One harness integration. Each adapter owns its setup strategy. */
+export interface HarnessAdapter {
+    id: string;
+    label: string;
+    description: string;
+    restartHint: string;
+    on(ctx: HarnessContext, options: HarnessOnOptions): Promise<HarnessResult>;
+    off(ctx: HarnessContext): Promise<HarnessResult> | HarnessResult;
+    status(ctx: HarnessContext): Promise<HarnessResult> | HarnessResult;
+}

--- a/packages/polli-cli/src/index.ts
+++ b/packages/polli-cli/src/index.ts
@@ -2,9 +2,12 @@ import { readFileSync } from "node:fs";
 import chalk from "chalk";
 import { Command } from "commander";
 
+import { agentsCommand } from "./commands/agents.js";
 import { authCommand } from "./commands/auth.js";
 import { docsCommand } from "./commands/docs.js";
+import { earningsCommand } from "./commands/earnings.js";
 import { createGenCommand } from "./commands/gen/index.js";
+import { harnessCommand } from "./commands/harness.js";
 import { keysCommand } from "./commands/keys.js";
 import { modelsCommand } from "./commands/models.js";
 import { myModelsCommand } from "./commands/my-models.js";
@@ -62,8 +65,13 @@ program
 program.addCommand(authCommand);
 program.addCommand(keysCommand);
 program.addCommand(usageCommand);
+program.addCommand(earningsCommand);
 program.addCommand(questsCommand);
+program.addCommand(agentsCommand);
 program.addCommand(myModelsCommand);
+
+// Coding harness integrations
+program.addCommand(harnessCommand);
 
 // Generation
 program.addCommand(createGenCommand());

--- a/packages/polli-cli/src/lib/api.ts
+++ b/packages/polli-cli/src/lib/api.ts
@@ -1,5 +1,5 @@
 import { BASE_URL, resolveApiKey } from "./config.js";
-import { printError } from "./output.js";
+import { fail, printError } from "./output.js";
 
 export class ApiError extends Error {
     constructor(
@@ -15,10 +15,9 @@ export const requireKey = (): string => {
     const key = resolveApiKey();
     if (!key) {
         printError("Not logged in. Run: polli auth login");
-        printError(
+        fail(
             "Or pipe a key: printf '%s' '<your-key>' | polli auth login --with-token",
         );
-        process.exit(1);
     }
     return key;
 };

--- a/packages/polli-cli/src/lib/errors.ts
+++ b/packages/polli-cli/src/lib/errors.ts
@@ -1,4 +1,6 @@
-import { gen, requireKey } from "./api.js";
+import { ApiError, gen, requireKey } from "./api.js";
+import { BASE_URL } from "./config.js";
+import { printError } from "./output.js";
 
 // Returns null for non-402 so callers fall through to their generic error path.
 export async function budgetHint(
@@ -19,4 +21,28 @@ export async function budgetHint(
     if (balance != null) lines.push(`Account balance: ${balance} pollen`);
     lines.push(`Server said: ${bodyText}`);
     return lines.join("\n");
+}
+
+export async function fetchGen(
+    path: string,
+    init: RequestInit = {},
+): Promise<Response> {
+    const headers = new Headers(init.headers);
+    headers.set("Authorization", `Bearer ${requireKey()}`);
+    const response = await fetch(`${BASE_URL}${path}`, {
+        ...init,
+        headers,
+    });
+    if (response.ok) return response;
+
+    const body = await response.text().catch(() => "");
+    const message =
+        (await budgetHint(response.status, body)) ??
+        `${response.status} ${response.statusText}: ${body}`;
+    throw new ApiError(response.status, message);
+}
+
+export function exitWithError(error: unknown): never {
+    printError(error instanceof Error ? error.message : "unknown error");
+    process.exit(1);
 }

--- a/packages/polli-cli/src/lib/output.ts
+++ b/packages/polli-cli/src/lib/output.ts
@@ -122,6 +122,16 @@ export const printError = (msg: string) => {
     process.stderr.write(`${chalk.red.bold("error:")} ${chalk.red(msg)}\n`);
 };
 
+/** Print a fatal command error and terminate with the CLI's standard exit code. */
+export const fail = (message: string, error?: unknown): never => {
+    const detail =
+        error === undefined
+            ? ""
+            : `: ${error instanceof Error ? error.message : "unknown"}`;
+    printError(`${message}${detail}`);
+    process.exit(1);
+};
+
 /** Warning message — always shown, always stderr */
 export const printWarn = (msg: string) => {
     process.stderr.write(

--- a/packages/polli-cli/src/raw.d.ts
+++ b/packages/polli-cli/src/raw.d.ts
@@ -1,0 +1,4 @@
+declare module "*.md?raw" {
+    const content: string;
+    export default content;
+}

--- a/packages/polli-cli/tsup.config.ts
+++ b/packages/polli-cli/tsup.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     dts: true,
     sourcemap: true,
     splitting: false,
+    loader: { ".md": "text" },
     noExternal: [],
     external: ["@modelcontextprotocol/sdk", "zod"],
 });


### PR DESCRIPTION
Fixes #14118

## What this adds

`polli harness opencode on/off/status` — wires OpenCode to Pollinations without a second login inside OpenCode.

### How it works

- Writes a `provider.pollinations` block to `~/.config/opencode/opencode.json` (or `$OPENCODE_CONFIG_DIR/opencode.json`). The provider uses the `@ai-sdk/openai-compatible` npm package pointing at `gen.pollinations.ai/v1`.
- Mints a dedicated child key via `polli login`; the `opencode-pollinations-plugin` reads it from `provider.pollinations.options.apiKey` — no `/poll login` needed inside OpenCode.
- Fetches the current tool-calling text models from the Pollinations catalog and writes them all to the provider's `models` map (with context windows and vision flags).
- Sets the top-level `model` key to the chosen default (`--model` flag, default: `openai`).
- Adds `opencode-pollinations-plugin` to the `plugin` array for media generation, usage tracking, and quest capabilities. Skip with `--no-mcp`.
- Detects missing OpenCode binary and prints the install command (`npm install -g opencode-ai`).
- Preserves all unrelated OpenCode config. `off` restores the snapshot byte-for-byte, or surgically strips only Pollinations-owned keys if the config was edited after `on`.

### Acceptance criteria mapping

| Requirement | How met |
|---|---|
| `polli harness opencode on` leaves user ready | Provider + models + plugin written in one command |
| Install experience if OpenCode missing | PATH check → prints install command |
| Polli login creates a dedicated key; no second login | `resolveHarnessKey` mints `polli-harness-opencode`; plugin reads key from config |
| Pollinations text models available + default selectable | Fetched from `/v1/models`, all tool-calling models written; `--model` flag |
| Existing plugin enabled | `opencode-pollinations-plugin` added to `plugin` array |
| Existing config unchanged | JSON merge preserves all other keys |
| `status` reports ready state | Returns `configured: true` when provider + key present |
| `off` removes only Pollinations config | Snapshot restore or surgical strip |
| Docs | README.md + SKILL.md updated |

### Files changed

- `packages/polli-cli/src/harnesses/opencode.ts` — new adapter (170 lines)
- `packages/polli-cli/src/harnesses/opencode.test.ts` — 15 unit tests (all pass)
- `packages/polli-cli/src/harnesses/index.ts` — register opencode in HARNESSES
- `packages/polli-cli/README.md` — document opencode harness commands
- `packages/polli-cli/SKILL.md` — update harness quick-reference and recipe

### Tests

All 39 tests pass (24 existing + 15 new opencode tests):
```
Test Files  6 passed (6)
     Tests  39 passed (39)
  Duration  367ms
```

### Relevant background

Experience: implemented this after reading the plugin source (`generate-config.ts`), which reveals that the plugin reads `provider.pollinations.options.apiKey` from `opencode.json` as a key source fallback — making it possible to pre-configure the key from the harness without a separate plugin login flow.