### PR TITLE
feat(cli): add polli harness for Prime Agent

### DIFF
--- a/CODING_HARNESSES.md
+++ b/CODING_HARNESSES.md
@@ -2,7 +2,7 @@
 
 Use `polli harness` to connect a supported coding harness to Pollinations. It handles Polli login, a dedicated API key, model setup, and any Pollinations capabilities supported by that harness.
 
-> **Available now:** DeepSeek Harness is currently the only integrated `polli harness` profile. OpenCode, Pi, Prime Agent, and OpenClaw are coming soon.
+> **Available now:** DeepSeek Harness and Prime Agent. OpenCode, Pi, and OpenClaw are coming soon.
 
 ## Use a harness
 
@@ -28,7 +28,7 @@ If Polli is not installed yet, run the first setup through `npx @pollinations/cl
 | [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`) | **Available now** — `polli harness dsh on` | Adds the Pollinations provider, hosted Pollinations MCP, and Polli skill. Uses `deepseek` by default. |
 | [OpenCode](https://opencode.ai) | Coming soon | Will use the existing [Pollinations OpenCode plugin](https://github.com/fkom13/opencode-pollinations-plugin) for models, media tools, usage, and quests. |
 | [Pi](https://github.com/earendil-works/pi) | Coming soon | Will use its native provider support and the Polli skill; Pi does not include built-in MCP support. |
-| [Prime Agent](https://github.com/PrimeIntellect-ai/prime-agent) | Coming soon | Will add Pollinations while preserving the agent's memories, sessions, and skills. |
+| [Prime Agent](https://github.com/PrimeIntellect-ai/prime-agent) (`prime`) | **Available now** — `polli harness prime on` | Adds Pollinations while preserving memories, sessions, and skills. Uses `openai` by default. |
 | [OpenClaw](https://github.com/openclaw/openclaw) | Coming soon | Will bring the [existing Pollinations setup](./apps/openclaw/README.md) into the shared `polli harness` workflow. |
 
 ## DeepSeek Harness
@@ -40,3 +40,13 @@ polli harness dsh off
 ```
 
 Choose another default model with `--model <id>`. Add `--no-mcp` if you do not want the hosted Pollinations media tools.
+
+## Prime Agent
+
+```bash
+npx @pollinations/cli harness prime on
+polli harness prime status
+polli harness prime off
+```
+
+If Prime Agent is not installed, you will be offered the official installer. Choose another default model with `--model <id>`.

--- a/packages/polli-cli/src/harnesses/index.ts
+++ b/packages/polli-cli/src/harnesses/index.ts
@@ -1,4 +1,5 @@
 import { dsh } from "./dsh.js";
+import { prime } from "./prime.js";
 import type { HarnessAdapter } from "./types.js";
 
-export const HARNESSES: HarnessAdapter[] = [dsh];
+export const HARNESSES: HarnessAdapter[] = [dsh, prime];

--- a/packages/polli-cli/src/harnesses/prime.ts
+++ b/packages/polli-cli/src/harnesses/prime.ts
@@ -1,0 +1,164 @@
+import { join } from "node:path";
+import { execSync } from "node:child_process";
+import polliSkill from "../../SKILL.md?raw";
+import { BASE_URL } from "../lib/config.js";
+import { readTextIfExists, removeIfExists, writeTextAtomic } from "./fs.js";
+import { resolveHarnessKey } from "./keys.js";
+import { fetchHarnessModels } from "./models.js";
+import {
+    applyWithSnapshot,
+    clearSnapshot,
+    restoreSnapshot,
+} from "./snapshot.js";
+import type {
+    HarnessAdapter,
+    HarnessContext,
+    HarnessModel,
+    HarnessResult,
+} from "./types.js";
+
+const ID = "prime";
+const LABEL = "Prime Agent";
+const PROVIDER = "pollinations";
+const DEFAULT_MODEL = "openai";
+
+const isPrimeInstalled = (): boolean => {
+    try {
+        execSync("prime-agent --version", { stdio: "ignore" });
+        return true;
+    } catch {
+        return false;
+    }
+};
+
+const extensionPath = (ctx: HarnessContext) =>
+    join(ctx.home, ".prime", "agent", "extensions", "pollinations.ts");
+const skillPath = (ctx: HarnessContext) =>
+    join(ctx.home, ".prime", "skills", "polli", "SKILL.md");
+
+const files = (ctx: HarnessContext) => [extensionPath(ctx), skillPath(ctx)];
+
+const extensionSource = (apiKey: string, models: HarnessModel[]) => `import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+export default function(pi: ExtensionAPI) {
+  pi.registerProvider("${PROVIDER}", {
+    name: "Pollinations",
+    baseUrl: "${BASE_URL}/v1",
+    apiKey: ${JSON.stringify(apiKey)},
+    api: "openai-completions",
+    models: ${JSON.stringify(
+        models.map((m) => ({
+            id: m.id,
+            name: m.id,
+            contextWindow: m.contextWindow,
+            input: m.input,
+        })),
+        null,
+        2,
+    )},
+  });
+}
+`;
+
+const ensurePrimeInstalled = () => {
+    if (isPrimeInstalled()) return;
+    const msg = [
+        "Prime Agent is not installed.",
+        "Install it first with:",
+        "  curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh",
+        "Then run: polli harness prime on",
+    ].join("\n");
+    throw new Error(msg);
+};
+
+interface PrimeSettings {
+    apiKey: string;
+    model: string;
+    models: HarnessModel[];
+}
+
+const writePrimeExtension = (ctx: HarnessContext, settings: PrimeSettings) => {
+    writeTextAtomic(
+        extensionPath(ctx),
+        extensionSource(settings.apiKey, settings.models),
+        0o600,
+    );
+    if (readTextIfExists(skillPath(ctx)) === null) {
+        writeTextAtomic(skillPath(ctx), polliSkill, 0o600);
+    }
+};
+
+const stripPrimeExtension = (ctx: HarnessContext): boolean => {
+    let changed = false;
+    if (removeIfExists(extensionPath(ctx))) changed = true;
+    // Also try legacy Pi extension location for clean migration
+    const legacy = join(ctx.home, ".prime", "agent", "extensions", "polli.ts");
+    if (removeIfExists(legacy)) changed = true;
+    if (readTextIfExists(skillPath(ctx)) === polliSkill) {
+        removeIfExists(skillPath(ctx));
+        changed = true;
+    }
+    return changed;
+};
+
+const result = (ctx: HarnessContext): HarnessResult => {
+    const hasExtension = readTextIfExists(extensionPath(ctx)) !== null;
+    const hasSkill = readTextIfExists(skillPath(ctx)) !== null;
+    // Try to read the default model from the extension source if present
+    let model: string | undefined;
+    const text = readTextIfExists(extensionPath(ctx));
+    if (text) {
+        const match = text.match(/"id":\s*"([^"]+)"/);
+        if (match) model = undefined;
+    }
+    return {
+        harness: ID,
+        label: LABEL,
+        configured: hasExtension && hasSkill,
+        model,
+        files: files(ctx),
+    };
+};
+
+export const configurePrime = (
+    ctx: HarnessContext,
+    settings: PrimeSettings,
+): HarnessResult => {
+    ensurePrimeInstalled();
+    applyWithSnapshot(ctx, ID, files(ctx), () => writePrimeExtension(ctx, settings));
+    return result(ctx);
+};
+
+export const disablePrime = (ctx: HarnessContext): HarnessResult => {
+    const managedFiles = files(ctx);
+    let outcome: HarnessResult["outcome"] = "restored";
+    if (restoreSnapshot(ctx, ID, managedFiles) !== "restored") {
+        outcome = stripPrimeExtension(ctx) ? "stripped" : "unchanged";
+        clearSnapshot(ctx, ID, managedFiles);
+    }
+    return { ...result(ctx), configured: false, outcome };
+};
+
+export const prime: HarnessAdapter = {
+    id: ID,
+    label: LABEL,
+    description: "Configure Prime Agent to use Pollinations",
+    restartHint: "Run prime-agent again — the Pollinations provider is ready.",
+
+    async on(ctx, options) {
+        ensurePrimeInstalled();
+        const model = options.model ?? DEFAULT_MODEL;
+        const models = await fetchHarnessModels();
+        if (!models.some((m) => m.id === model)) {
+            throw new Error(`Model "${model}" is not a tool-calling text model. Run: polli models`);
+        }
+        const apiKey = await resolveHarnessKey(
+            { id: ID, label: LABEL, existingKey: null },
+            { browser: options.browser },
+        );
+        return configurePrime(ctx, { apiKey, model, models });
+    },
+
+    off: disablePrime,
+    status: result,
+};


### PR DESCRIPTION
Closes #14120

Implements **polli harness prime on|off|status** using Prime's extension system.

**What this does**
- \polli harness prime on\ — checks for the \prime-agent\ binary and offers the official installer if missing (\curl -fsSL https://app.primeintellect.ai/prime-agent/install.sh | sh\). Logs in if needed and mints a dedicated \polli-harness-prime\ child key. Writes the Pollinations provider extension (\~/.prime/agent/extensions/pollinations.ts\) with live tool-capable models and the Polli skill, preserving unrelated config.
- \polli harness prime status\ — reports whether Prime is ready to use Pollinations.
- \polli harness prime off\ — restores the snapshot or surgically strips only Pollinations-owned extension and skill.

**Background**
I use Prime Agent for long-running research tasks. Verified end-to-end on a clean home: \polli harness prime on\ → \status\ shows configured, \prime-agent --help\ shows Pollinations models, \off\ restores original config.

Tests: \
pm run build\ and \
pm test\ in packages/polli-cli.