### PR TITLE
fix: send Inkling Opus audio as Ogg

### DIFF
--- a/gen.pollinations.ai/src/text/transforms/inputAudioToFireworks.ts
+++ b/gen.pollinations.ai/src/text/transforms/inputAudioToFireworks.ts
@@ -110,7 +110,7 @@ export function inputAudioToFireworks(
                 return {
                     type: "audio_url",
                     audio_url: {
-                        url: `data:audio/${isPcm16 ? "wav" : format};base64,${encodedAudio}`,
+                        url: `data:audio/${isPcm16 ? "wav" : format === "opus" ? "ogg" : format};base64,${encodedAudio}`,
                     },
                 };
             });

--- a/gen.pollinations.ai/test/text/transforms/inputAudioToFireworks.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/inputAudioToFireworks.test.ts
@@ -21,6 +21,13 @@ describe("Fireworks audio input", () => {
                                 format: "wav",
                             },
                         },
+                        {
+                            type: "input_audio",
+                            input_audio: {
+                                data: "T2dnUw==",
+                                format: "opus",
+                            },
+                        },
                     ],
                 },
             ],
@@ -33,6 +40,12 @@ describe("Fireworks audio input", () => {
                 type: "audio_url",
                 audio_url: {
                     url: "data:audio/wav;base64,UklGRgAAAABXQVZF",
+                },
+            },
+            {
+                type: "audio_url",
+                audio_url: {
+                    url: "data:audio/ogg;base64,T2dnUw==",
                 },
             },
         ]);


### PR DESCRIPTION
- Sends OpenAI `opus` input to Fireworks with its documented `audio/ogg` media type.
- Keeps the public `input_audio` contract unchanged.
- Adds focused coverage for the exact Ogg/Opus transformation.

Test: `npx vitest run test/text/transforms/inputAudioToFireworks.test.ts` (3 passed)