### PR TITLE
fix: make availability KPI trends legible

### DIFF
--- a/operations/kpi/src/components/KPITrendTable.jsx
+++ b/operations/kpi/src/components/KPITrendTable.jsx
@@ -88,10 +88,13 @@ export function KPITrendTable({ weeklyData, viewIndex, onCycle, onGraph }) {
                                     ? kpiValue(kpi, previousFull)
                                     : null,
                             );
+                            const improving = kpi.lowerIsBetter
+                                ? change < 0
+                                : change > 0;
                             const tone =
                                 change == null || Math.abs(change) <= 5
                                     ? "text-theme-text-muted"
-                                    : change > 0
+                                    : improving
                                       ? "text-intent-success-text"
                                       : "text-intent-danger-text";
                             return (

--- a/operations/kpi/src/components/LineChart.jsx
+++ b/operations/kpi/src/components/LineChart.jsx
@@ -209,9 +209,14 @@ export function LineChart({
     const axisLabel = (tick, seriesIndex) => {
         const scale = scaleOf(seriesIndex);
         const tickFormat = dual ? formatOf(series[seriesIndex]) : format;
-        if (tickFormat === "percent") {
+        if (
+            tickFormat === "percent" ||
+            tickFormat === "percentPrecise" ||
+            tickFormat === "perThousand"
+        ) {
             const decimals = scale.step >= 1 ? 0 : scale.step >= 0.1 ? 1 : 2;
-            return `${tick.toFixed(decimals)}%`;
+            const suffix = tickFormat === "perThousand" ? " / 1K" : "%";
+            return `${tick.toFixed(decimals)}${suffix}`;
         }
         return formatValue(
             tick,

--- a/operations/kpi/src/lib/format.js
+++ b/operations/kpi/src/lib/format.js
@@ -8,6 +8,8 @@ export function formatValue(value, format = "number") {
         return `${sign}$${Math.round(size).toLocaleString()}`;
     }
     if (format === "percent") return `${Math.round(value)}%`;
+    if (format === "percentPrecise") return `${value.toFixed(2)}%`;
+    if (format === "perThousand") return `${value.toFixed(1)} / 1K`;
     if (format === "compact") {
         if (Math.abs(value) >= 1e9) return `${(value / 1e9).toFixed(1)}B`;
         if (Math.abs(value) >= 1e6) return `${(value / 1e6).toFixed(1)}M`;

--- a/operations/kpi/src/lib/kpis.js
+++ b/operations/kpi/src/lib/kpis.js
@@ -12,6 +12,9 @@ const coverage = (week) =>
         ? (week.revenue / week.costUsd) * 100
         : null;
 
+const failuresPerThousand = (availability) =>
+    Number.isFinite(availability) ? (100 - availability) * 10 : null;
+
 // The KPI catalogue. Rows with `views` are the same measure in another
 // unit and cycle in place; the rest have a single definition.
 export const KPIS = [
@@ -148,13 +151,22 @@ export const KPIS = [
         category: "Health",
         views: [
             {
-                name: "Service availability",
-                format: "percent",
+                name: "Server errors / 1K",
+                format: "perThousand",
+                lowerIsBetter: true,
+                calc: (w) => failuresPerThousand(w.availability),
                 tooltip:
-                    "(Total − 5xx) / total × 100. User errors (4xx) do not count as downtime.",
+                    "5xx / (2xx + 5xx) × 1,000. A normalized failure rate that stays comparable as traffic changes. User errors (4xx) are excluded.",
+            },
+            {
+                name: "Service availability",
+                format: "percentPrecise",
+                tooltip:
+                    "2xx / (2xx + 5xx) × 100. User errors (4xx) are excluded because they do not indicate service downtime.",
             },
             {
                 name: "5xx errors",
+                lowerIsBetter: true,
                 calc: (w) => w.serverErrors5xx,
                 tooltip:
                     "Server errors behind the availability figure. 90% availability reads mild; the same week in raw failed requests does not.",
@@ -207,6 +219,7 @@ export const KPIS = [
             {
                 key: "communityAvailability",
                 name: "Community models · availability",
+                format: "percentPrecise",
                 tooltip:
                     "Community-model 2xx / (2xx + 5xx) × 100. 4xx is excluded from the denominator — auth, balance, rate-limit and bad-input errors are the caller's, not an endpoint being down. Includes top-level managed-agent runs until agent attribution exists.",
             },

--- a/operations/kpi/test/kpis.test.js
+++ b/operations/kpi/test/kpis.test.js
@@ -42,7 +42,7 @@ describe("community models row", () => {
             const view = kpiView(community, i);
             return formatValue(kpiValue(view, week), view.format);
         });
-        expect(shown).toEqual(["12%", "4%", "99%"]);
+        expect(shown).toEqual(["12%", "4%", "98.75%"]);
     });
 
     it("gives each view its own tooltip naming the 4xx treatment", () => {
@@ -58,6 +58,37 @@ describe("community models row", () => {
             expect(kpiValue(view, before)).toBeUndefined();
             expect(formatValue(kpiValue(view, before), view.format)).toBe("—");
         }
+    });
+});
+
+const availability = KPIS.find((row) => row.key === "availability");
+const healthWeek = {
+    availability: 99.12,
+    serverErrors5xx: 36691,
+};
+
+describe("service availability row", () => {
+    it("leads with normalized failures and keeps precise availability", () => {
+        expect([0, 1, 2].map((i) => kpiView(availability, i).name)).toEqual([
+            "Server errors / 1K",
+            "Service availability",
+            "5xx errors",
+        ]);
+        expect(kpiView(availability, 0).lowerIsBetter).toBe(true);
+        expect(kpiView(availability, 1).lowerIsBetter).toBeUndefined();
+        expect(kpiView(availability, 2).lowerIsBetter).toBe(true);
+        expect(
+            [0, 1, 2].map((i) => {
+                const view = kpiView(availability, i);
+                return formatValue(kpiValue(view, healthWeek), view.format);
+            }),
+        ).toEqual(["8.8 / 1K", "99.12%", "36,691"]);
+    });
+
+    it("does not invent a failure rate when health data is missing", () => {
+        const view = kpiView(availability, 0);
+        expect(kpiValue(view, {})).toBeNull();
+        expect(formatValue(kpiValue(view, {}), view.format)).toBe("—");
     });
 });
 


### PR DESCRIPTION
- Shows normalized 5xx errors per 1,000 valid requests as the primary health view
- Keeps precise service and community-model availability percentages
- Preserves raw 5xx counts and corrects lower-is-better trend coloring
- Adds focused KPI coverage for formatting and missing data

Tests: `npm test -- --run test/kpis.test.js`; `npm run build`