### PR TITLE
fix: add missing video/audio/embedding tabs to community model listing

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/models.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/models.tsx
@@ -65,8 +65,12 @@ const COMMUNITY_SECTION_ORDER: SectionType[] = [
     "all",
     "text",
     "image",
+    "video",
+    "audio",
+    "embedding",
     "agent",
 ];
+
 const SCOPE_ORDER: ModelScope[] = ["pollinations", "community"];
 
 const MODEL_SLUG_LIST_URL =


### PR DESCRIPTION
- Community models with video, audio, and embedding modalities were supported by the backend and dialog but missing from the section filter tabs, making them unfilterable in the Community view
- Adds `video`, `audio`, `embedding` to `COMMUNITY_SECTION_ORDER` in the models page

Before: community tab only showed All, Text, Image, Agents.
After: All, Text, Image, Video, Audio, Embedding, Agents.