### PR TITLE
fix: allow publishing community embeddings

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-dialog.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-dialog.tsx
@@ -21,9 +21,7 @@ import { useEffect, useState } from "react";
 import { apiClient } from "../../api.ts";
 import { ModelListingFields } from "./model-listing-fields.tsx";
 import {
-    BASE_TEXT_PRICE_KEYS,
-    BASE_TRANSCRIPTION_PRICE_KEYS,
-    BASE_VIDEO_PRICE_KEYS,
+    basePriceKeysForModality,
     formWithVisiblePrices,
     hasValidVisibleFormPrices,
     PriceGroups,
@@ -283,14 +281,7 @@ export function CommunityEndpointDialog({
         : [];
     // Reveal the modality's base price plus whatever the test observed or the
     // model already had saved. Blank and zero prices mean free.
-    const basePriceKeys =
-        form.modality === "image"
-            ? (["completionImagePrice"] as const)
-            : form.modality === "video"
-              ? BASE_VIDEO_PRICE_KEYS
-              : form.modality === "transcription"
-                ? BASE_TRANSCRIPTION_PRICE_KEYS
-                : BASE_TEXT_PRICE_KEYS;
+    const basePriceKeys = basePriceKeysForModality(form.modality);
     const visiblePriceKeys = new Set(
         isShared
             ? visiblePriceFieldKeys(savedPriceKeys, returnedFields, [

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/price-table.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/price-table.tsx
@@ -335,6 +335,8 @@ export const BASE_TEXT_PRICE_KEYS: PriceFieldKey[] = [
     "completionTextPrice",
 ];
 
+const BASE_EMBEDDING_PRICE_KEYS: PriceFieldKey[] = ["promptTextPrice"];
+
 // Transcription models bill per audio second, so their single price field is
 // revealed alongside the text fields once the model is public.
 export const BASE_TRANSCRIPTION_PRICE_KEYS: PriceFieldKey[] = [
@@ -342,6 +344,20 @@ export const BASE_TRANSCRIPTION_PRICE_KEYS: PriceFieldKey[] = [
 ];
 
 export const BASE_VIDEO_PRICE_KEYS: PriceFieldKey[] = ["completionVideoPrice"];
+
+export function basePriceKeysForModality(
+    modality: CommunityEndpointModality,
+): PriceFieldKey[] {
+    return modality === "image"
+        ? ["completionImagePrice"]
+        : modality === "video"
+          ? BASE_VIDEO_PRICE_KEYS
+          : modality === "transcription"
+            ? BASE_TRANSCRIPTION_PRICE_KEYS
+            : modality === "embedding"
+              ? BASE_EMBEDDING_PRICE_KEYS
+              : BASE_TEXT_PRICE_KEYS;
+}
 
 export function returnedPriceFields(
     testState: ActionState,

--- a/enter.pollinations.ai/test/community-endpoint-price-input.test.ts
+++ b/enter.pollinations.ai/test/community-endpoint-price-input.test.ts
@@ -8,6 +8,11 @@ import {
 } from "@shared/community-endpoints.ts";
 import { describe, expect, it } from "vitest";
 import {
+    basePriceKeysForModality,
+    hasValidVisibleFormPrices,
+} from "../frontend/src/components/community-endpoints/price-table.tsx";
+import {
+    emptyForm,
     formPriceToStoredPrice,
     isValidPriceInput,
     pricePerMillionToPerToken,
@@ -15,6 +20,18 @@ import {
 } from "../frontend/src/components/community-endpoints/types.ts";
 
 describe("community endpoint price input", () => {
+    it("allows publishing embeddings with only an input-token price", () => {
+        const visiblePriceKeys = new Set(basePriceKeysForModality("embedding"));
+
+        expect([...visiblePriceKeys]).toEqual(["promptTextPrice"]);
+        expect(
+            hasValidVisibleFormPrices(
+                { ...emptyForm, modality: "embedding" },
+                visiblePriceKeys,
+            ),
+        ).toBe(true);
+    });
+
     it("accepts free and minimum prices", () => {
         expect(isValidPriceInput("")).toBe(true);
         expect(isValidPriceInput("0")).toBe(true);


### PR DESCRIPTION
- Adds an embedding-specific base price rule with input tokens only
- Stops the public-model form from requiring an unsupported completion-token price
- Adds a regression test for the publishing validation path

Fixes #14203