### PR TITLE
fix(community-models): apply price delay only to adverse changes

### DIFF
--- a/enter.pollinations.ai/src/routes/community-endpoints.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints.ts
@@ -42,6 +42,7 @@ import {
     deriveCreateProxyPolicy,
     deriveUpdatedProxyPolicy,
     hasProxyPricingInput,
+    isAdversePricingChange,
     proxyPricingChanged,
     withoutProxyPricingChanges,
 } from "./community-endpoints/proxy-policy.ts";
@@ -821,7 +822,8 @@ export const communityEndpointsRoutes = new Hono<Env>()
                     targetVisibility === "public" &&
                     (currentVisibility === "public" ||
                         pendingVisibility === "public") &&
-                    hasProxyPricingInput(input);
+                    hasProxyPricingInput(input) &&
+                    isAdversePricingChange(targetBase, targetPolicy);
                 const pricingChanged = proxyPricingChanged(
                     targetBase,
                     targetPolicy,

--- a/enter.pollinations.ai/src/routes/community-endpoints/proxy-policy.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints/proxy-policy.ts
@@ -231,6 +231,23 @@ export function proxyPricingChanged(
     );
 }
 
+/**
+ * True when the pricing change is adverse to consumers — any price field
+ * increased, or paidOnly was enabled. A mix of increases and reductions
+ * within the same update is treated as adverse (one queued effective time).
+ * Price reductions, paidOnly disabling, and imagePricing changes alone
+ * are consumer-beneficial and take effect immediately.
+ */
+export function isAdversePricingChange(
+    current: Pick<ProxyListingPayload, "paidOnly" | "prices">,
+    target: Pick<ProxyListingPayload, "paidOnly" | "prices">,
+): boolean {
+    if (!current.paidOnly && target.paidOnly) return true;
+    return COMMUNITY_ENDPOINT_PRICE_FIELDS.some(
+        ({ key }) => target.prices[key] > current.prices[key],
+    );
+}
+
 export function hasProxyPricingInput(input: ProxyUpdateInput): boolean {
     return (
         input.paidOnly !== undefined ||

--- a/enter.pollinations.ai/test/integration/community-endpoint-price-delay.test.ts
+++ b/enter.pollinations.ai/test/integration/community-endpoint-price-delay.test.ts
@@ -431,4 +431,87 @@ describe("community endpoint 12-hour price-change delay", () => {
             pending: { visibility: "public" },
         });
     });
+
+    test("price reduction on a public model takes effect immediately", async ({
+        sessionToken,
+    }) => {
+        await approveCommunityModels();
+        const created = await postModel(sessionToken, "", {
+            name: "price-reduce-model",
+            title: "Price reduce model",
+            visibility: "public",
+            baseUrl: "https://text.example.com/v1",
+            bearerToken: "tok",
+            promptTextPrice: 0.000005,
+        });
+        await publishPendingModel(sessionToken, created.id as string);
+
+        const updated = await postModel(
+            sessionToken,
+            `/${created.id as string}/update`,
+            { promptTextPrice: 0.000001 },
+        );
+
+        // Price reduction takes effect immediately — no pending price.
+        expect(updated).toMatchObject({ promptTextPrice: 0.000001 });
+        expect(updated.pending).toBeNull();
+    });
+
+    test("disabling paidOnly on a public model takes effect immediately", async ({
+        sessionToken,
+    }) => {
+        await approveCommunityModels();
+        const created = await postModel(sessionToken, "", {
+            name: "paidonly-disable-model",
+            title: "PaidOnly disable model",
+            visibility: "public",
+            baseUrl: "https://text.example.com/v1",
+            bearerToken: "tok",
+            paidOnly: true,
+        });
+        await publishPendingModel(sessionToken, created.id as string);
+
+        const updated = await postModel(
+            sessionToken,
+            `/${created.id as string}/update`,
+            { paidOnly: false },
+        );
+
+        // Disabling paidOnly takes effect immediately — no pending change.
+        expect(updated).toMatchObject({ paidOnly: false });
+        expect(updated.pending).toBeNull();
+    });
+
+    test("mixed price increase and reduction remains queued as one policy", async ({
+        sessionToken,
+    }) => {
+        await approveCommunityModels();
+        const created = await postModel(sessionToken, "", {
+            name: "mixed-price-model",
+            title: "Mixed price model",
+            visibility: "public",
+            baseUrl: "https://text.example.com/v1",
+            bearerToken: "tok",
+            promptTextPrice: 0.000003,
+            completionTextPrice: 0.000006,
+        });
+        await publishPendingModel(sessionToken, created.id as string);
+
+        // Increase one field, reduce another — mixed change is adverse.
+        const updated = await postModel(
+            sessionToken,
+            `/${created.id as string}/update`,
+            { promptTextPrice: 0.000005, completionTextPrice: 0.000001 },
+        );
+
+        // Current prices unchanged; pending shows both new values.
+        expect(updated).toMatchObject({
+            promptTextPrice: 0.000003,
+            completionTextPrice: 0.000006,
+        });
+        expect(updated.pending).toMatchObject({
+            promptTextPrice: 0.000005,
+            completionTextPrice: 0.000001,
+        });
+    });
 });


### PR DESCRIPTION
## Summary

Fixes #13992

The 12-hour public community-model change delay introduced by #13800 currently treats consumer-beneficial pricing changes the same as adverse ones. This patch fixes that.

### What changes

- **Price reductions** now take effect **immediately** (no 12-hour wait)
- **Disabling paidOnly** now takes effect **immediately**
- **Price increases** and **enabling paidOnly** remain queued for 12 hours as before
- **Mixed updates** (both increases and reductions in one update) are treated as adverse and queued as one policy

### Implementation

Added `isAdversePricingChange()` in `proxy-policy.ts` that returns `true` when:
- Any price field increased, OR
- paidOnly was enabled from `false` → `true`

The existing `delayPricing` gate in `community-endpoints.ts` now checks `isAdversePricingChange()` in addition to the existing conditions. Consumer-beneficial changes bypass the delay entirely.

### What is NOT changed

- Private-model pricing (unchanged)
- Visibility rules (unchanged)
- Delete/recreate cooldown (unchanged)
- Existing pending-change responses and UI (unchanged — the pending field still shows queued changes correctly)

### Tests

Added 3 new integration tests:
1. **Price reduction** → takes effect immediately, no pending
2. **Disabling paidOnly** → takes effect immediately, no pending
3. **Mixed increase + reduction** → queued as one policy (adverse)