### PR TITLE
fix: generate endpoint agent request body in API docs

### DIFF
--- a/gen.pollinations.ai/scripts/generate-apidocs.ts
+++ b/gen.pollinations.ai/scripts/generate-apidocs.ts
@@ -992,6 +992,11 @@ const CURATED_BODIES: Record<string, Json> = {
     postAccountMyModelsByIdUpdate: {
         description: "Updated model description",
     },
+    postAccountMyModelsEndpointAgents: {
+        name: "my-agent",
+        title: "My Agent",
+        baseUrl: "https://agent.example.com/v1",
+    },
     postAccountAgents: {
         name: "my-agent",
         title: "My Agent",


### PR DESCRIPTION
- Adds a curated request body for postAccountMyModelsEndpointAgents.
- Fixes the generated POST curl example so it includes a JSON payload.
- Unblocks API documentation validation after gen deployments.
- Verifies formatting, live-schema generation, and static APIDOCS validation.