### PR TITLE
refactor: simplify Inkling audio adapter

### DIFF
--- a/gen.pollinations.ai/src/text/transforms/inputAudioToFireworks.ts
+++ b/gen.pollinations.ai/src/text/transforms/inputAudioToFireworks.ts
@@ -1,74 +1,8 @@
-import { arrayBufferToBase64 } from "@/util.ts";
 import type {
     ChatMessage,
-    ServiceError,
     TransformOptions,
     TransformResult,
 } from "../types.js";
-
-const PCM16_SAMPLE_RATE = 24_000;
-
-function invalidAudio(message: string): never {
-    const error = new Error(message) as ServiceError;
-    error.status = 400;
-    throw error;
-}
-
-function decodeBase64Audio(data: string): Uint8Array {
-    try {
-        const binary = atob(data);
-        return Uint8Array.from(binary, (character) => character.charCodeAt(0));
-    } catch {
-        return invalidAudio("input_audio.data must be valid base64 audio.");
-    }
-}
-
-function startsWith(bytes: Uint8Array, signature: string): boolean {
-    return [...signature].every(
-        (character, index) => bytes[index] === character.charCodeAt(0),
-    );
-}
-
-function validateContainer(bytes: Uint8Array, format: string): void {
-    const valid =
-        (format === "wav" &&
-            startsWith(bytes, "RIFF") &&
-            startsWith(bytes.subarray(8), "WAVE")) ||
-        (format === "mp3" &&
-            (startsWith(bytes, "ID3") ||
-                (bytes[0] === 0xff && (bytes[1] & 0xe0) === 0xe0))) ||
-        (format === "flac" && startsWith(bytes, "fLaC")) ||
-        (format === "opus" && startsWith(bytes, "OggS")) ||
-        (format === "pcm16" && bytes.length > 0 && bytes.length % 2 === 0);
-
-    if (!valid) invalidAudio(`input_audio.data is not valid ${format} audio.`);
-}
-
-function wrapPcm16InWav(pcm: Uint8Array): Uint8Array {
-    const wav = new Uint8Array(44 + pcm.length);
-    const view = new DataView(wav.buffer);
-    const writeText = (offset: number, value: string) => {
-        for (let index = 0; index < value.length; index += 1) {
-            wav[offset + index] = value.charCodeAt(index);
-        }
-    };
-
-    writeText(0, "RIFF");
-    view.setUint32(4, 36 + pcm.length, true);
-    writeText(8, "WAVE");
-    writeText(12, "fmt ");
-    view.setUint32(16, 16, true);
-    view.setUint16(20, 1, true);
-    view.setUint16(22, 1, true);
-    view.setUint32(24, PCM16_SAMPLE_RATE, true);
-    view.setUint32(28, PCM16_SAMPLE_RATE * 2, true);
-    view.setUint16(32, 2, true);
-    view.setUint16(34, 16, true);
-    writeText(36, "data");
-    view.setUint32(40, pcm.length, true);
-    wav.set(pcm, 44);
-    return wav;
-}
 
 /** Convert OpenAI input_audio parts to Fireworks' audio_url request shape. */
 export function inputAudioToFireworks(
@@ -80,37 +14,23 @@ export function inputAudioToFireworks(
             if (!Array.isArray(message.content)) return message;
 
             const content = message.content.map((part) => {
-                if (!part || typeof part !== "object" || Array.isArray(part)) {
-                    return part;
-                }
-
-                const record = part as Record<string, unknown>;
-                const inputAudio = record.input_audio;
+                const record = part as Record<string, unknown> | null;
+                const inputAudio = record?.input_audio as
+                    | Record<string, unknown>
+                    | undefined;
+                const data = inputAudio?.data;
+                const format = inputAudio?.format;
                 if (
-                    record.type !== "input_audio" ||
-                    !inputAudio ||
-                    typeof inputAudio !== "object" ||
-                    Array.isArray(inputAudio)
+                    record?.type !== "input_audio" ||
+                    typeof data !== "string" ||
+                    typeof format !== "string"
                 ) {
                     return part;
                 }
-
-                const { data, format } = inputAudio as Record<string, unknown>;
-                if (typeof data !== "string" || typeof format !== "string") {
-                    return part;
-                }
-
-                const bytes = decodeBase64Audio(data);
-                validateContainer(bytes, format);
-                const isPcm16 = format === "pcm16";
-                const encodedAudio = isPcm16
-                    ? arrayBufferToBase64(wrapPcm16InWav(bytes))
-                    : data;
-
                 return {
                     type: "audio_url",
                     audio_url: {
-                        url: `data:audio/${isPcm16 ? "wav" : format === "opus" ? "ogg" : format};base64,${encodedAudio}`,
+                        url: `data:audio/${format === "opus" ? "ogg" : format};base64,${data}`,
                     },
                 };
             });

--- a/gen.pollinations.ai/test/text/transforms/inputAudioToFireworks.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/inputAudioToFireworks.test.ts
@@ -1,13 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { findModelByName } from "../../../src/text/availableModels.js";
 
+const transform = findModelByName("thinkingmachines/inkling")?.transform;
+if (!transform) throw new Error("full Inkling transform missing");
+
 describe("Fireworks audio input", () => {
     it("converts OpenAI input_audio parts for full Inkling", async () => {
-        const transform = findModelByName(
-            "thinkingmachines/inkling",
-        )?.transform;
-        if (!transform) throw new Error("full Inkling transform missing");
-
         const { messages } = await transform(
             [
                 {
@@ -17,7 +15,7 @@ describe("Fireworks audio input", () => {
                         {
                             type: "input_audio",
                             input_audio: {
-                                data: "UklGRgAAAABXQVZF",
+                                data: "bm90LWF1ZGlv",
                                 format: "wav",
                             },
                         },
@@ -26,6 +24,13 @@ describe("Fireworks audio input", () => {
                             input_audio: {
                                 data: "T2dnUw==",
                                 format: "opus",
+                            },
+                        },
+                        {
+                            type: "input_audio",
+                            input_audio: {
+                                data: "AAABAA==",
+                                format: "pcm16",
                             },
                         },
                     ],
@@ -39,7 +44,7 @@ describe("Fireworks audio input", () => {
             {
                 type: "audio_url",
                 audio_url: {
-                    url: "data:audio/wav;base64,UklGRgAAAABXQVZF",
+                    url: "data:audio/wav;base64,bm90LWF1ZGlv",
                 },
             },
             {
@@ -48,65 +53,12 @@ describe("Fireworks audio input", () => {
                     url: "data:audio/ogg;base64,T2dnUw==",
                 },
             },
-        ]);
-    });
-
-    it("wraps standard 24 kHz mono PCM16 input in a WAV container", async () => {
-        const transform = findModelByName(
-            "thinkingmachines/inkling",
-        )?.transform;
-        if (!transform) throw new Error("full Inkling transform missing");
-
-        const { messages } = await transform(
-            [
-                {
-                    role: "user",
-                    content: [
-                        {
-                            type: "input_audio",
-                            input_audio: { data: "AAABAA==", format: "pcm16" },
-                        },
-                    ],
+            {
+                type: "audio_url",
+                audio_url: {
+                    url: "data:audio/pcm16;base64,AAABAA==",
                 },
-            ],
-            {},
-        );
-
-        const part = (messages[0].content as Record<string, unknown>[])[0];
-        const url = (part.audio_url as { url: string }).url;
-        expect(url).toMatch(/^data:audio\/wav;base64,/);
-        expect(atob(url.split(",")[1]).slice(0, 12)).toBe(
-            "RIFF(\u0000\u0000\u0000WAVE",
-        );
-    });
-
-    it("rejects malformed audio before Fireworks can return a 500", async () => {
-        const transform = findModelByName(
-            "thinkingmachines/inkling",
-        )?.transform;
-        if (!transform) throw new Error("full Inkling transform missing");
-
-        await expect(
-            transform(
-                [
-                    {
-                        role: "user",
-                        content: [
-                            {
-                                type: "input_audio",
-                                input_audio: {
-                                    data: "bm90LWF1ZGlv",
-                                    format: "wav",
-                                },
-                            },
-                        ],
-                    },
-                ],
-                {},
-            ),
-        ).rejects.toMatchObject({
-            status: 400,
-            message: "input_audio.data is not valid wav audio.",
-        });
+            },
+        ]);
     });
 });


### PR DESCRIPTION
- Keeps the public OpenAI `input_audio` shape and only converts it to Fireworks `audio_url`.
- Forwards base64 bytes unchanged; only maps the Opus format label to its Ogg container MIME type.
- Removes local base64/container validation and raw PCM16-to-WAV transcoding, leaving unsupported-format errors to Fireworks.
- Verified the exact Fireworks Inkling route with WAV, MP3, FLAC, and Ogg/Opus; all returned 200.

Tests: focused Vitest, Gen TypeScript typecheck, Biome, and local `/v1/chat/completions` audio requests.