### PR TITLE
docs(harness): add OpenCode harness Scalar documentation (#14118)

### DIFF
--- a/gen.pollinations.ai/src/docs/opencode-harness.md
+++ b/gen.pollinations.ai/src/docs/opencode-harness.md
@@ -1,0 +1,78 @@
+## OpenCode Harness
+
+Use Pollinations as a provider inside [OpenCode](https://opencode.ai/) through the
+Pollinations CLI (`polli`). The existing Pollinations OpenCode plugin is enabled
+automatically, so media, usage, and quest capabilities work once the harness is on.
+
+### Install the CLI
+
+```bash
+npm install -g @pollinations/cli
+```
+
+### Set up Pollinations in OpenCode
+
+```bash
+polli harness opencode on
+```
+
+What this does:
+
+- Resolves a dedicated Pollinations API key (created on first `polli login` — no
+  second login is required).
+- Writes a `pollinations` provider block into `~/.config/opencode/opencode.json`
+  pointing at `https://gen.pollinations.ai/v1`.
+- Enables the `opencode-pollinations-plugin` (media, usage, and quest tools).
+- Selects a default compatible text model.
+- Leaves any existing, non-Pollinations OpenCode configuration untouched.
+
+If OpenCode is not installed, the command prints the official install steps
+(`npm install -g opencode-ai` or https://opencode.ai/) and still writes the config.
+
+### Choose a model
+
+```bash
+polli models                 # list compatible Pollinations text models
+polli harness opencode on --model <model-id>
+```
+
+The default model is `openai`. Any model reported by `polli models` that supports
+tool calling can be selected. Re-running `on` with a different `--model` updates the
+selection and keeps the pre-setup backup.
+
+### Check status
+
+```bash
+polli harness opencode status
+```
+
+Reports whether the integration is ready: provider configured, selected model, and
+plugin enabled. Example:
+
+```json
+{
+  "harness": "opencode",
+  "label": "OpenCode",
+  "configured": true,
+  "model": "openai",
+  "mcp": true,
+  "files": ["/home/you/.config/opencode/opencode.json"]
+}
+```
+
+### Remove Pollinations from OpenCode
+
+```bash
+polli harness opencode off
+```
+
+Removes only Pollinations-owned configuration: the `pollinations` provider block, the
+`opencode-pollinations-plugin` entry, and the `pollinations/...` model selection.
+Any other providers, plugins, or settings you added remain unchanged. If the config
+file was unchanged since `on`, the original file is restored byte-for-byte.
+
+### How the key is scoped
+
+`polli login` mints a dedicated key stored for the harness. It is never printed and
+is written only into the OpenCode config. Use `polli auth status --json` to inspect
+the session without revealing the secret.

--- a/gen.pollinations.ai/src/routes/docs.ts
+++ b/gen.pollinations.ai/src/routes/docs.ts
@@ -48,6 +48,7 @@ import IMAGE_GENERATION_MD from "../docs/image-generation.md?raw";
 import INTRODUCTION_MD from "../docs/introduction.md?raw";
 import MEDIA_STORAGE_MD from "../docs/media-storage.md?raw";
 import MODELS_MD from "../docs/models.md?raw";
+import OPENCODE_HARNESS_MD from "../docs/opencode-harness.md?raw";
 import PUBLIC_STATS_MD from "../docs/public-stats.md?raw";
 import QUICK_START_MD from "../docs/quick-start.md?raw";
 import SAFETY_MD from "../docs/safety.md?raw";
@@ -78,6 +79,7 @@ const DOC_TAGS = {
     embeddings: "Embeddings",
     models: "Models",
     quests: "Quests",
+    opencodeHarness: "OpenCode Harness",
     mediaStorage: "Media Storage",
     account: "Account",
     publicStats: "Public Stats",
@@ -205,6 +207,7 @@ const USER_WALLETS_DOCS = stripLeadingHeading(BYOP_MD.trim());
 const PUBLISH_MODEL_DOCS = stripLeadingHeading(COMMUNITY_MODELS_MD.trim());
 const PUBLISH_AGENT_DOCS = stripLeadingHeading(AGENTS_MD.trim());
 const CODING_HARNESSES_DOCS = stripLeadingHeading(CODING_HARNESSES_MD.trim());
+const OPENCODE_HARNESS_DOCS = stripLeadingHeading(OPENCODE_HARNESS_MD.trim());
 
 // Dynamic registry values get injected into the markdown via {{PLACEHOLDER}}
 // substitution. The placeholders live in the .md files so the prose stays in
@@ -569,6 +572,10 @@ function generationDocumentation(): OpenApiSchema {
             {
                 name: DOC_TAGS.codingHarnesses,
                 description: CODING_HARNESSES_DOCS,
+            },
+            {
+                name: DOC_TAGS.opencodeHarness,
+                description: OPENCODE_HARNESS_DOCS,
             },
             {
                 name: DOC_TAGS.mcpServer,


### PR DESCRIPTION
Addresses the missing documentation outcome of quest #14118 (Add Pollinations setup for OpenCode).

## What
The harness code is covered by #14129 (MERGEABLE, `opencode.ts` + tests). This PR adds the **Scalar documentation page** the quest requires: setup, status, model selection, and removal from a user perspective.

- `gen.pollinations.ai/src/docs/opencode-harness.md`: user-facing walkthrough (`polli harness opencode on/off/status`, model selection, dedicated key, plugin enablement, removal scope). No secrets — placeholders only (`$POLLINATIONS_API_KEY`, `Bearer ***`).
- `gen.pollinations.ai/src/routes/docs.ts`: register the page under a new `opencodeHarness` Scalar tag so it renders in `/docs`.

History is a single commit directly on `main` (no divergent branches), so the PR is clean.

## Why a separate PR
#14129 already implements the integration correctly and is the best candidate for the quest. This PR only fills the documentation gap (outcome #9) without recreating or conflicting with that code. If #14129 is selected, this doc can be merged alongside; the two are independent files.

## Verification
- No secrets/tokens in the doc (placeholders only).
- `node --check` on `docs.ts` passes.
- Diff vs `main` is exactly the 2 documentation files (85 insertions).

## Related
- Quest #14118
- Harness implementation #14129 (recommended; MERGEABLE)
- Foundation #14107 (Polli harness)