### PR TITLE
feat(cli): add polli harness for OpenCode

### DIFF
--- a/CODING_HARNESSES.md
+++ b/CODING_HARNESSES.md
@@ -2,7 +2,7 @@
 
 Use `polli harness` to connect a supported coding harness to Pollinations. It handles Polli login, a dedicated API key, model setup, and any Pollinations capabilities supported by that harness.
 
-> **Available now:** DeepSeek Harness is currently the only integrated `polli harness` profile. OpenCode, Pi, Prime Agent, and OpenClaw are coming soon.
+> **Available now:** DeepSeek Harness and OpenCode. Pi, Prime Agent, and OpenClaw are coming soon.
 
 ## Use a harness
 
@@ -26,7 +26,7 @@ If Polli is not installed yet, run the first setup through `npx @pollinations/cl
 | Harness | Status | What is unique |
 | --- | --- | --- |
 | [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`) | **Available now** — `polli harness dsh on` | Adds the Pollinations provider, hosted Pollinations MCP, and Polli skill. Uses `deepseek` by default. |
-| [OpenCode](https://opencode.ai) | Coming soon | Will use the existing [Pollinations OpenCode plugin](https://github.com/fkom13/opencode-pollinations-plugin) for models, media tools, usage, and quests. |
+| [OpenCode](https://opencode.ai) (`opencode`) | **Available now** — `polli harness opencode on` | Uses the existing [Pollinations OpenCode plugin](https://github.com/fkom13/opencode-pollinations-plugin) for models, media, usage, and quests. Uses `openai` by default. |
 | [Pi](https://github.com/earendil-works/pi) | Coming soon | Will use its native provider support and the Polli skill; Pi does not include built-in MCP support. |
 | [Prime Agent](https://github.com/PrimeIntellect-ai/prime-agent) | Coming soon | Will add Pollinations while preserving the agent's memories, sessions, and skills. |
 | [OpenClaw](https://github.com/openclaw/openclaw) | Coming soon | Will bring the [existing Pollinations setup](./apps/openclaw/README.md) into the shared `polli harness` workflow. |
@@ -40,3 +40,13 @@ polli harness dsh off
 ```
 
 Choose another default model with `--model <id>`. Add `--no-mcp` if you do not want the hosted Pollinations media tools.
+
+## OpenCode
+
+```bash
+npx @pollinations/cli harness opencode on
+polli harness opencode status
+polli harness opencode off
+```
+
+If OpenCode is not installed, you will be offered the official installer. Choose another default model with `--model <id>`.

--- a/packages/polli-cli/src/harnesses/index.ts
+++ b/packages/polli-cli/src/harnesses/index.ts
@@ -1,4 +1,5 @@
 import { dsh } from "./dsh.js";
+import { opencode } from "./opencode.js";
 import type { HarnessAdapter } from "./types.js";
 
-export const HARNESSES: HarnessAdapter[] = [dsh];
+export const HARNESSES: HarnessAdapter[] = [dsh, opencode];

--- a/packages/polli-cli/src/harnesses/opencode.ts
+++ b/packages/polli-cli/src/harnesses/opencode.ts
@@ -1,5 +1,5 @@
-import { join, resolve } from "node:path";
 import { execSync } from "node:child_process";
+import { join, resolve } from "node:path";
 import polliSkill from "../../SKILL.md?raw";
 import { BASE_URL } from "../lib/config.js";
 import { readTextIfExists, removeIfExists, writeTextAtomic } from "./fs.js";
@@ -34,7 +34,8 @@ const isOpencodeInstalled = (): boolean => {
     }
 };
 
-const configPath = (ctx: HarnessContext) => join(ctx.home, CONFIG_DIR, CONFIG_FILE);
+const configPath = (ctx: HarnessContext) =>
+    join(ctx.home, CONFIG_DIR, CONFIG_FILE);
 const skillPath = (ctx: HarnessContext) =>
     join(ctx.home, CONFIG_DIR, "skills", "polli", "SKILL.md");
 
@@ -53,7 +54,11 @@ const readConfig = (ctx: HarnessContext): Record<string, unknown> => {
 };
 
 const writeConfig = (config: Record<string, unknown>, ctx: HarnessContext) => {
-    writeTextAtomic(configPath(ctx), `${JSON.stringify(config, null, 2)}\n`, 0o600);
+    writeTextAtomic(
+        configPath(ctx),
+        `${JSON.stringify(config, null, 2)}\n`,
+        0o600,
+    );
 };
 
 const ensureOpencodeInstalled = () => {
@@ -89,13 +94,18 @@ interface OpencodeSettings {
     models: HarnessModel[];
 }
 
-const writeOpencodeConfig = (ctx: HarnessContext, settings: OpencodeSettings) => {
+const writeOpencodeConfig = (
+    ctx: HarnessContext,
+    settings: OpencodeSettings,
+) => {
     const config = readConfig(ctx);
     const provider = providerConfig(settings.models, settings.apiKey);
 
     // Preserve unrelated config — only touch our provider and plugin.
     const existingProvider = (config.provider ?? {}) as Record<string, unknown>;
-    const existingPlugins = Array.isArray(config.plugin) ? [...(config.plugin as unknown[])] : [];
+    const existingPlugins = Array.isArray(config.plugin)
+        ? [...(config.plugin as unknown[])]
+        : [];
 
     // Merge provider.pollinations
     config.provider = {
@@ -154,7 +164,10 @@ const stripOpencodeConfig = (ctx: HarnessContext): boolean => {
         if ((config.plugin as unknown[]).length === 0) delete config.plugin;
     }
 
-    if (typeof config.model === "string" && String(config.model).startsWith(`${PROVIDER}/`)) {
+    if (
+        typeof config.model === "string" &&
+        String(config.model).startsWith(`${PROVIDER}/`)
+    ) {
         delete config.model;
         changed = true;
     }
@@ -175,20 +188,31 @@ const stripOpencodeConfig = (ctx: HarnessContext): boolean => {
 
 const result = (ctx: HarnessContext): HarnessResult => {
     const config = readConfig(ctx);
-    const provider = (config.provider as Record<string, unknown> | undefined)?.[PROVIDER] as
-        | Record<string, unknown>
-        | undefined;
+    const provider = (config.provider as Record<string, unknown> | undefined)?.[
+        PROVIDER
+    ] as Record<string, unknown> | undefined;
     const options = provider?.options as Record<string, unknown> | undefined;
-    const hasProvider = !!provider && options?.baseURL === `${BASE_URL}/v1` && typeof options?.apiKey === "string" && String(options.apiKey).length > 10;
-    const model = typeof config.model === "string" ? String(config.model) : undefined;
-    const hasPlugin = Array.isArray(config.plugin) && (config.plugin as unknown[]).some((p) => p === PLUGIN_ID || (Array.isArray(p) && p[0] === PLUGIN_ID));
+    const hasProvider =
+        !!provider &&
+        options?.baseURL === `${BASE_URL}/v1` &&
+        typeof options?.apiKey === "string" &&
+        String(options.apiKey).length > 10;
+    const model =
+        typeof config.model === "string" ? String(config.model) : undefined;
+    const hasPlugin =
+        Array.isArray(config.plugin) &&
+        (config.plugin as unknown[]).some(
+            (p) => p === PLUGIN_ID || (Array.isArray(p) && p[0] === PLUGIN_ID),
+        );
     const hasSkill = readTextIfExists(skillPath(ctx)) !== null;
 
     return {
         harness: ID,
         label: LABEL,
         configured: hasProvider && hasPlugin && hasSkill,
-        model: model?.startsWith(`${PROVIDER}/`) ? model.slice(PROVIDER.length + 1) : model,
+        model: model?.startsWith(`${PROVIDER}/`)
+            ? model.slice(PROVIDER.length + 1)
+            : model,
         files: files(ctx),
     };
 };
@@ -198,7 +222,9 @@ export const configureOpencode = (
     settings: OpencodeSettings,
 ): HarnessResult => {
     ensureOpencodeInstalled();
-    applyWithSnapshot(ctx, ID, files(ctx), () => writeOpencodeConfig(ctx, settings));
+    applyWithSnapshot(ctx, ID, files(ctx), () =>
+        writeOpencodeConfig(ctx, settings),
+    );
     return result(ctx);
 };
 
@@ -223,13 +249,21 @@ export const opencode: HarnessAdapter = {
         const model = options.model ?? DEFAULT_MODEL;
         const models = await fetchHarnessModels();
         if (!models.some((m) => m.id === model)) {
-            throw new Error(`Model "${model}" is not a tool-calling text model. Run: polli models`);
+            throw new Error(
+                `Model "${model}" is not a tool-calling text model. Run: polli models`,
+            );
         }
         const existingKey = (() => {
             const cfg = readConfig(ctx);
-            const provider = (cfg.provider as Record<string, unknown> | undefined)?.[PROVIDER] as Record<string, unknown> | undefined;
-            const opts = provider?.options as Record<string, unknown> | undefined;
-            return typeof opts?.apiKey === "string" ? String(opts.apiKey) : null;
+            const provider = (
+                cfg.provider as Record<string, unknown> | undefined
+            )?.[PROVIDER] as Record<string, unknown> | undefined;
+            const opts = provider?.options as
+                | Record<string, unknown>
+                | undefined;
+            return typeof opts?.apiKey === "string"
+                ? String(opts.apiKey)
+                : null;
         })();
         const apiKey = await resolveHarnessKey(
             { id: ID, label: LABEL, existingKey },

--- a/packages/polli-cli/src/harnesses/opencode.ts
+++ b/packages/polli-cli/src/harnesses/opencode.ts
@@ -1,0 +1,243 @@
+import { join, resolve } from "node:path";
+import { execSync } from "node:child_process";
+import polliSkill from "../../SKILL.md?raw";
+import { BASE_URL } from "../lib/config.js";
+import { readTextIfExists, removeIfExists, writeTextAtomic } from "./fs.js";
+import { resolveHarnessKey } from "./keys.js";
+import { fetchHarnessModels } from "./models.js";
+import {
+    applyWithSnapshot,
+    clearSnapshot,
+    restoreSnapshot,
+} from "./snapshot.js";
+import type {
+    HarnessAdapter,
+    HarnessContext,
+    HarnessModel,
+    HarnessResult,
+} from "./types.js";
+
+const ID = "opencode";
+const LABEL = "OpenCode";
+const PROVIDER = "pollinations";
+const DEFAULT_MODEL = "openai";
+const PLUGIN_ID = "opencode-pollinations-plugin";
+const CONFIG_DIR = ".config/opencode";
+const CONFIG_FILE = "opencode.json";
+
+const isOpencodeInstalled = (): boolean => {
+    try {
+        execSync("opencode --version", { stdio: "ignore" });
+        return true;
+    } catch {
+        return false;
+    }
+};
+
+const configPath = (ctx: HarnessContext) => join(ctx.home, CONFIG_DIR, CONFIG_FILE);
+const skillPath = (ctx: HarnessContext) =>
+    join(ctx.home, CONFIG_DIR, "skills", "polli", "SKILL.md");
+
+const files = (ctx: HarnessContext) => [configPath(ctx), skillPath(ctx)];
+
+const readConfig = (ctx: HarnessContext): Record<string, unknown> => {
+    const text = readTextIfExists(configPath(ctx));
+    if (!text) return {};
+    try {
+        return JSON.parse(text) as Record<string, unknown>;
+    } catch {
+        throw new Error(
+            `${configPath(ctx)} is not valid JSON — fix or remove it and try again`,
+        );
+    }
+};
+
+const writeConfig = (config: Record<string, unknown>, ctx: HarnessContext) => {
+    writeTextAtomic(configPath(ctx), `${JSON.stringify(config, null, 2)}\n`, 0o600);
+};
+
+const ensureOpencodeInstalled = () => {
+    if (isOpencodeInstalled()) return;
+    const msg = [
+        "OpenCode is not installed.",
+        "Install it first with the official installer:",
+        "  curl -fsSL https://opencode.ai/install | bash",
+        "or: npm i -g opencode-ai",
+        "Then run: polli harness opencode on",
+    ].join("\n");
+    throw new Error(msg);
+};
+
+const providerConfig = (models: HarnessModel[], apiKey: string) => ({
+    pollinations: {
+        options: {
+            baseURL: `${BASE_URL}/v1`,
+            apiKey,
+        },
+        models: models.map((m) => ({
+            id: m.id,
+            name: m.id,
+            contextWindow: m.contextWindow,
+            input: m.input,
+        })),
+    },
+});
+
+interface OpencodeSettings {
+    apiKey: string;
+    model: string;
+    models: HarnessModel[];
+}
+
+const writeOpencodeConfig = (ctx: HarnessContext, settings: OpencodeSettings) => {
+    const config = readConfig(ctx);
+    const provider = providerConfig(settings.models, settings.apiKey);
+
+    // Preserve unrelated config — only touch our provider and plugin.
+    const existingProvider = (config.provider ?? {}) as Record<string, unknown>;
+    const existingPlugins = Array.isArray(config.plugin) ? [...(config.plugin as unknown[])] : [];
+
+    // Merge provider.pollinations
+    config.provider = {
+        ...(config.provider as Record<string, unknown>),
+        ...provider,
+    };
+
+    // Ensure plugin is enabled
+    const hasPlugin = existingPlugins.some(
+        (p) => p === PLUGIN_ID || (Array.isArray(p) && p[0] === PLUGIN_ID),
+    );
+    if (!hasPlugin) {
+        config.plugin = [...existingPlugins, PLUGIN_ID];
+    }
+
+    // Default model
+    if (!config.model || typeof config.model !== "string") {
+        config.model = `${PROVIDER}/${settings.model}`;
+    } else if (!String(config.model).startsWith(`${PROVIDER}/`)) {
+        // Keep user's default if it's not pollinations, don't override
+    } else {
+        config.model = `${PROVIDER}/${settings.model}`;
+    }
+
+    writeConfig(config as Record<string, unknown>, ctx);
+
+    if (readTextIfExists(skillPath(ctx)) === null) {
+        writeTextAtomic(skillPath(ctx), polliSkill, 0o600);
+    }
+};
+
+const stripOpencodeConfig = (ctx: HarnessContext): boolean => {
+    const text = readTextIfExists(configPath(ctx));
+    if (text === null) return false;
+    let config: Record<string, unknown>;
+    try {
+        config = JSON.parse(text) as Record<string, unknown>;
+    } catch {
+        return false;
+    }
+    let changed = false;
+
+    const provider = config.provider as Record<string, unknown> | undefined;
+    if (provider && PROVIDER in provider) {
+        delete provider[PROVIDER];
+        changed = true;
+        if (Object.keys(provider).length === 0) delete config.provider;
+    }
+
+    if (Array.isArray(config.plugin)) {
+        const before = (config.plugin as unknown[]).length;
+        config.plugin = (config.plugin as unknown[]).filter(
+            (p) => p !== PLUGIN_ID && !(Array.isArray(p) && p[0] === PLUGIN_ID),
+        );
+        if ((config.plugin as unknown[]).length !== before) changed = true;
+        if ((config.plugin as unknown[]).length === 0) delete config.plugin;
+    }
+
+    if (typeof config.model === "string" && String(config.model).startsWith(`${PROVIDER}/`)) {
+        delete config.model;
+        changed = true;
+    }
+
+    if (changed) {
+        const hasContent = Object.keys(config).length > 0;
+        if (hasContent) writeConfig(config, ctx);
+        else removeIfExists(configPath(ctx));
+    }
+
+    if (readTextIfExists(skillPath(ctx)) === polliSkill) {
+        removeIfExists(skillPath(ctx));
+        changed = true;
+    }
+
+    return changed;
+};
+
+const result = (ctx: HarnessContext): HarnessResult => {
+    const config = readConfig(ctx);
+    const provider = (config.provider as Record<string, unknown> | undefined)?.[PROVIDER] as
+        | Record<string, unknown>
+        | undefined;
+    const options = provider?.options as Record<string, unknown> | undefined;
+    const hasProvider = !!provider && options?.baseURL === `${BASE_URL}/v1` && typeof options?.apiKey === "string" && String(options.apiKey).length > 10;
+    const model = typeof config.model === "string" ? String(config.model) : undefined;
+    const hasPlugin = Array.isArray(config.plugin) && (config.plugin as unknown[]).some((p) => p === PLUGIN_ID || (Array.isArray(p) && p[0] === PLUGIN_ID));
+    const hasSkill = readTextIfExists(skillPath(ctx)) !== null;
+
+    return {
+        harness: ID,
+        label: LABEL,
+        configured: hasProvider && hasPlugin && hasSkill,
+        model: model?.startsWith(`${PROVIDER}/`) ? model.slice(PROVIDER.length + 1) : model,
+        files: files(ctx),
+    };
+};
+
+export const configureOpencode = (
+    ctx: HarnessContext,
+    settings: OpencodeSettings,
+): HarnessResult => {
+    ensureOpencodeInstalled();
+    applyWithSnapshot(ctx, ID, files(ctx), () => writeOpencodeConfig(ctx, settings));
+    return result(ctx);
+};
+
+export const disableOpencode = (ctx: HarnessContext): HarnessResult => {
+    const managedFiles = files(ctx);
+    let outcome: HarnessResult["outcome"] = "restored";
+    if (restoreSnapshot(ctx, ID, managedFiles) !== "restored") {
+        outcome = stripOpencodeConfig(ctx) ? "stripped" : "unchanged";
+        clearSnapshot(ctx, ID, managedFiles);
+    }
+    return { ...result(ctx), configured: false, outcome };
+};
+
+export const opencode: HarnessAdapter = {
+    id: ID,
+    label: LABEL,
+    description: "Configure OpenCode to use Pollinations",
+    restartHint: "Run opencode again — the Pollinations provider is ready.",
+
+    async on(ctx, options) {
+        ensureOpencodeInstalled();
+        const model = options.model ?? DEFAULT_MODEL;
+        const models = await fetchHarnessModels();
+        if (!models.some((m) => m.id === model)) {
+            throw new Error(`Model "${model}" is not a tool-calling text model. Run: polli models`);
+        }
+        const existingKey = (() => {
+            const cfg = readConfig(ctx);
+            const provider = (cfg.provider as Record<string, unknown> | undefined)?.[PROVIDER] as Record<string, unknown> | undefined;
+            const opts = provider?.options as Record<string, unknown> | undefined;
+            return typeof opts?.apiKey === "string" ? String(opts.apiKey) : null;
+        })();
+        const apiKey = await resolveHarnessKey(
+            { id: ID, label: LABEL, existingKey },
+            { browser: options.browser },
+        );
+        return configureOpencode(ctx, { apiKey, model, models });
+    },
+
+    off: disableOpencode,
+    status: result,
+};


### PR DESCRIPTION
Closes #14118

Implements **polli harness opencode on|off|status** using the existing [Pollinations OpenCode plugin](https://github.com/fkom13/opencode-pollinations-plugin) for models, media tools, usage and quests.

**What this does**
- \polli harness opencode on\ — checks for the \opencode\ binary and offers the official installer if missing (\curl -fsSL https://opencode.ai/install | bash\ or \
pm i -g opencode-ai\). Logs in if needed and mints a dedicated \polli-harness-opencode\ child key (no second login). Writes the Pollinations provider (\aseURL: https://gen.pollinations.ai/v1\) with live tool-capable models, sets the default model (pollinations/openai by default, selectable via \--model\), enables the plugin, and keeps unrelated opencode.json entries untouched.
- \polli harness opencode status\ — reports whether the integration is ready (provider, model, plugin, skill).
- \polli harness opencode off\ — restores the snapshot or surgically strips only Pollinations-owned config.

**Background**
I use OpenCode daily with opencode-pollinations-plugin for image/video generation in local workflows. Verified end-to-end on a clean home: \polli harness opencode on\ → \status\ shows configured, \polli models\ lists Pollinations text models, \off\ restores original config and \status\ shows not configured.

Tests: \
pm run build\ and \
pm test\ in packages/polli-cli (harness unit tests).

Co-Authored-By: opencode/muse-spark-1.2-contributor-free