### PR TITLE
feat(cli): add Polli harness adapters for OpenClaw, Pi, Prime Agent, OpenCode (issues #14118-#14121)

### DIFF
--- a/packages/polli-cli/src/harnesses/index.ts
+++ b/packages/polli-cli/src/harnesses/index.ts
@@ -1,4 +1,8 @@
 import { dsh } from "./dsh.js";
+import { openclaw } from "./openclaw.js";
+import { opencode } from "./opencode.js";
+import { pi } from "./pi.js";
+import { prime } from "./prime.js";
 import type { HarnessAdapter } from "./types.js";
 
-export const HARNESSES: HarnessAdapter[] = [dsh];
+export const HARNESSES: HarnessAdapter[] = [dsh, openclaw, pi, prime, opencode];

--- a/packages/polli-cli/src/harnesses/openclaw.ts
+++ b/packages/polli-cli/src/harnesses/openclaw.ts
@@ -1,0 +1,186 @@
+import { join } from "node:path";
+import polliSkill from "../../SKILL.md?raw";
+import { BASE_URL } from "../lib/config.js";
+import { readTextIfExists, writeTextAtomic } from "./fs.js";
+import { resolveHarnessKey } from "./keys.js";
+import { fetchHarnessModels } from "./models.js";
+import {
+    applyWithSnapshot,
+    clearSnapshot,
+    restoreSnapshot,
+} from "./snapshot.js";
+import type {
+    HarnessAdapter,
+    HarnessContext,
+    HarnessModel,
+    HarnessResult,
+} from "./types.js";
+
+const ID = "openclaw";
+const LABEL = "OpenClaw";
+const DEFAULT_MODEL = "deepseek";
+const KEY_ENV = "POLLI_OPENCLAW_API_KEY";
+
+const openclawHome = (ctx: HarnessContext) => join(ctx.home, ".openclaw");
+const configPath = (ctx: HarnessContext) =>
+    join(openclawHome(ctx), "openclaw.json");
+const envPath = (ctx: HarnessContext) => join(openclawHome(ctx), ".env");
+const skillPath = (ctx: HarnessContext) =>
+    join(openclawHome(ctx), "skills", "polli", "SKILL.md");
+
+const files = (ctx: HarnessContext) => [
+    configPath(ctx),
+    envPath(ctx),
+    skillPath(ctx),
+];
+
+const readConfig = (ctx: HarnessContext): Record<string, unknown> => {
+    const text = readTextIfExists(configPath(ctx));
+    if (!text) return {};
+    try {
+        return JSON.parse(text) as Record<string, unknown>;
+    } catch {
+        return {};
+    }
+};
+
+const writeConfig = (ctx: HarnessContext, config: Record<string, unknown>) => {
+    writeTextAtomic(configPath(ctx), `${JSON.stringify(config, null, 2)}\n`);
+};
+
+const readKey = (ctx: HarnessContext) => {
+    const text = readTextIfExists(envPath(ctx));
+    if (!text) return null;
+    const match = text.match(new RegExp(`^${KEY_ENV}=(.+)$`, "m"));
+    return match?.[1] ?? null;
+};
+
+const setEnvKey = (ctx: HarnessContext, key: string) => {
+    const lines = (readTextIfExists(envPath(ctx)) ?? "").split("\n");
+    const idx = lines.findIndex((l) => l.startsWith(`${KEY_ENV}=`));
+    const line = `${KEY_ENV}=${key}`;
+    if (idx === -1) {
+        lines.push(line);
+    } else {
+        lines[idx] = line;
+    }
+    writeTextAtomic(envPath(ctx), lines.join("\n"), 0o600);
+};
+
+const deleteEnvKey = (ctx: HarnessContext) => {
+    const text = readTextIfExists(envPath(ctx));
+    if (!text) return false;
+    const lines = text.split("\n").filter((l) => !l.startsWith(`${KEY_ENV}=`));
+    writeTextAtomic(envPath(ctx), lines.join("\n"), 0o600);
+    return true;
+};
+
+const providerConfig = (models: HarnessModel[]) => ({
+    baseUrl: `${BASE_URL}/v1`,
+    apiKey: `\${env:${KEY_ENV}}`,
+    models: models.map((m) => m.id),
+});
+
+const patchConfig = (
+    config: Record<string, unknown>,
+    models: HarnessModel[],
+    _apiKey: string,
+) => {
+    const providers = (config.providers ?? {}) as Record<string, unknown>;
+    providers.pollinations = providerConfig(models);
+    config.providers = providers;
+
+    const models_ = (config.models ?? {}) as Record<string, unknown>;
+    models_.pollinations = {
+        provider: "pollinations",
+        model: DEFAULT_MODEL,
+    };
+    config.models = models_;
+    return config;
+};
+
+const stripPollinations = (config: Record<string, unknown>) => {
+    const providers = config.providers as Record<string, unknown> | undefined;
+    if (providers) delete providers.pollinations;
+    const models_ = config.models as Record<string, unknown> | undefined;
+    if (models_) delete models_.pollinations;
+    return config;
+};
+
+const result = (ctx: HarnessContext): HarnessResult => {
+    const config = readConfig(ctx);
+    const providers = config.providers as Record<string, unknown> | undefined;
+    const pollinations = providers?.pollinations as
+        | Record<string, unknown>
+        | undefined;
+    return {
+        harness: ID,
+        label: LABEL,
+        configured:
+            pollinations?.baseUrl === `${BASE_URL}/v1` &&
+            readKey(ctx) !== null &&
+            readTextIfExists(skillPath(ctx)) !== null,
+        model: (config.models as Record<string, unknown>)?.pollinations
+            ? ((
+                  (config.models as Record<string, unknown>)
+                      .pollinations as Record<string, unknown>
+              )?.model as string)
+            : undefined,
+        files: files(ctx),
+    };
+};
+
+export const openclaw: HarnessAdapter = {
+    id: ID,
+    label: LABEL,
+    description: "Configure OpenClaw as a Pollinations provider",
+    restartHint: "Restart OpenClaw to apply changes: openclaw restart",
+
+    async on(ctx, options) {
+        const model = options.model ?? DEFAULT_MODEL;
+        const models = await fetchHarnessModels();
+        if (!models.some((c) => c.id === model)) {
+            throw new Error(
+                `Model "${model}" is not a tool-calling text model. Run: polli models`,
+            );
+        }
+
+        const apiKey = await resolveHarnessKey(
+            { id: ID, label: LABEL, existingKey: readKey(ctx) },
+            { browser: options.browser },
+        );
+
+        applyWithSnapshot(ctx, ID, files(ctx), () => {
+            const config = readConfig(ctx);
+            const patched = patchConfig(config, models, apiKey);
+            writeConfig(ctx, patched);
+            setEnvKey(ctx, apiKey);
+            if (readTextIfExists(skillPath(ctx)) === null) {
+                writeTextAtomic(skillPath(ctx), polliSkill, 0o600);
+            }
+        });
+
+        return result(ctx);
+    },
+
+    off(ctx) {
+        const managedFiles = files(ctx);
+        let outcome: HarnessResult["outcome"] = "restored";
+        if (restoreSnapshot(ctx, ID, managedFiles) !== "restored") {
+            const config = readConfig(ctx);
+            const stripped = stripPollinations(config);
+            writeConfig(ctx, stripped);
+            deleteEnvKey(ctx);
+            const skill = readTextIfExists(skillPath(ctx));
+            if (skill === polliSkill) {
+                const fs = require("node:fs") as typeof import("node:fs");
+                fs.unlinkSync(skillPath(ctx));
+            }
+            outcome = "stripped";
+        }
+        clearSnapshot(ctx, ID, managedFiles);
+        return { ...result(ctx), configured: false, outcome };
+    },
+
+    status: result,
+};

--- a/packages/polli-cli/src/harnesses/opencode.ts
+++ b/packages/polli-cli/src/harnesses/opencode.ts
@@ -1,0 +1,186 @@
+import { join } from "node:path";
+import { BASE_URL } from "../lib/config.js";
+import { readTextIfExists, writeTextAtomic } from "./fs.js";
+import { resolveHarnessKey } from "./keys.js";
+import { fetchHarnessModels } from "./models.js";
+import {
+    applyWithSnapshot,
+    clearSnapshot,
+    restoreSnapshot,
+} from "./snapshot.js";
+import type {
+    HarnessAdapter,
+    HarnessContext,
+    HarnessModel,
+    HarnessResult,
+} from "./types.js";
+
+const ID = "opencode";
+const LABEL = "OpenCode";
+const DEFAULT_MODEL = "deepseek";
+const KEY_ENV = "POLLI_OPENCODE_API_KEY";
+const _PLUGIN_NAME = "opencode-pollinations-plugin";
+
+const opencodeHome = (ctx: HarnessContext) =>
+    join(ctx.home, ".config", "opencode");
+const configPath = (ctx: HarnessContext) =>
+    join(opencodeHome(ctx), "opencode.json");
+const envPath = (ctx: HarnessContext) => join(opencodeHome(ctx), ".env");
+const skillPath = (ctx: HarnessContext) =>
+    join(opencodeHome(ctx), "skills", "polli", "SKILL.md");
+
+const files = (ctx: HarnessContext) => [
+    configPath(ctx),
+    envPath(ctx),
+    skillPath(ctx),
+];
+
+const readConfig = (ctx: HarnessContext): Record<string, unknown> => {
+    const text = readTextIfExists(configPath(ctx));
+    if (!text) return {};
+    try {
+        return JSON.parse(text) as Record<string, unknown>;
+    } catch {
+        return {};
+    }
+};
+
+const writeConfig = (ctx: HarnessContext, config: Record<string, unknown>) => {
+    writeTextAtomic(configPath(ctx), `${JSON.stringify(config, null, 2)}\n`);
+};
+
+const readKey = (ctx: HarnessContext) => {
+    const text = readTextIfExists(envPath(ctx));
+    if (!text) return null;
+    const match = text.match(new RegExp(`^${KEY_ENV}=(.+)$`, "m"));
+    return match?.[1] ?? null;
+};
+
+const setEnvKey = (ctx: HarnessContext, key: string) => {
+    const lines = (readTextIfExists(envPath(ctx)) ?? "").split("\n");
+    const idx = lines.findIndex((l) => l.startsWith(`${KEY_ENV}=`));
+    const line = `${KEY_ENV}=${key}`;
+    if (idx === -1) {
+        lines.push(line);
+    } else {
+        lines[idx] = line;
+    }
+    writeTextAtomic(envPath(ctx), lines.join("\n"), 0o600);
+};
+
+const deleteEnvKey = (ctx: HarnessContext) => {
+    const text = readTextIfExists(envPath(ctx));
+    if (!text) return false;
+    const lines = text.split("\n").filter((l) => !l.startsWith(`${KEY_ENV}=`));
+    writeTextAtomic(envPath(ctx), lines.join("\n"), 0o600);
+    return true;
+};
+
+const providerBlock = (models: HarnessModel[]) => ({
+    name: "pollinations",
+    displayName: "Pollinations.ai",
+    type: "openai",
+    baseUrl: `${BASE_URL}/v1`,
+    apiKey: `\${env:${KEY_ENV}}`,
+    models: models.map((m) => ({
+        id: m.id,
+        name: m.id,
+        contextLength: m.contextWindow,
+    })),
+});
+
+const patchConfig = (
+    config: Record<string, unknown>,
+    models: HarnessModel[],
+) => {
+    const providers = (config.providers ?? []) as Array<
+        Record<string, unknown>
+    >;
+    const filtered = providers.filter((p) => p.name !== "pollinations");
+    filtered.push(providerBlock(models));
+    config.providers = filtered;
+    return config;
+};
+
+const stripPollinations = (config: Record<string, unknown>) => {
+    const providers = config.providers as
+        | Array<Record<string, unknown>>
+        | undefined;
+    if (Array.isArray(providers)) {
+        config.providers = providers.filter((p) => p.name !== "pollinations");
+    }
+    return config;
+};
+
+const result = (ctx: HarnessContext): HarnessResult => {
+    const config = readConfig(ctx);
+    const providers = config.providers as
+        | Array<Record<string, unknown>>
+        | undefined;
+    const has =
+        Array.isArray(providers) &&
+        providers.some((p) => p.name === "pollinations" && p.type === "openai");
+    return {
+        harness: ID,
+        label: LABEL,
+        configured:
+            has &&
+            readKey(ctx) !== null &&
+            readTextIfExists(skillPath(ctx)) !== null,
+        files: files(ctx),
+    };
+};
+
+export const opencode: HarnessAdapter = {
+    id: ID,
+    label: LABEL,
+    description: "Configure OpenCode as a Pollinations provider",
+    restartHint: "Restart OpenCode to apply changes",
+
+    async on(ctx, options) {
+        const model = options.model ?? DEFAULT_MODEL;
+        const models = await fetchHarnessModels();
+        if (!models.some((c) => c.id === model)) {
+            throw new Error(
+                `Model "${model}" is not a tool-calling text model. Run: polli models`,
+            );
+        }
+
+        const apiKey = await resolveHarnessKey(
+            { id: ID, label: LABEL, existingKey: readKey(ctx) },
+            { browser: options.browser },
+        );
+
+        applyWithSnapshot(ctx, ID, files(ctx), () => {
+            const config = readConfig(ctx);
+            const patched = patchConfig(config, models);
+            writeConfig(ctx, patched);
+            setEnvKey(ctx, apiKey);
+            if (readTextIfExists(skillPath(ctx)) === null) {
+                writeTextAtomic(
+                    skillPath(ctx),
+                    `# Pollinations Skill\n\nUse Pollinations models via the configured provider.`,
+                    0o600,
+                );
+            }
+        });
+
+        return result(ctx);
+    },
+
+    off(ctx) {
+        const managedFiles = files(ctx);
+        let outcome: HarnessResult["outcome"] = "restored";
+        if (restoreSnapshot(ctx, ID, managedFiles) !== "restored") {
+            const config = readConfig(ctx);
+            stripPollinations(config);
+            writeConfig(ctx, config);
+            deleteEnvKey(ctx);
+            outcome = "stripped";
+        }
+        clearSnapshot(ctx, ID, managedFiles);
+        return { ...result(ctx), configured: false, outcome };
+    },
+
+    status: result,
+};

--- a/packages/polli-cli/src/harnesses/pi.ts
+++ b/packages/polli-cli/src/harnesses/pi.ts
@@ -1,0 +1,170 @@
+import { join } from "node:path";
+import polliSkill from "../../SKILL.md?raw";
+import { BASE_URL } from "../lib/config.js";
+import { readTextIfExists, writeTextAtomic } from "./fs.js";
+import { resolveHarnessKey } from "./keys.js";
+import { fetchHarnessModels } from "./models.js";
+import {
+    applyWithSnapshot,
+    clearSnapshot,
+    restoreSnapshot,
+} from "./snapshot.js";
+import type {
+    HarnessAdapter,
+    HarnessContext,
+    HarnessModel,
+    HarnessResult,
+} from "./types.js";
+
+const ID = "pi";
+const LABEL = "Pi";
+const PROVIDER = "pollinations";
+const DEFAULT_MODEL = "deepseek";
+const KEY_ENV = "POLLI_PI_API_KEY";
+
+const piHome = (ctx: HarnessContext) => join(ctx.home, ".pi");
+const settingsPath = (ctx: HarnessContext) =>
+    join(piHome(ctx), "settings.yaml");
+const envPath = (ctx: HarnessContext) => join(piHome(ctx), ".env");
+const skillPath = (ctx: HarnessContext) =>
+    join(piHome(ctx), "skills", "polli", "SKILL.md");
+
+const files = (ctx: HarnessContext) => [
+    settingsPath(ctx),
+    envPath(ctx),
+    skillPath(ctx),
+];
+
+const readKey = (ctx: HarnessContext) => {
+    const text = readTextIfExists(envPath(ctx));
+    if (!text) return null;
+    const match = text.match(new RegExp(`${KEY_ENV}=(.+)`, "m"));
+    return match?.[1] ?? null;
+};
+
+const setEnvKey = (ctx: HarnessContext, key: string) => {
+    const lines = (readTextIfExists(envPath(ctx)) ?? "").split("\n");
+    const idx = lines.findIndex((l) => l.includes(KEY_ENV));
+    const line = `${KEY_ENV}=${key}`;
+    if (idx === -1) {
+        lines.push(line);
+    } else {
+        lines[idx] = line;
+    }
+    writeTextAtomic(envPath(ctx), lines.join("\n"), 0o600);
+};
+
+const deleteEnvKey = (ctx: HarnessContext) => {
+    const text = readTextIfExists(envPath(ctx));
+    if (!text) return false;
+    const lines = text.split("\n").filter((l) => !l.includes(KEY_ENV));
+    writeTextAtomic(envPath(ctx), lines.join("\n"), 0o600);
+    return true;
+};
+
+const providerBlock = (models: HarnessModel[]) => ({
+    displayName: "Pollinations.ai",
+    apiKeyEnv: KEY_ENV,
+    api: "openai-completions",
+    baseURL: `${BASE_URL}/v1`,
+    compat: {
+        supportsStore: false,
+        supportsDeveloperRole: false,
+        supportsReasoningEffort: true,
+        supportsUsageInStreaming: true,
+        supportsStrictMode: false,
+        maxTokensField: "max_tokens",
+    },
+    models: models.map((m) => ({
+        id: m.id,
+        name: m.id,
+        contextWindow: m.contextWindow,
+        input: m.input,
+        reasoningEfforts: false,
+    })),
+});
+
+const result = (ctx: HarnessContext): HarnessResult => {
+    const text = readTextIfExists(settingsPath(ctx)) ?? "";
+    const hasProvider =
+        text.includes(`"displayName": "Pollinations.ai"`) ||
+        text.includes("displayName: Pollinations.ai");
+    return {
+        harness: ID,
+        label: LABEL,
+        configured:
+            hasProvider &&
+            readKey(ctx) !== null &&
+            readTextIfExists(skillPath(ctx)) !== null,
+        files: files(ctx),
+    };
+};
+
+export const pi: HarnessAdapter = {
+    id: ID,
+    label: LABEL,
+    description: "Configure Pi as a Pollinations provider",
+    restartHint: "Restart Pi to apply changes",
+
+    async on(ctx, options) {
+        const model = options.model ?? DEFAULT_MODEL;
+        const models = await fetchHarnessModels();
+        if (!models.some((c) => c.id === model)) {
+            throw new Error(
+                `Model "${model}" is not a tool-calling text model. Run: polli models`,
+            );
+        }
+
+        const apiKey = await resolveHarnessKey(
+            { id: ID, label: LABEL, existingKey: readKey(ctx) },
+            { browser: options.browser },
+        );
+
+        applyWithSnapshot(ctx, ID, files(ctx), () => {
+            writeTextAtomic(
+                settingsPath(ctx),
+                `${JSON.stringify(
+                    {
+                        providers: { [PROVIDER]: providerBlock(models) },
+                        defaultModel: { provider: PROVIDER, model },
+                    },
+                    null,
+                    2,
+                )}\n`,
+            );
+            setEnvKey(ctx, apiKey);
+            if (readTextIfExists(skillPath(ctx)) === null) {
+                writeTextAtomic(skillPath(ctx), polliSkill, 0o600);
+            }
+        });
+
+        return result(ctx);
+    },
+
+    off(ctx) {
+        const managedFiles = files(ctx);
+        let outcome: HarnessResult["outcome"] = "restored";
+        if (restoreSnapshot(ctx, ID, managedFiles) !== "restored") {
+            const text = readTextIfExists(settingsPath(ctx)) ?? "";
+            if (text.includes("Pollinations.ai")) {
+                const fs = require("node:fs") as typeof import("node:fs");
+                try {
+                    fs.unlinkSync(settingsPath(ctx));
+                } catch {}
+            }
+            deleteEnvKey(ctx);
+            const skill = readTextIfExists(skillPath(ctx));
+            if (skill === polliSkill) {
+                try {
+                    const fs = require("node:fs") as typeof import("node:fs");
+                    fs.unlinkSync(skillPath(ctx));
+                } catch {}
+            }
+            outcome = "stripped";
+        }
+        clearSnapshot(ctx, ID, managedFiles);
+        return { ...result(ctx), configured: false, outcome };
+    },
+
+    status: result,
+};

--- a/packages/polli-cli/src/harnesses/prime.ts
+++ b/packages/polli-cli/src/harnesses/prime.ts
@@ -1,0 +1,168 @@
+import { join } from "node:path";
+import polliSkill from "../../SKILL.md?raw";
+import { BASE_URL } from "../lib/config.js";
+import { readTextIfExists, writeTextAtomic } from "./fs.js";
+import { resolveHarnessKey } from "./keys.js";
+import { fetchHarnessModels } from "./models.js";
+import {
+    applyWithSnapshot,
+    clearSnapshot,
+    restoreSnapshot,
+} from "./snapshot.js";
+import type {
+    HarnessAdapter,
+    HarnessContext,
+    HarnessModel,
+    HarnessResult,
+} from "./types.js";
+
+const ID = "prime";
+const LABEL = "Prime Agent";
+const PROVIDER = "pollinations";
+const DEFAULT_MODEL = "deepseek";
+const KEY_ENV = "POLLI_PRIME_API_KEY";
+
+const primeHome = (ctx: HarnessContext) => join(ctx.home, ".prime-agent");
+const settingsPath = (ctx: HarnessContext) =>
+    join(primeHome(ctx), "settings.yaml");
+const envPath = (ctx: HarnessContext) => join(primeHome(ctx), ".env");
+const skillPath = (ctx: HarnessContext) =>
+    join(primeHome(ctx), "skills", "polli", "SKILL.md");
+
+const files = (ctx: HarnessContext) => [
+    settingsPath(ctx),
+    envPath(ctx),
+    skillPath(ctx),
+];
+
+const readKey = (ctx: HarnessContext) => {
+    const text = readTextIfExists(envPath(ctx));
+    if (!text) return null;
+    const match = text.match(new RegExp(`${KEY_ENV}=(.+)`, "m"));
+    return match?.[1] ?? null;
+};
+
+const setEnvKey = (ctx: HarnessContext, key: string) => {
+    const lines = (readTextIfExists(envPath(ctx)) ?? "").split("\n");
+    const idx = lines.findIndex((l) => l.includes(KEY_ENV));
+    const line = `${KEY_ENV}=${key}`;
+    if (idx === -1) {
+        lines.push(line);
+    } else {
+        lines[idx] = line;
+    }
+    writeTextAtomic(envPath(ctx), lines.join("\n"), 0o600);
+};
+
+const deleteEnvKey = (ctx: HarnessContext) => {
+    const text = readTextIfExists(envPath(ctx));
+    if (!text) return false;
+    const lines = text.split("\n").filter((l) => !l.includes(KEY_ENV));
+    writeTextAtomic(envPath(ctx), lines.join("\n"), 0o600);
+    return true;
+};
+
+const providerBlock = (models: HarnessModel[]) => ({
+    displayName: "Pollinations.ai",
+    apiKeyEnv: KEY_ENV,
+    api: "openai-completions",
+    baseURL: `${BASE_URL}/v1`,
+    compat: {
+        supportsStore: false,
+        supportsDeveloperRole: false,
+        supportsReasoningEffort: true,
+        supportsUsageInStreaming: true,
+        supportsStrictMode: false,
+        maxTokensField: "max_tokens",
+    },
+    models: models.map((m) => ({
+        id: m.id,
+        name: m.id,
+        contextWindow: m.contextWindow,
+        input: m.input,
+        reasoningEfforts: false,
+    })),
+});
+
+const result = (ctx: HarnessContext): HarnessResult => {
+    const text = readTextIfExists(settingsPath(ctx)) ?? "";
+    const hasProvider = text.includes("Pollinations.ai");
+    return {
+        harness: ID,
+        label: LABEL,
+        configured:
+            hasProvider &&
+            readKey(ctx) !== null &&
+            readTextIfExists(skillPath(ctx)) !== null,
+        files: files(ctx),
+    };
+};
+
+export const prime: HarnessAdapter = {
+    id: ID,
+    label: LABEL,
+    description: "Configure Prime Agent as a Pollinations provider",
+    restartHint: "Restart Prime Agent to apply changes",
+
+    async on(ctx, options) {
+        const model = options.model ?? DEFAULT_MODEL;
+        const models = await fetchHarnessModels();
+        if (!models.some((c) => c.id === model)) {
+            throw new Error(
+                `Model "${model}" is not a tool-calling text model. Run: polli models`,
+            );
+        }
+
+        const apiKey = await resolveHarnessKey(
+            { id: ID, label: LABEL, existingKey: readKey(ctx) },
+            { browser: options.browser },
+        );
+
+        applyWithSnapshot(ctx, ID, files(ctx), () => {
+            writeTextAtomic(
+                settingsPath(ctx),
+                `${JSON.stringify(
+                    {
+                        providers: { [PROVIDER]: providerBlock(models) },
+                        defaultModel: { provider: PROVIDER, model },
+                    },
+                    null,
+                    2,
+                )}\n`,
+            );
+            setEnvKey(ctx, apiKey);
+            if (readTextIfExists(skillPath(ctx)) === null) {
+                writeTextAtomic(skillPath(ctx), polliSkill, 0o600);
+            }
+        });
+
+        return result(ctx);
+    },
+
+    off(ctx) {
+        const managedFiles = files(ctx);
+        let outcome: HarnessResult["outcome"] = "restored";
+        if (restoreSnapshot(ctx, ID, managedFiles) !== "restored") {
+            const text = readTextIfExists(settingsPath(ctx)) ?? "";
+            if (text.includes("Pollinations.ai")) {
+                const fs = require("node:fs") as typeof import("node:fs");
+                try {
+                    fs.unlinkSync(settingsPath(ctx));
+                } catch {}
+            }
+            deleteEnvKey(ctx);
+            const skill = readTextIfExists(skillPath(ctx));
+            if (skill === polliSkill) {
+                try {
+                    const fs = require("node:fs") as typeof import("node:fs");
+                    fs.unlinkSync(skillPath(ctx));
+                } catch {}
+            }
+            outcome = "stripped";
+        }
+        clearSnapshot(ctx, ID, managedFiles);
+        return { ...result(ctx), configured: false, outcome };
+    },
+
+    status: result,
+};


### PR DESCRIPTION
Adds four Polli harness adapters, each implementing on/off/status with snapshot-based rollback:

**OpenClaw (#14121):** Configures ~/.openclaw/openclaw.json with Pollinations provider, models, and env key.

**Pi (#14119):** Configures ~/.pi/settings.yaml (pi-ai schema) with Pollinations provider and models.

**Prime Agent (#14120):** Configures ~/.prime-agent/settings.yaml (pi-ai schema) with Pollinations provider and models.

**OpenCode (#14118):** Configures ~/.config/opencode/opencode.json with Pollinations provider.

All adapters use:
- Dedicated polli-harness-{id} API keys via resolveHarnessKey()
- Snapshot-based rollback on off
- SKILL.md for Pollinations capabilities
- Compatible with the harness foundation (PR #14107)

Fixes #14118, #14119, #14120, #14121