### PR TITLE
feat(floret): add prompt-complexity classifier for tier-based model routing

### DIFF
--- a/apps/floret/src/floret/complexity.py
+++ b/apps/floret/src/floret/complexity.py
@@ -1,0 +1,292 @@
+"""Prompt-complexity classifier for automatic tier-based model routing.
+
+Maps a prompt to a complexity tier (fast / balanced / quality) using
+lightweight heuristic scoring.  The classifier is designed to be fast,
+deterministic, and have zero external dependencies.
+
+Signals considered:
+  - Prompt length (word count, character count)
+  - Reasoning keywords (analysis, planning, multi-step logic)
+  - Tool-call / multi-step task indicators
+  - Code presence (language tags, function definitions)
+  - Structure indicators (lists, tables, numbered steps)
+  - Question complexity (simple vs. open-ended)
+
+The inferred tier feeds into ``registry.pick_model(modality, tier, ...)``
+so callers get automatic complexity-aware routing without any extra work.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+Tier = Literal["fast", "balanced", "quality"]
+
+# ---------------------------------------------------------------------------
+# Keyword sets
+# ---------------------------------------------------------------------------
+
+_REASONING_KEYWORDS: set[str] = {
+    "analyze",
+    "analysis",
+    "analyse",
+    "compare",
+    "contrast",
+    "evaluate",
+    "explain",
+    "reason",
+    "reasoning",
+    "think",
+    "thinking",
+    "step by step",
+    "step-by-step",
+    "first principles",
+    "pros and cons",
+    "tradeoff",
+    "trade-offs",
+    "tradeoffs",
+    "implications",
+    "consequences",
+    "critique",
+    "critically",
+    "deconstruct",
+    "synthesize",
+    "synthesis",
+    "elaborate",
+    "deep dive",
+    "in depth",
+    "in-depth",
+    "thorough",
+    "comprehensive",
+    "detailed analysis",
+    "root cause",
+    "why does",
+    "how does",
+    "what would happen",
+    "what are the tradeoffs",
+    "what are the implications",
+    "design a system",
+    "architect",
+    "architecture",
+    "strategy",
+    "strategic",
+    "plan for",
+    "planning",
+    "roadmap",
+    "outline a plan",
+    "multi-step",
+    "multi step",
+    "chain of thought",
+    "chain-of-thought",
+    "cot",
+    "let's think",
+    "let us think",
+    "think carefully",
+    "think through",
+    "walk me through",
+    "break down",
+    "breakdown",
+    "dissect",
+    "examine",
+    "investigate",
+    "research",
+    "survey",
+    "literature review",
+    "meta-analysis",
+    "systematic",
+    "methodology",
+    "hypothesis",
+    "hypotheses",
+    "experiment design",
+    "controlled experiment",
+}
+
+_TOOL_CALL_KEYWORDS: set[str] = {
+    "use the tool",
+    "call the api",
+    "invoke",
+    "function call",
+    "tool call",
+    "use a function",
+    "execute",
+    "run a script",
+    "run code",
+    "call endpoint",
+    "api call",
+    "webhook",
+    "pipeline",
+    "workflow",
+    "orchestrate",
+    "chain",
+    "agentic",
+    "agent",
+    "multi-agent",
+    "swarm",
+    "collaborate",
+    "delegate",
+    "parallel",
+    "concurrent",
+}
+
+_CODE_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"```"),  # fenced code blocks
+    re.compile(r"\b(def |class |function |import |from |const |let |var |async |await )\b"),
+    re.compile(r"\b(python|javascript|typescript|rust|go|java|c\+\+|ruby|swift|kotlin|sql|html|css|bash|shell| powershell)\b", re.IGNORECASE),
+    re.compile(r"\bfor\s*\(|while\s*\(|if\s*\(|switch\s*\(|return\s+"),
+    re.compile(r"[{}\[\]();].*[{}\[\]();]"),  # multiple brackets on one line
+    re.compile(r"\bprint\(|console\.log\(|fmt\.Print|System\.out\.|printf\("),
+]
+
+_STRUCTURE_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"^\s*[-*+]\s+", re.MULTILINE),  # bullet lists
+    re.compile(r"^\s*\d+\.\s+", re.MULTILINE),  # numbered lists
+    re.compile(r"^\s*\|.*\|.*\|", re.MULTILINE),  # tables
+    re.compile(r"^\s*#{1,6}\s+", re.MULTILINE),  # markdown headers
+    re.compile(r"^\s*>", re.MULTILINE),  # blockquotes
+]
+
+_SIMPLE_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"^(hi|hello|hey|yo|sup|thanks|thank you|ok|okay|yes|no|sure|cool|great|nice)\s*[!.?]?\s*$", re.IGNORECASE),
+    re.compile(r"^(what time|what day|what date|who is|when is|where is)\b", re.IGNORECASE),
+    re.compile(r"^(tell me a joke|say something funny|one word|one line)\b", re.IGNORECASE),
+    re.compile(r"^(translate|summarize|tldr|tl;dr|short|brief|quick)\b", re.IGNORECASE),
+]
+
+
+def _word_count(text: str) -> int:
+    return len(text.split())
+
+
+def _char_count(text: str) -> int:
+    return len(text)
+
+
+def _has_reasoning_keywords(text: str) -> int:
+    lower = text.lower()
+    return sum(1 for kw in _REASONING_KEYWORDS if kw in lower)
+
+
+def _has_tool_keywords(text: str) -> int:
+    lower = text.lower()
+    return sum(1 for kw in _TOOL_CALL_KEYWORDS if kw in lower)
+
+
+def _has_code(text: str) -> int:
+    return sum(1 for p in _CODE_PATTERNS if p.search(text))
+
+
+def _has_structure(text: str) -> int:
+    return sum(1 for p in _STRUCTURE_PATTERNS if p.search(text))
+
+
+def _is_simple(text: str) -> bool:
+    return any(p.match(text.strip()) for p in _SIMPLE_PATTERNS)
+
+
+def _line_count(text: str) -> int:
+    return len(text.strip().splitlines())
+
+
+def _avg_line_length(text: str) -> float:
+    lines = text.strip().splitlines()
+    if not lines:
+        return 0.0
+    return sum(len(line) for line in lines) / len(lines)
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+def _complexity_score(text: str) -> float:
+    """Return a raw complexity score for *text*.  Higher = more complex."""
+    if not text or not text.strip():
+        return 0.0
+
+    words = _word_count(text)
+    chars = _char_count(text)
+    lines = _line_count(text)
+
+    score = 0.0
+
+    # Length signals (logarithmic to avoid dominating)
+    import math
+    score += min(math.log2(max(words, 1)) * 2.0, 12.0)   # up to ~12 pts
+    score += min(math.log2(max(chars, 1)) * 0.5, 6.0)    # up to ~6 pts
+    score += min(math.log2(max(lines, 1)) * 1.5, 6.0)    # up to ~6 pts
+
+    # Reasoning keywords (strong signal)
+    reasoning = _has_reasoning_keywords(text)
+    score += reasoning * 3.0  # up to ~15 pts (5 keywords)
+
+    # Tool-call / multi-step
+    tool_calls = _has_tool_keywords(text)
+    score += tool_calls * 2.5  # up to ~10 pts
+
+    # Code presence
+    code = _has_code(text)
+    score += code * 2.0  # up to ~8 pts
+
+    # Structure (lists, tables, headers)
+    structure = _has_structure(text)
+    score += structure * 1.5  # up to ~6 pts
+
+    # Simple prompt penalty
+    if _is_simple(text):
+        score -= 15.0
+
+    # Very short = definitely fast
+    if words <= 5:
+        score -= 10.0
+    elif words <= 15:
+        score -= 3.0
+
+    # Very long = definitely quality
+    if words > 200:
+        score += 5.0
+    if lines > 20:
+        score += 3.0
+
+    return max(score, 0.0)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+# Thresholds (tuned for balanced distribution)
+_FAST_THRESHOLD = 8.0
+_QUALITY_THRESHOLD = 22.0
+
+
+def classify_tier(text: str) -> Tier:
+    """Classify prompt complexity into a routing tier.
+
+    Returns one of ``"fast"``, ``"balanced"``, or ``"quality"``.
+
+    The classification is purely heuristic — no model calls, no network,
+    no async.  Typical execution is < 1 ms for any reasonable prompt.
+    """
+    if _is_simple(text):
+        return "fast"
+
+    score = _complexity_score(text)
+
+    if score < _FAST_THRESHOLD:
+        return "fast"
+    if score >= _QUALITY_THRESHOLD:
+        return "quality"
+    return "balanced"
+
+
+def classify_with_score(text: str) -> tuple[Tier, float]:
+    """Like :func:`classify_tier` but also returns the raw score."""
+    if _is_simple(text):
+        return "fast", 0.0
+    score = _complexity_score(text)
+    if score < _FAST_THRESHOLD:
+        return "fast", score
+    if score >= _QUALITY_THRESHOLD:
+        return "quality", score
+    return "balanced", score

--- a/apps/floret/src/floret/registry.py
+++ b/apps/floret/src/floret/registry.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import httpx
 
+from floret.complexity import classify_tier
 from floret.config import settings
 
 logger = logging.getLogger(__name__)
@@ -432,8 +433,22 @@ async def warm_registry() -> None:
 
 
 def pick_model(
-    modality: str, tier: str = "balanced", prompt: str = "", paid: bool = True
+    modality: str,
+    tier: str | None = None,
+    prompt: str = "",
+    paid: bool = True,
+    *,
+    auto_tier: bool = True,
 ) -> str:
+    """Select the best model for *modality* at a given complexity *tier*.
+
+    When *tier* is ``None`` (the default) and *auto_tier* is ``True``, the
+    tier is inferred from *prompt* using :mod:`floret.complexity`.
+    Pass an explicit *tier* to override the classifier.
+    """
+    # Infer tier from prompt when not explicitly provided
+    if tier is None:
+        tier = classify_tier(prompt) if (auto_tier and prompt) else "balanced"
     if _registry_cache is None:
         try:
             loop = asyncio.get_event_loop()

--- a/apps/floret/tests/test_complexity.py
+++ b/apps/floret/tests/test_complexity.py
@@ -1,0 +1,131 @@
+"""Unit tests for the prompt-complexity classifier."""
+
+from __future__ import annotations
+
+from floret.complexity import classify_tier, classify_with_score
+
+
+class TestClassifyTier:
+    """Test tier classification for various prompt types."""
+
+    def test_empty_prompt_returns_fast(self):
+        """Empty prompt is simple, so it should be classified as fast."""
+        assert classify_tier("") == "fast"
+
+    def test_simple_greeting_returns_fast(self):
+        """Simple greetings should be classified as fast."""
+        assert classify_tier("hello") == "fast"
+        assert classify_tier("hi") == "fast"
+        assert classify_tier("hey") == "fast"
+        assert classify_tier("thanks") == "fast"
+        assert classify_tier("ok") == "fast"
+
+    def test_simple_question_returns_fast(self):
+        """Simple factual questions should be classified as fast."""
+        assert classify_tier("what time is it?") == "fast"
+        assert classify_tier("who is the president?") == "fast"
+        assert classify_tier("where is Paris?") == "fast"
+
+    def test_short_prompt_returns_fast(self):
+        """Very short prompts (<=5 words) should be classified as fast."""
+        assert classify_tier("hello world") == "fast"
+        assert classify_tier("what is 2+2?") == "fast"
+
+    def test_medium_prompt_returns_balanced(self):
+        """Medium-length prompts with moderate complexity should be balanced."""
+        assert classify_tier("Write a function to sort an array of integers") == "balanced"
+        assert classify_tier("Explain how photosynthesis works in plants") == "balanced"
+
+    def test_reasoning_keywords_returns_quality(self):
+        """Prompts with reasoning keywords should be classified as quality."""
+        assert classify_tier(
+            "Analyze the tradeoffs between microservices and monolithic architecture. "
+            "Compare the pros and cons, evaluate the implications for scalability, "
+            "and provide a comprehensive critique of each approach."
+        ) == "quality"
+
+    def test_code_heavy_prompt_returns_quality(self):
+        """Prompts with code blocks should be classified as quality."""
+        assert classify_tier(
+            "```python\ndef complex_algorithm():\n"
+            "    # Implement dynamic programming solution\n"
+            "    pass\n```\n"
+            "Explain this algorithm step by step."
+        ) == "quality"
+
+    def test_tool_call_keywords_returns_quality(self):
+        """Prompts with tool-call indicators should be classified as quality."""
+        assert classify_tier(
+            "Use the tool to call the API endpoint, then execute the pipeline "
+            "and orchestrate the multi-agent workflow."
+        ) == "quality"
+
+    def test_structured_prompt_returns_quality(self):
+        """Prompts with structure (lists, tables) should be classified as quality."""
+        assert classify_tier(
+            "# Analysis Report\n\n"
+            "## Requirements\n"
+            "- Requirement 1: Scalability\n"
+            "- Requirement 2: Security\n"
+            "- Requirement 3: Performance\n\n"
+            "## Evaluation Criteria\n"
+            "1. Cost\n"
+            "2. Complexity\n"
+            "3. Maintenance\n\n"
+            "Please evaluate each option against these criteria."
+        ) == "quality"
+
+    def test_very_long_prompt_returns_quality(self):
+        """Very long prompts (>200 words) should be classified as quality."""
+        long_prompt = " ".join(["word"] * 250)
+        assert classify_tier(long_prompt) == "quality"
+
+
+class TestClassifyWithScore:
+    """Test that classify_with_score returns both tier and score."""
+
+    def test_returns_tuple(self):
+        """Should return a (tier, score) tuple."""
+        tier, score = classify_with_score("hello")
+        assert tier == "fast"
+        assert isinstance(score, float)
+
+    def test_score_increases_with_complexity(self):
+        """More complex prompts should have higher scores."""
+        _, simple_score = classify_with_score("hi")
+        _, complex_score = classify_with_score(
+            "Analyze the architectural implications of adopting event-driven "
+            "microservices, compare with synchronous alternatives, and evaluate "
+            "the tradeoffs for our current system."
+        )
+        assert complex_score > simple_score
+
+    def test_balanced_score_range(self):
+        """Balanced prompts should have scores in the middle range."""
+        tier, score = classify_with_score(
+            "Write a Python function that sorts a list of integers."
+        )
+        assert tier == "balanced"
+        assert 8.0 <= score < 22.0
+
+
+class TestEdgeCases:
+    """Test edge cases and special characters."""
+
+    def test_unicode_characters(self):
+        """Prompts with unicode should work."""
+        tier = classify_tier("分析这个系统的架构设计")
+        assert tier in ("fast", "balanced", "quality")
+
+    def test_special_characters(self):
+        """Prompts with special characters should work."""
+        tier = classify_tier("What's the @#$%^&*() meaning of life?")
+        assert tier in ("fast", "balanced", "quality")
+
+    def test_whitespace_only(self):
+        """Whitespace-only prompts are simple, so they should be fast."""
+        assert classify_tier("   ") == "fast"
+
+    def test_newlines_only(self):
+        """Newline-only prompts are simple, so they should be fast."""
+        assert classify_tier("\n\n\n") == "fast"


### PR DESCRIPTION
## Summary

Fixes #14076

Adds a lightweight heuristic prompt-complexity classifier that maps prompts to routing tiers (fast / balanced / quality) for automatic model selection in Floret.

### What this does

The classifier sits in front of `pick_model()` and determines the appropriate tier from the prompt itself, enabling fully automatic routing:
- **Simple prompts** → `fast` (smaller, cheaper, faster models)
- **Complex prompts** → `quality` (larger, more capable models)
- **Medium prompts** → `balanced`

### Signals considered

| Signal | Weight | Example |
|--------|--------|---------|
| Prompt length | Logarithmic | 5 words vs 200 words |
| Reasoning keywords | +3.0 each | "analyze", "compare", "evaluate" |
| Tool-call indicators | +2.5 each | "use the tool", "call the API" |
| Code presence | +2.0 each | code blocks, function defs |
| Structure | +1.5 each | Lists, tables, headers |
| Simple patterns | -15.0 | "hello", "what time?" |

### Performance

- **Zero external dependencies** — pure Python regex + arithmetic
- **Zero network calls** — no model inference needed
- **< 1 ms execution** — suitable for hot path

### Backward compatibility

- Existing callers passing `tier='balanced'` are **unaffected**
- `tier=None` (new default) triggers automatic inference
- `auto_tier=False` preserves old behavior exactly

### Tests

17 new unit tests covering simple, medium, complex, and edge-case prompts. All 127 existing tests pass.

### Design decisions

- **Heuristic first** (as suggested in issue): no model calls, deterministic
- **Caller overridable**: explicit `tier` param takes precedence
- **No telemetry** (can be added later): keeps implementation minimal
