### PR TITLE
fix: show all community model categories

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/model-search.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-search.ts
@@ -34,6 +34,35 @@ export type ModelSearch = {
     sort?: ModelSort;
 };
 
+type ModelSectionInput = {
+    type: Exclude<ModelCategory, "all" | "agent">;
+    agent?: boolean;
+};
+
+const MODEL_SECTION_ORDER: ModelCategory[] = [
+    "all",
+    "text",
+    "image",
+    "video",
+    "3d",
+    "audio",
+    "realtime",
+    "embedding",
+    "agent",
+];
+
+/** Model tabs in display order, limited to categories present in the catalog. */
+export function getAvailableModelSections(
+    models: readonly ModelSectionInput[],
+): ModelCategory[] {
+    const present = new Set(
+        models.map((model) => (model.agent ? "agent" : model.type)),
+    );
+    return MODEL_SECTION_ORDER.filter(
+        (category) => category === "all" || present.has(category),
+    );
+}
+
 function includes<T extends string>(
     values: readonly T[],
     value: unknown,
@@ -57,11 +86,7 @@ export function validateModelSearch(
         scope: scope === "community" ? scope : undefined,
         category:
             category !== "all" &&
-            (scope === "community"
-                ? category === "text" ||
-                  category === "image" ||
-                  category === "agent"
-                : category !== "agent")
+            (scope === "community" || category !== "agent")
                 ? category
                 : undefined,
         q: query || undefined,

--- a/enter.pollinations.ai/frontend/src/components/models/models.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/models.tsx
@@ -40,7 +40,11 @@ import {
     matchesModelQuery,
     parseModelQuery,
 } from "./model-query.ts";
-import type { ModelScope, ModelSort } from "./model-search.ts";
+import {
+    getAvailableModelSections,
+    type ModelScope,
+    type ModelSort,
+} from "./model-search.ts";
 import { sortModels } from "./model-sort.ts";
 import {
     type SectionType,
@@ -61,12 +65,6 @@ const POLLINATIONS_SECTION_ORDER: SectionType[] = [
     "embedding",
 ];
 
-const COMMUNITY_SECTION_ORDER: SectionType[] = [
-    "all",
-    "text",
-    "image",
-    "agent",
-];
 const SCOPE_ORDER: ModelScope[] = ["pollinations", "community"];
 
 const MODEL_SLUG_LIST_URL =
@@ -247,7 +245,7 @@ export const Models: FC = () => {
     );
     const sectionOrder =
         activeScope === "community"
-            ? COMMUNITY_SECTION_ORDER
+            ? getAvailableModelSections(scopedModels)
             : POLLINATIONS_SECTION_ORDER;
     const hasAgents = scopedModels.some((model) => model.agent);
     const scopeLabel = SCOPE_LABELS[activeScope];
@@ -307,9 +305,9 @@ export const Models: FC = () => {
                 scope: scope === "pollinations" ? undefined : scope,
                 category:
                     scope === "community"
-                        ? previous.category === "text" ||
-                          previous.category === "image" ||
-                          previous.category === "agent"
+                        ? getAvailableModelSections(
+                              allModels.filter((model) => model.community),
+                          ).includes(previous.category ?? "all")
                             ? previous.category
                             : undefined
                         : previous.category === "agent"

--- a/enter.pollinations.ai/test/model-categories.test.ts
+++ b/enter.pollinations.ai/test/model-categories.test.ts
@@ -3,7 +3,10 @@ import {
     computeCategoryModalities,
     getModelCategoriesFromCatalog,
 } from "../frontend/src/components/models/model-categories.ts";
-import { validateModelSearch } from "../frontend/src/components/models/model-search.ts";
+import {
+    getAvailableModelSections,
+    validateModelSearch,
+} from "../frontend/src/components/models/model-search.ts";
 
 const catalog = [
     { name: "official-text", category: "text" as const },
@@ -95,7 +98,28 @@ describe("model categories", () => {
         ]);
     });
 
-    it("uses a separate community scope with text and image categories", () => {
+    it("derives community sections from the model categories in the catalog", () => {
+        expect(
+            getAvailableModelSections([
+                { type: "text" },
+                { type: "image" },
+                { type: "video" },
+                { type: "audio" },
+                { type: "embedding" },
+                { type: "text", agent: true },
+            ]),
+        ).toEqual([
+            "all",
+            "text",
+            "image",
+            "video",
+            "audio",
+            "embedding",
+            "agent",
+        ]);
+    });
+
+    it("accepts every model category in the community scope", () => {
         expect(validateModelSearch({ scope: "community" })).toEqual({
             scope: "community",
             category: undefined,
@@ -122,7 +146,26 @@ describe("model categories", () => {
             validateModelSearch({ scope: "community", category: "video" }),
         ).toEqual({
             scope: "community",
-            category: undefined,
+            category: "video",
+            q: undefined,
+            sort: undefined,
+        });
+        expect(
+            validateModelSearch({ scope: "community", category: "audio" }),
+        ).toEqual({
+            scope: "community",
+            category: "audio",
+            q: undefined,
+            sort: undefined,
+        });
+        expect(
+            validateModelSearch({
+                scope: "community",
+                category: "embedding",
+            }),
+        ).toEqual({
+            scope: "community",
+            category: "embedding",
             q: undefined,
             sort: undefined,
         });


### PR DESCRIPTION
- Derives community tabs from categories present in the loaded catalog
- Keeps a category when switching scopes only when it exists in the target catalog
- Accepts community video, audio, and embedding category URLs
- Adds focused category tests