### PR TITLE
fix: preserve omitted text parameters

### DIFF
--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -52,39 +52,6 @@ const grokTransform: TransformFn = (messages, options) =>
         ? stripCacheControl(messages, options)
         : pipe(stripCacheControl, stripReasoning)(messages, options);
 
-const grok46AzureTransform: TransformFn = (messages, options) => {
-    const unsupported = [
-        options.frequency_penalty !== undefined &&
-        options.frequency_penalty !== null &&
-        options.frequency_penalty !== 0
-            ? "frequency_penalty"
-            : undefined,
-        options.presence_penalty !== undefined &&
-        options.presence_penalty !== null &&
-        options.presence_penalty !== 0
-            ? "presence_penalty"
-            : undefined,
-        options.logprobs === true ? "logprobs" : undefined,
-        options.top_logprobs !== undefined ? "top_logprobs" : undefined,
-    ].filter(Boolean);
-    if (unsupported.length > 0) {
-        const error = new Error(
-            `Grok 4.6 on Azure does not support: ${unsupported.join(", ")}`,
-        ) as Error & { status: number };
-        error.status = 400;
-        throw error;
-    }
-
-    const {
-        frequency_penalty: _frequencyPenalty,
-        presence_penalty: _presencePenalty,
-        logprobs: _logprobs,
-        top_logprobs: _topLogprobs,
-        ...supportedOptions
-    } = options;
-    return stripCacheControl(messages, supportedOptions);
-};
-
 const models: ModelDefinition[] = [
     {
         name: "openai",
@@ -245,7 +212,7 @@ const models: ModelDefinition[] = [
     {
         name: "grok-4.6",
         config: portkeyConfig["grok-4.6"],
-        transform: grok46AzureTransform,
+        transform: stripCacheControl,
     },
     {
         name: "openai-audio",

--- a/gen.pollinations.ai/test/mocks/snapshots/portkey-0e9b78036a9c98664a09072413f6bee0.json
+++ b/gen.pollinations.ai/test/mocks/snapshots/portkey-0e9b78036a9c98664a09072413f6bee0.json
@@ -12,10 +12,7 @@
             "content": "vcr chat json"
           }
         ],
-        "presence_penalty": 0,
-        "frequency_penalty": 0,
         "stream": false,
-        "logprobs": false,
         "temperature": 1
       }
     },

--- a/gen.pollinations.ai/test/mocks/snapshots/portkey-eb942691f3dcb649bff93c8679dec3cf.json
+++ b/gen.pollinations.ai/test/mocks/snapshots/portkey-eb942691f3dcb649bff93c8679dec3cf.json
@@ -12,10 +12,7 @@
             "content": "vcr chat stream"
           }
         ],
-        "presence_penalty": 0,
-        "frequency_penalty": 0,
         "stream": true,
-        "logprobs": false,
         "stream_options": {
           "include_usage": true
         },

--- a/gen.pollinations.ai/test/text/requestSchema.test.ts
+++ b/gen.pollinations.ai/test/text/requestSchema.test.ts
@@ -2,6 +2,27 @@ import { CreateChatCompletionRequestSchema } from "@shared/schemas/openai.ts";
 import { describe, expect, it } from "vitest";
 
 describe("CreateChatCompletionRequestSchema", () => {
+    it("preserves omission and explicit values for optional model parameters", () => {
+        const omitted = CreateChatCompletionRequestSchema.parse({
+            messages: [{ role: "user", content: "hello" }],
+        });
+        expect(omitted).not.toHaveProperty("frequency_penalty");
+        expect(omitted).not.toHaveProperty("presence_penalty");
+        expect(omitted).not.toHaveProperty("logprobs");
+
+        const explicit = CreateChatCompletionRequestSchema.parse({
+            messages: [{ role: "user", content: "hello" }],
+            frequency_penalty: 0,
+            presence_penalty: 0,
+            logprobs: false,
+        });
+        expect(explicit).toMatchObject({
+            frequency_penalty: 0,
+            presence_penalty: 0,
+            logprobs: false,
+        });
+    });
+
     it("preserves message-level provider extensions", () => {
         const result = CreateChatCompletionRequestSchema.parse({
             model: "gemini-fast",

--- a/gen.pollinations.ai/test/text/transforms/stripCacheControl.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/stripCacheControl.test.ts
@@ -77,40 +77,9 @@ describe("stripCacheControl model wiring", () => {
     it.each([
         "grok-large",
         "grok-4.3",
+        "grok-4.6",
     ])("wires stripCacheControl onto %s", (modelName) => {
         expect(findModelByName(modelName)?.transform).toBe(stripCacheControl);
-    });
-
-    it("strips unsupported OpenAI defaults for Grok 4.6 on Azure", async () => {
-        const transform = findModelByName("grok-4.6")?.transform;
-        if (!transform) throw new Error("grok-4.6 transform missing");
-
-        const { options } = await transform([], {
-            frequency_penalty: 0,
-            presence_penalty: 0,
-            logprobs: false,
-            stream: false,
-        });
-
-        expect(options).toEqual({ stream: false });
-    });
-
-    it.each([
-        "frequency_penalty",
-        "presence_penalty",
-        "logprobs",
-        "top_logprobs",
-    ])("rejects unsupported Grok 4.6 parameter %s", async (parameter) => {
-        const transform = findModelByName("grok-4.6")?.transform;
-        if (!transform) throw new Error("grok-4.6 transform missing");
-
-        await expect(
-            Promise.resolve().then(() =>
-                transform([], {
-                    [parameter]: parameter === "logprobs" ? true : 1,
-                }),
-            ),
-        ).rejects.toMatchObject({ status: 400 });
     });
 });
 

--- a/shared/schemas/openai.ts
+++ b/shared/schemas/openai.ts
@@ -294,29 +294,17 @@ export const CreateChatCompletionRequestSchema = z
                 format: z.enum(["wav", "mp3", "flac", "opus", "pcm16"]),
             })
             .optional(),
-        frequency_penalty: z
-            .number()
-            .min(-2)
-            .max(2)
-            .nullable()
-            .optional()
-            .default(0),
+        frequency_penalty: z.number().min(-2).max(2).nullable().optional(),
         repetition_penalty: z.number().min(0).max(2).nullable().optional(),
         logit_bias: z
             .record(z.string(), z.number().int())
             .nullable()
             .optional()
             .default(null),
-        logprobs: z.boolean().nullable().optional().default(false),
+        logprobs: z.boolean().nullable().optional(),
         top_logprobs: z.number().int().min(0).max(20).nullable().optional(),
         max_tokens: z.number().int().min(0).nullable().optional(),
-        presence_penalty: z
-            .number()
-            .min(-2)
-            .max(2)
-            .nullable()
-            .optional()
-            .default(0),
+        presence_penalty: z.number().min(-2).max(2).nullable().optional(),
         response_format: ResponseFormatUnionSchema.optional(),
         seed: z.number().int().min(-1).max(2147483647).nullable().optional(),
         stop: z


### PR DESCRIPTION
- Stops injecting `frequency_penalty`, `presence_penalty`, and `logprobs` when callers omit them.
- Removes the Grok 4.6 compatibility transform added in #14185; explicit unsupported parameters now reach Azure and fail upstream.
- Preserves explicitly supplied values and updates the affected VCR snapshots.
- Tests: Gen typecheck; 17 schema/transform tests; 2 VCR replay tests.