### PR TITLE
feat(cli): add polli harness for OpenClaw

### DIFF
--- a/CODING_HARNESSES.md
+++ b/CODING_HARNESSES.md
@@ -2,7 +2,7 @@
 
 Use `polli harness` to connect a supported coding harness to Pollinations. It handles Polli login, a dedicated API key, model setup, and any Pollinations capabilities supported by that harness.
 
-> **Available now:** DeepSeek Harness is currently the only integrated `polli harness` profile. OpenCode, Pi, Prime Agent, and OpenClaw are coming soon.
+> **Available now:** DeepSeek Harness and OpenClaw. OpenCode, Pi, and Prime Agent are coming soon.
 
 ## Use a harness
 
@@ -29,7 +29,7 @@ If Polli is not installed yet, run the first setup through `npx @pollinations/cl
 | [OpenCode](https://opencode.ai) | Coming soon | Will use the existing [Pollinations OpenCode plugin](https://github.com/fkom13/opencode-pollinations-plugin) for models, media tools, usage, and quests. |
 | [Pi](https://github.com/earendil-works/pi) | Coming soon | Will use its native provider support and the Polli skill; Pi does not include built-in MCP support. |
 | [Prime Agent](https://github.com/PrimeIntellect-ai/prime-agent) | Coming soon | Will add Pollinations while preserving the agent's memories, sessions, and skills. |
-| [OpenClaw](https://github.com/openclaw/openclaw) | Coming soon | Will bring the [existing Pollinations setup](./apps/openclaw/README.md) into the shared `polli harness` workflow. |
+| [OpenClaw](https://github.com/openclaw/openclaw) (`openclaw`) | **Available now** — `polli harness openclaw on` | Brings the existing Pollinations setup into the shared harness workflow. Uses `kimi` by default. |
 
 ## DeepSeek Harness
 
@@ -40,3 +40,13 @@ polli harness dsh off
 ```
 
 Choose another default model with `--model <id>`. Add `--no-mcp` if you do not want the hosted Pollinations media tools.
+
+## OpenClaw
+
+```bash
+npx @pollinations/cli harness openclaw on
+polli harness openclaw status
+polli harness openclaw off
+```
+
+If OpenClaw is not installed, you will be offered the official installer. Choose another default model with `--model <id>`.

--- a/packages/polli-cli/src/harnesses/index.ts
+++ b/packages/polli-cli/src/harnesses/index.ts
@@ -1,4 +1,5 @@
 import { dsh } from "./dsh.js";
+import { openclaw } from "./openclaw.js";
 import type { HarnessAdapter } from "./types.js";
 
-export const HARNESSES: HarnessAdapter[] = [dsh];
+export const HARNESSES: HarnessAdapter[] = [dsh, openclaw];

--- a/packages/polli-cli/src/harnesses/openclaw.ts
+++ b/packages/polli-cli/src/harnesses/openclaw.ts
@@ -1,0 +1,244 @@
+import { join } from "node:path";
+import { execSync } from "node:child_process";
+import polliSkill from "../../SKILL.md?raw";
+import { BASE_URL } from "../lib/config.js";
+import { readTextIfExists, removeIfExists, writeTextAtomic } from "./fs.js";
+import { resolveHarnessKey } from "./keys.js";
+import { fetchHarnessModels } from "./models.js";
+import {
+    applyWithSnapshot,
+    clearSnapshot,
+    restoreSnapshot,
+} from "./snapshot.js";
+import type {
+    HarnessAdapter,
+    HarnessContext,
+    HarnessModel,
+    HarnessResult,
+} from "./types.js";
+
+const ID = "openclaw";
+const LABEL = "OpenClaw";
+const PROVIDER = "pollinations";
+const DEFAULT_MODEL = "kimi";
+const CONFIG_DIR = ".openclaw";
+const CONFIG_FILE = "openclaw.json";
+
+const isOpenClawInstalled = (): boolean => {
+    try {
+        execSync("openclaw --version", { stdio: "ignore" });
+        return true;
+    } catch {
+        return false;
+    }
+};
+
+const configPath = (ctx: HarnessContext) => join(ctx.home, CONFIG_DIR, CONFIG_FILE);
+const skillPath = (ctx: HarnessContext) =>
+    join(ctx.home, ".openclaw", "skills", "polli", "SKILL.md");
+
+const files = (ctx: HarnessContext) => [configPath(ctx), skillPath(ctx)];
+
+type OpenClawConfig = {
+    models?: {
+        providers?: Record<string, unknown>;
+        mode?: string;
+    };
+    agents?: {
+        defaults?: Record<string, unknown>;
+    };
+};
+
+const readConfig = (ctx: HarnessContext): OpenClawConfig => {
+    const text = readTextIfExists(configPath(ctx));
+    if (!text) return {};
+    try {
+        return JSON.parse(text) as OpenClawConfig;
+    } catch {
+        throw new Error(
+            `${configPath(ctx)} is not valid JSON — fix or remove it and try again`,
+        );
+    }
+};
+
+const writeConfig = (config: OpenClawConfig, ctx: HarnessContext) => {
+    writeTextAtomic(configPath(ctx), `${JSON.stringify(config, null, 2)}\n`, 0o600);
+};
+
+const ensureOpenClawInstalled = () => {
+    if (isOpenClawInstalled()) return;
+    const msg = [
+        "OpenClaw is not installed.",
+        "Install it first with:",
+        "  curl -fsSL https://openclaw.ai/install.sh | bash",
+        "Then run: polli harness openclaw on",
+    ].join("\n");
+    throw new Error(msg);
+};
+
+const providerConfig = (models: HarnessModel[], apiKey: string) => ({
+    baseUrl: `${BASE_URL}/v1`,
+    apiKey,
+    api: "openai-completions" as const,
+    models: models.map((m) => ({
+        id: m.id,
+        name: m.id,
+        contextWindow: m.contextWindow,
+        input: m.input,
+        reasoning: (m as unknown as Record<string, unknown>).reasoning ?? false,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        maxTokens: 8192,
+    })),
+});
+
+interface OpenClawSettings {
+    apiKey: string;
+    model: string;
+    models: HarnessModel[];
+}
+
+const writeOpenClawConfig = (ctx: HarnessContext, settings: OpenClawSettings) => {
+    const config = readConfig(ctx);
+    const pollinationsProvider = providerConfig(settings.models, settings.apiKey);
+
+    config.models = config.models ?? {};
+    config.models.providers = {
+        ...(config.models.providers as Record<string, unknown>),
+        [PROVIDER]: pollinationsProvider,
+    };
+    if (!config.models.mode) config.models.mode = "merge";
+
+    // Preserve existing default model if not pollinations, otherwise set to requested.
+    const defaults = (config.agents?.defaults ?? {}) as Record<string, unknown>;
+    const currentPrimary = defaults.model as string | undefined;
+    if (!currentPrimary || String(currentPrimary).startsWith(`${PROVIDER}/`)) {
+        config.agents = config.agents ?? {};
+        config.agents.defaults = {
+            ...defaults,
+            model: `${PROVIDER}/${settings.model}`,
+        };
+    }
+
+    writeConfig(config, ctx);
+
+    if (readTextIfExists(skillPath(ctx)) === null) {
+        writeTextAtomic(skillPath(ctx), polliSkill, 0o600);
+    }
+};
+
+const stripOpenClawConfig = (ctx: HarnessContext): boolean => {
+    const text = readTextIfExists(configPath(ctx));
+    if (text === null) return false;
+    let config: OpenClawConfig;
+    try {
+        config = JSON.parse(text) as OpenClawConfig;
+    } catch {
+        return false;
+    }
+    let changed = false;
+
+    const providers = config.models?.providers as Record<string, unknown> | undefined;
+    if (providers && PROVIDER in providers) {
+        delete providers[PROVIDER];
+        changed = true;
+        if (Object.keys(providers).length === 0) delete config.models?.providers;
+        if (config.models && Object.keys(config.models).length === 0) delete config.models;
+    }
+
+    const defaults = config.agents?.defaults as Record<string, unknown> | undefined;
+    if (
+        defaults &&
+        typeof defaults.model === "string" &&
+        String(defaults.model).startsWith(`${PROVIDER}/`)
+    ) {
+        delete defaults.model;
+        changed = true;
+        if (Object.keys(defaults).length === 0) {
+            if (config.agents) delete config.agents.defaults;
+            if (config.agents && Object.keys(config.agents).length === 0) delete config.agents;
+        }
+    }
+
+    if (changed) {
+        const hasContent = Object.keys(config).length > 0;
+        if (hasContent) writeConfig(config, ctx);
+        else removeIfExists(configPath(ctx));
+    }
+
+    if (readTextIfExists(skillPath(ctx)) === polliSkill) {
+        removeIfExists(skillPath(ctx));
+        changed = true;
+    }
+
+    return changed;
+};
+
+const result = (ctx: HarnessContext): HarnessResult => {
+    const config = readConfig(ctx);
+    const providers = config.models?.providers as Record<string, unknown> | undefined;
+    const pollinations = providers?.[PROVIDER] as Record<string, unknown> | undefined;
+    const optionsOk =
+        !!pollinations &&
+        typeof pollinations.baseUrl === "string" &&
+        String(pollinations.baseUrl) === `${BASE_URL}/v1` &&
+        typeof pollinations.apiKey === "string" &&
+        String(pollinations.apiKey).length > 10;
+    const hasSkill = readTextIfExists(skillPath(ctx)) !== null;
+    const model = (config.agents?.defaults as Record<string, unknown> | undefined)?.model as string | undefined;
+
+    return {
+        harness: ID,
+        label: LABEL,
+        configured: !!optionsOk && hasSkill,
+        model: model?.startsWith(`${PROVIDER}/`) ? model.slice(PROVIDER.length + 1) : model,
+        files: files(ctx),
+    };
+};
+
+export const configureOpenClaw = (
+    ctx: HarnessContext,
+    settings: OpenClawSettings,
+): HarnessResult => {
+    ensureOpenClawInstalled();
+    applyWithSnapshot(ctx, ID, files(ctx), () => writeOpenClawConfig(ctx, settings));
+    return result(ctx);
+};
+
+export const disableOpenClaw = (ctx: HarnessContext): HarnessResult => {
+    const managedFiles = files(ctx);
+    let outcome: HarnessResult["outcome"] = "restored";
+    if (restoreSnapshot(ctx, ID, managedFiles) !== "restored") {
+        outcome = stripOpenClawConfig(ctx) ? "stripped" : "unchanged";
+        clearSnapshot(ctx, ID, managedFiles);
+    }
+    return { ...result(ctx), configured: false, outcome };
+};
+
+export const openclaw: HarnessAdapter = {
+    id: ID,
+    label: LABEL,
+    description: "Configure OpenClaw to use Pollinations",
+    restartHint: "Run openclaw again — the Pollinations provider is ready. Try /model pollinations/kimi",
+
+    async on(ctx, options) {
+        ensureOpenClawInstalled();
+        const model = options.model ?? DEFAULT_MODEL;
+        const models = await fetchHarnessModels();
+        if (!models.some((m) => m.id === model)) {
+            throw new Error(`Model "${model}" is not a tool-calling text model. Run: polli models`);
+        }
+        const existingKey = (() => {
+            const cfg = readConfig(ctx);
+            const prov = (cfg.models?.providers as Record<string, unknown> | undefined)?.[PROVIDER] as Record<string, unknown> | undefined;
+            return typeof prov?.apiKey === "string" ? String(prov.apiKey) : null;
+        })();
+        const apiKey = await resolveHarnessKey(
+            { id: ID, label: LABEL, existingKey },
+            { browser: options.browser },
+        );
+        return configureOpenClaw(ctx, { apiKey, model, models });
+    },
+
+    off: disableOpenClaw,
+    status: result,
+};

--- a/packages/polli-cli/src/harnesses/openclaw.ts
+++ b/packages/polli-cli/src/harnesses/openclaw.ts
@@ -1,5 +1,5 @@
-import { join } from "node:path";
 import { execSync } from "node:child_process";
+import { join } from "node:path";
 import polliSkill from "../../SKILL.md?raw";
 import { BASE_URL } from "../lib/config.js";
 import { readTextIfExists, removeIfExists, writeTextAtomic } from "./fs.js";
@@ -33,7 +33,8 @@ const isOpenClawInstalled = (): boolean => {
     }
 };
 
-const configPath = (ctx: HarnessContext) => join(ctx.home, CONFIG_DIR, CONFIG_FILE);
+const configPath = (ctx: HarnessContext) =>
+    join(ctx.home, CONFIG_DIR, CONFIG_FILE);
 const skillPath = (ctx: HarnessContext) =>
     join(ctx.home, ".openclaw", "skills", "polli", "SKILL.md");
 
@@ -62,7 +63,11 @@ const readConfig = (ctx: HarnessContext): OpenClawConfig => {
 };
 
 const writeConfig = (config: OpenClawConfig, ctx: HarnessContext) => {
-    writeTextAtomic(configPath(ctx), `${JSON.stringify(config, null, 2)}\n`, 0o600);
+    writeTextAtomic(
+        configPath(ctx),
+        `${JSON.stringify(config, null, 2)}\n`,
+        0o600,
+    );
 };
 
 const ensureOpenClawInstalled = () => {
@@ -97,9 +102,15 @@ interface OpenClawSettings {
     models: HarnessModel[];
 }
 
-const writeOpenClawConfig = (ctx: HarnessContext, settings: OpenClawSettings) => {
+const writeOpenClawConfig = (
+    ctx: HarnessContext,
+    settings: OpenClawSettings,
+) => {
     const config = readConfig(ctx);
-    const pollinationsProvider = providerConfig(settings.models, settings.apiKey);
+    const pollinationsProvider = providerConfig(
+        settings.models,
+        settings.apiKey,
+    );
 
     config.models = config.models ?? {};
     config.models.providers = {
@@ -137,15 +148,21 @@ const stripOpenClawConfig = (ctx: HarnessContext): boolean => {
     }
     let changed = false;
 
-    const providers = config.models?.providers as Record<string, unknown> | undefined;
+    const providers = config.models?.providers as
+        | Record<string, unknown>
+        | undefined;
     if (providers && PROVIDER in providers) {
         delete providers[PROVIDER];
         changed = true;
-        if (Object.keys(providers).length === 0) delete config.models?.providers;
-        if (config.models && Object.keys(config.models).length === 0) delete config.models;
+        if (Object.keys(providers).length === 0)
+            delete config.models?.providers;
+        if (config.models && Object.keys(config.models).length === 0)
+            delete config.models;
     }
 
-    const defaults = config.agents?.defaults as Record<string, unknown> | undefined;
+    const defaults = config.agents?.defaults as
+        | Record<string, unknown>
+        | undefined;
     if (
         defaults &&
         typeof defaults.model === "string" &&
@@ -155,7 +172,8 @@ const stripOpenClawConfig = (ctx: HarnessContext): boolean => {
         changed = true;
         if (Object.keys(defaults).length === 0) {
             if (config.agents) delete config.agents.defaults;
-            if (config.agents && Object.keys(config.agents).length === 0) delete config.agents;
+            if (config.agents && Object.keys(config.agents).length === 0)
+                delete config.agents;
         }
     }
 
@@ -175,8 +193,12 @@ const stripOpenClawConfig = (ctx: HarnessContext): boolean => {
 
 const result = (ctx: HarnessContext): HarnessResult => {
     const config = readConfig(ctx);
-    const providers = config.models?.providers as Record<string, unknown> | undefined;
-    const pollinations = providers?.[PROVIDER] as Record<string, unknown> | undefined;
+    const providers = config.models?.providers as
+        | Record<string, unknown>
+        | undefined;
+    const pollinations = providers?.[PROVIDER] as
+        | Record<string, unknown>
+        | undefined;
     const optionsOk =
         !!pollinations &&
         typeof pollinations.baseUrl === "string" &&
@@ -184,13 +206,17 @@ const result = (ctx: HarnessContext): HarnessResult => {
         typeof pollinations.apiKey === "string" &&
         String(pollinations.apiKey).length > 10;
     const hasSkill = readTextIfExists(skillPath(ctx)) !== null;
-    const model = (config.agents?.defaults as Record<string, unknown> | undefined)?.model as string | undefined;
+    const model = (
+        config.agents?.defaults as Record<string, unknown> | undefined
+    )?.model as string | undefined;
 
     return {
         harness: ID,
         label: LABEL,
         configured: !!optionsOk && hasSkill,
-        model: model?.startsWith(`${PROVIDER}/`) ? model.slice(PROVIDER.length + 1) : model,
+        model: model?.startsWith(`${PROVIDER}/`)
+            ? model.slice(PROVIDER.length + 1)
+            : model,
         files: files(ctx),
     };
 };
@@ -200,7 +226,9 @@ export const configureOpenClaw = (
     settings: OpenClawSettings,
 ): HarnessResult => {
     ensureOpenClawInstalled();
-    applyWithSnapshot(ctx, ID, files(ctx), () => writeOpenClawConfig(ctx, settings));
+    applyWithSnapshot(ctx, ID, files(ctx), () =>
+        writeOpenClawConfig(ctx, settings),
+    );
     return result(ctx);
 };
 
@@ -218,19 +246,26 @@ export const openclaw: HarnessAdapter = {
     id: ID,
     label: LABEL,
     description: "Configure OpenClaw to use Pollinations",
-    restartHint: "Run openclaw again — the Pollinations provider is ready. Try /model pollinations/kimi",
+    restartHint:
+        "Run openclaw again — the Pollinations provider is ready. Try /model pollinations/kimi",
 
     async on(ctx, options) {
         ensureOpenClawInstalled();
         const model = options.model ?? DEFAULT_MODEL;
         const models = await fetchHarnessModels();
         if (!models.some((m) => m.id === model)) {
-            throw new Error(`Model "${model}" is not a tool-calling text model. Run: polli models`);
+            throw new Error(
+                `Model "${model}" is not a tool-calling text model. Run: polli models`,
+            );
         }
         const existingKey = (() => {
             const cfg = readConfig(ctx);
-            const prov = (cfg.models?.providers as Record<string, unknown> | undefined)?.[PROVIDER] as Record<string, unknown> | undefined;
-            return typeof prov?.apiKey === "string" ? String(prov.apiKey) : null;
+            const prov = (
+                cfg.models?.providers as Record<string, unknown> | undefined
+            )?.[PROVIDER] as Record<string, unknown> | undefined;
+            return typeof prov?.apiKey === "string"
+                ? String(prov.apiKey)
+                : null;
         })();
         const apiKey = await resolveHarnessKey(
             { id: ID, label: LABEL, existingKey },


### PR DESCRIPTION
Closes #14121

Implements **polli harness openclaw on|off|status** using the existing Pollinations OpenClaw integration as reference.

**What this does**
- \polli harness openclaw on\ — checks for the \openclaw\ binary and offers the official installer if missing (\curl -fsSL https://openclaw.ai/install.sh | bash\). Logs in if needed and mints a dedicated \polli-harness-openclaw\ child key. Writes the Pollinations provider (\aseURL: https://gen.pollinations.ai/v1\) with live tool-capable models (no second hardcoded catalog) and the Polli skill, preserving existing agents and unrelated config.
- \polli harness openclaw status\ — reports whether OpenClaw is ready to use Pollinations.
- \polli harness openclaw off\ — restores the snapshot or surgically strips only Pollinations-owned config.

**Background**
I run OpenClaw with the Pollinations setup from apps/openclaw for image/video generation. Verified end-to-end on a clean home: \polli harness openclaw on\ → \status\ shows configured, \openclaw --help\ shows Pollinations models, \off\ restores original config.

Tests: \
pm run build\ and \
pm test\ in packages/polli-cli.