### PR TITLE
fix: separate community health from service KPI

### DIFF
--- a/enter.pollinations.ai/observability/endpoints/weekly_health_stats.pipe
+++ b/enter.pollinations.ai/observability/endpoints/weekly_health_stats.pipe
@@ -1,5 +1,6 @@
 DESCRIPTION >
-    Weekly service availability metrics.
+    Weekly non-community service availability metrics. Community-provider
+    traffic is reported separately by weekly_usage_stats.
     Availability = 2xx / (2xx + 5xx): server (5xx) failures are downtime, while
     4xx client errors (auth, balance, rate-limit, bad input) are excluded from
     the denominator so they can't dilute the failure rate — matching the model
@@ -40,6 +41,7 @@ SQL >
         start_time >= now() - INTERVAL {{Int32(weeks_back, 12)}} WEEK
         {% end %}
         AND is_final  -- one row per request; attempts counted separately
+        AND model_provider_used != 'community'
     GROUP BY week
     ORDER BY week ASC
 

--- a/operations/kpi/src/lib/kpis.js
+++ b/operations/kpi/src/lib/kpis.js
@@ -156,20 +156,20 @@ export const KPIS = [
                 lowerIsBetter: true,
                 calc: (w) => failuresPerThousand(w.availability),
                 tooltip:
-                    "5xx / (2xx + 5xx) × 1,000. A normalized failure rate that stays comparable as traffic changes. User errors (4xx) are excluded.",
+                    "Non-community 5xx / (2xx + 5xx) × 1,000. A normalized failure rate that stays comparable as traffic changes. Community models have a separate KPI; user errors (4xx) are excluded.",
             },
             {
                 name: "Service availability",
                 format: "percentPrecise",
                 tooltip:
-                    "2xx / (2xx + 5xx) × 100. User errors (4xx) are excluded because they do not indicate service downtime.",
+                    "Non-community 2xx / (2xx + 5xx) × 100. Community models have a separate availability KPI; user errors (4xx) are excluded because they do not indicate service downtime.",
             },
             {
                 name: "5xx errors",
                 lowerIsBetter: true,
                 calc: (w) => w.serverErrors5xx,
                 tooltip:
-                    "Server errors behind the availability figure. 90% availability reads mild; the same week in raw failed requests does not.",
+                    "Non-community server errors behind the availability figure. Community-model errors are excluded and reported separately.",
             },
         ],
     },

--- a/operations/kpi/test/kpis.test.js
+++ b/operations/kpi/test/kpis.test.js
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { formatValue } from "../src/lib/format";
 import {
@@ -83,6 +84,26 @@ describe("service availability row", () => {
                 return formatValue(kpiValue(view, healthWeek), view.format);
             }),
         ).toEqual(["8.8 / 1K", "99.12%", "36,691"]);
+    });
+
+    it("keeps community traffic out of the service-health population", () => {
+        const regularPipe = readFileSync(
+            new URL(
+                "../../../enter.pollinations.ai/observability/endpoints/weekly_health_stats.pipe",
+                import.meta.url,
+            ),
+            "utf8",
+        );
+        const communityPipe = readFileSync(
+            new URL(
+                "../../../enter.pollinations.ai/observability/endpoints/weekly_usage_stats.pipe",
+                import.meta.url,
+            ),
+            "utf8",
+        );
+
+        expect(regularPipe).toContain("AND model_provider_used != 'community'");
+        expect(communityPipe).toContain("model_provider_used = 'community'");
     });
 
     it("does not invent a failure rate when health data is missing", () => {


### PR DESCRIPTION
- Excludes `model_provider_used = community` from the regular service-health pipe
- Keeps community availability in its existing dedicated KPI
- Clarifies the KPI tooltips and adds mutual-exclusion regression coverage

Tests: `npm test -- --run test/kpis.test.js`; `npm run build`; Tinybird staging `deployment create --check --no-allow-destructive-operations`