### PR TITLE
feat: add mise.toml for reproducible dev environments

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,22 @@
+[tools]
+node = "24"
+python = "3.12"
+sops = "3.13.3"
+age = "1.3.1"
+biome = "2.5.11"
+
+[tasks.dev]
+run = "npm run dev"
+description = "Start local dev servers (enter + gen)"
+
+[tasks.test]
+run = "npm run test"
+description = "Run all tests"
+
+[tasks.lint]
+run = "biome check ."
+description = "Lint and format check"
+
+[tasks.lint-fix]
+run = "biome check --write --unsafe ."
+description = "Auto-fix lint and format issues"


### PR DESCRIPTION
## Summary

Adds a root `mise.toml` so every developer gets identical tool versions via `mise install`.

## Pinned tools

| Tool | Version | Why |
|------|---------|-----|
| Node | 24 | Matches production Cloudflare Workers runtime |
| Python | 3.12 | Matches Dockerfiles and CI scripts |
| sops | 3.13.3 | Secrets decryption (`npm run decrypt-vars`) |
| age | 1.3.1 | sops encryption backend |
| biome | 2.5.11 | Linter/formatter (aligned with `package.json`) |

## Usage

```bash
# One-time setup
curl https://mise.run | sh

# Install all pinned tools
mise install

# Tools activate automatically per-directory
node --version  # v24.20.0
sops --version  # 3.13.3
biome --version # 2.5.11
```

## Why

Currently there are **zero version-pinning files** in the repo. CI uses three different Node versions (20, 22, 24) across workflows with no single source of truth. This causes:
- "Works on my machine" issues when local Node ≠ CI Node
- `npm run decrypt-vars` fails silently when sops isn't installed
- Biome version drift between local `rtk biome` and CI `npx biome`

`mise.toml` is the single source of truth — developers, CI, and Dockerfiles can all reference it.