### PR TITLE
feat(cli): add Prime Agent harness profile

### DIFF
--- a/CODING_HARNESSES.md
+++ b/CODING_HARNESSES.md
@@ -1,0 +1,64 @@
+# Coding Harnesses
+
+Coding harnesses — agentic coding tools such as DeepSeek Harness, OpenCode, Pi, or OpenClaw — can run with Pollinations. `polli harness` uses the integration each harness supports: a direct provider configuration or a dedicated plugin.
+
+## Connect a harness
+
+```bash
+npx @pollinations/cli harness dsh on    # DeepSeek Harness
+npx @pollinations/cli harness prime on  # Prime Agent
+```
+
+For DeepSeek Harness, `on`:
+
+1. Logs you in with the browser device flow if `polli` has no stored key (`polli auth login`).
+2. Mints a secret key named `polli-harness-dsh`. A still-valid key already in the DSH config is reused.
+3. Loads `GET /v1/models` and registers every first-party text model with tool calling.
+4. Saves a private snapshot before changing any DSH files.
+5. Enables the hosted Pollinations MCP so DSH can generate images, audio, and video as native tools.
+6. Installs the packaged `polli` skill globally for DSH.
+
+```bash
+polli harness --help                  # supported harnesses
+polli harness dsh on --model kimi     # pick the default model (default: deepseek)
+polli harness dsh on --no-mcp         # configure the provider and skill without MCP tools
+polli harness dsh on --no-browser     # print the login URL instead of opening it
+polli harness dsh status
+polli harness dsh off                 # remove Pollinations again
+
+polli harness prime on                # Prime Agent → Pollinations (default model: openai)
+polli harness prime on --model kimi   # choose a different default model
+polli harness prime on --no-browser   # print the login URL instead of opening it
+polli harness prime status
+polli harness prime off               # remove Pollinations from Prime Agent
+```
+
+For Prime Agent, `on`:
+
+1. Checks that Prime Agent (`pi`) is installed. If not, prints the install command.
+2. Logs you in with the browser device flow if `polli` has no stored key.
+3. Mints a secret key named `polli-harness-prime`. A still-valid key already in the config is reused.
+4. Loads `GET /v1/models` and registers every first-party text model with tool calling. The chosen model sorts first so Prime Agent's `/model` picker surfaces it.
+5. Saves a private snapshot before changing any Prime Agent files.
+6. Installs the packaged `polli` skill globally for Prime Agent.
+
+If Prime Agent is not installed, run:
+
+```bash
+curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh
+```
+
+`off` restores the backed-up files byte-for-byte when they are unchanged since `on` (`outcome: restored`). If you edited them in between, or the harness home moved, only the Pollinations entries are removed (`stripped`). A harness that was never on reports `unchanged`.
+
+The account key stored by `polli auth login` is never written into a harness; each harness gets its own child key, so revoking it (`polli keys revoke <id>`) does not affect anything else.
+
+## Supported harnesses
+
+| Harness | Command | Files | Notes |
+| --- | --- | --- | --- |
+| [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`) | `polli harness dsh on` | `$DSH_HOME/settings.yaml`, `.env`, `cordis.patch.yml`, and `skills/polli/SKILL.md` (default `~/.dsh`) | Adds the Pollinations provider, hosted Pollinations MCP, and Polli CLI skill globally. One dedicated key in `.env` authenticates both the provider and MCP. Changes apply on the next request. |
+| [Prime Agent](https://github.com/PrimeIntellect-ai/prime-agent) (`prime`) | `polli harness prime on` | `~/.prime/agent/models.json` and `~/.prime/agent/skills/polli/SKILL.md` | Adds the Pollinations provider and Polli CLI skill globally. The API key lives in `models.json` (owner-only). The chosen model sorts first in the provider's model list. Changes apply on the next `pi` session. |
+| [OpenClaw](https://github.com/openclaw/openclaw) | `apps/openclaw/setup-pollinations.sh` | `~/.openclaw/openclaw.json` | Shell script in this repo, not yet a `polli harness` profile. See [apps/openclaw](./apps/openclaw/README.md). |
+| [OpenCode](https://opencode.ai) | `opencode-pollinations-plugin` | `opencode.json`, `auth.json` | Community plugin that registers a Pollinations provider. A future adapter can install OpenCode when missing, enable the plugin, and store a dedicated child key in OpenCode's native auth file. |
+
+Any harness that accepts an OpenAI-compatible chat completions provider works with `base_url = https://gen.pollinations.ai/v1` and `Authorization: Bearer sk_…` set by hand. Codex CLI (needs `/v1/responses`) and Claude Code (needs `/v1/messages`) are not supported until those endpoints exist.

--- a/packages/polli-cli/README.md
+++ b/packages/polli-cli/README.md
@@ -67,7 +67,7 @@ polli docs                   # full API reference in the terminal
 polli docs /image            # one endpoint
 polli docs --open            # open in browser
 polli quests                 # public quest catalog
-polli quests mine            # your completed and earned quest status
+polli quests --claimed       # already-completed and earned quest status
 ```
 
 ## Account
@@ -92,11 +92,64 @@ Keys can't be edited — to change a name, budget, or model list, revoke and rec
 polli usage                  # pollen balance
 polli usage --history        # recent requests
 polli usage --daily          # daily spend
-polli quests mine --completed # completed and earned quests
-polli my-models list         # invite-only community text models
+polli earnings               # developer earnings (default 30 days, --days up to 90)
+polli quests --claimable     # only rewards ready to claim
+polli agents list            # managed prompt agents
+polli my-models list         # invite-only community text, image, and transcription models
 ```
 
+Manage agents with API-shaped JSON config files plus their callable model name
+and catalog title:
+
+```bash
+polli agents get <id>
+polli agents create --config agent.json --name my-agent --title "My Agent"
+polli agents update <id> --config agent.json
+polli agents delete <id>
+```
+
+`agent.json` contains the complete configuration:
+
+```json
+{
+  "systemPrompt": "You are a concise research assistant.",
+  "baseModel": "openai",
+  "mcpServers": ["pollinations"]
+}
+```
+
+Creating an agent also creates its callable model listing. See [Publish an Agent](https://github.com/pollinations/pollinations/blob/main/BUILD_YOUR_OWN_AGENT.md) for visibility, billing, and lifecycle details.
+
 `polli auth login` creates a key with all account permissions Polli needs: `profile`, `usage`, and `keys`. Use `account:usage` for narrow read-only account state like usage and quests. Use `account:keys` to manage keys and, where invite-only My Models access is enabled, my-models. Quest claiming remains in the dashboard.
+
+## Coding harnesses
+
+Point an agentic coding tool at Pollinations. `on` logs in if needed, mints a
+key for the harness, backs up its config, and writes the provider; `off`
+restores the backup.
+
+```bash
+polli harness --help              # supported harnesses
+polli harness dsh on              # DeepSeek Harness → Pollinations (default model: deepseek)
+polli harness dsh on --model kimi
+polli harness dsh on --no-mcp    # skip MCP tool configuration
+polli harness dsh status
+polli harness dsh off
+
+polli harness prime on            # Prime Agent → Pollinations (default model: openai)
+polli harness prime on --model kimi
+polli harness prime status
+polli harness prime off
+```
+
+The DSH adapter configures the Pollinations provider, hosted Pollinations MCP,
+and Polli CLI skill globally under `$DSH_HOME` (default `~/.dsh`).
+
+The Prime adapter registers the Pollinations provider in `~/.prime/agent/models.json`
+and installs the Polli CLI skill in `~/.prime/agent/skills/polli/SKILL.md`. If Prime
+Agent is not installed, `on` prints the install command.
+
+See [Coding Harnesses](https://github.com/pollinations/pollinations/blob/main/CODING_HARNESSES.md) for what each profile changes and how to add one.
 
 ## Links
 

--- a/packages/polli-cli/src/harnesses/index.ts
+++ b/packages/polli-cli/src/harnesses/index.ts
@@ -1,0 +1,5 @@
+import { dsh } from "./dsh.js";
+import { prime } from "./prime.js";
+import type { HarnessAdapter } from "./types.js";
+
+export const HARNESSES: HarnessAdapter[] = [dsh, prime];

--- a/packages/polli-cli/src/harnesses/prime.test.ts
+++ b/packages/polli-cli/src/harnesses/prime.test.ts
@@ -1,0 +1,216 @@
+import {
+    existsSync,
+    mkdirSync,
+    mkdtempSync,
+    readdirSync,
+    readFileSync,
+    rmSync,
+    statSync,
+    unlinkSync,
+    writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { configurePrime, disablePrime, prime } from "./prime.js";
+import type { HarnessContext } from "./types.js";
+
+const models = [
+    { id: "openai", contextWindow: 128000, input: ["text", "image"] },
+    { id: "deepseek", contextWindow: 65536, input: ["text"] },
+];
+const settings = { apiKey: "sk_test_key", model: "openai", models };
+
+let home: string;
+let ctx: HarnessContext;
+
+beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "polli-prime-"));
+    ctx = { home, env: {} };
+});
+
+afterEach(() => rmSync(home, { recursive: true, force: true }));
+
+const modelsFile = () => join(home, ".prime", "agent", "models.json");
+const skillFile = () =>
+    join(home, ".prime", "agent", "skills", "polli", "SKILL.md");
+const snapshotFiles = () => {
+    const dir = join(home, ".pollinations", "harnesses");
+    return existsSync(dir)
+        ? readdirSync(dir).filter((f) => f.startsWith("prime."))
+        : [];
+};
+const read = (path: string) => readFileSync(path, "utf-8");
+
+describe("prime harness", () => {
+    it("writes the provider and skill from scratch", () => {
+        const result = configurePrime(ctx, settings);
+        expect(result).toMatchObject({
+            harness: "prime",
+            configured: true,
+            model: "openai",
+        });
+
+        const doc = JSON.parse(read(modelsFile()));
+        const provider = doc.providers.pollinations;
+        expect(provider).toMatchObject({
+            api: "openai-completions",
+            apiKey: "sk_test_key",
+            baseUrl: "https://gen.pollinations.ai/v1",
+        });
+        expect(provider.compat).toMatchObject({
+            supportsDeveloperRole: false,
+            supportsReasoningEffort: true,
+            supportsUsageInStreaming: true,
+        });
+        expect(provider.models.map((m: { id: string }) => m.id)).toEqual([
+            "openai",
+            "deepseek",
+        ]);
+        expect(read(skillFile())).toContain("name: polli");
+        expect(statSync(modelsFile()).mode & 0o777).toBe(0o600);
+        expect(statSync(skillFile()).mode & 0o777).toBe(0o600);
+        expect(prime.status(ctx)).toMatchObject({
+            configured: true,
+            model: "openai",
+        });
+    });
+
+    it("sorts the chosen model first in the models list", () => {
+        configurePrime(ctx, { ...settings, model: "deepseek" });
+        const doc = JSON.parse(read(modelsFile()));
+        const ids = doc.providers.pollinations.models.map(
+            (m: { id: string }) => m.id,
+        );
+        expect(ids[0]).toBe("deepseek");
+        expect(ids).toContain("openai");
+        expect(prime.status(ctx).model).toBe("deepseek");
+    });
+
+    it("preserves existing models.json entries and other providers", () => {
+        mkdirSync(join(home, ".prime", "agent"), { recursive: true });
+        writeFileSync(
+            modelsFile(),
+            JSON.stringify({
+                providers: {
+                    anthropic: { baseUrl: "https://api.anthropic.com" },
+                },
+            }),
+        );
+
+        configurePrime(ctx, settings);
+
+        const doc = JSON.parse(read(modelsFile()));
+        expect(doc.providers.anthropic).toEqual({
+            baseUrl: "https://api.anthropic.com",
+        });
+        expect(doc.providers.pollinations).toBeDefined();
+    });
+
+    it("restores original files byte-for-byte on off", () => {
+        mkdirSync(join(home, ".prime", "agent"), { recursive: true });
+        const original = JSON.stringify({ providers: { anthropic: {} } });
+        writeFileSync(modelsFile(), original);
+
+        configurePrime(ctx, settings);
+        expect(snapshotFiles()).toHaveLength(1);
+        const result = disablePrime(ctx);
+
+        expect(result.outcome).toBe("restored");
+        expect(read(modelsFile())).toBe(original);
+        expect(existsSync(skillFile())).toBe(false);
+        expect(snapshotFiles()).toHaveLength(0);
+        expect(prime.status(ctx).configured).toBe(false);
+    });
+
+    it("strips only Pollinations entries when config changed since on", () => {
+        configurePrime(ctx, settings);
+
+        const doc = JSON.parse(read(modelsFile()));
+        doc.providers.local = { baseUrl: "http://localhost:11434/v1" };
+        writeFileSync(modelsFile(), JSON.stringify(doc, null, 2));
+
+        const result = disablePrime(ctx);
+
+        expect(result.outcome).toBe("stripped");
+        const updated = JSON.parse(read(modelsFile()));
+        expect(updated.providers.local).toBeDefined();
+        expect(updated.providers.pollinations).toBeUndefined();
+        expect(existsSync(skillFile())).toBe(false);
+        expect(snapshotFiles()).toHaveLength(0);
+    });
+
+    it("reports unchanged when off runs on a harness that was never on", () => {
+        expect(disablePrime(ctx).outcome).toBe("unchanged");
+    });
+
+    it("re-running on updates the model list and keeps the pre-on backup", () => {
+        configurePrime(ctx, settings);
+        const newModels = [
+            { id: "openai", contextWindow: 200000, input: ["text", "image"] },
+        ];
+        configurePrime(ctx, {
+            apiKey: "sk_test_key",
+            model: "openai",
+            models: newModels,
+        });
+
+        const doc = JSON.parse(read(modelsFile()));
+        expect(doc.providers.pollinations.models).toHaveLength(1);
+        expect(doc.providers.pollinations.models[0].contextWindow).toBe(200000);
+
+        disablePrime(ctx);
+        expect(existsSync(modelsFile())).toBe(false);
+    });
+
+    it("reports unconfigured when models.json is missing", () => {
+        expect(prime.status(ctx).configured).toBe(false);
+    });
+
+    it("reports unconfigured when the skill file is missing", () => {
+        configurePrime(ctx, settings);
+        unlinkSync(skillFile());
+        expect(prime.status(ctx).configured).toBe(false);
+    });
+
+    it("reports unconfigured when models.json is corrupt JSON", () => {
+        mkdirSync(join(home, ".prime", "agent"), { recursive: true });
+        writeFileSync(modelsFile(), "{bad json");
+        expect(prime.status(ctx).configured).toBe(false);
+    });
+
+    it("reports unconfigured when the api key is empty", () => {
+        configurePrime(ctx, settings);
+        const doc = JSON.parse(read(modelsFile()));
+        doc.providers.pollinations.apiKey = "";
+        writeFileSync(modelsFile(), JSON.stringify(doc, null, 2));
+        expect(prime.status(ctx).configured).toBe(false);
+    });
+
+    it("throws on corrupt models.json during on", () => {
+        mkdirSync(join(home, ".prime", "agent"), { recursive: true });
+        writeFileSync(modelsFile(), "{bad");
+        expect(() => configurePrime(ctx, settings)).toThrow();
+    });
+
+    it("preserves a corrupt snapshot and refuses to disable", () => {
+        configurePrime(ctx, settings);
+        const snapshot = join(
+            home,
+            ".pollinations",
+            "harnesses",
+            snapshotFiles()[0],
+        );
+        writeFileSync(snapshot, "{");
+        expect(() => disablePrime(ctx)).toThrow();
+        expect(snapshotFiles()).toHaveLength(1);
+        expect(prime.status(ctx).configured).toBe(true);
+    });
+
+    it("keeps one backup per home location", () => {
+        configurePrime(ctx, settings);
+        expect(snapshotFiles()).toHaveLength(1);
+        expect(disablePrime(ctx).outcome).toBe("restored");
+        expect(snapshotFiles()).toHaveLength(0);
+    });
+});

--- a/packages/polli-cli/src/harnesses/prime.ts
+++ b/packages/polli-cli/src/harnesses/prime.ts
@@ -1,0 +1,249 @@
+import { execSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import polliSkill from "../../SKILL.md?raw";
+import { BASE_URL } from "../lib/config.js";
+import { readTextIfExists, removeIfExists, writeTextAtomic } from "./fs.js";
+import { resolveHarnessKey } from "./keys.js";
+import { fetchHarnessModels } from "./models.js";
+import {
+    applyWithSnapshot,
+    clearSnapshot,
+    restoreSnapshot,
+} from "./snapshot.js";
+import type {
+    HarnessAdapter,
+    HarnessContext,
+    HarnessModel,
+    HarnessResult,
+} from "./types.js";
+
+const ID = "prime";
+const LABEL = "Prime Agent";
+const PROVIDER = "pollinations";
+const DEFAULT_MODEL = "openai";
+const INSTALL_CMD =
+    "curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh";
+
+export const primeHome = (ctx: HarnessContext) =>
+    join(ctx.home, ".prime", "agent");
+
+const modelsPath = (ctx: HarnessContext) => join(primeHome(ctx), "models.json");
+
+const skillPath = (ctx: HarnessContext) =>
+    join(primeHome(ctx), "skills", "polli", "SKILL.md");
+
+const files = (ctx: HarnessContext) => [modelsPath(ctx), skillPath(ctx)];
+
+const isPrimeInstalled = (ctx: HarnessContext): boolean => {
+    if (existsSync(join(ctx.home, ".prime"))) return true;
+    try {
+        execSync("command -v pi", {
+            stdio: "ignore",
+            shell: true,
+            timeout: 3000,
+        });
+        return true;
+    } catch {
+        return false;
+    }
+};
+
+const readKey = (ctx: HarnessContext): string | null => {
+    const text = readTextIfExists(modelsPath(ctx));
+    if (!text) return null;
+    try {
+        const doc = JSON.parse(text) as {
+            providers?: Record<string, { apiKey?: unknown }>;
+        };
+        const key = doc.providers?.[PROVIDER]?.apiKey;
+        return typeof key === "string" && key.length > 0 ? key : null;
+    } catch {
+        return null;
+    }
+};
+
+// The chosen default model sorts first so Prime Agent's model picker surfaces it.
+const providerEntry = (
+    apiKey: string,
+    models: HarnessModel[],
+    defaultModel: string,
+) => {
+    const sorted = [
+        ...models.filter((m) => m.id === defaultModel),
+        ...models.filter((m) => m.id !== defaultModel),
+    ];
+    return {
+        baseUrl: `${BASE_URL}/v1`,
+        api: "openai-completions",
+        apiKey,
+        compat: {
+            supportsDeveloperRole: false,
+            supportsReasoningEffort: true,
+            supportsUsageInStreaming: true,
+            supportsStrictMode: false,
+        },
+        models: sorted.map((m) => ({
+            id: m.id,
+            name: m.id,
+            contextWindow: m.contextWindow,
+            input: m.input,
+        })),
+    };
+};
+
+interface PrimeSettings {
+    apiKey: string;
+    model: string;
+    models: HarnessModel[];
+}
+
+const writeConfig = (ctx: HarnessContext, settings: PrimeSettings) => {
+    const existing: Record<string, unknown> = (() => {
+        const text = readTextIfExists(modelsPath(ctx));
+        if (!text) return {};
+        try {
+            return JSON.parse(text) as Record<string, unknown>;
+        } catch {
+            throw new Error(
+                `${modelsPath(ctx)} is not valid JSON — fix it before running on`,
+            );
+        }
+    })();
+
+    const providers =
+        (existing.providers as Record<string, unknown> | undefined) ?? {};
+    providers[PROVIDER] = providerEntry(
+        settings.apiKey,
+        settings.models,
+        settings.model,
+    );
+    existing.providers = providers;
+
+    writeTextAtomic(
+        modelsPath(ctx),
+        `${JSON.stringify(existing, null, 2)}\n`,
+        0o600,
+    );
+    if (readTextIfExists(skillPath(ctx)) === null) {
+        writeTextAtomic(skillPath(ctx), polliSkill, 0o600);
+    }
+};
+
+const stripConfig = (ctx: HarnessContext): boolean => {
+    let changed = false;
+    const text = readTextIfExists(modelsPath(ctx));
+    if (text) {
+        try {
+            const doc = JSON.parse(text) as {
+                providers?: Record<string, unknown>;
+            };
+            if (doc.providers && PROVIDER in doc.providers) {
+                delete doc.providers[PROVIDER];
+                writeTextAtomic(
+                    modelsPath(ctx),
+                    `${JSON.stringify(doc, null, 2)}\n`,
+                    0o600,
+                );
+                changed = true;
+            }
+        } catch {
+            // Leave corrupt files alone — user must fix manually.
+        }
+    }
+    if (readTextIfExists(skillPath(ctx)) === polliSkill) {
+        removeIfExists(skillPath(ctx));
+        changed = true;
+    }
+    return changed;
+};
+
+const result = (ctx: HarnessContext): HarnessResult => {
+    let configured = false;
+    let model: string | undefined;
+    const text = readTextIfExists(modelsPath(ctx));
+    if (text) {
+        try {
+            const doc = JSON.parse(text) as {
+                providers?: Record<
+                    string,
+                    {
+                        api?: string;
+                        baseUrl?: string;
+                        apiKey?: string;
+                        models?: Array<{ id: string }>;
+                    }
+                >;
+            };
+            const p = doc.providers?.[PROVIDER];
+            configured =
+                p?.api === "openai-completions" &&
+                p?.baseUrl === `${BASE_URL}/v1` &&
+                typeof p?.apiKey === "string" &&
+                p.apiKey.length > 0 &&
+                readTextIfExists(skillPath(ctx)) !== null;
+            model = p?.models?.[0]?.id;
+        } catch {
+            // JSON parse error → not configured
+        }
+    }
+    return {
+        harness: ID,
+        label: LABEL,
+        configured,
+        model,
+        files: files(ctx),
+    };
+};
+
+export const configurePrime = (
+    ctx: HarnessContext,
+    settings: PrimeSettings,
+): HarnessResult => {
+    applyWithSnapshot(ctx, ID, files(ctx), () => writeConfig(ctx, settings));
+    return result(ctx);
+};
+
+export const disablePrime = (ctx: HarnessContext): HarnessResult => {
+    const managedFiles = files(ctx);
+    let outcome: HarnessResult["outcome"] = "restored";
+    if (restoreSnapshot(ctx, ID, managedFiles) !== "restored") {
+        outcome = stripConfig(ctx) ? "stripped" : "unchanged";
+        clearSnapshot(ctx, ID, managedFiles);
+    }
+    return { ...result(ctx), configured: false, outcome };
+};
+
+export const prime: HarnessAdapter = {
+    id: ID,
+    label: LABEL,
+    description: "Configure Prime Agent as a Pollinations provider",
+    restartHint:
+        "Changes apply on the next Prime Agent session. Start it with: pi",
+
+    async on(ctx, options) {
+        if (!isPrimeInstalled(ctx)) {
+            throw new Error(
+                `Prime Agent (pi) is not installed.\nInstall it with: ${INSTALL_CMD}`,
+            );
+        }
+
+        const model = options.model ?? DEFAULT_MODEL;
+        const models = await fetchHarnessModels();
+        if (!models.some((m) => m.id === model)) {
+            throw new Error(
+                `Model "${model}" is not a tool-calling text model. Run: polli models`,
+            );
+        }
+
+        const apiKey = await resolveHarnessKey(
+            { id: ID, label: LABEL, existingKey: readKey(ctx) },
+            { browser: options.browser },
+        );
+
+        return configurePrime(ctx, { apiKey, model, models });
+    },
+
+    off: disablePrime,
+    status: result,
+};


### PR DESCRIPTION
## Summary

- Adds `polli harness prime on|off|status` to configure [Prime Agent](https://github.com/PrimeIntellect-ai/prime-agent) (`pi`) as a Pollinations provider
- Writes provider config to `~/.prime/agent/models.json`, merging with existing providers; installs Polli skill in `~/.prime/agent/skills/polli/SKILL.md`
- Mints a dedicated `polli-harness-prime` child key; reuses a still-valid stored key
- Chosen model sorts first in the provider's model list (Prime Agent's `/model` picker respects order)
- Snapshots files before changes; `off` restores byte-for-byte or surgically strips Pollinations entries
- Detects missing Prime Agent installation and prints the install command
- Extends `CODING_HARNESSES.md` and README with Prime setup, status, model selection, and removal docs

## Tests

14 new passing tests in `prime.test.ts` covering scratch setup, preservation of existing providers/config, byte-for-byte restore, strip on modified config, unchanged outcome, model sorting, corruption handling, and snapshot lifecycle.

Full suite: 39 tests pass (`npm test` in `packages/polli-cli`).

## Background

I reviewed the [Prime Agent custom-provider docs](https://github.com/PrimeIntellect-ai/prime-agent/blob/main/packages/coding-agent/docs/models.md) and [skills docs](https://github.com/PrimeIntellect-ai/prime-agent/blob/main/packages/coding-agent/docs/skills.md) to implement this. Prime Agent uses `~/.prime/agent/models.json` for providers (JSON, not YAML like DSH) and `~/.prime/agent/skills/` for global skills. The API key is stored as a literal value in `models.json` (owner-only, 0o600). A bespoke MCP integration is left for future work per the quest spec.

Fixes #14120