### PR TITLE
feat(cli): add OpenClaw harness to polli CLI

### DIFF
--- a/apps/openclaw/README.md
+++ b/apps/openclaw/README.md
@@ -2,95 +2,54 @@
 
 Use **25+ AI models** as your OpenClaw brain through a single API.
 
-**Kimi K2.5** as default (256K context, vision, tools, reasoning), with DeepSeek, GLM 5, and Claude Haiku as free alternatives. Premium models (Claude Opus, Gemini 3 Pro) available on paid tier.
+**Kimi K2.5** as default (256K context, vision, tools, reasoning), with DeepSeek, GLM 5, and Claude Haiku as free alternatives. Premium models (Claude Opus, Gemini Pro) available on paid tier.
 
 ## Setup
 
-**Step 1:** Get your API key (comes with free credits) at [enter.pollinations.ai](https://enter.pollinations.ai/keys)
-
-**Step 2:** Run the setup script (requires `jq`):
+Install the [Polli CLI](https://www.npmjs.com/package/@pollinations/cli) and run:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/pollinations/pollinations/main/apps/openclaw/setup-pollinations.sh | bash -s -- YOUR_API_KEY
+npm install -g @pollinations/cli
+polli harness openclaw on
 ```
 
-This works for both fresh installs and existing OpenClaw setups. It:
-- Runs `openclaw onboard` for fresh installs (creates config + workspace)
-- Adds the Pollinations provider with 9 models to `~/.openclaw/openclaw.json`
-- Sets Kimi K2.5 as default with DeepSeek + GLM fallbacks
+`polli harness openclaw on` will:
+- Log in and create a dedicated Pollinations API key for OpenClaw
+- Write the Pollinations provider with current models to `~/.openclaw/openclaw.json`
+- Set `kimi` as the default model
+- Install the Polli skill so your agent can generate images, audio, and video
 
-**Step 3 (fresh install only):** Start the gateway:
+Pick a different default model with `--model`:
 
 ```bash
-openclaw gateway start
+polli harness openclaw on --model deepseek
 ```
 
-## Available Models
+Run `openclaw gateway restart` after setup for the new provider to take effect.
 
-Switch models anytime in chat with `/model pollinations/<name>`:
+## Status and removal
 
-| Model | ID | Best for |
+```bash
+polli harness openclaw status   # show whether the integration is ready
+polli harness openclaw off      # remove only Pollinations-owned changes
+```
+
+## Available models
+
+Switch models anytime in chat with `/model pollinations/<name>`. Current models are fetched live from `gen.pollinations.ai/v1/models` during setup. Common choices:
+
+| Model | ID | Notes |
 |---|---|---|
-| **Kimi K2.5** (default) | `pollinations/kimi` | Agentic tasks, vision, reasoning (256K context) |
-| **Kimi K2.6** | `pollinations/kimi-k2.6` | Flagship agentic, vision, reasoning (262K context, paid) |
-| **DeepSeek V4 Flash** | `pollinations/deepseek` | Fast reasoning & tool calling (paid) |
-| **DeepSeek V4 Pro** | `pollinations/deepseek-pro` | Advanced reasoning & coding (paid) |
-| **GLM 5.1** | `pollinations/glm` | Coding, reasoning, agentic workflows |
-| **Gemini + Search** | `pollinations/gemini-search` | Web search grounded answers |
-| **Claude Haiku 4.5** | `pollinations/claude-fast` | Fast with good reasoning |
-| **Claude Opus 4.6** | `pollinations/claude-large` | Most intelligent (paid) |
-| **Gemini 3.1 Pro** | `pollinations/gemini-large` | 1M context (paid) |
+| Kimi K2.5 (default) | `pollinations/kimi` | 256K context, vision, reasoning |
+| DeepSeek V4 Flash | `pollinations/deepseek` | Fast reasoning & tool calling |
+| GLM 5 | `pollinations/glm` | Coding, agentic workflows |
+| Claude Haiku 4.5 | `pollinations/claude-fast` | Fast, good reasoning |
 
-## Manual Setup
-
-If you prefer not to run the script, edit `~/.openclaw/openclaw.json` directly. Add a `pollinations` provider under `models.providers`:
-
-```json
-{
-  "models": {
-    "providers": {
-      "pollinations": {
-        "baseUrl": "https://gen.pollinations.ai/v1",
-        "apiKey": "YOUR_API_KEY",
-        "api": "openai-completions",
-        "models": [
-          {
-            "id": "kimi",
-            "name": "Kimi K2.5",
-            "reasoning": true,
-            "input": ["text", "image"],
-            "contextWindow": 256000,
-            "maxTokens": 8192
-          },
-          {
-            "id": "kimi-k2.6",
-            "name": "Kimi K2.6",
-            "reasoning": true,
-            "input": ["text", "image"],
-            "contextWindow": 262000,
-            "maxTokens": 8192
-          }
-        ]
-      }
-    }
-  }
-}
-```
-
-Then set the default model:
-
-```bash
-openclaw models set pollinations/kimi
-openclaw models fallbacks add pollinations/deepseek
-openclaw models fallbacks add pollinations/glm
-openclaw gateway restart
-```
-
-See all available models at [gen.pollinations.ai/v1/models](https://gen.pollinations.ai/v1/models).
+See the full live list: [gen.pollinations.ai/v1/models](https://gen.pollinations.ai/v1/models)
 
 ## Pollinations Skill (Image/Video/Audio)
 
-The [Pollinations skill on ClawHub](https://github.com/openclaw/skills/blob/main/skills/isaacgounton/pollinations/SKILL.md) gives your agent image, video, and audio generation:
+`polli harness openclaw on` installs the Polli skill automatically. To install it separately:
 
 ```
 /skill install isaacgounton/pollinations

--- a/packages/polli-cli/SKILL.md
+++ b/packages/polli-cli/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: polli
-description: Generate images, text, audio, video, and transcribe speech via the Pollinations API using the polli CLI. Use when asked to generate media, call pollinations.ai, check pollen balance, list models, manage API keys, inspect quests, manage my-models, or run polli commands.
+description: Generate images, text, audio, video, and transcribe speech via the Pollinations API using the polli CLI. Use when asked to generate media, call pollinations.ai, check pollen balance, list models, manage API keys, inspect quests, manage agents or my-models, or run polli commands.
 allowed-tools: Bash(polli *)
 ---
 
 # polli — Pollinations CLI
 
-Thin wrapper around `gen.pollinations.ai`. Generates images, text, audio, video; transcribes speech; manages API keys, usage, quests, and invite-only my-models.
+Thin wrapper around `gen.pollinations.ai`. Generates images, text, audio, video; transcribes speech; manages API keys, usage, quests, agents, and invite-only my-models.
 
-Install: `npm i -g @pollinations/cli@latest` (provides the `polli` binary).
+If `polli` is not installed, run `npm i -g @pollinations/cli@latest` (provides the `polli` binary).
 
 ## When to use this skill
 
@@ -18,6 +18,7 @@ Install: `npm i -g @pollinations/cli@latest` (provides the `polli` binary).
 - User asks about their **pollen balance, usage, or API keys**
 - User wants to **browse or filter available models**
 - User wants to inspect **quests** or manage invite-only **my-models**
+- User wants to create or update a hosted prompt **agent**
 
 ## Quick reference
 
@@ -38,8 +39,11 @@ Install: `npm i -g @pollinations/cli@latest` (provides the `polli` binary).
 | Filter models by type | `polli models --type image` |
 | Model health + latency | `polli models --stats` (default 60m, `--window <min>`) |
 | Check balance | `polli usage` |
+| Developer earnings | `polli earnings` (`--days <n>`, max 90) |
 | List your quests + claim state | `polli quests` (filters: `--open --claimable --claimed --coming-soon`) |
+| Manage prompt agents | `polli agents list` |
 | Manage invite-only community models | `polli my-models list` |
+| Connect a coding harness to Pollinations | `polli harness dsh on` or `polli harness openclaw on` (available adapters: `polli harness --help`) |
 | Machine-readable output | append `--json` to any command |
 
 ## Setup
@@ -145,6 +149,8 @@ Use `--stats` before choosing a model. **Caveat**: the `err%` column counts **5x
 polli usage              # current pollen balance
 polli usage --history    # recent individual requests
 polli usage --daily      # daily cost summary
+polli earnings           # developer earnings total + per-entity breakdown (default 30d)
+polli earnings --days 7  # rolling window, max 90
 polli quests             # your quests + claim state (open/claimable/claimed/coming)
 polli quests --claimable # only rewards ready to claim
 ```
@@ -155,10 +161,38 @@ polli quests --claimable # only rewards ready to claim
 polli my-models list
 polli my-models models --base-url https://api.example.com/v1 --bearer-token "$UPSTREAM_KEY"
 polli my-models create --name my-model --title "My Model" --base-url https://api.example.com/v1 --bearer-token "$UPSTREAM_KEY" --upstream-model gpt-4.1-mini
+polli my-models create --name my-image --title "My Image" --modality image --image-pricing request --completion-image-price 0.01 --base-url https://api.example.com/v1 --bearer-token "$UPSTREAM_KEY" --upstream-model flux
 polli my-models update <id> --description "Updated description"
+polli my-models update <id> --paid-only            # only accept Paid Pollen; --no-paid-only reverts
 polli my-models delete <id>
 ```
-`my-models` manages owned community text models for invite-only accounts. It requires `communityEndpointsAllowed: true` plus a key with `account:keys`, or an authenticated dashboard session through the API. Use `account:usage` for narrow read-only usage and `polli quests`; use both permissions when a client needs both read-only account state and admin operations. Quest claiming is dashboard-only; `polli quests` is read-only and account-aware.
+`my-models` manages owned community text, image, and transcription models. Any account can create private models; `communityEndpointsAllowed: true` is required only to publish them. API keys require `account:keys`. Use `account:usage` for narrow read-only usage and `polli quests`; use both permissions when a client needs both read-only account state and admin operations. Quest claiming is dashboard-only; `polli quests` is read-only and account-aware.
+
+### Register an image my-model
+```bash
+polli my-models test --modality image --base-url https://api.example.com/v1 --bearer-token "$UPSTREAM_KEY" --model image-v1
+polli my-models create --name my-image --title "My Image" --modality image --image-pricing request --completion-image-price 0.01 --input-modalities text,image --base-url https://api.example.com/v1 --bearer-token "$UPSTREAM_KEY" --upstream-model image-v1
+```
+Test before creating. The probe reports the pricing mode it detected and the input modalities it found, including whether the endpoint accepts image edits; pass those back as `--input-modalities text,image` to advertise edit support. `polli my-models list` shows them in the `inputs` column.
+
+Two billing modes: `--image-pricing request` charges `--completion-image-price` per generated image, while `--image-pricing tokens` bills returned token usage per 1M through `--prompt-text-price`, `--prompt-image-price`, and `--completion-image-price`.
+
+Prices only apply to `--visibility public` models. A private model is owner-only and always free, so every price flag above is stored as `0` until you publish — and making a published model private clears its prices again.
+
+`--modality` is fixed at creation — `update` cannot change it.
+
+### Manage agents
+
+```bash
+polli agents list
+polli agents get <id>
+polli agents create --config agent.json --name my-agent --title "My Agent"
+polli agents update <id> --config agent.json
+polli agents delete <id>
+```
+The config file contains `systemPrompt`, `baseModel`, and optional `mcpServers`; create also requires `--name` and `--title` for the callable model listing. The only supported server ID is currently `"pollinations"`. Updates replace the complete agent configuration.
+
+Creating an agent also creates its callable model listing. Managed agents are text-only and free, with no fallbacks or per-user RPM. Deleting the agent also deletes its model listing. See [Publish an Agent](https://github.com/pollinations/pollinations/blob/main/BUILD_YOUR_OWN_AGENT.md).
 
 ### Manage API keys
 ```bash
@@ -169,6 +203,19 @@ polli keys create --name "my-app" --type publishable --redirect-uri https://app.
 polli keys revoke <id>                                             # id comes from `keys list --json`
 ```
 `--permissions <perms...>` scopes what the new key can do on the account (e.g. `profile usage` lets it call `polli --key <new> usage`). **Without `--permissions`, new scoped keys can generate media but cannot read account state** — `polli --key <new> usage` will 403. `"keys"` is auto-stripped from the list so a scoped key can never mint further keys. Existing keys with `account:keys` can manage my-models where that invite-only feature is enabled, but still need `account:usage` for read-only account state. Publishable app keys default developer earnings off; pass `--earnings` to enable them. To inspect a specific key other than the current one, use `polli keys list --json | jq '.[] | select(.id == "<id>")'`. `keys info` is intentionally scoped to the caller's own key.
+
+### Connect a coding harness
+```bash
+polli harness --help                # supported harnesses
+polli harness dsh on                # login if needed, mint key "polli-harness-dsh", write provider + default model
+polli harness dsh on --model kimi   # any tool-calling text model from `polli models`
+polli harness dsh on --no-mcp       # configure the provider and skill without MCP tools
+polli harness dsh off               # restore the config backed up before "on"
+polli harness openclaw on           # OpenClaw integration
+polli harness openclaw on --model deepseek  # any tool-calling text model from `polli models`
+polli harness openclaw off          # restore the config backed up before "on"
+```
+The DSH adapter globally configures the Pollinations provider, hosted Pollinations MCP, and this skill under `$DSH_HOME` (default `~/.dsh`). It stores one dedicated child key in `$DSH_HOME/.env` for the provider and MCP, plus a private snapshot under `~/.pollinations/harnesses/`. Reruns reuse a valid key already in the harness config. The OpenClaw adapter writes `~/.openclaw/openclaw.json` (JSON) with the Pollinations provider block, sets the default model, and installs this skill under `~/.openclaw/skills/polli/SKILL.md`. Other adapters may use their harness's official plugin or installer instead. Guide: `polli docs` section "Coding Harnesses".
 
 ### Read API docs
 ```bash

--- a/packages/polli-cli/src/harnesses/index.ts
+++ b/packages/polli-cli/src/harnesses/index.ts
@@ -1,0 +1,5 @@
+import { dsh } from "./dsh.js";
+import { openclaw } from "./openclaw.js";
+import type { HarnessAdapter } from "./types.js";
+
+export const HARNESSES: HarnessAdapter[] = [dsh, openclaw];

--- a/packages/polli-cli/src/harnesses/openclaw.test.ts
+++ b/packages/polli-cli/src/harnesses/openclaw.test.ts
@@ -1,0 +1,145 @@
+import {
+    existsSync,
+    mkdirSync,
+    mkdtempSync,
+    readdirSync,
+    readFileSync,
+    rmSync,
+    statSync,
+    unlinkSync,
+    writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { configureOpenclaw, disableOpenclaw, openclaw } from "./openclaw.js";
+import type { HarnessContext } from "./types.js";
+
+const models = [
+    { id: "kimi", contextWindow: 256000, input: ["text", "image"] },
+    { id: "deepseek", contextWindow: 1000000, input: ["text"] },
+];
+const settings = { apiKey: "sk_test_key", model: "kimi", models };
+
+let home: string;
+let ctx: HarnessContext;
+
+beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "polli-harness-"));
+    ctx = { home, env: {} };
+});
+
+afterEach(() => rmSync(home, { recursive: true, force: true }));
+
+const configFile = () => join(home, ".openclaw", "openclaw.json");
+const skillFile = () => join(home, ".openclaw", "skills", "polli", "SKILL.md");
+const snapshotFiles = () => {
+    const dir = join(home, ".pollinations", "harnesses");
+    return existsSync(dir)
+        ? readdirSync(dir).filter((f) => f.startsWith("openclaw."))
+        : [];
+};
+const read = (path: string) => readFileSync(path, "utf-8");
+const readJson = (path: string) => JSON.parse(read(path));
+
+describe("openclaw harness", () => {
+    it("writes the provider, skill, and credential from scratch", () => {
+        const result = configureOpenclaw(ctx, settings);
+        expect(result).toMatchObject({
+            harness: "openclaw",
+            configured: true,
+            model: "kimi",
+        });
+
+        const doc = readJson(configFile());
+        const provider = doc.models.providers.pollinations;
+        expect(provider.apiKey).toBe("sk_test_key");
+        expect(provider.baseUrl).toBe("https://gen.pollinations.ai/v1");
+        expect(provider.api).toBe("openai-completions");
+        expect(doc.models.mode).toBe("merge");
+        expect(doc.models.defaultModel).toBe("pollinations/kimi");
+        expect(provider.models.map((m: { id: string }) => m.id)).toEqual([
+            "kimi",
+            "deepseek",
+        ]);
+
+        expect(read(skillFile())).toContain("name: polli");
+        expect(statSync(configFile()).mode & 0o777).toBe(0o600);
+        expect(openclaw.status(ctx)).toMatchObject({
+            configured: true,
+            model: "kimi",
+        });
+    });
+
+    it("keeps existing config entries", () => {
+        mkdirSync(join(home, ".openclaw"), { recursive: true });
+        writeFileSync(
+            configFile(),
+            JSON.stringify(
+                { ui: { theme: "dark" }, other: { setting: 42 } },
+                null,
+                2,
+            ),
+        );
+
+        configureOpenclaw(ctx, settings);
+
+        const doc = readJson(configFile());
+        expect(doc.ui).toEqual({ theme: "dark" });
+        expect(doc.other).toEqual({ setting: 42 });
+        expect(doc.models.providers.pollinations.apiKey).toBe("sk_test_key");
+    });
+
+    it("restores the original files byte-for-byte on off", () => {
+        mkdirSync(join(home, ".openclaw"), { recursive: true });
+        const original = `${JSON.stringify({ existing: true }, null, 2)}\n`;
+        writeFileSync(configFile(), original);
+
+        configureOpenclaw(ctx, settings);
+        expect(snapshotFiles()).toHaveLength(1);
+        const result = disableOpenclaw(ctx);
+
+        expect(result.outcome).toBe("restored");
+        expect(read(configFile())).toBe(original);
+        expect(existsSync(skillFile())).toBe(false);
+        expect(snapshotFiles()).toHaveLength(0);
+        expect(openclaw.status(ctx).configured).toBe(false);
+    });
+
+    it("only strips the Pollinations entries when the config changed since on", () => {
+        configureOpenclaw(ctx, settings);
+        const edited = readJson(configFile());
+        edited["agent-presets"] = { default: "mine" };
+        writeFileSync(configFile(), JSON.stringify(edited, null, 2));
+
+        const result = disableOpenclaw(ctx);
+
+        expect(result.outcome).toBe("stripped");
+        const doc = readJson(configFile());
+        expect(doc["agent-presets"]).toEqual({ default: "mine" });
+        expect(doc.models?.providers?.pollinations).toBeUndefined();
+        expect(doc.models?.mode).toBeUndefined();
+        expect(doc.models?.defaultModel).toBeUndefined();
+        expect(existsSync(skillFile())).toBe(false);
+        expect(snapshotFiles()).toHaveLength(0);
+    });
+
+    it("reports unchanged when off runs on a harness that was never on", () => {
+        expect(disableOpenclaw(ctx).outcome).toBe("unchanged");
+    });
+
+    it("reports unconfigured when the credential is missing", () => {
+        configureOpenclaw(ctx, settings);
+        unlinkSync(configFile());
+        expect(openclaw.status(ctx).configured).toBe(false);
+    });
+
+    it("re-running on switches the model and keeps the pre-on backup", () => {
+        configureOpenclaw(ctx, settings);
+        configureOpenclaw(ctx, { ...settings, model: "deepseek" });
+        expect(openclaw.status(ctx).model).toBe("deepseek");
+
+        disableOpenclaw(ctx);
+        expect(existsSync(configFile())).toBe(false);
+    });
+});

--- a/packages/polli-cli/src/harnesses/openclaw.test.ts
+++ b/packages/polli-cli/src/harnesses/openclaw.test.ts
@@ -12,7 +12,12 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { configureOpenclaw, disableOpenclaw, openclaw } from "./openclaw.js";
+import {
+    configureOpenclaw,
+    disableOpenclaw,
+    openclaw,
+    openclawHome,
+} from "./openclaw.js";
 import type { HarnessContext } from "./types.js";
 
 const models = [
@@ -53,11 +58,12 @@ describe("openclaw harness", () => {
 
         const doc = readJson(configFile());
         const provider = doc.models.providers.pollinations;
-        expect(provider.apiKey).toBe("sk_test_key");
+        expect(provider.apiKey).toBe("${POLLI_OPENCLAW_API_KEY}");
         expect(provider.baseUrl).toBe("https://gen.pollinations.ai/v1");
         expect(provider.api).toBe("openai-completions");
         expect(doc.models.mode).toBe("merge");
-        expect(doc.models.defaultModel).toBe("pollinations/kimi");
+        expect(doc.agents.defaults.model.primary).toBe("pollinations/kimi");
+        expect(doc.env.vars.POLLI_OPENCLAW_API_KEY).toBe("sk_test_key");
         expect(provider.models.map((m: { id: string }) => m.id)).toEqual([
             "kimi",
             "deepseek",
@@ -87,7 +93,10 @@ describe("openclaw harness", () => {
         const doc = readJson(configFile());
         expect(doc.ui).toEqual({ theme: "dark" });
         expect(doc.other).toEqual({ setting: 42 });
-        expect(doc.models.providers.pollinations.apiKey).toBe("sk_test_key");
+        expect(doc.models.providers.pollinations.apiKey).toBe(
+            "${POLLI_OPENCLAW_API_KEY}",
+        );
+        expect(doc.env.vars.POLLI_OPENCLAW_API_KEY).toBe("sk_test_key");
     });
 
     it("restores the original files byte-for-byte on off", () => {
@@ -119,7 +128,8 @@ describe("openclaw harness", () => {
         expect(doc["agent-presets"]).toEqual({ default: "mine" });
         expect(doc.models?.providers?.pollinations).toBeUndefined();
         expect(doc.models?.mode).toBeUndefined();
-        expect(doc.models?.defaultModel).toBeUndefined();
+        expect(doc.agents?.defaults?.model?.primary).toBeUndefined();
+        expect(doc.env?.vars?.POLLI_OPENCLAW_API_KEY).toBeUndefined();
         expect(existsSync(skillFile())).toBe(false);
         expect(snapshotFiles()).toHaveLength(0);
     });
@@ -141,5 +151,22 @@ describe("openclaw harness", () => {
 
         disableOpenclaw(ctx);
         expect(existsSync(configFile())).toBe(false);
+    });
+
+    it("respects OPENCLAW_HOME env var", () => {
+        const customHome = mkdtempSync(join(tmpdir(), "openclaw-home-"));
+        const customCtx: HarnessContext = {
+            home,
+            env: { OPENCLAW_HOME: customHome },
+        };
+        try {
+            expect(openclawHome(customCtx)).toBe(customHome);
+            configureOpenclaw(customCtx, settings);
+            const doc = readJson(join(customHome, "openclaw.json"));
+            expect(doc.env.vars.POLLI_OPENCLAW_API_KEY).toBe("sk_test_key");
+            expect(doc.agents.defaults.model.primary).toBe("pollinations/kimi");
+        } finally {
+            rmSync(customHome, { recursive: true, force: true });
+        }
     });
 });

--- a/packages/polli-cli/src/harnesses/openclaw.ts
+++ b/packages/polli-cli/src/harnesses/openclaw.ts
@@ -1,0 +1,225 @@
+import { join } from "node:path";
+import polliSkill from "../../SKILL.md?raw";
+import { BASE_URL } from "../lib/config.js";
+import { readTextIfExists, removeIfExists, writeTextAtomic } from "./fs.js";
+import { resolveHarnessKey } from "./keys.js";
+import { fetchHarnessModels } from "./models.js";
+import {
+    applyWithSnapshot,
+    clearSnapshot,
+    restoreSnapshot,
+} from "./snapshot.js";
+import type {
+    HarnessAdapter,
+    HarnessContext,
+    HarnessModel,
+    HarnessResult,
+} from "./types.js";
+
+const ID = "openclaw";
+const LABEL = "OpenClaw";
+const PROVIDER = "pollinations";
+const DEFAULT_MODEL = "kimi";
+
+const configPath = (ctx: HarnessContext) =>
+    join(ctx.home, ".openclaw", "openclaw.json");
+const skillPath = (ctx: HarnessContext) =>
+    join(ctx.home, ".openclaw", "skills", "polli", "SKILL.md");
+
+const files = (ctx: HarnessContext) => [configPath(ctx), skillPath(ctx)];
+
+const loadJson = (path: string): Record<string, unknown> => {
+    const text = readTextIfExists(path);
+    if (!text) return {};
+    try {
+        return JSON.parse(text) as Record<string, unknown>;
+    } catch {
+        return {};
+    }
+};
+
+const readKey = (ctx: HarnessContext): string | null => {
+    const config = loadJson(configPath(ctx));
+    try {
+        const key = (
+            (config.models as Record<string, unknown>)?.providers as Record<
+                string,
+                unknown
+            >
+        )?.[PROVIDER] as Record<string, unknown> | undefined;
+        const apiKey = key?.apiKey;
+        return typeof apiKey === "string" && apiKey ? apiKey : null;
+    } catch {
+        return null;
+    }
+};
+
+const providerConfig = (models: HarnessModel[], apiKey: string) => ({
+    baseUrl: `${BASE_URL}/v1`,
+    apiKey,
+    api: "openai-completions",
+    models: models.map((m) => ({
+        id: m.id,
+        name: m.id,
+        reasoning: false,
+        input: m.input,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: m.contextWindow,
+        maxTokens: 8192,
+    })),
+});
+
+interface OpenclawSettings {
+    apiKey: string;
+    model: string;
+    models: HarnessModel[];
+}
+
+const writeConfig = (ctx: HarnessContext, settings: OpenclawSettings) => {
+    const config = loadJson(configPath(ctx));
+    if (!config.models || typeof config.models !== "object") {
+        config.models = {};
+    }
+    const modelsSection = config.models as Record<string, unknown>;
+    if (
+        !modelsSection.providers ||
+        typeof modelsSection.providers !== "object"
+    ) {
+        modelsSection.providers = {};
+    }
+    const providers = modelsSection.providers as Record<string, unknown>;
+    providers[PROVIDER] = providerConfig(settings.models, settings.apiKey);
+    modelsSection.mode = "merge";
+    modelsSection.defaultModel = `${PROVIDER}/${settings.model}`;
+    const text = `${JSON.stringify(config, null, 2)}\n`;
+    writeTextAtomic(configPath(ctx), text, 0o600);
+    if (readTextIfExists(skillPath(ctx)) === null) {
+        writeTextAtomic(skillPath(ctx), polliSkill, 0o600);
+    }
+};
+
+const stripConfig = (ctx: HarnessContext): boolean => {
+    const text = readTextIfExists(configPath(ctx));
+    if (!text) {
+        let changed = false;
+        if (readTextIfExists(skillPath(ctx)) === polliSkill) {
+            removeIfExists(skillPath(ctx));
+            changed = true;
+        }
+        return changed;
+    }
+    let config: Record<string, unknown>;
+    try {
+        config = JSON.parse(text) as Record<string, unknown>;
+    } catch {
+        return false;
+    }
+    let changed = false;
+    const modelsSection = config.models as Record<string, unknown> | undefined;
+    if (modelsSection) {
+        const providers = modelsSection.providers as
+            | Record<string, unknown>
+            | undefined;
+        if (providers && PROVIDER in providers) {
+            delete providers[PROVIDER];
+            changed = true;
+        }
+        if (modelsSection.mode === "merge") {
+            delete modelsSection.mode;
+            changed = true;
+        }
+        const defaultModel = modelsSection.defaultModel;
+        if (
+            typeof defaultModel === "string" &&
+            defaultModel.startsWith(`${PROVIDER}/`)
+        ) {
+            delete modelsSection.defaultModel;
+            changed = true;
+        }
+    }
+    if (changed) {
+        writeTextAtomic(
+            configPath(ctx),
+            `${JSON.stringify(config, null, 2)}\n`,
+            0o600,
+        );
+    }
+    if (readTextIfExists(skillPath(ctx)) === polliSkill) {
+        removeIfExists(skillPath(ctx));
+        changed = true;
+    }
+    return changed;
+};
+
+const result = (ctx: HarnessContext): HarnessResult => {
+    const config = loadJson(configPath(ctx));
+    const modelsSection = config.models as Record<string, unknown> | undefined;
+    const providers = modelsSection?.providers as
+        | Record<string, unknown>
+        | undefined;
+    const provider = providers?.[PROVIDER] as
+        | Record<string, unknown>
+        | undefined;
+    const defaultModel = modelsSection?.defaultModel;
+    const model =
+        typeof defaultModel === "string" &&
+        defaultModel.startsWith(`${PROVIDER}/`)
+            ? defaultModel.slice(PROVIDER.length + 1)
+            : undefined;
+    return {
+        harness: ID,
+        label: LABEL,
+        configured:
+            provider?.baseUrl === `${BASE_URL}/v1` &&
+            provider?.api === "openai-completions" &&
+            readKey(ctx) !== null &&
+            readTextIfExists(skillPath(ctx)) !== null,
+        model,
+        files: files(ctx),
+    };
+};
+
+export const configureOpenclaw = (
+    ctx: HarnessContext,
+    settings: OpenclawSettings,
+): HarnessResult => {
+    applyWithSnapshot(ctx, ID, files(ctx), () => writeConfig(ctx, settings));
+    return result(ctx);
+};
+
+export const disableOpenclaw = (ctx: HarnessContext): HarnessResult => {
+    const managedFiles = files(ctx);
+    let outcome: HarnessResult["outcome"] = "restored";
+    if (restoreSnapshot(ctx, ID, managedFiles) !== "restored") {
+        outcome = stripConfig(ctx) ? "stripped" : "unchanged";
+        clearSnapshot(ctx, ID, managedFiles);
+    }
+    return { ...result(ctx), configured: false, outcome };
+};
+
+export const openclaw: HarnessAdapter = {
+    id: ID,
+    label: LABEL,
+    description: "Configure OpenClaw as a Pollinations provider",
+    restartHint:
+        "Run `openclaw gateway restart` for the new provider to take effect.",
+
+    async on(ctx, options) {
+        const model = options.model ?? DEFAULT_MODEL;
+        const models = await fetchHarnessModels();
+        if (!models.some((candidate) => candidate.id === model)) {
+            throw new Error(
+                `Model "${model}" is not a tool-calling text model. Run: polli models`,
+            );
+        }
+
+        const apiKey = await resolveHarnessKey(
+            { id: ID, label: LABEL, existingKey: readKey(ctx) },
+            { browser: options.browser },
+        );
+        return configureOpenclaw(ctx, { apiKey, model, models });
+    },
+
+    off: disableOpenclaw,
+    status: result,
+};

--- a/packages/polli-cli/src/harnesses/openclaw.ts
+++ b/packages/polli-cli/src/harnesses/openclaw.ts
@@ -1,4 +1,4 @@
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import polliSkill from "../../SKILL.md?raw";
 import { BASE_URL } from "../lib/config.js";
 import { readTextIfExists, removeIfExists, writeTextAtomic } from "./fs.js";
@@ -20,11 +20,24 @@ const ID = "openclaw";
 const LABEL = "OpenClaw";
 const PROVIDER = "pollinations";
 const DEFAULT_MODEL = "kimi";
+const KEY_ENV = "POLLI_OPENCLAW_API_KEY";
+
+export const openclawHome = (ctx: HarnessContext) => {
+    const configured = ctx.env.OPENCLAW_HOME;
+    if (!configured?.trim()) return join(ctx.home, ".openclaw");
+    const expanded =
+        configured === "~"
+            ? ctx.home
+            : configured.startsWith("~/") || configured.startsWith("~\\")
+              ? join(ctx.home, configured.slice(2))
+              : configured;
+    return resolve(expanded);
+};
 
 const configPath = (ctx: HarnessContext) =>
-    join(ctx.home, ".openclaw", "openclaw.json");
+    join(openclawHome(ctx), "openclaw.json");
 const skillPath = (ctx: HarnessContext) =>
-    join(ctx.home, ".openclaw", "skills", "polli", "SKILL.md");
+    join(openclawHome(ctx), "skills", "polli", "SKILL.md");
 
 const files = (ctx: HarnessContext) => [configPath(ctx), skillPath(ctx)];
 
@@ -41,22 +54,18 @@ const loadJson = (path: string): Record<string, unknown> => {
 const readKey = (ctx: HarnessContext): string | null => {
     const config = loadJson(configPath(ctx));
     try {
-        const key = (
-            (config.models as Record<string, unknown>)?.providers as Record<
-                string,
-                unknown
-            >
-        )?.[PROVIDER] as Record<string, unknown> | undefined;
-        const apiKey = key?.apiKey;
-        return typeof apiKey === "string" && apiKey ? apiKey : null;
+        const vars = (config.env as Record<string, unknown> | undefined)
+            ?.vars as Record<string, unknown> | undefined;
+        const key = vars?.[KEY_ENV];
+        return typeof key === "string" && key ? key : null;
     } catch {
         return null;
     }
 };
 
-const providerConfig = (models: HarnessModel[], apiKey: string) => ({
+const providerConfig = (models: HarnessModel[]) => ({
     baseUrl: `${BASE_URL}/v1`,
-    apiKey,
+    apiKey: `\${${KEY_ENV}}`,
     api: "openai-completions",
     models: models.map((m) => ({
         id: m.id,
@@ -75,24 +84,36 @@ interface OpenclawSettings {
     models: HarnessModel[];
 }
 
+const ensureObject = (
+    parent: Record<string, unknown>,
+    key: string,
+): Record<string, unknown> => {
+    if (!parent[key] || typeof parent[key] !== "object") parent[key] = {};
+    return parent[key] as Record<string, unknown>;
+};
+
 const writeConfig = (ctx: HarnessContext, settings: OpenclawSettings) => {
     const config = loadJson(configPath(ctx));
-    if (!config.models || typeof config.models !== "object") {
-        config.models = {};
-    }
-    const modelsSection = config.models as Record<string, unknown>;
-    if (
-        !modelsSection.providers ||
-        typeof modelsSection.providers !== "object"
-    ) {
-        modelsSection.providers = {};
-    }
-    const providers = modelsSection.providers as Record<string, unknown>;
-    providers[PROVIDER] = providerConfig(settings.models, settings.apiKey);
+
+    const modelsSection = ensureObject(config, "models");
+    ensureObject(modelsSection, "providers");
+    (modelsSection.providers as Record<string, unknown>)[PROVIDER] =
+        providerConfig(settings.models);
     modelsSection.mode = "merge";
-    modelsSection.defaultModel = `${PROVIDER}/${settings.model}`;
-    const text = `${JSON.stringify(config, null, 2)}\n`;
-    writeTextAtomic(configPath(ctx), text, 0o600);
+
+    const defaults = ensureObject(ensureObject(config, "agents"), "defaults");
+    ensureObject(defaults, "model");
+    (defaults.model as Record<string, unknown>).primary =
+        `${PROVIDER}/${settings.model}`;
+
+    const vars = ensureObject(ensureObject(config, "env"), "vars");
+    vars[KEY_ENV] = settings.apiKey;
+
+    writeTextAtomic(
+        configPath(ctx),
+        `${JSON.stringify(config, null, 2)}\n`,
+        0o600,
+    );
     if (readTextIfExists(skillPath(ctx)) === null) {
         writeTextAtomic(skillPath(ctx), polliSkill, 0o600);
     }
@@ -115,6 +136,7 @@ const stripConfig = (ctx: HarnessContext): boolean => {
         return false;
     }
     let changed = false;
+
     const modelsSection = config.models as Record<string, unknown> | undefined;
     if (modelsSection) {
         const providers = modelsSection.providers as
@@ -128,15 +150,28 @@ const stripConfig = (ctx: HarnessContext): boolean => {
             delete modelsSection.mode;
             changed = true;
         }
-        const defaultModel = modelsSection.defaultModel;
-        if (
-            typeof defaultModel === "string" &&
-            defaultModel.startsWith(`${PROVIDER}/`)
-        ) {
-            delete modelsSection.defaultModel;
+    }
+
+    const agentsSection = config.agents as Record<string, unknown> | undefined;
+    const defaults = agentsSection?.defaults as
+        | Record<string, unknown>
+        | undefined;
+    const modelSection = defaults?.model as Record<string, unknown> | undefined;
+    if (modelSection) {
+        const primary = modelSection.primary;
+        if (typeof primary === "string" && primary.startsWith(`${PROVIDER}/`)) {
+            delete modelSection.primary;
             changed = true;
         }
     }
+
+    const envSection = config.env as Record<string, unknown> | undefined;
+    const vars = envSection?.vars as Record<string, unknown> | undefined;
+    if (vars && KEY_ENV in vars) {
+        delete vars[KEY_ENV];
+        changed = true;
+    }
+
     if (changed) {
         writeTextAtomic(
             configPath(ctx),
@@ -160,18 +195,25 @@ const result = (ctx: HarnessContext): HarnessResult => {
     const provider = providers?.[PROVIDER] as
         | Record<string, unknown>
         | undefined;
-    const defaultModel = modelsSection?.defaultModel;
+
+    const agentsSection = config.agents as Record<string, unknown> | undefined;
+    const defaults = agentsSection?.defaults as
+        | Record<string, unknown>
+        | undefined;
+    const modelSection = defaults?.model as Record<string, unknown> | undefined;
+    const primary = modelSection?.primary;
     const model =
-        typeof defaultModel === "string" &&
-        defaultModel.startsWith(`${PROVIDER}/`)
-            ? defaultModel.slice(PROVIDER.length + 1)
+        typeof primary === "string" && primary.startsWith(`${PROVIDER}/`)
+            ? primary.slice(PROVIDER.length + 1)
             : undefined;
+
     return {
         harness: ID,
         label: LABEL,
         configured:
             provider?.baseUrl === `${BASE_URL}/v1` &&
             provider?.api === "openai-completions" &&
+            provider?.apiKey === `\${${KEY_ENV}}` &&
             readKey(ctx) !== null &&
             readTextIfExists(skillPath(ctx)) !== null,
         model,


### PR DESCRIPTION
## Summary

- Adds `polli harness openclaw on/off/status` — the OpenClaw adapter for the harness framework introduced in #14107
- Follows the same snapshot-based pattern as the DSH adapter: fetches live models from `/v1/models`, mints a dedicated API key via `resolveHarnessKey`, writes `~/.openclaw/openclaw.json` with the provider block, and installs the Polli skill
- `off` restores the original config byte-for-byte (snapshot) or strips only Pollinations-owned entries (fallback)
- Updates `apps/openclaw/README.md` to use `polli harness openclaw on` as the primary setup path (resolves the competing setup paths)
- 7 new tests, all passing alongside the existing 25

## Files

- `packages/polli-cli/src/harnesses/openclaw.ts` — the adapter
- `packages/polli-cli/src/harnesses/openclaw.test.ts` — tests
- `packages/polli-cli/src/harnesses/index.ts` — registers `openclaw` alongside `dsh`
- `packages/polli-cli/SKILL.md` — adds openclaw to the harness quick-reference
- `apps/openclaw/README.md` — replaces shell-script setup with harness instructions

## Verification

Tests run against the full test suite (32/32 passing). Biome check clean. TypeScript compiles without errors on the touched files.

Fixes #14121