### PR TITLE
chore: add dashboard OAuth session secret

### DIFF
--- a/operations/economics/secrets/web.json
+++ b/operations/economics/secrets/web.json
@@ -1,6 +1,7 @@
 {
 	"ECONOMICS_PASSWORD": "ENC[AES256_GCM,data:+2MCUSFFCoBLZw==,iv:ebqin5KeSl/yocoqUNTjxOk/979bVyYzHiBHIbxNXGA=,tag:7VaEx62qGB52pEewVOxkLw==,type:str]",
 	"TINYBIRD_ECONOMICS_READ_TOKEN": "ENC[AES256_GCM,data:vg9G74LuhLRCye/1nWLItnPBH3iI6u5HRnahlOCIMGE4Krj1nNbaOKmXdmpYClHrbEDS6tX0UXZJ2+nf+dc1G8gbCnFcJdi2Ie1OCOfD0ruGbEvh//+6xC3qM0CnxmvUNog6hjiIXxfTnqQJBw+rcEUctv2x0O2X7ZPALobmf1wl1DxBcLZJbOEupWxEXrtuYjewhW/TLURv3t96SvNfcaILMjx8K6Rww2VJs8/eUKdL/htH9/pmkAOqeSNSbr+aCcdrabij4CxKSpnk9Q==,iv:sPsLfbTFRC2Fr8O7KS6LxMVlxqDihyWD2baClOiXge8=,tag:E2m2FqcLci4U0JrO3bmb6A==,type:str]",
+	"POLLINATIONS_AUTH_SESSION_SECRET": "ENC[AES256_GCM,data:YygwV+onuQBzQvn523kRowvfEPo6geK4L6aKKDbJoYr0v1i3EcTcmfHPv/dO0rcgwd0iKwskQH2DBR6SUyqxhQ==,iv:3F7rGl291JtPtrJFOADzWrihxF8ko1iJ6NnubFvuFaQ=,tag:h2+2YEQJ01uKD5DHsLZjng==,type:str]",
 	"sops": {
 		"age": [
 			{
@@ -8,8 +9,8 @@
 				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByd1NiaFZqVm9hQzEwYi9t\nVThxUCt2NXRiZ3lZQ2FPc3lEcmwyRFI3ekhNCjJheDdBZkg1YThXMkxGSHVJWUNo\nM0tHSmc2aEllSHVockhSb3k4Njc1eFUKLS0tIGNiV09JUnlDOW54a2crdWI5VE1I\nRHY1RFVUOHhMQlRwZkcvbGdKWDVxTkEKI5MLBODf3HagktF+j8oU7p7RUOgAZYmx\nAdglYRfZKKlmCb5994hfw3teJw2EwnuXCF5h+1FdIJhpw0iCg77Gkw==\n-----END AGE ENCRYPTED FILE-----\n"
 			}
 		],
-		"lastmodified": "2026-07-12T23:05:53Z",
-		"mac": "ENC[AES256_GCM,data:+WdirYCOfxkRDtyeM646B5klF87M9j44iVQrkFkyvLy5QnAr77Ua9LUf1iEVR/qY+10CVhehGP0ROSuAERhxVtUFhK5Hb5kT37b5H8u3/1dZeLqBhXkMfHKpZ+0WuiWMlEJX0+NxklQJg0yi6qeZ5c6f1DVK3qAYQu6VR6F6fRA=,iv:gvnTUNG8uhV5enP+9ZQcMQP+pm2gLqBs6UwrCOGqHb8=,tag:fNDE/eNaqd/ocqdVkH17rQ==,type:str]",
+		"lastmodified": "2026-08-31T12:47:25Z",
+		"mac": "ENC[AES256_GCM,data:TjYnQFkGAcKEuN/sSx9o3LOr8VhYmpViSR8OaUkgfveEN1XRh5ll7XhG45Bz1511bnxC+EidelkqrYveXOybFwvfKpCsu0IYaScRs8TYWhIEB3WTSynU9MxcpjDqpjToDCq8s6eimd3jBluYTqJbzKpkLr+xBqryC9p8NAOaoXY=,iv:qOP/UZKc7MMjWRMVyqRm8b/B7ZMOx0Ytpn10P321vJI=,tag:0EV4k8SD2bh4MOYfJ259dA==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.11.0"
 	}

--- a/operations/kpi/secrets/env.json
+++ b/operations/kpi/secrets/env.json
@@ -1,5 +1,6 @@
 {
 	"TINYBIRD_READ_TOKEN": "ENC[AES256_GCM,data:89X74PzztmH7y4AAGcdB0w5fAqJeyjh8MfnwXpeODVzAjchEL1ClxTW3z4t2H8jZobOjwyPbH5I4Q4hCLc/ZW8x9yn/r3Zihr7HI6y+0MhHUpqm9BUoQp5M4nHmJE63vfCrf99x40rMw7dBEN+UHVuCHTA2DXfeWbtjxfVJMa7w9ArEzd5EwDRh2zOvoS3TnFzDd5IsbJOSKl2gGE6rKmQp2JxooAshDclO68hhWlr9KnJkt1j8AsdPNVb5RcpeWZEIRHetCI/+ZfH+UQQ==,iv:4eUApo5lbqSowPGmIjx1s9WH415Qzxbb09aGnjgRuz8=,tag:iW/QLfWOGyV3m5oy6Uk/hw==,type:str]",
+	"POLLINATIONS_AUTH_SESSION_SECRET": "ENC[AES256_GCM,data:zwjj81m/VIHXPBOJTbr7kWGS3MXoeziY3Z/bnHdKUJH81Cw8ghJgiogqs7x4pGr9AvMC7nUNhOEBKzedJFswQw==,iv:sUHbvPOu1ZedDjknM9IpWTbhDXpZhV9cBe4bBQZ+Z90=,tag:qPBcEjXevnd5oHtLqzMxGw==,type:str]",
 	"sops": {
 		"age": [
 			{
@@ -11,8 +12,8 @@
 				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6TmptdVlVVjUvcUhaMWo1\nQzJTbHdXamxSMGdjYWsyMkFvQ2tEcU9uZFU0Ci9TZjdENHlnaUdES214TDZFS2h3\nS1JsYmFHYlpGU1I1ZStXL3VCVUJodnMKLS0tIHAwSlU0ODhEdEJENHgrNTE3cnlO\nSWNTQTd4WVlmTWNCU0hWa0cyTlVzcUEKs+WrmBDOyPCmlqAI5Opdg3mGLJkDH+dL\nvpZ+7jtZZuOvlZUsvQ24b2VagBdvAnZ5N5VkZgb3q2y8QySx8gXtAA==\n-----END AGE ENCRYPTED FILE-----\n"
 			}
 		],
-		"lastmodified": "2026-07-10T16:58:09Z",
-		"mac": "ENC[AES256_GCM,data:2U1682C4saVAHDKDjMUN71bYxZEmMNasuLykq3lFZpVzA7JZFyiW+mxtQvSa6Xk8KOr/oxnnRB8FiiJXC1TZToblHKP3vm56S/lpEiLGwvUrlIYcUMm8nuPhTc5mSZJekrk8/6q3b0MZIQ8B1oOEhmkcJ9MUCesG22qhx+W8m/s=,iv:ab5ZplLLYcT4NSy18KhVm4TjsGJqu0eUbO1laXsCJ+0=,tag:cRBTSPSK1eFNOO8elsohOw==,type:str]",
+		"lastmodified": "2026-08-31T12:47:26Z",
+		"mac": "ENC[AES256_GCM,data:E9CAdZIIxZLMYtUUmdsLdkH6gGRfA2qxb3HUhM4nMAuZcvkqQ0WiyTUQ48KXY79eXyKOishKHzY8J4wSpFaC6Bs4zclXEOxGADLWTCW7/eFFpdNOnXA+wgSHZAxynNWgKNeBTZt2H1H4kZvrHMjZbJSrpeJhHdoeMATbzma+fTs=,iv:5C5hpeMZs+OLr5koOr7JfKPvccCaKeOxn355nZbT+8I=,tag:y6CLWOnXbfpwmZy8STPPNg==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.11.0"
 	}

--- a/operations/observability/secrets/secrets.vars.json
+++ b/operations/observability/secrets/secrets.vars.json
@@ -5,6 +5,7 @@
 	"DISCORD_WEBHOOK_URL": "ENC[AES256_GCM,data:9Lg53OwsX7zRpHsOJGbWW/vgPKVx2ycbOehfjIXP/fxP+C65BWi4ZouJqA5jXCdkSQX0eUcrn5mvw7Eyh8uSpeTAyOQeMQnbuxYUit2N192on/DjC3fr7r+k/qWuq9eLUrA/TT7U1qXQEALXrSNk1sSpLizbSsFdkQ==,iv:7QS0/3WYLlqiZFRbUygRlI6viaBDW/4Y15QW3WGaOss=,tag:sIHI+C5Z50Dm9Af9Gsn+HA==,type:str]",
 	"TINYBIRD_READ_TOKEN": "ENC[AES256_GCM,data:SJOuQiK0+NT3BXcz44mSwbTBprDpIqyg9A7TRh00Pxpdk5HZAI/JQkSpBk4VFCZ7gz0glU4EnS+1Ra4WsqhpSlCI+VNKRFlcOm+ksPOe+u8gYGHmtqJ+oba3dpajEwFrCWJobZ40POsMBXf9dJ0RyQBEEYup2FX+F8DxNuISqHdnJ/Hq5pOGymqkUO0iai8bTBN6QtK/Ygyy4B0btDnveCrvokAtCyEr18lr+ogidWWqwegHJFGTeWPX9QB5sX/KgSNXJGQB3OA+Z5cvNA==,iv:34VPP1nolLzDUQUWDxLO0IHGTcZCa4/QTLq1njHeOcg=,tag:N12ioUJhAVppkzUjL0CgGg==,type:str]",
 	"TINYBIRD_LEGACY_READ_TOKEN": "ENC[AES256_GCM,data:0olrnT98x+PH4PEpEq9XoiCrEhu6i+Mq/SE+CPn6XJkvPutGabSa/FPsio2QO+mHBHPYpr0rH6pGW8n8FBIP5OaJxGSpfYxsblRrbIZwcDPzpJ7/cmLZ2Ng2QJtcflhn4gFDlNP3iucuwBoNqj6I+sYyQitqCATiQPO48jE37sajPsEHL6bf6Zgtfqwi9zkiU3UawO+4eN33HS+k3tCmpBByX9mkRQ9ar+ZtTCkjt0uqcbM+rMh2v/m+RL55vxK4drV3HrGFer/w1N/1ag==,iv:96HY1WlwYEnkJYWp6a9ZyN1MHIixtt5FSyDEKUK9ehw=,tag:vt1beEt2xxhhfrYYphS7Tw==,type:str]",
+	"POLLINATIONS_AUTH_SESSION_SECRET": "ENC[AES256_GCM,data:0WEiDc+jggXeHX2nn+cBfubBp00/Bazr9aNI5vVsa+eXMYS6mADitCQ+0FS/n/ZmilPg/qGRk/B0diV0uQknww==,iv:XBzuXyiBSV5STnckBozB8zSF8IHQfPXSz3o6irdEOko=,tag:Brznh+CYslWc6jXjvx3qbg==,type:str]",
 	"sops": {
 		"age": [
 			{
@@ -16,8 +17,8 @@
 				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvU2lycG55RDArMmQ4dWRJ\na0h4SUNEczlydWRqeUx0Z1hOUy8zUEJ1eUVzCjlQR2dLMXRpNlJZNi9NTlRXSEk3\neEMvWnptV2hwZVRqYm56dXprUHQ3ancKLS0tIGk2dFJSTk94V3pqcUFLbGswclor\ncVBWV2RnODdPNkFUTmJRWEFYdzA3VlkKecRDv2an9LhmGA9uLSPtz07mHDM64C8n\nqeY0P8bds1SSfv7UIy0Djbm0cxC/CF91hdWiC3ZJRgT8iFbWpnKHdA==\n-----END AGE ENCRYPTED FILE-----\n"
 			}
 		],
-		"lastmodified": "2026-04-14T10:22:06Z",
-		"mac": "ENC[AES256_GCM,data:1kVKMKhcH/hJQ9LxXZgjGE2j+Y20hhWW/bSHvAeDDVM530X9q1/ZVXsDCEpNB5pU3U2DvYBq+e3hRoJ4lQXhIGJWtb19qm6lE8TuFWmBESeLBuOCDiUbAc0UHWKxuP5khqLcfo3utBfgyNOIhlQSMFMcKqCuyvgrrRcFeLhXuF0=,iv:4Ta+193sYh6ewqeYqjCSd8gqyZgd2Q71ey2DFUUDkqE=,tag:h/ZgMiEyEIb+Cecatqping==,type:str]",
+		"lastmodified": "2026-08-31T12:47:26Z",
+		"mac": "ENC[AES256_GCM,data:0NR7rqmHNq9H7RtMkImhMwSfFalWMY2uFmO6g0/oGGFcEUONSDYHbbi9WK2zzjM3lg2MsWFi6GbKgLI5GFCitshKWV9klDNS+2GohfXRYA3SduzfNFkLCR63J4eg8xY11oTDxDBXW6TMeJhNyivBDGY9Z5I8S7Ks2cgtBzkpRVQ=,iv:hI6WrQZW5B5aCUE2PxvwB4WaovFcVKyWyS5RkkcQS3E=,tag:37+1pFheLgsjyDsrvH3uNw==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.11.0"
 	}


### PR DESCRIPTION
- Adds the approved POLLINATIONS_AUTH_SESSION_SECRET to the production SOPS stores for Economics, KPI, and Observability.
- Keeps the reusable value encrypted; temporary plaintext material was removed after exact cross-file consistency verification.
- Changes no application code or public configuration and does not synchronize or deploy production secrets.
- Merge this secrets PR before #14089. After both PRs merge, deploy only through the production workflow and verify login/logout on all dashboard hosts.
- Verification: all three JSON documents parse, SOPS reports them encrypted, each encrypted field exists, and the secrets-only diff contains exactly three files.