### PR TITLE
feat: add Paid Pollen share KPI

### DIFF
--- a/enter.pollinations.ai/observability/endpoints/weekly_usage_stats.pipe
+++ b/enter.pollinations.ai/observability/endpoints/weekly_usage_stats.pipe
@@ -21,6 +21,24 @@ SQL >
         sum(token_count_completion_text) AS completion_tokens,
         sum(token_count_prompt_text + token_count_completion_text) AS total_tokens,
         sum(total_price) AS revenue_usd,
+        sumIf(
+            total_price,
+            is_billed_usage
+            AND response_status >= 200
+            AND response_status < 300
+            AND selected_meter_slug IN ('v1:meter:pack', 'local:pack')
+        ) AS paid_pollen,
+        sumIf(
+            total_price,
+            is_billed_usage
+            AND response_status >= 200
+            AND response_status < 300
+            AND selected_meter_slug IN ('v1:meter:tier', 'local:tier')
+        ) AS quest_pollen,
+        round(
+            paid_pollen * 100.0 / nullIf(paid_pollen + quest_pollen, 0),
+            2
+        ) AS paid_pollen_pct,
         -- Community total_cost is its sale price, not an upstream bill. Its
         -- owner reward is the corresponding COGS for this gross-margin view.
         sum(if(

--- a/operations/kpi/src/hooks/useKpiData.js
+++ b/operations/kpi/src/hooks/useKpiData.js
@@ -124,6 +124,7 @@ export function useKpiData() {
                 // matched to the week's traffic, so it is the revenue side of
                 // gross margin.
                 pollenRevenue: row.revenue_usd,
+                paidPollenPct: row.paid_pollen_pct,
                 communityUserPct: row.served_community_user_pct,
                 communityUserPctAll: row.community_user_pct,
                 communityRequestPct: row.community_request_pct,

--- a/operations/kpi/src/lib/kpis.js
+++ b/operations/kpi/src/lib/kpis.js
@@ -129,6 +129,14 @@ export const KPIS = [
         ],
     },
     {
+        key: "paidPollenPct",
+        name: "Paid Pollen share",
+        category: "Revenue",
+        format: "percentPrecise",
+        tooltip:
+            "Paid Pollen spent / (Paid + Quest Pollen spent) × 100. Tracks how much generation consumption is funded by purchased credit. Source: Tinybird (weekly_usage_stats).",
+    },
+    {
         key: "grossMargin",
         name: "Gross margin",
         category: "Efficiency",

--- a/operations/kpi/test/kpis.test.js
+++ b/operations/kpi/test/kpis.test.js
@@ -160,6 +160,7 @@ describe("explorer view list", () => {
 const margin = KPIS.find((row) => row.key === "grossMargin");
 const coverage = KPIS.find((row) => row.key === "cashCoverage");
 const revenue = KPIS.find((row) => row.key === "revenue");
+const paidPollenShare = KPIS.find((row) => row.key === "paidPollenPct");
 
 // A real week from prod (2026-08-10), trimmed to the fields these rows read.
 const marginWeek = {
@@ -185,6 +186,21 @@ describe("revenue row", () => {
                 }),
             ),
         ).toEqual([2278, 3469, 2278 / 3352]);
+    });
+});
+
+describe("Paid Pollen share", () => {
+    it("is a precise percent KPI available to the history graph", () => {
+        expect(
+            formatValue(
+                kpiValue(paidPollenShare, { paidPollenPct: 33.9 }),
+                paidPollenShare.format,
+            ),
+        ).toBe("33.90%");
+        expect(kpiViewById("paidPollenPct:0")).toMatchObject({
+            name: "Paid Pollen share",
+            category: "Revenue",
+        });
     });
 });
 


### PR DESCRIPTION
- Adds the weekly Paid/Quest Pollen consumption split to `weekly_usage_stats`
- Adds a precise Paid Pollen share KPI under Revenue
- Makes the KPI available in the existing history graph explorer
- Adds focused KPI catalog coverage

Tests: `npm test -- test/kpis.test.js`; `npm run build`; production Tinybird SQL validated read-only.

After merge, deploy the Tinybird pipe to staging and production.