### PR TITLE
chore: promote Inkling audio fix to production

### DIFF
--- a/gen.pollinations.ai/src/text/transforms/inputAudioToFireworks.ts
+++ b/gen.pollinations.ai/src/text/transforms/inputAudioToFireworks.ts
@@ -110,7 +110,7 @@ export function inputAudioToFireworks(
                 return {
                     type: "audio_url",
                     audio_url: {
-                        url: `data:audio/${isPcm16 ? "wav" : format};base64,${encodedAudio}`,
+                        url: `data:audio/${isPcm16 ? "wav" : format === "opus" ? "ogg" : format};base64,${encodedAudio}`,
                     },
                 };
             });

--- a/gen.pollinations.ai/test/text/transforms/inputAudioToFireworks.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/inputAudioToFireworks.test.ts
@@ -21,6 +21,13 @@ describe("Fireworks audio input", () => {
                                 format: "wav",
                             },
                         },
+                        {
+                            type: "input_audio",
+                            input_audio: {
+                                data: "T2dnUw==",
+                                format: "opus",
+                            },
+                        },
                     ],
                 },
             ],
@@ -33,6 +40,12 @@ describe("Fireworks audio input", () => {
                 type: "audio_url",
                 audio_url: {
                     url: "data:audio/wav;base64,UklGRgAAAABXQVZF",
+                },
+            },
+            {
+                type: "audio_url",
+                audio_url: {
+                    url: "data:audio/ogg;base64,T2dnUw==",
                 },
             },
         ]);


### PR DESCRIPTION
- Promotes the documented Fireworks `audio/ogg` media type for Inkling Opus input.
- Keeps the public request contract unchanged.
- Includes the focused Ogg/Opus regression test.

Source PR: #14197