### PR TITLE
feat: add polli harness openclaw on|off|status

### DIFF
--- a/CODING_HARNESSES.md
+++ b/CODING_HARNESSES.md
@@ -2,7 +2,7 @@
 
 Use `polli harness` to connect a supported coding harness to Pollinations. It handles Polli login, a dedicated API key, model setup, and any Pollinations capabilities supported by that harness.
 
-> **Available now:** DeepSeek Harness, OpenCode, Pi, and Prime Agent are integrated `polli harness` profiles. OpenClaw is coming soon.
+> **Available now:** DeepSeek Harness, OpenClaw, OpenCode, Pi, and Prime Agent are integrated `polli harness` profiles.
 
 ## Use a harness
 
@@ -26,10 +26,10 @@ If a harness cannot be launched, `on` stops before login, key creation, or confi
 | Harness | Status | What is unique |
 | --- | --- | --- |
 | [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`) | **Available now** — `polli harness dsh on` | Adds the Pollinations provider, hosted Pollinations MCP, and Polli skill. Uses `deepseek` by default. Its official launch uses `npx`, so no separate global DSH installation is required. |
+| [OpenClaw](https://github.com/openclaw/openclaw) (`openclaw`) | **Available now** — `polli harness openclaw on` | Brings the [existing Pollinations OpenClaw setup](./apps/openclaw/README.md) into the shared `polli harness` workflow. Adds the Pollinations provider and Polli skill. Uses `kimi` by default. |
 | [OpenCode](https://opencode.ai) | **Available now** — `polli harness opencode on` | Uses the existing [Pollinations OpenCode plugin](https://github.com/fkom13/opencode-pollinations-plugin) for models, media tools, usage, and quests. Defaults to `openai`. |
 | [Pi](https://github.com/earendil-works/pi) | **Available now** — `polli harness pi on` | Uses Pi's native provider support and the Polli skill. Pi intentionally has no built-in MCP support. Defaults to `deepseek`. |
 | [Prime Agent](https://github.com/PrimeIntellect-ai/prime-agent) | **Available now** — `polli harness prime on` | Uses native provider support and the Polli skill while preserving memories, sessions, and unrelated configuration. |
-| [OpenClaw](https://github.com/openclaw/openclaw) | Coming soon | Will bring the [existing Pollinations setup](./apps/openclaw/README.md) into the shared `polli harness` workflow. |
 
 ## DeepSeek Harness
 
@@ -40,6 +40,16 @@ polli harness dsh off
 ```
 
 DeepSeek Harness is officially run with `npx @deepseek-ai/dsh web`. `on` verifies that `npx` is available before changing configuration. Choose another default model with `--model <id>`. Add `--no-mcp` if you do not want the hosted Pollinations media tools.
+
+## OpenClaw
+
+```bash
+npx @pollinations/cli harness openclaw on
+polli harness openclaw status
+polli harness openclaw off
+```
+
+`on` requires the `openclaw` binary; if it is missing, the official install page is shown. It logs Polli in if needed, mints a dedicated `polli-harness-openclaw` key, adds the Pollinations provider with the current live model catalog, and installs the Polli skill. The default model is `kimi`; choose another with `--model <id>`. `status` shows whether the integration is ready, and `off` removes only the Pollinations-owned provider, model, key, and skill. Existing agents and unrelated configuration are preserved. See [Pollinations × OpenClaw](./apps/openclaw/README.md).
 
 ## OpenCode
 

--- a/apps/openclaw/README.md
+++ b/apps/openclaw/README.md
@@ -1,23 +1,24 @@
 # Pollinations x OpenClaw
 
-Use **25+ AI models** as your OpenClaw brain through a single API.
-
-**Kimi K2.5** as default (256K context, vision, tools, reasoning), with DeepSeek, GLM 5, and Claude Haiku as free alternatives. Premium models (Claude Opus, Gemini 3 Pro) available on paid tier.
+Use **Pollinations' live model catalog** as your OpenClaw brain through a single API, set up with the polli CLI's integrated OpenClaw harness.
 
 ## Setup
 
-**Step 1:** Get your API key (comes with free credits) at [enter.pollinations.ai](https://enter.pollinations.ai/keys)
+The recommended setup goes through `polli harness`, which is the same single source of truth used for every coding harness (`deepseek`, `openclaw`, ...). It mints a dedicated key, writes the live provider catalog, and installs the Polli skill — no hand-maintained model list.
 
-**Step 2:** Run the setup script (requires `jq`):
+**Step 1:** Get an API key (comes with free credits) at [enter.pollinations.ai](https://enter.pollinations.ai/keys), or just let polli log you in and mint a harness key for you.
+
+**Step 2:** Install OpenClaw, then run:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/pollinations/pollinations/main/apps/openclaw/setup-pollinations.sh | bash -s -- YOUR_API_KEY
+npx @pollinations/cli harness openclaw on
 ```
 
-This works for both fresh installs and existing OpenClaw setups. It:
-- Runs `openclaw onboard` for fresh installs (creates config + workspace)
-- Adds the Pollinations provider with 9 models to `~/.openclaw/openclaw.json`
-- Sets Kimi K2.5 as default with DeepSeek + GLM fallbacks
+Or use the convenience shim (same thing under the hood):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/pollinations/pollinations/main/apps/openclaw/setup-pollinations.sh | bash
+```
 
 **Step 3 (fresh install only):** Start the gateway:
 
@@ -25,81 +26,39 @@ This works for both fresh installs and existing OpenClaw setups. It:
 openclaw gateway start
 ```
 
-## Available Models
-
-Switch models anytime in chat with `/model pollinations/<name>`:
-
-| Model | ID | Best for |
-|---|---|---|
-| **Kimi K2.5** (default) | `pollinations/kimi` | Agentic tasks, vision, reasoning (256K context) |
-| **Kimi K2.6** | `pollinations/kimi-k2.6` | Flagship agentic, vision, reasoning (262K context, paid) |
-| **DeepSeek V4 Flash** | `pollinations/deepseek` | Fast reasoning & tool calling (paid) |
-| **DeepSeek V4 Pro** | `pollinations/deepseek-pro` | Advanced reasoning & coding (paid) |
-| **GLM 5.1** | `pollinations/glm` | Coding, reasoning, agentic workflows |
-| **Gemini + Search** | `pollinations/gemini-search` | Web search grounded answers |
-| **Claude Haiku 4.5** | `pollinations/claude-fast` | Fast with good reasoning |
-| **Claude Opus 4.6** | `pollinations/claude-large` | Most intelligent (paid) |
-| **Gemini 3.1 Pro** | `pollinations/gemini-large` | 1M context (paid) |
-
-## Manual Setup
-
-If you prefer not to run the script, edit `~/.openclaw/openclaw.json` directly. Add a `pollinations` provider under `models.providers`:
-
-```json
-{
-  "models": {
-    "providers": {
-      "pollinations": {
-        "baseUrl": "https://gen.pollinations.ai/v1",
-        "apiKey": "YOUR_API_KEY",
-        "api": "openai-completions",
-        "models": [
-          {
-            "id": "kimi",
-            "name": "Kimi K2.5",
-            "reasoning": true,
-            "input": ["text", "image"],
-            "contextWindow": 256000,
-            "maxTokens": 8192
-          },
-          {
-            "id": "kimi-k2.6",
-            "name": "Kimi K2.6",
-            "reasoning": true,
-            "input": ["text", "image"],
-            "contextWindow": 262000,
-            "maxTokens": 8192
-          }
-        ]
-      }
-    }
-  }
-}
-```
-
-Then set the default model:
+### Managing the integration
 
 ```bash
-openclaw models set pollinations/kimi
-openclaw models fallbacks add pollinations/deepseek
-openclaw models fallbacks add pollinations/glm
-openclaw gateway restart
+polli harness openclaw status          # is OpenClaw ready to use Pollinations?
+polli harness openclaw on --model deepseek   # switch the default model
+polli harness openclaw off             # remove only the Pollinations-owned config + skill
 ```
 
-See all available models at [gen.pollinations.ai/v1/models](https://gen.pollinations.ai/v1/models).
+What `on` does:
+
+- Logs Polli in if needed and mints a dedicated `polli-harness-openclaw` API key.
+- Adds the Pollinations provider with the **current live catalog** (no hardcoded list) to `~/.openclaw/openclaw.json`, via the `pollinations/*` wildcard.
+- Installs the Polli skill under `~/.openclaw/skills/polli`.
+- Preserves existing agents, sources, fallbacks, and unrelated config.
+
+`off` restores a byte-for-byte backup taken before `on`, or strips only the Pollinations-owned provider, model, key, and skill.
+
+## Using models
+
+Switch models anytime in chat with `/model pollinations/<id>`. See the live list:
+
+```bash
+curl https://gen.pollinations.ai/v1/models
+```
 
 ## Pollinations Skill (Image/Video/Audio)
 
-The [Pollinations skill](https://github.com/pollinations/pollinations/tree/main/apps/openclaw) gives your agent image, video, and audio generation:
-
-```
-/skill install isaacgounton/pollinations
-```
+The [Polli skill](https://github.com/pollinations/pollinations/tree/main/packages/polli-cli) gives your agent image, video, audio, and speech generation. `polli harness openclaw on` installs it automatically.
 
 ## Links
 
 - **API Docs:** https://gen.pollinations.ai/docs
 - **Get API Key:** https://enter.pollinations.ai/keys
 - **Models:** https://gen.pollinations.ai/v1/models
-- **GitHub:** https://github.com/pollinations/pollinations
+- **Coding Harnesses:** https://github.com/pollinations/pollinations/blob/main/CODING_HARNESSES.md
 - **Discord:** https://discord.gg/pollinations-ai-885844321461485618

--- a/apps/openclaw/index.html
+++ b/apps/openclaw/index.html
@@ -119,47 +119,37 @@
                                 <div class="code-inner">
     curl -fsSL
     https://raw.githubusercontent.com/pollinations/pollinations/main/apps/openclaw/setup-pollinations.sh
-    \
-    | bash -s -- <span id="key-placeholder">YOUR_API_KEY</span></div>
+    | bash</div>
                             </div>
                             <ul style="margin:8px 0 12px 20px; font-size:14px; line-height:1.5; color:var(--muted)">
-                                <li>🔑 Saves API key to <code
+                                <li>🔑 Logs Polli in and mints a dedicated key into <code
                                         style="color:var(--accent); font-size:13px">~/.openclaw/openclaw.json</code>
                                 </li>
-                                <li>🤖 Adds 10 OpenClaw models: 7 free — OpenClaw, Kimi K2.5, DeepSeek, DeepSeek Pro,
-                                    GLM, Gemini + Search, Claude Haiku — plus 3 paid: Kimi K2.6, Claude Large, Gemini
-                                    Large</li>
-                                <li>🔍 Also enables Perplexity Fast for the <code
-                                        style="color:var(--accent); font-size:13px">web_search</code> tool <em>via
-                                        pollinations.ai</em> (preserves existing if already set)</li>
+                                <li>🤖 Adds the current live Pollinations model catalog via the
+                                    <code style="color:var(--accent); font-size:13px">pollinations/*</code> provider
+                                </li>
+                                <li>🤖 Installs the Polli skill for image, video, and audio generation</li>
                             </ul>
 
                             <button class="toggle-btn" onclick="toggleManual()">Manual JSON config ▾</button>
                             <div class="manual-config" id="manual-config">
-                                <div class="step-text">Or paste this into <code
-                                        style="color:var(--accent)">~/.openclaw/openclaw.json</code>:</div>
+                                <div class="step-text">The recommended setup is <code
+                                        style="color:var(--accent)">npx @pollinations/cli harness openclaw on</code> — it
+                                    pulls the live model catalog and the Polli skill automatically. To configure
+                                    manually, paste this into <code
+                                        style="color:var(--accent)">~/.openclaw/openclaw.json</code> (uses the
+                                    <code style="color:var(--accent)">pollinations/*</code> wildcard so every current
+                                    model is switchable; no hardcoded list):</div>
                                 <div class="code-block" id="json-config" style="font-size:12px;"><button
                                         class="copy-btn" onclick="copyCode('json-config')">Copy</button>
                                     <div class="code-inner">{
-                                        "env": { "POLLINATIONS_API_KEY": "<span class="key-in-json">YOUR_API_KEY</span>"
+                                        "env": {
+                                        "vars": { "POLLI_OPENCLAW_API_KEY": "<span class="key-in-json">YOUR_API_KEY</span>" }
                                         },
                                         "agents": {
                                         "defaults": {
-                                        "model": {
-                                        "primary": "pollinations/kimi",
-                                        "fallbacks": ["pollinations/deepseek", "pollinations/glm"]
-                                        },
-                                        "models": {
-                                        "pollinations/kimi": { "alias": "Kimi K2.5" },
-                                        "pollinations/kimi-k2.6": { "alias": "Kimi K2.6" },
-                                        "pollinations/deepseek": { "alias": "DeepSeek V4 Flash" },
-                                        "pollinations/deepseek-pro": { "alias": "DeepSeek V4 Pro" },
-                                        "pollinations/glm": { "alias": "GLM 5.1" },
-                                        "pollinations/gemini-search": { "alias": "Gemini + Search" },
-                                        "pollinations/claude-fast": { "alias": "Claude Haiku 4.5" },
-                                        "pollinations/claude-large": { "alias": "Claude Opus 4.6" },
-                                        "pollinations/gemini-large": { "alias": "Gemini 3 Pro" }
-                                        }
+                                        "model": { "primary": "pollinations/kimi" },
+                                        "models": { "pollinations/*": {} }
                                         }
                                         },
                                         "models": {
@@ -167,41 +157,18 @@
                                         "providers": {
                                         "pollinations": {
                                         "baseUrl": "https://gen.pollinations.ai/v1",
-                                        "apiKey": "${POLLINATIONS_API_KEY}",
+                                        "apiKey": "${POLLI_OPENCLAW_API_KEY}",
                                         "api": "openai-completions",
                                         "models": [
                                         { "id": "kimi", "name": "Kimi K2.5", "reasoning": true,
-                                        "input": ["text","image"], "contextWindow": 256000 },
-                                        { "id": "kimi-k2.6", "name": "Kimi K2.6 (Paid)", "reasoning": true,
-                                        "input": ["text","image"], "contextWindow": 262000 },
-                                        { "id": "deepseek", "name": "DeepSeek V4 Flash",
-                                        "input": ["text"], "contextWindow": 1000000 },
-                                        { "id": "deepseek-pro", "name": "DeepSeek V4 Pro",
-                                        "input": ["text"], "contextWindow": 65536 },
-                                        { "id": "glm", "name": "GLM 5.1",
-                                        "input": ["text"], "contextWindow": 128000 },
-                                        { "id": "gemini-search", "name": "Gemini + Search",
-                                        "input": ["text","image"], "contextWindow": 128000 },
-                                        { "id": "claude-fast", "name": "Claude Haiku 4.5",
-                                        "input": ["text","image"], "contextWindow": 200000 },
-                                        { "id": "claude-large", "name": "Claude Opus 4.6 (Paid)",
-                                        "input": ["text","image"], "contextWindow": 200000 },
-                                        { "id": "gemini-large", "name": "Gemini 3 Pro (Paid)", "reasoning": true,
-                                        "input": ["text","image"], "contextWindow": 1000000 }
+                                        "input": ["text","image"], "contextWindow": 256000 }
                                         ]
                                         }
                                         }
                                         },
-                                        "tools": {
-                                        "web": {
-                                        "search": {
-                                        "provider": "perplexity",
-                                        "perplexity": {
-                                        "baseUrl": "https://gen.pollinations.ai/v1",
-                                        "apiKey": "${POLLINATIONS_API_KEY}",
-                                        "model": "perplexity-fast"
-                                        }
-                                        }
+                                        "skills": {
+                                        "load": {
+                                        "extraDirs": ["~/skills"]
                                         }
                                         },
                                         "gateway": { "mode": "local" }
@@ -217,12 +184,11 @@
                             <div class="code-block" id="agent-msg" style="font-size:12px; line-height:1.6"><button
                                     class="copy-btn" onclick="copyCode('agent-msg')">Copy</button>
                                 <div class="code-inner" style="white-space:pre-wrap">
-        curl -fsSL
-        https://raw.githubusercontent.com/pollinations/pollinations/main/apps/openclaw/setup-pollinations.sh
-        | bash -s -- <span class="key-in-json">YOUR_API_KEY</span></div>
+        npx @pollinations/cli harness openclaw on</div>
                             </div>
-                            <p style="margin-top:8px;">The script will restart the gateway automatically. After that,
-                                switch to the new provider with: <code>/model pollinations/kimi</code></p>
+                            <p style="margin-top:8px;">This installs the Polli skills and restarts the gateway
+                                automatically. After that, switch to the new provider with:
+                                <code>/model pollinations/kimi</code></p>
                         </div>
                     </div>
                 </div>
@@ -286,17 +252,12 @@
 
             <section class="section">
                 <h2 class="section-title">Image, video & audio</h2>
-                <p class="section-subtitle">Community-built <span class="brand">pollinations.ai</span> skill by <a
-                        href="https://github.com/isaacgounton" target="_blank">@isaacgounton</a> — gives your agent
-                    multi-modal generation.</p>
+                <p class="section-subtitle">The <span class="brand">Polli</span> skill gives your agent multi-modal
+                    generation. It is installed automatically by
+                    <code style="color:var(--accent)">polli harness openclaw on</code>.</p>
                 <div class="skill-box">
-                    <div class="code-block" id="skill-cmd"><button class="copy-btn"
-                            onclick="copyCode('skill-cmd')">Copy</button>
-                        <div class="code-inner">/skill install isaacgounton/pollinations</div>
-                    </div>
-                    <p style="margin-top:16px">This adds image generation (Flux, GPT Image, Imagen 4), video (Veo 3.1,
-                        Seedance), text-to-speech (13 voices), and vision analysis to your agent. Separate from the LLM
-                        provider setup above.</p>
+                    <p style="margin:0">This adds image generation (Flux, GPT Image, Imagen), video (Veo, Seedance),
+                        text-to-speech (13 voices), and vision analysis to your agent.</p>
                 </div>
             </section>
 

--- a/apps/openclaw/setup-pollinations.sh
+++ b/apps/openclaw/setup-pollinations.sh
@@ -1,180 +1,37 @@
 #!/bin/bash
 
-# Configure OpenClaw to use Pollinations.ai models
+# Configure OpenClaw to use Pollinations.ai models.
 # Works on: macOS, Linux, Windows (WSL/Git Bash/MSYS2)
-# Usage: curl ... | bash -s -- YOUR_API_KEY
+#
+# This is a thin shim over the polli CLI's integrated `openclaw` harness, so
+# the model catalog, provider config, and default model all come from the same
+# live source of truth used by `polli harness` everywhere. It is intentionally
+# not a second, hand-maintained setup path.
 
 set -e
-
-if [ -z "$1" ]; then
-    echo "Usage: $0 <POLLINATIONS_API_KEY>"
-    echo ""
-    echo "Get your API key (with free credits) at: https://enter.pollinations.ai/keys"
-    exit 1
-fi
-
-API_KEY="$1"
 
 if ! command -v openclaw >/dev/null 2>&1; then
     echo "OpenClaw not found. Install it first:"
     echo "  curl -fsSL https://openclaw.ai/install.sh | bash"
+    echo "Then run this script again."
     exit 1
 fi
 
-if ! command -v jq >/dev/null 2>&1; then
-    echo "jq not found. Install it: brew install jq (macOS) or apt install jq (Linux)"
+if ! command -v npx >/dev/null 2>&1; then
+    echo "npx (Node.js) not found. Install Node.js 20+, then run this script again."
     exit 1
 fi
 
-CONFIG_FILE="${HOME}/.openclaw/openclaw.json"
+echo "Using the polli CLI to configure OpenClaw (provider, live models, skill)..."
+npx --yes @pollinations/cli@latest harness openclaw on "$@"
 
-# --- Step 1: Fresh install — run onboard to create config + workspace ---
-
-if [ ! -f "$CONFIG_FILE" ]; then
-    echo "Fresh install — running OpenClaw setup..."
-    openclaw onboard \
-      --non-interactive \
-      --accept-risk \
-      --mode local \
-      --flow quickstart \
-      --auth-choice custom-api-key \
-      --custom-base-url "https://gen.pollinations.ai/v1" \
-      --custom-provider-id pollinations \
-      --custom-model-id kimi \
-      --custom-api-key "$API_KEY" \
-      --secret-input-mode plaintext \
-      --skip-channels \
-      --skip-daemon \
-      --skip-skills \
-      --skip-ui \
-      --skip-health \
-      2>&1 | grep -v "^$" || true
+echo ""
+echo "Restarting the OpenClaw gateway so the config loads..."
+if command -v openclaw >/dev/null 2>&1; then
+    openclaw gateway restart >/dev/null 2>&1 || true
 fi
 
-# --- Step 2: Patch openclaw.json with full Pollinations provider + models ---
-
-echo "Adding Pollinations models..."
-
-# Patch provider + web search into openclaw.json (preserves all other config)
-POLLINATIONS_PROVIDER=$(cat <<'EOF'
-{
-  "baseUrl": "https://gen.pollinations.ai/v1",
-  "apiKey": "",
-  "api": "openai-completions",
-  "models": [
-    {
-      "id": "kimi",
-      "name": "Kimi K2.5 — 256K context, vision, tools, reasoning",
-      "reasoning": true,
-      "input": ["text", "image"],
-      "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
-      "contextWindow": 256000,
-      "maxTokens": 8192
-    },
-    {
-      "id": "kimi-k2.6",
-      "name": "Kimi K2.6 — Flagship agentic, vision, reasoning (paid)",
-      "reasoning": true,
-      "input": ["text", "image"],
-      "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
-      "contextWindow": 262000,
-      "maxTokens": 8192
-    },
-    {
-      "id": "deepseek",
-      "name": "DeepSeek V4 Flash — Fast reasoning & tool calling (paid)",
-      "reasoning": true,
-      "input": ["text"],
-      "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
-      "contextWindow": 1000000,
-      "maxTokens": 8192
-    },
-    {
-      "id": "deepseek-pro",
-      "name": "DeepSeek V4 Pro — Advanced reasoning & coding (paid)",
-      "reasoning": true,
-      "input": ["text"],
-      "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
-      "contextWindow": 65536,
-      "maxTokens": 8192
-    },
-    {
-      "id": "glm",
-      "name": "GLM 5 — Coding, reasoning, agentic workflows",
-      "reasoning": false,
-      "input": ["text"],
-      "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
-      "contextWindow": 128000,
-      "maxTokens": 8192
-    },
-    {
-      "id": "gemini-search",
-      "name": "Gemini + Search — Web search grounded answers",
-      "reasoning": false,
-      "input": ["text", "image"],
-      "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
-      "contextWindow": 128000,
-      "maxTokens": 8192
-    },
-    {
-      "id": "claude-fast",
-      "name": "Claude Haiku 4.5 — Fast with good reasoning",
-      "reasoning": false,
-      "input": ["text", "image"],
-      "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
-      "contextWindow": 200000,
-      "maxTokens": 8192
-    },
-    {
-      "id": "claude-large",
-      "name": "Claude Opus 4.6 — Most intelligent (paid)",
-      "reasoning": false,
-      "input": ["text", "image"],
-      "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
-      "contextWindow": 200000,
-      "maxTokens": 8192
-    },
-    {
-      "id": "gemini-large",
-      "name": "Gemini 3 Pro — 1M context (paid)",
-      "reasoning": true,
-      "input": ["text", "image"],
-      "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
-      "contextWindow": 1000000,
-      "maxTokens": 8192
-    }
-  ]
-}
-EOF
-)
-
-jq --argjson provider "$POLLINATIONS_PROVIDER" --arg key "$API_KEY" \
-  '(.models.providers.pollinations = ($provider | .apiKey = $key)) | .models.mode = "merge" |
-   .tools.web.search = {"provider":"perplexity","perplexity":{"baseUrl":"https://gen.pollinations.ai/v1","apiKey":$key,"model":"perplexity-fast"}}' \
-  "$CONFIG_FILE" > "${CONFIG_FILE}.tmp" && mv "${CONFIG_FILE}.tmp" "$CONFIG_FILE"
-
-# --- Step 3: Set default model + fallbacks via CLI ---
-
-openclaw models set pollinations/kimi >/dev/null
-openclaw models fallbacks add pollinations/deepseek >/dev/null
-openclaw models fallbacks add pollinations/glm >/dev/null
-
-# --- Step 4: Restart gateway if running ---
-
-openclaw gateway restart >/dev/null 2>&1 || true
-
-# --- Done ---
-
-MASKED="${API_KEY:0:8}...${API_KEY: -4}"
 echo ""
-echo "Done! Pollinations.ai is ready."
-echo ""
-echo "  API Key:   $MASKED"
-echo "  Default:   pollinations/kimi (256K context, vision, reasoning)"
-echo "  Fallbacks: deepseek, glm"
-echo ""
-echo "  Switch models:  /model pollinations/deepseek or /model pollinations/deepseek-pro"
-echo "  Your account:   https://enter.pollinations.ai"
-echo ""
-echo "  Free: kimi, glm, gemini-search, claude-fast"
-echo "  Paid: deepseek, deepseek-pro, claude-large, gemini-large"
+echo "Done! OpenClaw is ready to use Pollinations."
+echo "Switch models with:  /model pollinations/<id>   (see: polli models)"
+echo "Manage later with:   polli harness openclaw status|off"

--- a/packages/polli-cli/README.md
+++ b/packages/polli-cli/README.md
@@ -133,6 +133,10 @@ polli harness --help              # supported harnesses
 polli harness dsh on              # DeepSeek Harness → Pollinations (default model: deepseek)
 polli harness dsh on --model kimi
 polli harness dsh on --no-mcp     # skip MCP tool configuration
+polli harness openclaw on         # OpenClaw → Pollinations (default model: kimi)
+polli harness openclaw on --model deepseek
+polli harness openclaw status
+polli harness openclaw off
 polli harness opencode on         # enables the Pollinations OpenCode plugin + default model
 polli harness pi on               # native provider, key, startup model, and Polli skill
 polli harness prime on            # native Prime Agent provider support
@@ -144,6 +148,10 @@ The DSH adapter configures the Pollinations provider, hosted Pollinations MCP,
 and Polli CLI skill globally under `$DSH_HOME` (default `~/.dsh`). OpenCode uses
 its official plugin; Pi and Prime Agent use their native `models.json` provider
 support.
+
+The OpenClaw adapter adds the Pollinations provider with the live model catalog
+and the Polli skill under `~/.openclaw/openclaw.json`, using a dedicated
+`polli-harness-openclaw` key; `off` removes only the Pollinations-owned entries.
 
 See [Coding Harnesses](https://github.com/pollinations/pollinations/blob/main/CODING_HARNESSES.md) for what each profile changes and how to add one.
 

--- a/packages/polli-cli/SKILL.md
+++ b/packages/polli-cli/SKILL.md
@@ -43,7 +43,7 @@ If `polli` is not installed, run `npm i -g @pollinations/cli@latest` (provides t
 | List your quests + claim state | `polli quests` (filters: `--open --claimable --claimed --coming-soon`) |
 | Manage prompt agents | `polli agents list` |
 | Manage invite-only community models | `polli my-models list` |
-| Connect a coding harness to Pollinations | `polli harness <dsh\|opencode\|pi\|prime> on` (available adapters: `polli harness --help`) |
+| Connect a coding harness to Pollinations | `polli harness <dsh\|openclaw\|opencode\|pi\|prime> on` (available adapters: `polli harness --help`) |
 | Machine-readable output | append `--json` to any command |
 
 ## Setup
@@ -220,6 +220,15 @@ polli harness pi off                # restore the Pi config backed up before "on
 Each adapter checks that its harness can be launched before login, key creation, or configuration. DSH's official launch uses `npx`, so its adapter checks for `npx`; OpenCode and Pi require their installed commands.
 
 The DSH adapter globally configures the Pollinations provider, hosted Pollinations MCP, and this skill under `$DSH_HOME` (default `~/.dsh`). OpenCode enables the existing Pollinations plugin and stores its dedicated key in the plugin config. Pi writes `~/.pi/agent/models.json`, `auth.json`, and `settings.json`, and installs this skill under `~/.pi/agent/skills/polli/`. Guide: `polli docs` section "Coding Harnesses".
+
+### Connect OpenClaw
+```bash
+polli harness openclaw on           # requires the `openclaw` binary; adds pollinations provider + Polli skill
+polli harness openclaw on --model deepseek  # choose the default model from the live catalog
+polli harness openclaw status       # is this OpenClaw ready to use Pollinations?
+polli harness openclaw off          # remove only the Pollinations-owned provider, model, key, and skill
+```
+`on` logs Polli in if needed, mints a dedicated `polli-harness-openclaw` key, and writes it plus the live Pollinations model catalog into `~/.openclaw/openclaw.json`. The Polli skill is installed under `~/.openclaw/skills/polli`. `off` restores a byte-for-byte backup taken before `on`, or strips only the Pollinations-owned entries when the config changed since. See [Pollinations × OpenClaw](https://github.com/pollinations/pollinations/tree/main/apps/openclaw).
 
 ### Read API docs
 ```bash

--- a/packages/polli-cli/package-lock.json
+++ b/packages/polli-cli/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "chalk": "^5.4.1",
         "commander": "^14.0.3",
+        "json5": "^2.2.3",
         "open": "^11.0.0",
         "yaml": "^2.9.0"
       },
@@ -1418,6 +1419,18 @@
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",

--- a/packages/polli-cli/package.json
+++ b/packages/polli-cli/package.json
@@ -62,6 +62,7 @@
   "dependencies": {
     "chalk": "^5.4.1",
     "commander": "^14.0.3",
+    "json5": "^2.2.3",
     "open": "^11.0.0",
     "yaml": "^2.9.0"
   },

--- a/packages/polli-cli/src/harnesses/index.ts
+++ b/packages/polli-cli/src/harnesses/index.ts
@@ -1,7 +1,8 @@
 import { dsh } from "./dsh.js";
+import { openclaw } from "./openclaw.js";
 import { opencode } from "./opencode.js";
 import { pi } from "./pi.js";
 import { prime } from "./prime.js";
 import type { HarnessAdapter } from "./types.js";
 
-export const HARNESSES: HarnessAdapter[] = [dsh, opencode, pi, prime];
+export const HARNESSES: HarnessAdapter[] = [dsh, openclaw, opencode, pi, prime];

--- a/packages/polli-cli/src/harnesses/openclaw.test.ts
+++ b/packages/polli-cli/src/harnesses/openclaw.test.ts
@@ -1,0 +1,193 @@
+import {
+    existsSync,
+    mkdirSync,
+    mkdtempSync,
+    readdirSync,
+    readFileSync,
+    rmSync,
+    statSync,
+    writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import JSON5 from "json5";
+import { configureOpenclaw, disableOpenclaw, openclaw } from "./openclaw.js";
+import type { HarnessContext } from "./types.js";
+
+const models = [
+    { id: "kimi", contextWindow: 262000, input: ["text", "image"] },
+    { id: "deepseek", contextWindow: 1048576, input: ["text"] },
+];
+const settings = { apiKey: "sk_test_key", model: "kimi", models };
+
+let home: string;
+let ctx: HarnessContext;
+
+beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "polli-harness-"));
+    ctx = { home, env: {} };
+});
+
+afterEach(() => rmSync(home, { recursive: true, force: true }));
+
+const configFile = () => join(home, ".openclaw", "openclaw.json");
+const skillFile = () => join(home, ".openclaw", "skills", "polli", "SKILL.md");
+const snapshotFiles = () => {
+    const dir = join(home, ".pollinations", "harnesses");
+    return existsSync(dir)
+        ? readdirSync(dir).filter((f) => f.startsWith("openclaw."))
+        : [];
+};
+const read = (path: string) => readFileSync(path, "utf-8");
+
+describe("openclaw harness", () => {
+    it("writes the provider, live models, dedicated key, and skill from scratch", () => {
+        const result = configureOpenclaw(ctx, settings);
+        expect(result).toMatchObject({
+            harness: "openclaw",
+            configured: true,
+            model: "kimi",
+        });
+
+        const doc = JSON5.parse(read(configFile()));
+        expect(doc.env.vars.POLLI_OPENCLAW_API_KEY).toBe("sk_test_key");
+        expect(doc.models.mode).toBe("merge");
+        const provider = doc.models.providers.pollinations;
+        expect(provider).toMatchObject({
+            api: "openai-completions",
+            apiKey: "${POLLI_OPENCLAW_API_KEY}",
+            baseUrl: "https://gen.pollinations.ai/v1",
+        });
+        expect(provider.models.map((m: { id: string }) => m.id)).toEqual([
+            "kimi",
+            "deepseek",
+        ]);
+        expect(doc.agents.defaults.model.primary).toBe("pollinations/kimi");
+        expect(doc.agents.defaults.models["pollinations/*"]).toEqual({});
+        expect(doc.skills.load.extraDirs).toContain(
+            join(home, ".openclaw", "skills"),
+        );
+
+        expect(read(skillFile())).toContain("name: polli");
+        expect(statSync(configFile()).mode & 0o777).toBe(0o600);
+        expect(statSync(skillFile()).mode & 0o777).toBe(0o600);
+        expect(statSync(join(home, ".openclaw")).mode & 0o777).toBe(0o700);
+        expect(openclaw.status(ctx)).toMatchObject({
+            configured: true,
+            model: "kimi",
+        });
+    });
+
+    it("preserves existing config and env vars", () => {
+        mkdirSync(join(home, ".openclaw"), { recursive: true });
+        writeFileSync(
+            configFile(),
+            JSON.stringify(
+                {
+                    env: { vars: { MY_TOKEN: "abc" } },
+                    agents: {
+                        defaults: {
+                            model: { primary: "anthropic/claude-opus-5" },
+                            workspace: "~/.openclaw/workspace",
+                        },
+                    },
+                    models: {
+                        providers: {
+                            anthropic: { baseUrl: "https://api.anthropic.com" },
+                        },
+                    },
+                },
+                null,
+                2,
+            ),
+            { mode: 0o644 },
+        );
+
+        configureOpenclaw(ctx, settings);
+
+        const doc = JSON5.parse(read(configFile()));
+        expect(doc.env.vars.MY_TOKEN).toBe("abc");
+        expect(doc.env.vars.POLLI_OPENCLAW_API_KEY).toBe("sk_test_key");
+        expect(doc.agents.defaults.workspace).toBe("~/.openclaw/workspace");
+        expect(
+            doc.models.providers.pollinations.baseUrl,
+        ).toBeDefined();
+        expect(doc.models.providers.anthropic.baseUrl).toBe(
+            "https://api.anthropic.com",
+        );
+    });
+
+    it("restores the original files byte-for-byte on off", () => {
+        mkdirSync(join(home, ".openclaw"), { recursive: true });
+        const original = JSON.stringify(
+            { agents: { defaults: { model: { primary: "anthropic/claude" } } } },
+            null,
+            2,
+        );
+        writeFileSync(configFile(), original, { mode: 0o600 });
+
+        configureOpenclaw(ctx, settings);
+        expect(snapshotFiles()).toHaveLength(1);
+        const result = disableOpenclaw(ctx);
+
+        expect(result.outcome).toBe("restored");
+        expect(read(configFile())).toBe(original);
+        expect(existsSync(skillFile())).toBe(false);
+        expect(snapshotFiles()).toHaveLength(0);
+        expect(openclaw.status(ctx).configured).toBe(false);
+    });
+
+    it("only strips the Pollinations entries when the config changed since on", () => {
+        configureOpenclaw(ctx, settings);
+        const doc = JSON5.parse(read(configFile()));
+        doc.agents.defaults.workspace = "~/.openclaw/workspace";
+        writeFileSync(configFile(), JSON.stringify(doc, null, 2) + "\n");
+
+        const result = disableOpenclaw(ctx);
+
+        expect(result.outcome).toBe("stripped");
+        const stripped = JSON5.parse(read(configFile()));
+        expect(stripped.agents.defaults.workspace).toBe(
+            "~/.openclaw/workspace",
+        );
+        expect(stripped.env).toBeUndefined();
+        expect(stripped.models).toBeUndefined();
+        expect(stripped.skills).toBeUndefined();
+        expect(existsSync(skillFile())).toBe(false);
+        expect(snapshotFiles()).toHaveLength(0);
+    });
+
+    it("reports unchanged when off runs on a harness that was never on", () => {
+        expect(disableOpenclaw(ctx).outcome).toBe("unchanged");
+    });
+
+    it("re-running on switches the model and keeps the pre-on backup", () => {
+        configureOpenclaw(ctx, settings);
+        configureOpenclaw(ctx, { ...settings, model: "deepseek" });
+        expect(openclaw.status(ctx).model).toBe("deepseek");
+
+        disableOpenclaw(ctx);
+        expect(existsSync(configFile())).toBe(false);
+    });
+
+    it("preserves an unrelated skill dir already in extraDirs", () => {
+        mkdirSync(join(home, ".openclaw"), { recursive: true });
+        writeFileSync(
+            configFile(),
+            JSON.stringify({
+                skills: { load: { extraDirs: ["~/other-skills"] } },
+            }),
+            { mode: 0o600 },
+        );
+
+        configureOpenclaw(ctx, settings);
+        const doc = JSON5.parse(read(configFile()));
+        expect(doc.skills.load.extraDirs).toContain("~/other-skills");
+
+        disableOpenclaw(ctx);
+        const stripped = JSON5.parse(read(configFile()));
+        expect(stripped.skills.load.extraDirs).toEqual(["~/other-skills"]);
+        expect(stripped.env).toBeUndefined();
+    });
+});

--- a/packages/polli-cli/src/harnesses/openclaw.ts
+++ b/packages/polli-cli/src/harnesses/openclaw.ts
@@ -1,0 +1,327 @@
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import JSON5 from "json5";
+import polliSkill from "../../SKILL.md?raw";
+import { BASE_URL } from "../lib/config.js";
+import { readTextIfExists, removeIfExists, writeTextAtomic } from "./fs.js";
+import { resolveHarnessKey } from "./keys.js";
+import { fetchHarnessModels } from "./models.js";
+import {
+    applyWithSnapshot,
+    clearSnapshot,
+    restoreSnapshot,
+} from "./snapshot.js";
+import type {
+    HarnessAdapter,
+    HarnessContext,
+    HarnessModel,
+    HarnessResult,
+} from "./types.js";
+
+const ID = "openclaw";
+const LABEL = "OpenClaw";
+const PROVIDER = "pollinations";
+const KEY_ENV = "POLLI_OPENCLAW_API_KEY";
+// Any tool-calling text model is a valid target; OpenClaw exposes all
+// pollinations/* models via the default model's provider block.
+const INSTALL_URL = "https://docs.openclaw.ai/install";
+
+const openclawHome = (ctx: HarnessContext) => {
+    const configured = ctx.env.OPENCLAW_CONFIG_DIR;
+    return configured?.trim() ? configured.trim() : join(ctx.home, ".openclaw");
+};
+// Support OPENCLAW_CONFIG_PATH like the gateway does; fall back to the default
+// path under the resolved OpenClaw config dir.
+const configPath = (ctx: HarnessContext) =>
+    ctx.env.OPENCLAW_CONFIG_PATH?.trim() ||
+    join(openclawHome(ctx), "openclaw.json");
+// Shared skill root referenced from `skills.load.extraDirs`; OpenClaw expands
+// `~` in configured paths, so an absolute or home-anchored value both resolve.
+const skillDir = (ctx: HarnessContext) => join(openclawHome(ctx), "skills");
+const skillPath = (ctx: HarnessContext) =>
+    join(skillDir(ctx), "polli", "SKILL.md");
+
+const files = (ctx: HarnessContext) => [configPath(ctx), skillPath(ctx)];
+
+// JSON5 is a superset of JSON, so a structural merge on the parsed object is
+// safe. We do not round-trip comments (the reference `jq`-based setup script
+// does not either); `off` restores the original file byte-for-byte via snapshot.
+const loadConfig = (ctx: HarnessContext): Record<string, unknown> => {
+    const text = readTextIfExists(configPath(ctx));
+    if (text === null) return {};
+    return JSON5.parse(text) as Record<string, unknown>;
+};
+
+const asRecord = (value: unknown): Record<string, unknown> =>
+    value && typeof value === "object" && !Array.isArray(value)
+        ? (value as Record<string, unknown>)
+        : {};
+
+const getRecord = (
+    root: Record<string, unknown>,
+    ...path: string[]
+): Record<string, unknown> | undefined => {
+    let current: unknown = root;
+    for (const key of path) {
+        if (!(current && typeof current === "object")) return undefined;
+        current = (current as Record<string, unknown>)[key];
+    }
+    return asRecord(current);
+};
+
+const readKey = (ctx: HarnessContext): string | null => {
+    const config = loadConfig(ctx);
+    const value = getRecord(config, "env", "vars")?.[KEY_ENV];
+    return typeof value === "string" && value ? value : null;
+};
+
+const providerConfig = (models: HarnessModel[]) => ({
+    baseUrl: `${BASE_URL}/v1`,
+    apiKey: `\${${KEY_ENV}}`,
+    api: "openai-completions",
+    models: models.map((model) => ({
+        id: model.id,
+        name: model.id,
+        reasoning: false,
+        input: model.input,
+        contextWindow: model.contextWindow,
+    })),
+});
+
+interface OpenclawSettings {
+    apiKey: string;
+    model: string;
+    models: HarnessModel[];
+}
+
+const ensureOpenclaw = () => {
+    const which = process.platform === "win32" ? "where" : "which";
+    const installed = spawnSync(which, ["openclaw"], { stdio: "ignore" })
+        .status === 0;
+    if (!installed) {
+        throw new Error(
+            `OpenClaw is not installed. Install it first: ${INSTALL_URL}`,
+        );
+    }
+};
+
+const writeConfig = (ctx: HarnessContext, settings: OpenclawSettings) => {
+    const doc = loadConfig(ctx);
+    const env = asRecord(doc.env);
+    const vars = Object.assign({}, asRecord(env.vars));
+    vars[KEY_ENV] = settings.apiKey;
+    env.vars = vars;
+    doc.env = env;
+
+    const models = asRecord(doc.models);
+    if (models.mode === undefined || models.mode === null) {
+        models.mode = "merge";
+    }
+    // OpenClaw discovers every model the provider declares, so `pollinations/*`
+    // makes the full live catalog switchable without a second hardcoded list.
+    const providers = asRecord(models.providers);
+    providers[PROVIDER] = providerConfig(settings.models);
+    models.providers = providers;
+    doc.models = models;
+
+    const agents = asRecord(doc.agents);
+    const defaults = asRecord(agents.defaults);
+    const defaultModel = asRecord(defaults.model);
+    const fallbacks = Array.isArray(defaultModel.fallbacks)
+        ? defaultModel.fallbacks
+        : [];
+    defaultModel.primary = `${PROVIDER}/${settings.model}`;
+    defaultModel.fallbacks = fallbacks;
+    defaults.model = defaultModel;
+    const defaultModels = asRecord(defaults.models);
+    defaultModels[`${PROVIDER}/*`] = asRecord(defaultModels[`${PROVIDER}/*`]);
+    defaults.models = defaultModels;
+    agents.defaults = defaults;
+    doc.agents = agents;
+
+    const skills = asRecord(doc.skills);
+    const load = asRecord(skills.load);
+    const extraDirs = Array.isArray(load.extraDirs)
+        ? (load.extraDirs as string[]).filter((dir) => dir !== skillDir(ctx))
+        : [];
+    extraDirs.push(skillDir(ctx));
+    load.extraDirs = extraDirs;
+    skills.load = load;
+    doc.skills = skills;
+
+    writeTextAtomic(configPath(ctx), JSON.stringify(doc, null, 2) + "\n", 0o600);
+    if (readTextIfExists(skillPath(ctx)) === null) {
+        writeTextAtomic(skillPath(ctx), polliSkill, 0o600);
+    }
+};
+
+const stripProvider = (doc: Record<string, unknown>): boolean => {
+    const models = asRecord(doc.models);
+    const providers = asRecord(models.providers);
+    if (providers[PROVIDER] === undefined) return false;
+    delete providers[PROVIDER];
+    if (Object.keys(providers).length === 0) {
+        // If pollinations was the only provider, `merge` mode we introduced has
+        // nothing left to merge, so drop it along with the empty provider map.
+        if (models.mode === "merge") delete models.mode;
+        delete models.providers;
+        if (Object.keys(models).length === 0) delete doc.models;
+        else doc.models = models;
+    } else {
+        models.providers = providers;
+        doc.models = models;
+    }
+    return true;
+};
+
+const stripConfig = (ctx: HarnessContext) => {
+    const doc = loadConfig(ctx);
+    let changed = false;
+
+    const env = asRecord(doc.env);
+    const vars = asRecord(env.vars);
+    if (vars[KEY_ENV] !== undefined) {
+        delete vars[KEY_ENV];
+        if (Object.keys(vars).length === 0) {
+            delete env.vars;
+            if (Object.keys(env).length === 0) delete doc.env;
+            else doc.env = env;
+        } else {
+            env.vars = vars;
+            doc.env = env;
+        }
+        changed = true;
+    }
+
+    changed = stripProvider(doc) || changed;
+
+    const agents = asRecord(doc.agents);
+    const defaults = asRecord(agents.defaults);
+    const defaultModels = asRecord(defaults.models);
+    delete defaultModels[`${PROVIDER}/*`];
+    if (Object.keys(defaultModels).length === 0) delete defaults.models;
+    else defaults.models = defaultModels;
+    const defaultModel = asRecord(defaults.model);
+    if (
+        typeof defaultModel.primary === "string" &&
+        defaultModel.primary.startsWith(`${PROVIDER}/`)
+    ) {
+        delete defaultModel.primary;
+        if (Object.keys(defaultModel).length === 0) delete defaults.model;
+        else defaults.model = defaultModel;
+        changed = true;
+    }
+    agents.defaults = defaults;
+    doc.agents = agents;
+
+    const skills = asRecord(doc.skills);
+    const load = asRecord(skills.load);
+    const removingSkillDir =
+        Array.isArray(load.extraDirs) &&
+        (load.extraDirs as string[]).includes(skillDir(ctx));
+    if (removingSkillDir) {
+        const remaining = (load.extraDirs as string[]).filter(
+            (dir) => dir !== skillDir(ctx),
+        );
+        if (remaining.length === 0) delete load.extraDirs;
+        else load.extraDirs = remaining;
+        if (Object.keys(load).length === 0) delete skills.load;
+        if (Object.keys(skills).length === 0) delete doc.skills;
+        else doc.skills = skills;
+        changed = true;
+    }
+
+    if (changed) {
+        if (Object.keys(doc).length === 0) {
+            removeIfExists(configPath(ctx));
+        } else {
+            writeTextAtomic(
+                configPath(ctx),
+                JSON.stringify(doc, null, 2) + "\n",
+                0o600,
+            );
+        }
+    }
+
+    if (readTextIfExists(skillPath(ctx)) === polliSkill) {
+        removeIfExists(skillPath(ctx));
+        changed = true;
+    }
+    return changed;
+};
+
+const result = (ctx: HarnessContext): HarnessResult => {
+    const doc = loadConfig(ctx);
+    const primary = getRecord(doc, "agents", "defaults", "model")?.primary;
+    const provider = getRecord(doc, "models", "providers", PROVIDER);
+    return {
+        harness: ID,
+        label: LABEL,
+        configured:
+            readKey(ctx) !== null &&
+            provider?.baseUrl === `${BASE_URL}/v1` &&
+            provider?.api === "openai-completions" &&
+            typeof primary === "string" &&
+            primary.startsWith(`${PROVIDER}/`) &&
+            readTextIfExists(skillPath(ctx)) !== null,
+        model:
+            typeof primary === "string" && primary.startsWith(`${PROVIDER}/`)
+                ? primary.slice(PROVIDER.length + 1)
+                : undefined,
+        files: files(ctx),
+    };
+};
+
+export const configureOpenclaw = (
+    ctx: HarnessContext,
+    settings: OpenclawSettings,
+): HarnessResult => {
+    applyWithSnapshot(ctx, ID, files(ctx), () => writeConfig(ctx, settings));
+    return result(ctx);
+};
+
+export const disableOpenclaw = (ctx: HarnessContext): HarnessResult => {
+    const managedFiles = files(ctx);
+    let outcome: HarnessResult["outcome"] = "restored";
+    if (restoreSnapshot(ctx, ID, managedFiles) !== "restored") {
+        outcome = stripConfig(ctx) ? "stripped" : "unchanged";
+        clearSnapshot(ctx, ID, managedFiles);
+    }
+    return { ...result(ctx), configured: false, outcome };
+};
+
+export const openclaw: HarnessAdapter = {
+    id: ID,
+    label: LABEL,
+    description: "Configure OpenClaw as a Pollinations provider",
+    restartHint: "Restart the gateway so the config loads: openclaw gateway restart",
+
+    async on(ctx, options) {
+        ensureOpenclaw();
+        const models = await fetchHarnessModels();
+        const defaultModel =
+            options.model ??
+            (models.some((m) => m.id === "kimi") ? "kimi" : models[0]?.id);
+        if (!defaultModel) {
+            throw new Error("No tool-calling Pollinations models are available.");
+        }
+        if (!models.some((candidate) => candidate.id === defaultModel)) {
+            throw new Error(
+                `Model "${defaultModel}" is not a tool-calling text model. Run: polli models`,
+            );
+        }
+
+        const apiKey = await resolveHarnessKey(
+            { id: ID, label: LABEL, existingKey: readKey(ctx) },
+            { browser: options.browser },
+        );
+        return configureOpenclaw(ctx, {
+            apiKey,
+            model: defaultModel,
+            models,
+        });
+    },
+
+    off: disableOpenclaw,
+    status: result,
+};


### PR DESCRIPTION
Adds an `openclaw` adapter to `polli harness`, mirroring `dsh`.

**`on`** requires the `openclaw` binary (offers the official install page if missing), logs Polli in if needed, mints a dedicated `polli-harness-openclaw` key, and writes:
- `env.vars.POLLI_OPENCLAW_API_KEY`
- `models.providers.pollinations` with the **live model catalog** (`pollinations/*` wildcard — no second hardcoded list), `mode: "merge"`
- `agents.defaults.model.primary` (default `kimi`; override with `--model <id>`), preserving existing fallbacks
- the Polli skill under `~/.openclaw/skills/polli` via `skills.load.extraDirs`

**`status`** reports whether the integration is ready and which model is default.

**`off`** restores the byte-for-byte backup taken before `on`, or strips only the Pollinations-owned provider, model, key, and skill when the config changed since. Existing agents and unrelated config are preserved.

Also retires the competing hand-maintained path: `apps/openclaw/setup-pollinations.sh` becomes a shim over the harness, and `apps/openclaw/index.html` + `README.md` now use the current `env.vars` schema and the `pollinations/*` wildcard instead of a hardcoded model catalog.

- Adds `openclaw` harness adapter + tests (7) in `packages/polli-cli/src/harnesses/`
- Updates `CODING_HARNESSES.md` (Scala Coding Harnesses docs), polli-cli `SKILL.md`/`README.md`
- Converts `apps/openclaw` setup/manual config to the shared `polli harness` path

Fixes #14121