### PR TITLE
feat(cli): add OpenCode, Pi, Prime Agent, and OpenClaw harnesses

### DIFF
--- a/packages/polli-cli/src/harnesses/index.ts
+++ b/packages/polli-cli/src/harnesses/index.ts
@@ -1,4 +1,14 @@
 import { dsh } from "./dsh.js";
+import { openclaw } from "./openclaw.js";
+import { opencode } from "./opencode.js";
+import { pi } from "./pi.js";
+import { prime } from "./prime.js";
 import type { HarnessAdapter } from "./types.js";
 
-export const HARNESSES: HarnessAdapter[] = [dsh];
+export const HARNESSES: HarnessAdapter[] = [
+    dsh,
+    opencode,
+    pi,
+    prime,
+    openclaw,
+];

--- a/packages/polli-cli/src/harnesses/index.ts
+++ b/packages/polli-cli/src/harnesses/index.ts
@@ -5,10 +5,4 @@ import { pi } from "./pi.js";
 import { prime } from "./prime.js";
 import type { HarnessAdapter } from "./types.js";
 
-export const HARNESSES: HarnessAdapter[] = [
-    dsh,
-    opencode,
-    pi,
-    prime,
-    openclaw,
-];
+export const HARNESSES: HarnessAdapter[] = [dsh, opencode, pi, prime, openclaw];

--- a/packages/polli-cli/src/harnesses/openclaw.ts
+++ b/packages/polli-cli/src/harnesses/openclaw.ts
@@ -1,0 +1,227 @@
+import { join, resolve } from "node:path";
+import { parseEnv } from "node:util";
+import { isMap, isSeq, parseDocument } from "yaml";
+import polliSkill from "../../SKILL.md?raw";
+import { BASE_URL } from "../lib/config.js";
+import { readTextIfExists, removeIfExists, writeTextAtomic } from "./fs.js";
+import { resolveHarnessKey } from "./keys.js";
+import { fetchHarnessModels } from "./models.js";
+import {
+    applyWithSnapshot,
+    clearSnapshot,
+    restoreSnapshot,
+} from "./snapshot.js";
+import type {
+    HarnessAdapter,
+    HarnessContext,
+    HarnessModel,
+    HarnessResult,
+} from "./types.js";
+
+const ID = "openclaw";
+const LABEL = "OpenClaw";
+const PROVIDER_ID = "pollinations";
+const DEFAULT_MODEL = "openai";
+const KEY_ENV = "POLLI_OPENCLAW_API_KEY";
+
+const YAML_OUT = { lineWidth: 0 };
+const JS_TAG = {
+    tag: "tag:yaml.org,2002:js",
+    resolve: (value: string) => value,
+};
+
+export const openclawHome = (ctx: HarnessContext) => {
+    const configured = ctx.env.OPENCLAW_HOME;
+    if (!configured?.trim()) return join(ctx.home, ".openclaw");
+    const expanded =
+        configured === "~"
+            ? ctx.home
+            : configured.startsWith("~/") || configured.startsWith("~\\")
+              ? join(ctx.home, configured.slice(2))
+              : configured;
+    return resolve(expanded);
+};
+
+const configPath = (ctx: HarnessContext) =>
+    join(openclawHome(ctx), "config.yaml");
+const envPath = (ctx: HarnessContext) => join(openclawHome(ctx), ".env");
+const skillPath = (ctx: HarnessContext) =>
+    join(openclawHome(ctx), "skills", "polli", "SKILL.md");
+
+const loadYaml = (path: string) =>
+    parseDocument(readTextIfExists(path) ?? "", { customTags: [JS_TAG] });
+
+const files = (ctx: HarnessContext) => [
+    configPath(ctx),
+    envPath(ctx),
+    skillPath(ctx),
+];
+
+const readKey = (ctx: HarnessContext) => {
+    const text = readTextIfExists(envPath(ctx));
+    if (text === null) return null;
+    return parseEnv(text)[KEY_ENV] || null;
+};
+
+const envLine = (key: string) => `${KEY_ENV}=${JSON.stringify(key)}`;
+const keyLine = new RegExp(
+    `^\\s*(?:export\\s+)?${KEY_ENV}\\s*=`,
+    "u",
+);
+
+const setEnvKey = (ctx: HarnessContext, key: string) => {
+    const lines = (readTextIfExists(envPath(ctx)) ?? "").split("\n");
+    const index = lines.findIndex((line) => keyLine.test(line));
+    const filtered = lines.filter(
+        (line, i) => i === index || !keyLine.test(line),
+    );
+    if (index === -1) {
+        const insertAt =
+            filtered.at(-1) === "" ? filtered.length - 1 : filtered.length;
+        filtered.splice(insertAt, 0, envLine(key));
+    } else filtered[index] = envLine(key);
+    writeTextAtomic(envPath(ctx), filtered.join("\n"), 0o600);
+};
+
+const deleteEnvKey = (ctx: HarnessContext) => {
+    const text = readTextIfExists(envPath(ctx));
+    if (text === null) return false;
+    const lines = text.split("\n");
+    const filtered = lines.filter((line) => !keyLine.test(line));
+    if (filtered.length === lines.length) return false;
+    writeTextAtomic(envPath(ctx), filtered.join("\n"), 0o600);
+    return true;
+};
+
+const providerConfig = (models: HarnessModel[]) => ({
+    api_key: `\${env:${KEY_ENV}}`,
+    base_url: `${BASE_URL}/v1`,
+    models: Object.fromEntries(
+        models.map((m) => [
+            m.id,
+            {
+                name: m.id,
+                context_window: m.contextWindow,
+                input_modalities: m.input,
+            },
+        ]),
+    ),
+});
+
+interface OpenClawSettings {
+    apiKey: string;
+    model: string;
+    models: HarnessModel[];
+}
+
+const writeConfig = (ctx: HarnessContext, settings: OpenClawSettings) => {
+    const doc = loadYaml(configPath(ctx));
+    if (doc.contents === null || !isMap(doc.contents)) {
+        doc.contents = doc.createNode({});
+    }
+    // Set provider
+    doc.setIn(
+        ["providers", PROVIDER_ID],
+        doc.createNode(providerConfig(settings.models)),
+    );
+    // Set default provider and model
+    doc.setIn(["provider"], PROVIDER_ID);
+    doc.setIn(["model"], settings.model);
+    writeTextAtomic(configPath(ctx), doc.toString(YAML_OUT), 0o600);
+    setEnvKey(ctx, settings.apiKey);
+    if (readTextIfExists(skillPath(ctx)) === null) {
+        writeTextAtomic(skillPath(ctx), polliSkill, 0o600);
+    }
+};
+
+const stripConfig = (ctx: HarnessContext) => {
+    const doc = loadYaml(configPath(ctx));
+    let changed = false;
+    if (doc.hasIn(["providers", PROVIDER_ID])) {
+        doc.deleteIn(["providers", PROVIDER_ID]);
+        changed = true;
+    }
+    if (doc.getIn(["provider"]) === PROVIDER_ID) {
+        doc.deleteIn(["provider"]);
+        changed = true;
+    }
+    if (doc.getIn(["model"]) !== undefined && !changed) {
+        // Only delete model if we own the provider
+    }
+    if (changed)
+        writeTextAtomic(configPath(ctx), doc.toString(YAML_OUT), 0o600);
+    changed = deleteEnvKey(ctx) || changed;
+    if (readTextIfExists(skillPath(ctx)) === polliSkill) {
+        removeIfExists(skillPath(ctx));
+        changed = true;
+    }
+    return changed;
+};
+
+const result = (ctx: HarnessContext): HarnessResult => {
+    const doc = loadYaml(configPath(ctx));
+    const provider = doc.getIn(["providers", PROVIDER_ID]);
+    const defaultProvider = doc.getIn(["provider"]);
+    const model = doc.getIn(["model"]);
+    const isConfigured =
+        isMap(provider) &&
+        doc.getIn(["providers", PROVIDER_ID, "base_url"]) ===
+            `${BASE_URL}/v1` &&
+        defaultProvider === PROVIDER_ID &&
+        typeof model === "string" &&
+        readKey(ctx) !== null;
+
+    return {
+        harness: ID,
+        label: LABEL,
+        configured: isConfigured,
+        model: typeof model === "string" ? model : undefined,
+        files: files(ctx),
+    };
+};
+
+export const configureOpenClaw = (
+    ctx: HarnessContext,
+    settings: OpenClawSettings,
+): HarnessResult => {
+    applyWithSnapshot(ctx, ID, files(ctx), () =>
+        writeConfig(ctx, settings),
+    );
+    return result(ctx);
+};
+
+export const disableOpenClaw = (ctx: HarnessContext): HarnessResult => {
+    const managedFiles = files(ctx);
+    let outcome: HarnessResult["outcome"] = "restored";
+    if (restoreSnapshot(ctx, ID, managedFiles) !== "restored") {
+        outcome = stripConfig(ctx) ? "stripped" : "unchanged";
+        clearSnapshot(ctx, ID, managedFiles);
+    }
+    return { ...result(ctx), configured: false, outcome };
+};
+
+export const openclaw: HarnessAdapter = {
+    id: ID,
+    label: LABEL,
+    description: "Configure OpenClaw as a Pollinations provider",
+    restartHint:
+        "Changes apply on the next request. Restart OpenClaw to pick up the new provider.",
+
+    async on(ctx, options) {
+        const model = options.model ?? DEFAULT_MODEL;
+        const models = await fetchHarnessModels();
+        if (!models.some((c) => c.id === model)) {
+            throw new Error(
+                `Model "${model}" is not a tool-calling text model. Run: polli models`,
+            );
+        }
+        const apiKey = await resolveHarnessKey(
+            { id: ID, label: LABEL, existingKey: readKey(ctx) },
+            { browser: options.browser },
+        );
+        return configureOpenClaw(ctx, { apiKey, model, models });
+    },
+
+    off: disableOpenClaw,
+    status: result,
+};

--- a/packages/polli-cli/src/harnesses/openclaw.ts
+++ b/packages/polli-cli/src/harnesses/openclaw.ts
@@ -64,10 +64,7 @@ const readKey = (ctx: HarnessContext) => {
 };
 
 const envLine = (key: string) => `${KEY_ENV}=${JSON.stringify(key)}`;
-const keyLine = new RegExp(
-    `^\\s*(?:export\\s+)?${KEY_ENV}\\s*=`,
-    "u",
-);
+const keyLine = new RegExp(`^\\s*(?:export\\s+)?${KEY_ENV}\\s*=`, "u");
 
 const setEnvKey = (ctx: HarnessContext, key: string) => {
     const lines = (readTextIfExists(envPath(ctx)) ?? "").split("\n");

--- a/packages/polli-cli/src/harnesses/openclaw.ts
+++ b/packages/polli-cli/src/harnesses/openclaw.ts
@@ -1,6 +1,6 @@
 import { join, resolve } from "node:path";
 import { parseEnv } from "node:util";
-import { isMap, isSeq, parseDocument } from "yaml";
+import { isMap, parseDocument } from "yaml";
 import polliSkill from "../../SKILL.md?raw";
 import { BASE_URL } from "../lib/config.js";
 import { readTextIfExists, removeIfExists, writeTextAtomic } from "./fs.js";
@@ -181,9 +181,7 @@ export const configureOpenClaw = (
     ctx: HarnessContext,
     settings: OpenClawSettings,
 ): HarnessResult => {
-    applyWithSnapshot(ctx, ID, files(ctx), () =>
-        writeConfig(ctx, settings),
-    );
+    applyWithSnapshot(ctx, ID, files(ctx), () => writeConfig(ctx, settings));
     return result(ctx);
 };
 

--- a/packages/polli-cli/src/harnesses/opencode.ts
+++ b/packages/polli-cli/src/harnesses/opencode.ts
@@ -1,0 +1,230 @@
+import { join } from "node:path";
+import polliSkill from "../../SKILL.md?raw";
+import { BASE_URL } from "../lib/config.js";
+import { readTextIfExists, removeIfExists, writeTextAtomic } from "./fs.js";
+import { resolveHarnessKey } from "./keys.js";
+import { fetchHarnessModels } from "./models.js";
+import {
+    applyWithSnapshot,
+    clearSnapshot,
+    restoreSnapshot,
+} from "./snapshot.js";
+import type {
+    HarnessAdapter,
+    HarnessContext,
+    HarnessModel,
+    HarnessResult,
+} from "./types.js";
+
+const ID = "opencode";
+const LABEL = "OpenCode";
+const PROVIDER_ID = "pollinations";
+const DEFAULT_MODEL = "openai";
+const KEY_ENV = "POLLI_OPENCODE_API_KEY";
+
+const configDir = (ctx: HarnessContext) => {
+    const configured = ctx.env.OPENCODE_CONFIG_DIR;
+    if (!configured?.trim()) return join(ctx.home, ".config", "opencode");
+    return configured;
+};
+
+const configPath = (ctx: HarnessContext) =>
+    join(configDir(ctx), "opencode.json");
+
+const authPath = (ctx: HarnessContext) =>
+    join(ctx.home, ".local", "share", "opencode", "auth.json");
+
+const skillDir = (ctx: HarnessContext) =>
+    join(ctx.home, ".config", "opencode", "skills", "polli");
+
+const skillPath = (ctx: HarnessContext) => join(skillDir(ctx), "SKILL.md");
+
+const files = (ctx: HarnessContext) => [
+    configPath(ctx),
+    authPath(ctx),
+    skillPath(ctx),
+];
+
+interface OpenCodeConfig {
+    $schema?: string;
+    provider?: Record<string, unknown>;
+    model?: string;
+    [key: string]: unknown;
+}
+
+const readConfig = (ctx: HarnessContext): OpenCodeConfig => {
+    const text = readTextIfExists(configPath(ctx));
+    if (!text) return {};
+    try {
+        return JSON.parse(text) as OpenCodeConfig;
+    } catch {
+        return {};
+    }
+};
+
+const writeConfig = (ctx: HarnessContext, config: OpenCodeConfig) => {
+    writeTextAtomic(configPath(ctx), JSON.stringify(config, null, 2) + "\n");
+};
+
+const readKey = (ctx: HarnessContext): string | null => {
+    const text = readTextIfExists(authPath(ctx));
+    if (!text) return null;
+    try {
+        const auth = JSON.parse(text) as Record<string, string>;
+        // OpenCode stores keys under provider IDs
+        return auth[PROVIDER_ID] ?? auth.pollinations ?? null;
+    } catch {
+        return null;
+    }
+};
+
+const writeKey = (ctx: HarnessContext, key: string) => {
+    const existing = readTextIfExists(authPath(ctx));
+    let auth: Record<string, string> = {};
+    if (existing) {
+        try {
+            auth = JSON.parse(existing) as Record<string, string>;
+        } catch {
+            auth = {};
+        }
+    }
+    auth[PROVIDER_ID] = key;
+    writeTextAtomic(authPath(ctx), JSON.stringify(auth, null, 2) + "\n", 0o600);
+};
+
+const deleteKey = (ctx: HarnessContext): boolean => {
+    const text = readTextIfExists(authPath(ctx));
+    if (!text) return false;
+    try {
+        const auth = JSON.parse(text) as Record<string, string>;
+        if (!(PROVIDER_ID in auth)) return false;
+        delete auth[PROVIDER_ID];
+        writeTextAtomic(
+            authPath(ctx),
+            JSON.stringify(auth, null, 2) + "\n",
+            0o600,
+        );
+        return true;
+    } catch {
+        return false;
+    }
+};
+
+const providerBlock = (models: HarnessModel[]) => ({
+    npm: "@ai-sdk/openai-compatible",
+    name: "Pollinations.ai",
+    options: {
+        baseURL: `${BASE_URL}/v1`,
+    },
+    models: Object.fromEntries(
+        models.map((m) => [
+            m.id,
+            {
+                name: m.id,
+                ...(m.contextWindow ? { contextLength: m.contextWindow } : {}),
+            },
+        ]),
+    ),
+});
+
+const writeProviderConfig = (
+    ctx: HarnessContext,
+    models: HarnessModel[],
+    model: string,
+) => {
+    const config = readConfig(ctx);
+    config.$schema = "https://opencode.ai/config.json";
+    config.provider = config.provider ?? {};
+    (config.provider as Record<string, unknown>)[PROVIDER_ID] =
+        providerBlock(models);
+    config.model = `${PROVIDER_ID}/${model}`;
+    writeConfig(ctx, config);
+};
+
+const stripProviderConfig = (ctx: HarnessContext): boolean => {
+    const config = readConfig(ctx);
+    if (!config.provider) return false;
+    const providers = config.provider as Record<string, unknown>;
+    if (!(PROVIDER_ID in providers)) return false;
+    delete providers[PROVIDER_ID];
+    if (Object.keys(providers).length === 0) delete config.provider;
+    if (config.model?.startsWith(`${PROVIDER_ID}/`)) delete config.model;
+    writeConfig(ctx, config);
+    return true;
+};
+
+const result = (ctx: HarnessContext): HarnessResult => {
+    const config = readConfig(ctx);
+    const providers = (config.provider ?? {}) as Record<string, unknown>;
+    const provider = providers[PROVIDER_ID] as Record<string, unknown> | undefined;
+    const model = config.model;
+    return {
+        harness: ID,
+        label: LABEL,
+        configured:
+            provider !== undefined &&
+            provider.npm === "@ai-sdk/openai-compatible" &&
+            readKey(ctx) !== null,
+        model:
+            typeof model === "string" && model.startsWith(`${PROVIDER_ID}/`)
+                ? model.slice(`${PROVIDER_ID}/`.length)
+                : undefined,
+        files: files(ctx),
+    };
+};
+
+const configureOpenCode = (
+    ctx: HarnessContext,
+    settings: { apiKey: string; model: string; models: HarnessModel[] },
+): HarnessResult => {
+    applyWithSnapshot(ctx, ID, files(ctx), () => {
+        writeProviderConfig(ctx, settings.models, settings.model);
+        writeKey(ctx, settings.apiKey);
+        if (readTextIfExists(skillPath(ctx)) === null) {
+            writeTextAtomic(skillPath(ctx), polliSkill, 0o600);
+        }
+    });
+    return result(ctx);
+};
+
+const disableOpenCode = (ctx: HarnessContext): HarnessResult => {
+    const managedFiles = files(ctx);
+    let outcome: HarnessResult["outcome"] = "restored";
+    if (restoreSnapshot(ctx, ID, managedFiles) !== "restored") {
+        outcome = stripProviderConfig(ctx) ? "stripped" : "unchanged";
+        deleteKey(ctx);
+        if (readTextIfExists(skillPath(ctx)) === polliSkill) {
+            removeIfExists(skillPath(ctx));
+            outcome = "stripped";
+        }
+        clearSnapshot(ctx, ID, managedFiles);
+    }
+    return { ...result(ctx), configured: false, outcome };
+};
+
+export const opencode: HarnessAdapter = {
+    id: ID,
+    label: LABEL,
+    description: "Configure OpenCode as a Pollinations provider",
+    restartHint:
+        "Changes apply on the next request. Restart OpenCode to pick up the new provider.",
+
+    async on(ctx, options) {
+        const model = options.model ?? DEFAULT_MODEL;
+        const models = await fetchHarnessModels();
+        if (!models.some((c) => c.id === model)) {
+            throw new Error(
+                `Model "${model}" is not a tool-calling text model. Run: polli models`,
+            );
+        }
+
+        const apiKey = await resolveHarnessKey(
+            { id: ID, label: LABEL, existingKey: readKey(ctx) },
+            { browser: options.browser },
+        );
+        return configureOpenCode(ctx, { apiKey, model, models });
+    },
+
+    off: disableOpenCode,
+    status: result,
+};

--- a/packages/polli-cli/src/harnesses/opencode.ts
+++ b/packages/polli-cli/src/harnesses/opencode.ts
@@ -20,7 +20,7 @@ const ID = "opencode";
 const LABEL = "OpenCode";
 const PROVIDER_ID = "pollinations";
 const DEFAULT_MODEL = "openai";
-const KEY_ENV = "POLLI_OPENCODE_API_KEY";
+const _KEY_ENV = "POLLI_OPENCODE_API_KEY";
 
 const configDir = (ctx: HarnessContext) => {
     const configured = ctx.env.OPENCODE_CONFIG_DIR;
@@ -63,7 +63,7 @@ const readConfig = (ctx: HarnessContext): OpenCodeConfig => {
 };
 
 const writeConfig = (ctx: HarnessContext, config: OpenCodeConfig) => {
-    writeTextAtomic(configPath(ctx), JSON.stringify(config, null, 2) + "\n");
+    writeTextAtomic(configPath(ctx), `${JSON.stringify(config, null, 2)}\n`);
 };
 
 const readKey = (ctx: HarnessContext): string | null => {
@@ -89,7 +89,7 @@ const writeKey = (ctx: HarnessContext, key: string) => {
         }
     }
     auth[PROVIDER_ID] = key;
-    writeTextAtomic(authPath(ctx), JSON.stringify(auth, null, 2) + "\n", 0o600);
+    writeTextAtomic(authPath(ctx), `${JSON.stringify(auth, null, 2)}\n`, 0o600);
 };
 
 const deleteKey = (ctx: HarnessContext): boolean => {
@@ -101,7 +101,7 @@ const deleteKey = (ctx: HarnessContext): boolean => {
         delete auth[PROVIDER_ID];
         writeTextAtomic(
             authPath(ctx),
-            JSON.stringify(auth, null, 2) + "\n",
+            `${JSON.stringify(auth, null, 2)}\n`,
             0o600,
         );
         return true;
@@ -156,7 +156,9 @@ const stripProviderConfig = (ctx: HarnessContext): boolean => {
 const result = (ctx: HarnessContext): HarnessResult => {
     const config = readConfig(ctx);
     const providers = (config.provider ?? {}) as Record<string, unknown>;
-    const provider = providers[PROVIDER_ID] as Record<string, unknown> | undefined;
+    const provider = providers[PROVIDER_ID] as
+        | Record<string, unknown>
+        | undefined;
     const model = config.model;
     return {
         harness: ID,

--- a/packages/polli-cli/src/harnesses/pi.ts
+++ b/packages/polli-cli/src/harnesses/pi.ts
@@ -1,0 +1,313 @@
+import { join, resolve } from "node:path";
+import { parseEnv } from "node:util";
+import { isMap, isSeq, parseDocument, Scalar } from "yaml";
+import polliSkill from "../../SKILL.md?raw";
+import { BASE_URL } from "../lib/config.js";
+import { readTextIfExists, removeIfExists, writeTextAtomic } from "./fs.js";
+import { resolveHarnessKey } from "./keys.js";
+import { fetchHarnessModels } from "./models.js";
+import {
+    applyWithSnapshot,
+    clearSnapshot,
+    restoreSnapshot,
+} from "./snapshot.js";
+import type {
+    HarnessAdapter,
+    HarnessContext,
+    HarnessModel,
+    HarnessResult,
+} from "./types.js";
+
+const ID = "pi";
+const LABEL = "Pi";
+const PROVIDER = "pollinations";
+const DEFAULT_MODEL = "openai";
+const KEY_ENV = "POLLI_PI_API_KEY";
+const MCP_ID = "mcp-pollinations";
+const MCP_URL = `${BASE_URL}/mcp/pollinations`;
+
+// Pi shares the pi-ai schema with DSH and Prime Agent.
+const PROVIDER_PATH = ["llm-pi-ai", "providers", PROVIDER];
+const DEFAULT_MODEL_PATH = ["agent-default-model"];
+
+const YAML_OUT = { lineWidth: 0 };
+const JS_TAG = {
+    tag: "tag:yaml.org,2002:js",
+    resolve: (value: string) => value,
+};
+
+export const piHome = (ctx: HarnessContext) => {
+    const configured = ctx.env.PI_HOME;
+    if (!configured?.trim()) return join(ctx.home, ".pi");
+    const expanded =
+        configured === "~"
+            ? ctx.home
+            : configured.startsWith("~/") || configured.startsWith("~\\")
+              ? join(ctx.home, configured.slice(2))
+              : configured;
+    return resolve(expanded);
+};
+
+const settingsPath = (ctx: HarnessContext) =>
+    join(piHome(ctx), "settings.yaml");
+const envPath = (ctx: HarnessContext) => join(piHome(ctx), ".env");
+const patchPath = (ctx: HarnessContext) =>
+    join(piHome(ctx), "cordis.patch.yml");
+const skillPath = (ctx: HarnessContext) =>
+    join(piHome(ctx), "skills", "polli", "SKILL.md");
+
+const loadYaml = (path: string) =>
+    parseDocument(readTextIfExists(path) ?? "", { customTags: [JS_TAG] });
+
+const files = (ctx: HarnessContext) => [
+    settingsPath(ctx),
+    envPath(ctx),
+    patchPath(ctx),
+    skillPath(ctx),
+];
+
+const readKey = (ctx: HarnessContext) => {
+    const text = readTextIfExists(envPath(ctx));
+    if (text === null) return null;
+    return parseEnv(text)[KEY_ENV] || null;
+};
+
+const envLine = (key: string) => `${KEY_ENV}=${JSON.stringify(key)}`;
+const keyLine = new RegExp(
+    `^\\s*(?:export\\s+)?${KEY_ENV}\\s*=`,
+    "u",
+);
+
+const setEnvKey = (ctx: HarnessContext, key: string) => {
+    const lines = (readTextIfExists(envPath(ctx)) ?? "").split("\n");
+    const index = lines.findIndex((line) => keyLine.test(line));
+    const filtered = lines.filter(
+        (line, i) => i === index || !keyLine.test(line),
+    );
+    if (index === -1) {
+        const insertAt =
+            filtered.at(-1) === "" ? filtered.length - 1 : filtered.length;
+        filtered.splice(insertAt, 0, envLine(key));
+    } else filtered[index] = envLine(key);
+    writeTextAtomic(envPath(ctx), filtered.join("\n"), 0o600);
+};
+
+const deleteEnvKey = (ctx: HarnessContext) => {
+    const text = readTextIfExists(envPath(ctx));
+    if (text === null) return false;
+    const lines = text.split("\n");
+    const filtered = lines.filter((line) => !keyLine.test(line));
+    if (filtered.length === lines.length) return false;
+    writeTextAtomic(envPath(ctx), filtered.join("\n"), 0o600);
+    return true;
+};
+
+const stripMcpEntry = (doc: ReturnType<typeof loadYaml>) => {
+    if (!isSeq(doc.contents)) return false;
+    let changed = false;
+    for (let i = doc.contents.items.length - 1; i >= 0; i--) {
+        const patch = doc.contents.items[i];
+        if (!isMap(patch)) continue;
+        const inserted = patch.get("insert", true);
+        if (!isSeq(inserted)) continue;
+        const before = inserted.items.length;
+        inserted.items = inserted.items.filter(
+            (entry) => !isMap(entry) || entry.get("id") !== MCP_ID,
+        );
+        changed ||= inserted.items.length !== before;
+        if (inserted.items.length === 0 && patch.items.length === 1) {
+            doc.contents.items.splice(i, 1);
+        }
+    }
+    return changed;
+};
+
+const removeMcpEntry = (ctx: HarnessContext) => {
+    const doc = loadYaml(patchPath(ctx));
+    if (!stripMcpEntry(doc)) return false;
+    writeTextAtomic(patchPath(ctx), doc.toString(YAML_OUT), 0o600);
+    return true;
+};
+
+const writeMcpEntry = (ctx: HarnessContext) => {
+    const doc = loadYaml(patchPath(ctx));
+    if (doc.contents === null) doc.contents = doc.createNode([]);
+    if (!isSeq(doc.contents)) {
+        throw new Error(`${patchPath(ctx)} must contain a YAML list`);
+    }
+    stripMcpEntry(doc);
+    const authorization = doc.createNode(
+        `\`Bearer \${process.env.${KEY_ENV}}\``,
+    );
+    authorization.tag = "tag:yaml.org,2002:js";
+    authorization.type = Scalar.QUOTE_SINGLE;
+    doc.add({
+        insert: [
+            {
+                id: MCP_ID,
+                name: "@pollinations/mcp-server",
+                config: {
+                    serverName: "pollinations",
+                    transport: "streamable-http",
+                    url: MCP_URL,
+                    headers: { Authorization: authorization },
+                },
+            },
+        ],
+    });
+    writeTextAtomic(patchPath(ctx), doc.toString(YAML_OUT), 0o600);
+};
+
+const hasMcpEntry = (ctx: HarnessContext) => {
+    const doc = loadYaml(patchPath(ctx));
+    if (!isSeq(doc.contents)) return false;
+    return doc.contents.items.some((patch) => {
+        if (!isMap(patch)) return false;
+        const inserted = patch.get("insert", true);
+        return (
+            isSeq(inserted) &&
+            inserted.items.some(
+                (entry) =>
+                    isMap(entry) &&
+                    entry.get("id") === MCP_ID &&
+                    entry.getIn(["config", "url"]) === MCP_URL,
+            )
+        );
+    });
+};
+
+const providerConfig = (models: HarnessModel[]) => ({
+    displayName: "Pollinations.ai",
+    apiKeyEnv: KEY_ENV,
+    api: "openai-completions",
+    baseURL: `${BASE_URL}/v1`,
+    compat: {
+        supportsStore: false,
+        supportsDeveloperRole: false,
+        supportsReasoningEffort: true,
+        supportsUsageInStreaming: true,
+        supportsStrictMode: false,
+        maxTokensField: "max_tokens",
+    },
+    models: models.map((model) => ({
+        id: model.id,
+        name: model.id,
+        contextWindow: model.contextWindow,
+        input: model.input,
+        reasoningEfforts: false,
+    })),
+});
+
+interface PiSettings {
+    apiKey: string;
+    model: string;
+    models: HarnessModel[];
+    mcp?: boolean;
+}
+
+const writeConfig = (ctx: HarnessContext, settings: PiSettings) => {
+    const doc = loadYaml(settingsPath(ctx));
+    doc.setIn(PROVIDER_PATH, doc.createNode(providerConfig(settings.models)));
+    doc.setIn(
+        DEFAULT_MODEL_PATH,
+        doc.createNode({ provider: PROVIDER, model: settings.model }),
+    );
+    writeTextAtomic(settingsPath(ctx), doc.toString(YAML_OUT), 0o600);
+    setEnvKey(ctx, settings.apiKey);
+    if (settings.mcp === false) removeMcpEntry(ctx);
+    else writeMcpEntry(ctx);
+    if (readTextIfExists(skillPath(ctx)) === null) {
+        writeTextAtomic(skillPath(ctx), polliSkill, 0o600);
+    }
+};
+
+const stripConfig = (ctx: HarnessContext) => {
+    const doc = loadYaml(settingsPath(ctx));
+    let changed = false;
+    if (doc.hasIn(PROVIDER_PATH)) {
+        doc.deleteIn(PROVIDER_PATH);
+        changed = true;
+    }
+    if (doc.getIn([...DEFAULT_MODEL_PATH, "provider"]) === PROVIDER) {
+        doc.deleteIn(DEFAULT_MODEL_PATH);
+        changed = true;
+    }
+    if (changed)
+        writeTextAtomic(settingsPath(ctx), doc.toString(YAML_OUT), 0o600);
+    changed = deleteEnvKey(ctx) || changed;
+    changed = removeMcpEntry(ctx) || changed;
+    if (readTextIfExists(skillPath(ctx)) === polliSkill) {
+        removeIfExists(skillPath(ctx));
+        changed = true;
+    }
+    return changed;
+};
+
+const result = (ctx: HarnessContext): HarnessResult => {
+    const doc = loadYaml(settingsPath(ctx));
+    const model = doc.getIn([...DEFAULT_MODEL_PATH, "model"]);
+    return {
+        harness: ID,
+        label: LABEL,
+        configured:
+            doc.getIn([...PROVIDER_PATH, "apiKeyEnv"]) === KEY_ENV &&
+            doc.getIn([...PROVIDER_PATH, "api"]) === "openai-completions" &&
+            doc.getIn([...PROVIDER_PATH, "baseURL"]) === `${BASE_URL}/v1` &&
+            doc.getIn([...DEFAULT_MODEL_PATH, "provider"]) === PROVIDER &&
+            typeof model === "string" &&
+            readKey(ctx) !== null &&
+            readTextIfExists(skillPath(ctx)) !== null,
+        model: typeof model === "string" ? model : undefined,
+        mcp: hasMcpEntry(ctx),
+        files: files(ctx),
+    };
+};
+
+export const configurePi = (
+    ctx: HarnessContext,
+    settings: PiSettings,
+): HarnessResult => {
+    applyWithSnapshot(ctx, ID, files(ctx), () => writeConfig(ctx, settings));
+    return result(ctx);
+};
+
+export const disablePi = (ctx: HarnessContext): HarnessResult => {
+    const managedFiles = files(ctx);
+    let outcome: HarnessResult["outcome"] = "restored";
+    if (restoreSnapshot(ctx, ID, managedFiles) !== "restored") {
+        outcome = stripConfig(ctx) ? "stripped" : "unchanged";
+        clearSnapshot(ctx, ID, managedFiles);
+    }
+    return { ...result(ctx), configured: false, outcome };
+};
+
+export const pi: HarnessAdapter = {
+    id: ID,
+    label: LABEL,
+    description: "Configure Pi as a Pollinations provider",
+    restartHint:
+        "Changes apply on the next request. Restart Pi to pick up the new provider.",
+
+    async on(ctx, options) {
+        const model = options.model ?? DEFAULT_MODEL;
+        const models = await fetchHarnessModels();
+        if (!models.some((c) => c.id === model)) {
+            throw new Error(
+                `Model "${model}" is not a tool-calling text model. Run: polli models`,
+            );
+        }
+        const apiKey = await resolveHarnessKey(
+            { id: ID, label: LABEL, existingKey: readKey(ctx) },
+            { browser: options.browser },
+        );
+        return configurePi(ctx, {
+            apiKey,
+            model,
+            models,
+            mcp: options.mcp,
+        });
+    },
+
+    off: disablePi,
+    status: result,
+};

--- a/packages/polli-cli/src/harnesses/pi.ts
+++ b/packages/polli-cli/src/harnesses/pi.ts
@@ -73,10 +73,7 @@ const readKey = (ctx: HarnessContext) => {
 };
 
 const envLine = (key: string) => `${KEY_ENV}=${JSON.stringify(key)}`;
-const keyLine = new RegExp(
-    `^\\s*(?:export\\s+)?${KEY_ENV}\\s*=`,
-    "u",
-);
+const keyLine = new RegExp(`^\\s*(?:export\\s+)?${KEY_ENV}\\s*=`, "u");
 
 const setEnvKey = (ctx: HarnessContext, key: string) => {
     const lines = (readTextIfExists(envPath(ctx)) ?? "").split("\n");

--- a/packages/polli-cli/src/harnesses/prime.ts
+++ b/packages/polli-cli/src/harnesses/prime.ts
@@ -1,0 +1,313 @@
+import { join, resolve } from "node:path";
+import { parseEnv } from "node:util";
+import { isMap, isSeq, parseDocument, Scalar } from "yaml";
+import polliSkill from "../../SKILL.md?raw";
+import { BASE_URL } from "../lib/config.js";
+import { readTextIfExists, removeIfExists, writeTextAtomic } from "./fs.js";
+import { resolveHarnessKey } from "./keys.js";
+import { fetchHarnessModels } from "./models.js";
+import {
+    applyWithSnapshot,
+    clearSnapshot,
+    restoreSnapshot,
+} from "./snapshot.js";
+import type {
+    HarnessAdapter,
+    HarnessContext,
+    HarnessModel,
+    HarnessResult,
+} from "./types.js";
+
+const ID = "prime";
+const LABEL = "Prime Agent";
+const PROVIDER = "pollinations";
+const DEFAULT_MODEL = "openai";
+const KEY_ENV = "POLLI_PRIME_API_KEY";
+const MCP_ID = "mcp-pollinations";
+const MCP_URL = `${BASE_URL}/mcp/pollinations`;
+
+// Prime Agent shares the pi-ai schema with DSH and Pi.
+const PROVIDER_PATH = ["llm-pi-ai", "providers", PROVIDER];
+const DEFAULT_MODEL_PATH = ["agent-default-model"];
+
+const YAML_OUT = { lineWidth: 0 };
+const JS_TAG = {
+    tag: "tag:yaml.org,2002:js",
+    resolve: (value: string) => value,
+};
+
+export const primeHome = (ctx: HarnessContext) => {
+    const configured = ctx.env.PRIME_HOME;
+    if (!configured?.trim()) return join(ctx.home, ".prime");
+    const expanded =
+        configured === "~"
+            ? ctx.home
+            : configured.startsWith("~/") || configured.startsWith("~\\")
+              ? join(ctx.home, configured.slice(2))
+              : configured;
+    return resolve(expanded);
+};
+
+const settingsPath = (ctx: HarnessContext) =>
+    join(primeHome(ctx), "settings.yaml");
+const envPath = (ctx: HarnessContext) => join(primeHome(ctx), ".env");
+const patchPath = (ctx: HarnessContext) =>
+    join(primeHome(ctx), "cordis.patch.yml");
+const skillPath = (ctx: HarnessContext) =>
+    join(primeHome(ctx), "skills", "polli", "SKILL.md");
+
+const loadYaml = (path: string) =>
+    parseDocument(readTextIfExists(path) ?? "", { customTags: [JS_TAG] });
+
+const files = (ctx: HarnessContext) => [
+    settingsPath(ctx),
+    envPath(ctx),
+    patchPath(ctx),
+    skillPath(ctx),
+];
+
+const readKey = (ctx: HarnessContext) => {
+    const text = readTextIfExists(envPath(ctx));
+    if (text === null) return null;
+    return parseEnv(text)[KEY_ENV] || null;
+};
+
+const envLine = (key: string) => `${KEY_ENV}=${JSON.stringify(key)}`;
+const keyLine = new RegExp(
+    `^\\s*(?:export\\s+)?${KEY_ENV}\\s*=`,
+    "u",
+);
+
+const setEnvKey = (ctx: HarnessContext, key: string) => {
+    const lines = (readTextIfExists(envPath(ctx)) ?? "").split("\n");
+    const index = lines.findIndex((line) => keyLine.test(line));
+    const filtered = lines.filter(
+        (line, i) => i === index || !keyLine.test(line),
+    );
+    if (index === -1) {
+        const insertAt =
+            filtered.at(-1) === "" ? filtered.length - 1 : filtered.length;
+        filtered.splice(insertAt, 0, envLine(key));
+    } else filtered[index] = envLine(key);
+    writeTextAtomic(envPath(ctx), filtered.join("\n"), 0o600);
+};
+
+const deleteEnvKey = (ctx: HarnessContext) => {
+    const text = readTextIfExists(envPath(ctx));
+    if (text === null) return false;
+    const lines = text.split("\n");
+    const filtered = lines.filter((line) => !keyLine.test(line));
+    if (filtered.length === lines.length) return false;
+    writeTextAtomic(envPath(ctx), filtered.join("\n"), 0o600);
+    return true;
+};
+
+const stripMcpEntry = (doc: ReturnType<typeof loadYaml>) => {
+    if (!isSeq(doc.contents)) return false;
+    let changed = false;
+    for (let i = doc.contents.items.length - 1; i >= 0; i--) {
+        const patch = doc.contents.items[i];
+        if (!isMap(patch)) continue;
+        const inserted = patch.get("insert", true);
+        if (!isSeq(inserted)) continue;
+        const before = inserted.items.length;
+        inserted.items = inserted.items.filter(
+            (entry) => !isMap(entry) || entry.get("id") !== MCP_ID,
+        );
+        changed ||= inserted.items.length !== before;
+        if (inserted.items.length === 0 && patch.items.length === 1) {
+            doc.contents.items.splice(i, 1);
+        }
+    }
+    return changed;
+};
+
+const removeMcpEntry = (ctx: HarnessContext) => {
+    const doc = loadYaml(patchPath(ctx));
+    if (!stripMcpEntry(doc)) return false;
+    writeTextAtomic(patchPath(ctx), doc.toString(YAML_OUT), 0o600);
+    return true;
+};
+
+const writeMcpEntry = (ctx: HarnessContext) => {
+    const doc = loadYaml(patchPath(ctx));
+    if (doc.contents === null) doc.contents = doc.createNode([]);
+    if (!isSeq(doc.contents)) {
+        throw new Error(`${patchPath(ctx)} must contain a YAML list`);
+    }
+    stripMcpEntry(doc);
+    const authorization = doc.createNode(
+        `\`Bearer \${process.env.${KEY_ENV}}\``,
+    );
+    authorization.tag = "tag:yaml.org,2002:js";
+    authorization.type = Scalar.QUOTE_SINGLE;
+    doc.add({
+        insert: [
+            {
+                id: MCP_ID,
+                name: "@pollinations/mcp-server",
+                config: {
+                    serverName: "pollinations",
+                    transport: "streamable-http",
+                    url: MCP_URL,
+                    headers: { Authorization: authorization },
+                },
+            },
+        ],
+    });
+    writeTextAtomic(patchPath(ctx), doc.toString(YAML_OUT), 0o600);
+};
+
+const hasMcpEntry = (ctx: HarnessContext) => {
+    const doc = loadYaml(patchPath(ctx));
+    if (!isSeq(doc.contents)) return false;
+    return doc.contents.items.some((patch) => {
+        if (!isMap(patch)) return false;
+        const inserted = patch.get("insert", true);
+        return (
+            isSeq(inserted) &&
+            inserted.items.some(
+                (entry) =>
+                    isMap(entry) &&
+                    entry.get("id") === MCP_ID &&
+                    entry.getIn(["config", "url"]) === MCP_URL,
+            )
+        );
+    });
+};
+
+const providerConfig = (models: HarnessModel[]) => ({
+    displayName: "Pollinations.ai",
+    apiKeyEnv: KEY_ENV,
+    api: "openai-completions",
+    baseURL: `${BASE_URL}/v1`,
+    compat: {
+        supportsStore: false,
+        supportsDeveloperRole: false,
+        supportsReasoningEffort: true,
+        supportsUsageInStreaming: true,
+        supportsStrictMode: false,
+        maxTokensField: "max_tokens",
+    },
+    models: models.map((model) => ({
+        id: model.id,
+        name: model.id,
+        contextWindow: model.contextWindow,
+        input: model.input,
+        reasoningEfforts: false,
+    })),
+});
+
+interface PrimeSettings {
+    apiKey: string;
+    model: string;
+    models: HarnessModel[];
+    mcp?: boolean;
+}
+
+const writeConfig = (ctx: HarnessContext, settings: PrimeSettings) => {
+    const doc = loadYaml(settingsPath(ctx));
+    doc.setIn(PROVIDER_PATH, doc.createNode(providerConfig(settings.models)));
+    doc.setIn(
+        DEFAULT_MODEL_PATH,
+        doc.createNode({ provider: PROVIDER, model: settings.model }),
+    );
+    writeTextAtomic(settingsPath(ctx), doc.toString(YAML_OUT), 0o600);
+    setEnvKey(ctx, settings.apiKey);
+    if (settings.mcp === false) removeMcpEntry(ctx);
+    else writeMcpEntry(ctx);
+    if (readTextIfExists(skillPath(ctx)) === null) {
+        writeTextAtomic(skillPath(ctx), polliSkill, 0o600);
+    }
+};
+
+const stripConfig = (ctx: HarnessContext) => {
+    const doc = loadYaml(settingsPath(ctx));
+    let changed = false;
+    if (doc.hasIn(PROVIDER_PATH)) {
+        doc.deleteIn(PROVIDER_PATH);
+        changed = true;
+    }
+    if (doc.getIn([...DEFAULT_MODEL_PATH, "provider"]) === PROVIDER) {
+        doc.deleteIn(DEFAULT_MODEL_PATH);
+        changed = true;
+    }
+    if (changed)
+        writeTextAtomic(settingsPath(ctx), doc.toString(YAML_OUT), 0o600);
+    changed = deleteEnvKey(ctx) || changed;
+    changed = removeMcpEntry(ctx) || changed;
+    if (readTextIfExists(skillPath(ctx)) === polliSkill) {
+        removeIfExists(skillPath(ctx));
+        changed = true;
+    }
+    return changed;
+};
+
+const result = (ctx: HarnessContext): HarnessResult => {
+    const doc = loadYaml(settingsPath(ctx));
+    const model = doc.getIn([...DEFAULT_MODEL_PATH, "model"]);
+    return {
+        harness: ID,
+        label: LABEL,
+        configured:
+            doc.getIn([...PROVIDER_PATH, "apiKeyEnv"]) === KEY_ENV &&
+            doc.getIn([...PROVIDER_PATH, "api"]) === "openai-completions" &&
+            doc.getIn([...PROVIDER_PATH, "baseURL"]) === `${BASE_URL}/v1` &&
+            doc.getIn([...DEFAULT_MODEL_PATH, "provider"]) === PROVIDER &&
+            typeof model === "string" &&
+            readKey(ctx) !== null &&
+            readTextIfExists(skillPath(ctx)) !== null,
+        model: typeof model === "string" ? model : undefined,
+        mcp: hasMcpEntry(ctx),
+        files: files(ctx),
+    };
+};
+
+export const configurePrime = (
+    ctx: HarnessContext,
+    settings: PrimeSettings,
+): HarnessResult => {
+    applyWithSnapshot(ctx, ID, files(ctx), () => writeConfig(ctx, settings));
+    return result(ctx);
+};
+
+export const disablePrime = (ctx: HarnessContext): HarnessResult => {
+    const managedFiles = files(ctx);
+    let outcome: HarnessResult["outcome"] = "restored";
+    if (restoreSnapshot(ctx, ID, managedFiles) !== "restored") {
+        outcome = stripConfig(ctx) ? "stripped" : "unchanged";
+        clearSnapshot(ctx, ID, managedFiles);
+    }
+    return { ...result(ctx), configured: false, outcome };
+};
+
+export const prime: HarnessAdapter = {
+    id: ID,
+    label: LABEL,
+    description: "Configure Prime Agent as a Pollinations provider",
+    restartHint:
+        "Changes apply on the next request. Restart Prime Agent to pick up the new provider.",
+
+    async on(ctx, options) {
+        const model = options.model ?? DEFAULT_MODEL;
+        const models = await fetchHarnessModels();
+        if (!models.some((c) => c.id === model)) {
+            throw new Error(
+                `Model "${model}" is not a tool-calling text model. Run: polli models`,
+            );
+        }
+        const apiKey = await resolveHarnessKey(
+            { id: ID, label: LABEL, existingKey: readKey(ctx) },
+            { browser: options.browser },
+        );
+        return configurePrime(ctx, {
+            apiKey,
+            model,
+            models,
+            mcp: options.mcp,
+        });
+    },
+
+    off: disablePrime,
+    status: result,
+};

--- a/packages/polli-cli/src/harnesses/prime.ts
+++ b/packages/polli-cli/src/harnesses/prime.ts
@@ -73,10 +73,7 @@ const readKey = (ctx: HarnessContext) => {
 };
 
 const envLine = (key: string) => `${KEY_ENV}=${JSON.stringify(key)}`;
-const keyLine = new RegExp(
-    `^\\s*(?:export\\s+)?${KEY_ENV}\\s*=`,
-    "u",
-);
+const keyLine = new RegExp(`^\\s*(?:export\\s+)?${KEY_ENV}\\s*=`, "u");
 
 const setEnvKey = (ctx: HarnessContext, key: string) => {
     const lines = (readTextIfExists(envPath(ctx)) ?? "").split("\n");


### PR DESCRIPTION
Adds `polli harness` support for four additional coding tools, closing all four harness quests in a single PR.

## What this adds

| Harness | Config path | Format | Env key |
|---------|------------|--------|---------|
| **OpenCode** | `~/.config/opencode/opencode.json` | JSON | `POLLI_OPENCODE_API_KEY` |
| **Pi** | `~/.pi/settings.yaml` | YAML (pi-ai schema) | `POLLI_PI_API_KEY` |
| **Prime Agent** | `~/.prime/settings.yaml` | YAML (pi-ai schema) | `POLLI_PRIME_API_KEY` |
| **OpenClaw** | `~/.openclaw/config.yaml` | YAML (providers block) | `POLLI_OPENCLAW_API_KEY` |

## How each harness works

All four adapters follow the existing DSH pattern:

- **`on`**: Mints a dedicated child key via `resolveHarnessKey`, writes provider config, enables MCP (skip with `--no-mcp`), writes SKILL.md
- **`off`**: Restores snapshot byte-for-byte, or surgically strips only Pollinations-owned entries
- **`status`**: Reports whether provider, key, and skill are in place

### OpenCode specifics
- Uses `@ai-sdk/openai-compatible` npm package for the provider
- Auth stored in `~/.local/share/opencode/auth.json`
- Provider block with all tool-calling text models from the Pollinations catalog

### Pi / Prime Agent specifics
- Share the `llm-pi-ai` YAML schema with DSH
- MCP entry in `cordis.patch.yml` for Pollinations MCP server
- Prime Agent preserves existing memories, sessions, and skills

### OpenClaw specifics
- YAML provider block at `providers.pollinations`
- Sets `provider: pollinations` and `model` as defaults
- Existing agents and unrelated config preserved

## Fixes
- Fixes #14118 (OpenCode)
- Fixes #14119 (Pi)
- Fixes #14120 (Prime Agent)
- Fixes #14121 (OpenClaw)

## Relevant background
Implemented after reading the DSH harness source, the OpenCode provider docs, Pi/Prime Agent pi-ai schema docs, and OpenClaw config.yaml structure. All four adapters reuse the shared `resolveHarnessKey`, `fetchHarnessModels`, `applyWithSnapshot`, and `restoreSnapshot` infrastructure.