### PR TITLE
chore: promote main to production

### DIFF
--- a/.github/ISSUE_TEMPLATE/quest.yml
+++ b/.github/ISSUE_TEMPLATE/quest.yml
@@ -13,7 +13,7 @@ body:
         1. Read the issue and submit a focused PR against `main`. Multiple contributors may submit solutions; no assignment is needed before starting.
         2. **Start the PR description with `Fixes #N`** so GitHub links it to this quest.
         3. Maintainers compare completed approaches and select the best one, preferring correctness, clarity, and minimal code.
-        4. The selected contributor is assigned before merge so the reward goes to the right person.
+        4. The author of the selected merged PR earns the reward; no issue assignment is needed.
         5. After merge, open [enter.pollinations.ai](https://enter.pollinations.ai/quests), check quests, and claim the pending reward.
 
         Need help? Drop a comment here or ask in [Discord #dev-talk](https://discord.com/channels/885844321461485618/920274483896516609).

--- a/APIDOCS.md
+++ b/APIDOCS.md
@@ -333,13 +333,13 @@ Supports streaming, function calling, vision (image input), structured outputs, 
 | `audio` | `object` | — |
 | `audio.voice` * | enum (13) — `"alloy"`, `"echo"`, `"fable"`, … | — |
 | `audio.format` * | `"wav"` \| `"mp3"` \| `"flac"` \| `"opus"` \| `"pcm16"` | — |
-| `frequency_penalty` | `number` \| `null` | default: `0` |
+| `frequency_penalty` | `number` \| `null` | — |
 | `repetition_penalty` | `number` \| `null` | — |
 | `logit_bias` | `object` \| `null` | default: `null` |
-| `logprobs` | `boolean` \| `null` | default: `false` |
+| `logprobs` | `boolean` \| `null` | — |
 | `top_logprobs` | `integer` \| `null` | — |
 | `max_tokens` | `integer` \| `null` | — |
-| `presence_penalty` | `number` \| `null` | default: `0` |
+| `presence_penalty` | `number` \| `null` | — |
 | `response_format` | `object` | — |
 | `seed` | `integer` \| `null` | — |
 | `stop` | `string` \| `null` \| `string`[] | — |
@@ -435,13 +435,13 @@ Use `/v1/chat/completions` when you need the full OpenAI-compatible JSON respons
 | `audio` | `object` | — |
 | `audio.voice` * | enum (13) — `"alloy"`, `"echo"`, `"fable"`, … | — |
 | `audio.format` * | `"wav"` \| `"mp3"` \| `"flac"` \| `"opus"` \| `"pcm16"` | — |
-| `frequency_penalty` | `number` \| `null` | default: `0` |
+| `frequency_penalty` | `number` \| `null` | — |
 | `repetition_penalty` | `number` \| `null` | — |
 | `logit_bias` | `object` \| `null` | default: `null` |
-| `logprobs` | `boolean` \| `null` | default: `false` |
+| `logprobs` | `boolean` \| `null` | — |
 | `top_logprobs` | `integer` \| `null` | — |
 | `max_tokens` | `integer` \| `null` | — |
-| `presence_penalty` | `number` \| `null` | default: `0` |
+| `presence_penalty` | `number` \| `null` | — |
 | `response_format` | `object` | — |
 | `seed` | `integer` \| `null` | — |
 | `stop` | `string` \| `null` \| `string`[] | — |

--- a/apps/exa-mcp/worker.js
+++ b/apps/exa-mcp/worker.js
@@ -130,7 +130,7 @@ function buildServer(env, fetchImpl, reportUsage) {
                 "Search the live web for current information and return relevant pages with highlights.",
             inputSchema: z.object({
                 query: z.string().min(1),
-                numResults: z.number().int().min(1).max(100).optional(),
+                numResults: z.number().int().min(1).max(10).optional(),
             }),
         },
         (params) =>

--- a/apps/exa-mcp/worker.test.js
+++ b/apps/exa-mcp/worker.test.js
@@ -73,10 +73,12 @@ test("lists Exa's default tools without usage", async () => {
     const { calls, env, worker } = createHarness();
     const responses = [];
     const client = await connect(worker, env, responses);
+    const { tools } = await client.listTools();
     assert.deepEqual(
-        (await client.listTools()).tools.map(({ name }) => name),
+        tools.map(({ name }) => name),
         ["web_search_exa", "web_fetch_exa"],
     );
+    assert.equal(tools[0].inputSchema.properties.numResults.maximum, 10);
     assert.equal(calls.length, 0);
     assert.equal(
         responses.some((response) =>

--- a/apps/ffmpeg-mcp/ffmpeg.js
+++ b/apps/ffmpeg-mcp/ffmpeg.js
@@ -1,9 +1,9 @@
+import { FFMPEG_MCP_PRICE_PER_SECOND } from "../../shared/registry/mcp.ts";
+
 export const FFMPEG_MAX_RUN_MS = 110_000;
 export const FFMPEG_MAX_MEDIA_BYTES = 100 * 1024 * 1024;
 
-// Cloudflare basic Container: 1/4 vCPU, 1 GiB memory, 4 GB disk.
-export const FFMPEG_COST_PER_SECOND =
-    0.25 * 0.00002 + 1 * 0.0000025 + 4 * 0.00000007;
+export const FFMPEG_COST_PER_SECOND = FFMPEG_MCP_PRICE_PER_SECOND;
 
 export function calculateFfmpegCharge(runtimeMs) {
     return (Math.max(0, runtimeMs) / 1000) * FFMPEG_COST_PER_SECOND;

--- a/enter.pollinations.ai/drizzle/0058_rekey_issue_rewards.sql
+++ b/enter.pollinations.ai/drizzle/0058_rekey_issue_rewards.sql
@@ -1,0 +1,11 @@
+-- Issue bounties used to be one reward per issue, so their keys omitted the
+-- winner's identity. Re-key them before allowing every merged PR author to
+-- earn the bounty. The NOT NULL and unique constraints abort if an identity is
+-- missing or a key collides; exact-key matching makes this migration idempotent.
+-- Read-only production audit on 2026-08-31: 37 legacy rows, 0 missing GitHub
+-- identities, and 0 target-key collisions.
+UPDATE `rewards`
+   SET `idempotency_key` = `idempotency_key` || ':github:' ||
+       (SELECT `github_id` FROM `user` WHERE `user`.`id` = `rewards`.`user_id`)
+ WHERE `quest_id` LIKE 'github:issue:%'
+   AND `idempotency_key` = 'quest:' || `quest_id`;

--- a/enter.pollinations.ai/drizzle/meta/_journal.json
+++ b/enter.pollinations.ai/drizzle/meta/_journal.json
@@ -407,6 +407,13 @@
       "when": 1788182587055,
       "tag": "0057_require-community-titles",
       "breakpoints": true
+    },
+    {
+      "idx": 58,
+      "version": "6",
+      "when": 1788203007557,
+      "tag": "0058_rekey_issue_rewards",
+      "breakpoints": true
     }
   ]
 }

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-dialog.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-dialog.tsx
@@ -21,9 +21,7 @@ import { useEffect, useState } from "react";
 import { apiClient } from "../../api.ts";
 import { ModelListingFields } from "./model-listing-fields.tsx";
 import {
-    BASE_TEXT_PRICE_KEYS,
-    BASE_TRANSCRIPTION_PRICE_KEYS,
-    BASE_VIDEO_PRICE_KEYS,
+    basePriceKeysForModality,
     formWithVisiblePrices,
     hasValidVisibleFormPrices,
     PriceGroups,
@@ -283,14 +281,7 @@ export function CommunityEndpointDialog({
         : [];
     // Reveal the modality's base price plus whatever the test observed or the
     // model already had saved. Blank and zero prices mean free.
-    const basePriceKeys =
-        form.modality === "image"
-            ? (["completionImagePrice"] as const)
-            : form.modality === "video"
-              ? BASE_VIDEO_PRICE_KEYS
-              : form.modality === "transcription"
-                ? BASE_TRANSCRIPTION_PRICE_KEYS
-                : BASE_TEXT_PRICE_KEYS;
+    const basePriceKeys = basePriceKeysForModality(form.modality);
     const visiblePriceKeys = new Set(
         isShared
             ? visiblePriceFieldKeys(savedPriceKeys, returnedFields, [

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/price-table.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/price-table.tsx
@@ -335,6 +335,8 @@ export const BASE_TEXT_PRICE_KEYS: PriceFieldKey[] = [
     "completionTextPrice",
 ];
 
+const BASE_EMBEDDING_PRICE_KEYS: PriceFieldKey[] = ["promptTextPrice"];
+
 // Transcription models bill per audio second, so their single price field is
 // revealed alongside the text fields once the model is public.
 export const BASE_TRANSCRIPTION_PRICE_KEYS: PriceFieldKey[] = [
@@ -342,6 +344,20 @@ export const BASE_TRANSCRIPTION_PRICE_KEYS: PriceFieldKey[] = [
 ];
 
 export const BASE_VIDEO_PRICE_KEYS: PriceFieldKey[] = ["completionVideoPrice"];
+
+export function basePriceKeysForModality(
+    modality: CommunityEndpointModality,
+): PriceFieldKey[] {
+    return modality === "image"
+        ? ["completionImagePrice"]
+        : modality === "video"
+          ? BASE_VIDEO_PRICE_KEYS
+          : modality === "transcription"
+            ? BASE_TRANSCRIPTION_PRICE_KEYS
+            : modality === "embedding"
+              ? BASE_EMBEDDING_PRICE_KEYS
+              : BASE_TEXT_PRICE_KEYS;
+}
 
 export function returnedPriceFields(
     testState: ActionState,

--- a/enter.pollinations.ai/frontend/src/components/models/formatters.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/formatters.ts
@@ -30,7 +30,7 @@ const displayPriceNumber = new Intl.NumberFormat("en", {
     maximumFractionDigits: 4,
 });
 const smallDisplayPriceNumber = new Intl.NumberFormat("en", {
-    maximumFractionDigits: 6,
+    maximumFractionDigits: 8,
 });
 
 export const formatDisplayPrice = (

--- a/enter.pollinations.ai/frontend/src/components/models/mcp-server-list.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/mcp-server-list.tsx
@@ -1,0 +1,125 @@
+import {
+    CheckIcon,
+    Chip,
+    ClipboardIcon,
+    CopyButton,
+    InlineLink,
+} from "@pollinations/ui";
+import { getMcpPricingInfo, MCP_SERVERS } from "@shared/registry/mcp.ts";
+import type { FC } from "react";
+import { config, genDocsUrl } from "../../config.ts";
+import { UsagePriceRows } from "./price-badge.tsx";
+
+export const McpServerList: FC<{ query: string }> = ({ query }) => {
+    const normalizedQuery = query.trim().toLowerCase();
+    const servers = MCP_SERVERS.filter((server) => {
+        const pricing = getMcpPricingInfo(server);
+        return [
+            server.id,
+            server.name,
+            server.description,
+            pricing.description ?? "",
+            ...pricing.rates.map(({ label }) => label),
+        ].some((value) => value.toLowerCase().includes(normalizedQuery));
+    });
+
+    if (servers.length === 0) {
+        return (
+            <p className="py-8 text-center text-sm text-theme-text-muted">
+                No MCP servers match “{query.trim()}”.
+            </p>
+        );
+    }
+
+    return (
+        <div className="space-y-4">
+            <div className="flex flex-col gap-2">
+                {servers.map((server) => {
+                    const endpoint = `${config.genBaseUrl}/mcp/${server.id}`;
+                    const pricing = getMcpPricingInfo(server);
+                    return (
+                        <div
+                            key={server.id}
+                            className="flex items-start gap-3 rounded-xl bg-surface-opaque p-4 shadow-sm"
+                        >
+                            <span
+                                aria-hidden="true"
+                                className="mt-0.5 h-7 w-7 shrink-0 bg-current text-ink-900 opacity-55"
+                                style={{
+                                    mask: "url(/brand-logos/pollinations.svg) center / contain no-repeat",
+                                    WebkitMask:
+                                        "url(/brand-logos/pollinations.svg) center / contain no-repeat",
+                                }}
+                            />
+                            <div className="min-w-0 flex-1 space-y-1.5">
+                                <div className="flex flex-wrap items-center gap-2">
+                                    <span className="font-medium text-theme-text-strong">
+                                        {server.name} MCP
+                                    </span>
+                                    <Chip size="sm" intent="neutral">
+                                        Built-in
+                                    </Chip>
+                                </div>
+                                <p className="text-sm text-theme-text-muted">
+                                    {server.description}
+                                </p>
+                                <div className="pt-1">
+                                    <p className="mb-1 text-xs font-medium text-theme-text-strong">
+                                        Billing
+                                    </p>
+                                    {pricing.rates.length > 0 && (
+                                        <div className="grid w-fit grid-cols-[auto_auto_auto] gap-x-2">
+                                            <UsagePriceRows
+                                                adjustments={pricing.rates}
+                                                align="left"
+                                            />
+                                        </div>
+                                    )}
+                                    {pricing.description && (
+                                        <p className="text-xs text-theme-text-muted">
+                                            {pricing.description}
+                                        </p>
+                                    )}
+                                </div>
+                                <div className="flex min-w-0 items-center gap-1.5 text-xs">
+                                    <span className="min-w-0 truncate font-mono text-theme-text-muted">
+                                        {endpoint}
+                                    </span>
+                                    <CopyButton
+                                        value={endpoint}
+                                        tooltip="Copy MCP endpoint"
+                                        copiedTooltip="Copied"
+                                        aria-label={`Copy ${server.name} MCP endpoint`}
+                                        className="inline-flex shrink-0 items-center justify-center rounded-md p-1 text-theme-text-muted transition-colors hover:bg-theme-bg-active hover:text-theme-text-strong"
+                                    >
+                                        {(copied) =>
+                                            copied ? (
+                                                <CheckIcon className="h-3.5 w-3.5" />
+                                            ) : (
+                                                <ClipboardIcon className="h-3.5 w-3.5" />
+                                            )
+                                        }
+                                    </CopyButton>
+                                </div>
+                            </div>
+                        </div>
+                    );
+                })}
+            </div>
+            <p className="text-xs text-theme-text-muted">
+                <span className="font-medium text-theme-text-strong">
+                    Code quality:
+                </span>{" "}
+                Built-in MCPs favor stateless HTTP, thin proxy logic, clear
+                Pollen billing, and focused tests.
+            </p>
+            <p className="text-xs text-theme-text-muted">
+                Connect with your Pollinations API key. See the{" "}
+                <InlineLink href={genDocsUrl("#tag/mcp-server")}>
+                    MCP docs
+                </InlineLink>
+                .
+            </p>
+        </div>
+    );
+};

--- a/enter.pollinations.ai/frontend/src/components/models/model-search.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-search.ts
@@ -8,6 +8,7 @@ export const MODEL_CATEGORIES = [
     "text",
     "embedding",
     "agent",
+    "mcp",
 ] as const;
 
 export type ModelCategory = (typeof MODEL_CATEGORIES)[number];
@@ -87,7 +88,7 @@ export function validateModelSearch(
         scope: scope === "community" ? scope : undefined,
         category:
             category !== "all" &&
-            (scope === "community" || category !== "agent")
+            category !== (scope === "community" ? "mcp" : "agent")
                 ? category
                 : undefined,
         q: query || undefined,

--- a/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/model-table.tsx
@@ -65,6 +65,7 @@ export const sectionLabels: Record<SectionType, string> = {
     text: "Text",
     embedding: "Embedding",
     agent: "Agents",
+    mcp: "MCPs",
 };
 
 // --- Tab content ---

--- a/enter.pollinations.ai/frontend/src/components/models/models.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/models.tsx
@@ -30,6 +30,7 @@ import {
     useRef,
     useState,
 } from "react";
+import { McpServerList } from "./mcp-server-list.tsx";
 import {
     type ApiModelInfo,
     fetchModelCatalog,
@@ -63,6 +64,7 @@ const POLLINATIONS_SECTION_ORDER: SectionType[] = [
     "audio",
     "realtime",
     "embedding",
+    "mcp",
 ];
 
 const SCOPE_ORDER: ModelScope[] = ["pollinations", "community"];
@@ -125,6 +127,7 @@ const SEARCH_LABELS: Record<SectionType, string> = {
     text: "text",
     embedding: "embedding",
     agent: "agent",
+    mcp: "MCP server",
 };
 
 function categorizeModels(
@@ -140,6 +143,7 @@ function categorizeModels(
         text: [],
         embedding: [],
         agent: [],
+        mcp: [],
     };
 
     for (const model of models) {
@@ -217,8 +221,11 @@ export const Models: FC = () => {
         [parsedQuery, query, scopedModels],
     );
     const searchOptions = useMemo(
-        () => getModelQuerySuggestions(search, scopedModels),
-        [search, scopedModels],
+        () =>
+            activeTab === "mcp"
+                ? []
+                : getModelQuerySuggestions(search, scopedModels),
+        [activeTab, search, scopedModels],
     );
 
     useEffect(() => {
@@ -257,9 +264,11 @@ export const Models: FC = () => {
     const scopeLabel = SCOPE_LABELS[activeScope];
     const searchLabel = SEARCH_LABELS[activeTab];
     const searchTarget =
-        activeTab === "all"
-            ? `${scopeLabel} models`
-            : `${scopeLabel} ${searchLabel} models`;
+        activeTab === "mcp"
+            ? "MCP servers"
+            : activeTab === "all"
+              ? `${scopeLabel} models`
+              : `${scopeLabel} ${searchLabel} models`;
 
     const pushSearch = useCallback(
         (nextSearch: string) => {
@@ -471,56 +480,60 @@ export const Models: FC = () => {
                                 />
                             </div>
                         </div>
-                        <Dropdown
-                            align="end"
-                            className="w-max p-2"
-                            trigger={(open) => (
-                                <Button
-                                    type="button"
-                                    size="md"
-                                    aria-label={`Sort models by ${activeSortAccessibleLabel}`}
-                                    className="shrink-0 justify-end gap-2"
-                                >
-                                    <span className="text-right">
-                                        {activeSortLabel}
-                                    </span>
-                                    <ChevronIcon expanded={open} />
-                                </Button>
-                            )}
-                        >
-                            {(close) => (
-                                <div
-                                    role="menu"
-                                    aria-label="Sort models"
-                                    onKeyDown={handleSortMenuKeyDown}
-                                    className="flex flex-col gap-1"
-                                >
-                                    {SORT_OPTIONS.map((option) => (
-                                        <DropdownItem
-                                            key={option.value}
-                                            role="menuitemradio"
-                                            aria-label={option.accessibleLabel}
-                                            aria-checked={
-                                                activeSort === option.value
-                                            }
-                                            onClick={() => {
-                                                setActiveSort(option.value);
-                                                close();
-                                            }}
-                                            className={
-                                                activeSort === option.value
-                                                    ? "justify-end bg-theme-bg-active text-right text-theme-text-strong"
-                                                    : "justify-end text-right"
-                                            }
-                                        >
-                                            <span className="flex-1 text-right">
-                                                {option.label}
-                                            </span>
-                                        </DropdownItem>
-                                    ))}
-                                </div>
-                            )}
-                        </Dropdown>
+                        {activeTab !== "mcp" && (
+                            <Dropdown
+                                align="end"
+                                className="w-max p-2"
+                                trigger={(open) => (
+                                    <Button
+                                        type="button"
+                                        size="md"
+                                        aria-label={`Sort models by ${activeSortAccessibleLabel}`}
+                                        className="shrink-0 justify-end gap-2"
+                                    >
+                                        <span className="text-right">
+                                            {activeSortLabel}
+                                        </span>
+                                        <ChevronIcon expanded={open} />
+                                    </Button>
+                                )}
+                            >
+                                {(close) => (
+                                    <div
+                                        role="menu"
+                                        aria-label="Sort models"
+                                        onKeyDown={handleSortMenuKeyDown}
+                                        className="flex flex-col gap-1"
+                                    >
+                                        {SORT_OPTIONS.map((option) => (
+                                            <DropdownItem
+                                                key={option.value}
+                                                role="menuitemradio"
+                                                aria-label={
+                                                    option.accessibleLabel
+                                                }
+                                                aria-checked={
+                                                    activeSort === option.value
+                                                }
+                                                onClick={() => {
+                                                    setActiveSort(option.value);
+                                                    close();
+                                                }}
+                                                className={
+                                                    activeSort === option.value
+                                                        ? "justify-end bg-theme-bg-active text-right text-theme-text-strong"
+                                                        : "justify-end text-right"
+                                                }
+                                            >
+                                                <span className="flex-1 text-right">
+                                                    {option.label}
+                                                </span>
+                                            </DropdownItem>
+                                        ))}
+                                    </div>
+                                )}
+                            </Dropdown>
+                        )}
                     </div>
                 </div>
                 {activeScope === "community" && (
@@ -554,12 +567,14 @@ export const Models: FC = () => {
                         </p>
                     </Alert>
                 )}
-                {catalogError && (
+                {catalogError && activeTab !== "mcp" && (
                     <Alert intent="danger" className="mb-4">
                         {catalogError}
                     </Alert>
                 )}
-                {query && sectionModels[activeTab].length === 0 ? (
+                {activeTab === "mcp" ? (
+                    <McpServerList query={query} />
+                ) : query && sectionModels[activeTab].length === 0 ? (
                     <p className="py-8 text-center text-sm text-theme-text-muted">
                         No {searchTarget.toLowerCase()} match “{search.trim()}”.
                     </p>
@@ -580,46 +595,49 @@ export const Models: FC = () => {
                         />
                     </div>
                 )}
-                <div className="mt-4 space-y-2 border-t border-divider pt-4 text-[13px] leading-snug text-theme-text-muted">
-                    {activeTab === "agent" && (
+                {activeTab !== "mcp" && (
+                    <div className="mt-4 space-y-2 border-t border-divider pt-4 text-[13px] leading-snug text-theme-text-muted">
+                        {activeTab === "agent" && (
+                            <p className="flex items-start gap-1.5">
+                                <BotIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                                <span>
+                                    <strong>agent pricing</strong> — listed
+                                    rates are for the agent&apos;s base model
+                                    running its saved instructions.
+                                </span>
+                            </p>
+                        )}
                         <p className="flex items-start gap-1.5">
-                            <BotIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                            <SparklesIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
                             <span>
-                                <strong>agent pricing</strong> — listed rates
-                                are for the agent&apos;s base model running its
-                                saved instructions.
+                                <strong>/gen</strong> — flat rate per image or
+                                audio generation.
                             </span>
                         </p>
-                    )}
-                    <p className="flex items-start gap-1.5">
-                        <SparklesIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                        <span>
-                            <strong>/gen</strong> — flat rate per image or audio
-                            generation.
-                        </span>
-                    </p>
-                    <p className="flex items-start gap-1.5">
-                        <TokensIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                        <span>
-                            <strong>/K · /M</strong> — rates per thousand or
-                            million tokens.
-                        </span>
-                    </p>
-                    <p className="flex items-start gap-1.5">
-                        <ClockIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                        <span>
-                            <strong>/sec</strong> — per second of video/audio;
-                            TTS is estimated from text length.
-                        </span>
-                    </p>
-                    <p className="flex items-start gap-1.5">
-                        <UsageIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                        <span>
-                            <strong>requests /pollen</strong> — estimated from
-                            the median observed cost over the last 7 days.
-                        </span>
-                    </p>
-                </div>
+                        <p className="flex items-start gap-1.5">
+                            <TokensIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                            <span>
+                                <strong>/K · /M</strong> — rates per thousand or
+                                million tokens.
+                            </span>
+                        </p>
+                        <p className="flex items-start gap-1.5">
+                            <ClockIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                            <span>
+                                <strong>/sec</strong> — per second of
+                                video/audio; TTS is estimated from text length.
+                            </span>
+                        </p>
+                        <p className="flex items-start gap-1.5">
+                            <UsageIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                            <span>
+                                <strong>requests /pollen</strong> — estimated
+                                from the median observed cost over the last 7
+                                days.
+                            </span>
+                        </p>
+                    </div>
+                )}
             </Section>
         </div>
     );

--- a/enter.pollinations.ai/frontend/src/components/models/price-badge.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/price-badge.tsx
@@ -76,12 +76,13 @@ const formatAdjustmentUnit = ({
     const quantityLabel = compactNumber
         .format(quantity)
         .replace(/^1(?=[A-Z])/, "");
-    if (kind === "search_request") return `${quantityLabel} req`;
-    if (kind === "grounded_prompt") return `${quantityLabel} prompts`;
+    const detail = suffix ? ` · ${suffix}` : "";
+    if (kind === "search_request") return `${quantityLabel} req${detail}`;
+    if (kind === "grounded_prompt") return `${quantityLabel} prompts${detail}`;
     if (kind === "cache_storage") {
-        return `${quantityLabel} tokens`;
+        return `${quantityLabel} tokens${detail}`;
     }
-    return `${quantityLabel} ${unit}${suffix ? ` · ${suffix}` : ""}`;
+    return `${quantityLabel} ${unit}${detail}`;
 };
 
 export type PriceBadgeConfig = Omit<ModelPriceLine, "direction"> & {
@@ -353,7 +354,7 @@ const RequestBasedAdjustmentKinds = new Set([
     "grounded_prompt",
 ]);
 
-const PricingAdjustmentRows: FC<{
+export const UsagePriceRows: FC<{
     adjustments: ModelPriceAdjustment[];
     align: "left" | "right";
 }> = ({ adjustments, align }) =>
@@ -642,7 +643,7 @@ export const ModelPricingLedger: FC<{
                 standaloneTokenAdjustments.length > 0) && (
                 <div className="grid col-span-full grid-cols-subgrid">
                     {renderRateRows(cacheRateRows)}
-                    <PricingAdjustmentRows
+                    <UsagePriceRows
                         adjustments={standaloneTokenAdjustments}
                         align={align}
                     />
@@ -662,7 +663,7 @@ export const ModelPricingLedger: FC<{
                             align === "right" ? "col-start-2" : "col-start-1",
                         )}
                     />
-                    <PricingAdjustmentRows
+                    <UsagePriceRows
                         adjustments={requestBasedAdjustments}
                         align={align}
                     />

--- a/enter.pollinations.ai/frontend/src/components/models/types.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/types.ts
@@ -1,3 +1,5 @@
+import type { PublicPriceInfo } from "@shared/registry/public-pricing.ts";
+
 export type ModelCategory =
     | "text"
     | "image"
@@ -49,21 +51,7 @@ export type ModelPriceVariant = {
     prices: ModelPriceLine[];
 };
 
-export type ModelPriceAdjustment = {
-    name: string;
-    label: string;
-    kind: string;
-    price: string;
-    quantity: number;
-    unit: string;
-    suffix?: string;
-    option?: {
-        group: string;
-        value: string;
-        label: string;
-        default?: boolean;
-    };
-};
+export type ModelPriceAdjustment = PublicPriceInfo;
 
 export type ModelPrice = {
     name: string;

--- a/enter.pollinations.ai/src/services/quests/definitions.ts
+++ b/enter.pollinations.ai/src/services/quests/definitions.ts
@@ -25,8 +25,7 @@ export type QuestCategory = (typeof QUEST_CATEGORIES)[number];
  *   - "perUser" — each GitHub identity earns it independently. Key includes the
  *                 immutable GitHub user ID (`quest:${id}:github:${githubId}`).
  *   - "once"    — one reward total, whoever triggers it. Key omits the userId
- *                 (`quest:${id}`), so it can only ever be recorded once. Used by
- *                 issue bounties: one issue, one reward, regardless of assignee.
+ *                 (`quest:${id}`), so it can only ever be recorded once.
  */
 export type QuestScope = "perUser" | "once";
 

--- a/enter.pollinations.ai/src/services/quests/groups/github-contributions.ts
+++ b/enter.pollinations.ai/src/services/quests/groups/github-contributions.ts
@@ -3,7 +3,7 @@ import {
     githubAppCredentialsFromEnv,
 } from "@shared/github/app-auth.ts";
 import { graphql } from "@shared/github/client.ts";
-import type { QuestDefinition, QuestState } from "../definitions.ts";
+import type { QuestDefinition } from "../definitions.ts";
 import {
     type QuestCard,
     type QuestEvaluation,
@@ -44,7 +44,7 @@ const solveGithubIssueQuest: QuestDefinition = {
     id: "solve_github_issue",
     title: "Solve a quest issue in GitHub",
     description:
-        "Pick an open POLLEN-QUEST issue and submit a focused PR. Multiple contributors may submit; the author of the selected merged PR earns the reward.",
+        "Pick an open POLLEN-QUEST issue and submit a focused PR. Each author of a merged PR that closes the issue earns the reward.",
     category: CONTRIBUTION_CATEGORY,
     scope: "perUser",
     rewardAmount: 0,
@@ -59,13 +59,13 @@ type DerivedQuestIssue = {
     description: string;
     url: string;
     rewardAmount: number | null;
-    // "available" = open bounty; "completed" = closed by a merged PR.
+    // "completed" issues stay off the open board once assigned or merged.
     state: "available" | "completed";
-    completedByGithubId: number | null;
+    completedByGithubIds: number[];
 };
 
 type GitHubUser = {
-    databaseId?: number;
+    databaseId?: number | null;
 };
 
 type GitHubIssueNode = {
@@ -75,6 +75,7 @@ type GitHubIssueNode = {
     url: string;
     body: string | null;
     labels: { nodes: { name: string }[] };
+    assignees: { nodes: GitHubUser[] };
     closedByPullRequestsReferences: {
         nodes: {
             number: number;
@@ -102,6 +103,7 @@ query($query:String!){
       ... on Issue{
         number state title url body
         labels(first:100){ nodes{ name } }
+        assignees(first:1){ nodes{ databaseId } }
         closedByPullRequestsReferences(first:10){
           nodes{ number mergedAt author{ ... on User{ databaseId } } }
         }
@@ -167,21 +169,19 @@ function hasQuestLabel(labels: { name: string }[]): boolean {
     return labels.some((label) => label.name === QUEST_LABEL);
 }
 
-function firstMergedCloser(issue: GitHubIssueNode) {
-    return (
-        issue.closedByPullRequestsReferences.nodes
-            .flatMap((pr) =>
-                pr.mergedAt === null ? [] : [{ ...pr, mergedAt: pr.mergedAt }],
-            )
-            .sort((a, b) => a.mergedAt.localeCompare(b.mergedAt))[0] ?? null
+function mergedClosers(issue: GitHubIssueNode) {
+    return issue.closedByPullRequestsReferences.nodes.filter(
+        (pr) => pr.mergedAt !== null,
     );
 }
 
 function toDerivedQuestIssue(issue: GitHubIssueNode): DerivedQuestIssue {
     const body = issue.body ?? "";
-    const completedBy = firstMergedCloser(issue);
+    const closers = mergedClosers(issue);
     const state: DerivedQuestIssue["state"] =
-        completedBy !== null ? "completed" : "available";
+        closers.length > 0 || issue.assignees.nodes.length > 0
+            ? "completed"
+            : "available";
     return {
         issueNumber: issue.number,
         title: issue.title,
@@ -189,7 +189,11 @@ function toDerivedQuestIssue(issue: GitHubIssueNode): DerivedQuestIssue {
         url: issue.url,
         rewardAmount: parseReward(body),
         state,
-        completedByGithubId: completedBy?.author?.databaseId ?? null,
+        completedByGithubIds: closers.flatMap((pr) =>
+            typeof pr.author?.databaseId === "number"
+                ? [pr.author.databaseId]
+                : [],
+        ),
     };
 }
 
@@ -204,31 +208,25 @@ async function loadQuestIssues(token: string): Promise<DerivedQuestIssue[]> {
         .filter((issue) => hasQuestLabel(issue.labels.nodes))
         .filter(
             (issue) =>
-                issue.state === "OPEN" || firstMergedCloser(issue) !== null,
+                issue.state === "OPEN" || mergedClosers(issue).length > 0,
         )
         .map(toDerivedQuestIssue)
         .filter((issue) => issue.rewardAmount !== null);
 }
 
-function issueState(issue: DerivedQuestIssue): QuestState {
-    return issue.state;
-}
-
 function toIssueQuestDefinition(issue: DerivedQuestIssue): QuestDefinition {
     return {
-        // Per-issue idempotency identity. The reward key for a scope:"once" quest
-        // is `quest:${id}` (no userId), so `id` MUST be unique per issue or every
-        // community bounty collapses to one key and only the first ever records.
-        // Derive the id from issueNumber so the key remains stable across runs.
+        // Keep the issue-derived id stable; per-user reward keys add the
+        // immutable GitHub id so each merged PR author can earn it once.
         id: `github:issue:${issue.issueNumber}`,
         title: `Ship bounty #${issue.issueNumber}: ${issue.title}`,
         description: `Help close this POLLEN-QUEST issue. ${issue.description}`,
         category: CONTRIBUTION_CATEGORY,
-        scope: "once",
+        scope: "perUser",
         rewardAmount: issue.rewardAmount ?? 0,
         balanceBucket: "tier",
         url: issue.url,
-        state: issueState(issue),
+        state: issue.state,
     };
 }
 
@@ -259,7 +257,8 @@ export async function evaluateUser(
     ctx: QuestEvaluationContext,
     user: QuestUser,
 ): Promise<QuestEvaluation> {
-    if (user.githubId === null) return { proposals: [] };
+    const githubId = user.githubId;
+    if (githubId === null) return { proposals: [] };
 
     const token = await githubToken(ctx.env);
     const [issues, mergedPr] = await Promise.all([
@@ -272,8 +271,7 @@ export async function evaluateUser(
     const issueProposals = issues
         .filter(
             (issue) =>
-                issue.state === "completed" &&
-                issue.completedByGithubId === user.githubId &&
+                issue.completedByGithubIds.includes(githubId) &&
                 (issue.rewardAmount ?? 0) > 0,
         )
         .map((issue) => ({

--- a/enter.pollinations.ai/test/community-endpoint-price-input.test.ts
+++ b/enter.pollinations.ai/test/community-endpoint-price-input.test.ts
@@ -8,6 +8,11 @@ import {
 } from "@shared/community-endpoints.ts";
 import { describe, expect, it } from "vitest";
 import {
+    basePriceKeysForModality,
+    hasValidVisibleFormPrices,
+} from "../frontend/src/components/community-endpoints/price-table.tsx";
+import {
+    emptyForm,
     formPriceToStoredPrice,
     isValidPriceInput,
     pricePerMillionToPerToken,
@@ -15,6 +20,18 @@ import {
 } from "../frontend/src/components/community-endpoints/types.ts";
 
 describe("community endpoint price input", () => {
+    it("allows publishing embeddings with only an input-token price", () => {
+        const visiblePriceKeys = new Set(basePriceKeysForModality("embedding"));
+
+        expect([...visiblePriceKeys]).toEqual(["promptTextPrice"]);
+        expect(
+            hasValidVisibleFormPrices(
+                { ...emptyForm, modality: "embedding" },
+                visiblePriceKeys,
+            ),
+        ).toBe(true);
+    });
+
     it("accepts free and minimum prices", () => {
         expect(isValidPriceInput("")).toBe(true);
         expect(isValidPriceInput("0")).toBe(true);

--- a/enter.pollinations.ai/test/model-categories.test.ts
+++ b/enter.pollinations.ai/test/model-categories.test.ts
@@ -175,6 +175,20 @@ describe("model categories", () => {
             q: undefined,
             sort: undefined,
         });
+        expect(validateModelSearch({ category: "mcp" })).toEqual({
+            scope: undefined,
+            category: "mcp",
+            q: undefined,
+            sort: undefined,
+        });
+        expect(
+            validateModelSearch({ scope: "community", category: "mcp" }),
+        ).toEqual({
+            scope: "community",
+            category: undefined,
+            q: undefined,
+            sort: undefined,
+        });
     });
 
     it("accepts model sort options and ignores obsolete values", () => {

--- a/enter.pollinations.ai/test/pricing-data.test.ts
+++ b/enter.pollinations.ai/test/pricing-data.test.ts
@@ -136,6 +136,10 @@ test("display prices stay compact and use a readable token scale", () => {
         value: "0.00001",
         tokenScale: "M",
     });
+    expect(formatDisplayPrice("0.00000778")).toEqual({
+        value: "0.00000778",
+        tokenScale: "M",
+    });
 });
 
 test("catalog prices format token rates through formatPricePer1M", () => {

--- a/enter.pollinations.ai/test/quests.test.ts
+++ b/enter.pollinations.ai/test/quests.test.ts
@@ -4,6 +4,7 @@ import * as schema from "@shared/db/better-auth.ts";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { expect } from "vitest";
+import issueRewardMigration from "../drizzle/0058_rekey_issue_rewards.sql?raw";
 import { checkQuestsForUser } from "../src/services/quest-checker.ts";
 import * as discordCommunity from "../src/services/quests/groups/discord-community.ts";
 import * as questIndex from "../src/services/quests/index.ts";
@@ -129,6 +130,49 @@ async function getOnlyUser() {
     if (!user) throw new Error("Expected fixture user");
     return user;
 }
+
+test("issue reward migration embeds the legacy winner's GitHub id", async ({
+    sessionToken: _sessionToken,
+}) => {
+    const db = drizzle(env.DB, { schema });
+    const user = await getOnlyUser();
+    if (user.githubId === null) throw new Error("Expected fixture GitHub id");
+
+    const questId = "github:issue:legacy-migration";
+    const legacyKey = `quest:${questId}`;
+    await db.insert(schema.rewards).values({
+        id: legacyKey,
+        idempotencyKey: legacyKey,
+        userId: user.id,
+        questId,
+        title: "Legacy issue reward",
+        pollenAmount: 5,
+        balanceBucket: "tier",
+        earnedAt: new Date(),
+    });
+
+    await env.DB.prepare(issueRewardMigration).run();
+    await env.DB.prepare(issueRewardMigration).run();
+
+    const [reward] = await db
+        .select({ idempotencyKey: schema.rewards.idempotencyKey })
+        .from(schema.rewards)
+        .where(eq(schema.rewards.id, legacyKey));
+    expect(reward?.idempotencyKey).toBe(`${legacyKey}:github:${user.githubId}`);
+
+    const unmappedKey = "quest:github:issue:unmapped";
+    await db.insert(schema.rewards).values({
+        id: unmappedKey,
+        idempotencyKey: unmappedKey,
+        userId: null,
+        questId: "github:issue:unmapped",
+        title: "Unmapped legacy issue reward",
+        pollenAmount: 5,
+        balanceBucket: "tier",
+        earnedAt: new Date(),
+    });
+    await expect(env.DB.prepare(issueRewardMigration).run()).rejects.toThrow();
+});
 
 /** Distinct GitHub id per fixture account — github_id is unique. */
 function hashGithubId(seed: string): number {
@@ -460,7 +504,7 @@ test("catalog includes coming-soon GitHub issue placeholder", async ({
     expect(placeholder?.description).toEqual(expect.any(String));
 });
 
-test("catalog excludes closed GitHub quest issues without merged PRs", async ({
+test("catalog hides assigned and closed GitHub quest issues", async ({
     mocks,
     sessionToken: _sessionToken,
 }) => {
@@ -489,6 +533,12 @@ test("catalog excludes closed GitHub quest issues without merged PRs", async ({
         reward: 5,
         completedByPrNumber: 1803,
     });
+    seedQuestIssue(mocks.github.state, {
+        issueNumber: 804,
+        title: "Unassigned bounty",
+        goal: "Still available.",
+        reward: 6,
+    });
 
     const response = await SELF.fetch(
         "http://localhost:3000/api/quests/catalog",
@@ -502,9 +552,10 @@ test("catalog excludes closed GitHub quest issues without merged PRs", async ({
     };
     const byId = new Map(payload.quests.map((quest) => [quest.id, quest]));
 
-    expect(byId.get("github:issue:801")?.state).toBe("available");
+    expect(byId.get("github:issue:801")?.state).toBe("completed");
     expect(byId.has("github:issue:802")).toBe(false);
     expect(byId.get("github:issue:803")?.state).toBe("completed");
+    expect(byId.get("github:issue:804")?.state).toBe("available");
 });
 
 test("account quests merge earned rewards into completed status", async ({
@@ -1488,7 +1539,7 @@ test("quest check records elixpo intern easter egg once", async ({
     });
 });
 
-test("quest check rewards the merged quest PR author, not the issue assignee", async ({
+test("quest check rewards every merged author without duplicating a legacy assignee", async ({
     mocks,
     sessionToken: _sessionToken,
 }) => {
@@ -1500,18 +1551,18 @@ test("quest check rewards the merged quest PR author, not the issue assignee", a
     const issueNumber = 777;
     const issueQuestId = `github:issue:${issueNumber}`;
     const issueTitle = "Ship a focused fix";
-    const otherGithubId = 987654;
+    const secondAuthorGithubId = 987654;
 
     await db.insert(schema.user).values({
-        id: "github-quest-other-user",
-        name: "Other Dev",
-        email: "other-dev@example.com",
+        id: "github-quest-second-author",
+        name: "Second Author",
+        email: "second-author@example.com",
         emailVerified: false,
         image: null,
         createdAt: new Date(),
         updatedAt: new Date(),
-        githubId: otherGithubId,
-        githubUsername: "other-dev",
+        githubId: secondAuthorGithubId,
+        githubUsername: "second-author",
         tierBalance: 0,
         packBalance: 0,
     });
@@ -1521,18 +1572,42 @@ test("quest check rewards the merged quest PR author, not the issue assignee", a
         title: issueTitle,
         goal: "Merge the quest PR.",
         reward: 17,
-        assigneeGithubId: otherGithubId,
-        assigneeLogin: "other-dev",
+        assigneeGithubId: secondAuthorGithubId,
+        assigneeLogin: "second-author",
         completedByPrNumber: 888,
         completedByGithubId: user.githubId,
         completedByLogin: user.githubUsername,
     });
+    const seededIssue = mocks.github.state.questIssues.find(
+        (issue) => issue.number === issueNumber,
+    );
+    seededIssue?.closedByPullRequestsReferences?.push({
+        number: 889,
+        mergedAt: new Date("2026-06-03T00:00:00Z").toISOString(),
+        author: { databaseId: secondAuthorGithubId },
+    });
+    mocks.github.state.mergedPullRequests.push({
+        number: 889,
+        authorLogin: "second-author",
+        mergedAt: new Date("2026-06-03T00:00:00Z").toISOString(),
+    });
 
-    const first = await checkQuestsForUser(env, user.id);
-    expect(first.recorded).toBeGreaterThanOrEqual(1);
+    // The migration gives an existing winner the same per-author key that new
+    // checks produce, so the normal unique constraint prevents a second reward.
+    const migratedRewardKey = `quest:${issueQuestId}:github:${secondAuthorGithubId}`;
+    await db.insert(schema.rewards).values({
+        id: migratedRewardKey,
+        idempotencyKey: migratedRewardKey,
+        userId: "github-quest-second-author",
+        questId: issueQuestId,
+        title: `Ship bounty #${issueNumber}: ${issueTitle}`,
+        pollenAmount: 17,
+        balanceBucket: "tier",
+        earnedAt: new Date(),
+    });
 
-    const second = await checkQuestsForUser(env, "github-quest-other-user");
-    expect(second.recorded).toBe(0);
+    await checkQuestsForUser(env, user.id);
+    await checkQuestsForUser(env, "github-quest-second-author");
 
     // Recording does not credit either balance; pollen moves only when claimed.
     const [balance] = await db
@@ -1540,11 +1615,11 @@ test("quest check rewards the merged quest PR author, not the issue assignee", a
         .from(schema.user)
         .where(eq(schema.user.id, user.id));
     expect(balance?.tierBalance).toBeCloseTo(user.tierBalance ?? 0);
-    const [otherBalance] = await db
+    const [secondAuthorBalance] = await db
         .select({ tierBalance: schema.user.tierBalance })
         .from(schema.user)
-        .where(eq(schema.user.githubId, otherGithubId));
-    expect(otherBalance?.tierBalance).toBeCloseTo(0);
+        .where(eq(schema.user.githubId, secondAuthorGithubId));
+    expect(secondAuthorBalance?.tierBalance).toBeCloseTo(0);
 
     const rewards = await db
         .select({
@@ -1558,21 +1633,26 @@ test("quest check rewards the merged quest PR author, not the issue assignee", a
         .from(schema.rewards)
         .where(eq(schema.rewards.questId, issueQuestId));
 
-    // scope:"once" idempotency: exactly one reward, keyed WITHOUT a userId, owned
-    // by the merged PR author who triggered the first recording.
-    expect(rewards).toHaveLength(1);
-    expect(rewards[0]).toMatchObject({
-        idempotencyKey: `quest:github:issue:${issueNumber}`,
-        userId: user.id,
-        title: `Ship bounty #${issueNumber}: ${issueTitle}`,
-        pollenAmount: 17,
-        balanceBucket: "tier",
-    });
+    expect(rewards).toHaveLength(2);
+    expect(rewards).toEqual(
+        expect.arrayContaining([
+            expect.objectContaining({
+                idempotencyKey: migratedRewardKey,
+                userId: "github-quest-second-author",
+            }),
+            expect.objectContaining({
+                idempotencyKey: `quest:${issueQuestId}:github:${user.githubId}`,
+                userId: user.id,
+                title: `Ship bounty #${issueNumber}: ${issueTitle}`,
+                pollenAmount: 17,
+                balanceBucket: "tier",
+            }),
+        ]),
+    );
 });
 
-// Regression guard for the idempotency-key collapse: issue bounty quest ids MUST
-// be derived from the issue number. Otherwise every scope:"once" bounty would
-// share one key and only the first one ever records.
+// Regression guard: each issue keeps its own quest id, and each author gets a
+// per-user key under that issue.
 test("two lazy GitHub issue bounties each record independently", async ({
     mocks,
     sessionToken: _sessionToken,
@@ -1646,8 +1726,8 @@ test("two lazy GitHub issue bounties each record independently", async ({
     );
     expect(issueRewards).toHaveLength(2);
     expect(issueRewards.map((g) => g.idempotencyKey).sort()).toEqual([
-        "quest:github:issue:901",
-        "quest:github:issue:902",
+        `quest:github:issue:901:github:${user.githubId}`,
+        `quest:github:issue:902:github:${secondGithubId}`,
     ]);
     // Both PR authors have their own issue's reward (901→user, 902→other).
     expect(

--- a/gen.pollinations.ai/src/community-endpoints.test.ts
+++ b/gen.pollinations.ai/src/community-endpoints.test.ts
@@ -47,6 +47,7 @@ import {
     PROMPT_AGENT_BASE_URL_PLACEHOLDER,
     type PromptAgentListingPayload,
     parseCommunityModelId,
+    parseListingPayload,
     validateCommunityEndpointUrl,
 } from "@shared/community-endpoints.ts";
 import {
@@ -488,6 +489,69 @@ async function createCommunityFallbackPair({
 }
 
 describe("community endpoint helpers", () => {
+    it("parses stored proxy payloads into the canonical schema", () => {
+        const payload = parseListingPayload(
+            "proxy",
+            JSON.stringify({
+                bearerTokenCiphertext: "ciphertext",
+                modality: "image",
+                imagePricing: "request",
+                inputModalities: ["image", "image"],
+                perUserRpm: null,
+                fallbacks: ["owner/model"],
+                prices: { completionImagePrice: 0.2 },
+            }),
+        );
+
+        expect(payload).toMatchObject({
+            bearerTokenCiphertext: "ciphertext",
+            paidOnly: false,
+            modality: "image",
+            imagePricing: "request",
+            inputModalities: ["image"],
+            perUserRpm: null,
+            fallbacks: ["owner/model"],
+            prices: {
+                promptTextPrice: 0,
+                completionImagePrice: 0.2,
+                completionVideoPrice: 0,
+            },
+        });
+    });
+
+    it("rejects stored payloads that do not match their listing schema", () => {
+        expect(parseListingPayload("proxy", "not json")).toBeNull();
+        expect(
+            parseListingPayload("proxy", JSON.stringify({ prices: {} })),
+        ).toBeNull();
+        expect(
+            parseListingPayload(
+                "prompt_agent",
+                JSON.stringify({ systemPrompt: "Missing base model" }),
+            ),
+        ).toBeNull();
+        expect(
+            parseListingPayload(
+                "endpoint_agent",
+                JSON.stringify({ perUserRpm: -1 }),
+            ),
+        ).toBeNull();
+        expect(
+            parseListingPayload(
+                "proxy",
+                JSON.stringify({
+                    bearerTokenCiphertext: "ciphertext",
+                    modality: "image",
+                    imagePricing: "request",
+                    inputModalities: ["unsupported"],
+                    perUserRpm: null,
+                    fallbacks: [],
+                    prices: {},
+                }),
+            ),
+        ).toBeNull();
+    });
+
     it("checks the community endpoint owner GitHub ID allowlist", () => {
         expect(
             isCommunityEndpointOwnerAllowed({

--- a/gen.pollinations.ai/src/routes/mcp.ts
+++ b/gen.pollinations.ai/src/routes/mcp.ts
@@ -7,6 +7,7 @@ import {
 } from "@shared/mcp-usage.ts";
 import { getPublicOrigin } from "@shared/public-origin.ts";
 import {
+    getMcpPricingInfo,
     getMcpServerDefinition,
     MCP_SERVERS,
     MCP_USAGE_HEADERS,
@@ -148,6 +149,7 @@ export const mcpRoutes = new Hono<Env>()
                 name: server.name,
                 description: server.description,
                 url: `${getPublicOrigin(c)}/mcp/${server.id}`,
+                pricing: getMcpPricingInfo(server),
             })),
         }),
     )

--- a/gen.pollinations.ai/test/mcp-proxy.test.ts
+++ b/gen.pollinations.ai/test/mcp-proxy.test.ts
@@ -26,6 +26,11 @@ test("lists the MCP servers exposed through Gen", async () => {
                 description:
                     "Access Pollinations models and API capabilities through agent tools.",
                 url: "https://gen.pollinations.ai/mcp/pollinations",
+                pricing: {
+                    description:
+                        "Generation tools use each selected model's listed rate. Discovery and account tools are free.",
+                    rates: [],
+                },
             },
             {
                 id: "ffmpeg",
@@ -33,6 +38,19 @@ test("lists the MCP servers exposed through Gen", async () => {
                 description:
                     "Trim, convert, resize, compress, and remix audio and video.",
                 url: "https://gen.pollinations.ai/mcp/ffmpeg",
+                pricing: {
+                    rates: [
+                        {
+                            name: "cloudflare.container.basic_runtime.v1",
+                            label: "Runtime",
+                            kind: "compute",
+                            price: "0.00000778",
+                            currency: "pollen",
+                            quantity: 1,
+                            unit: "second",
+                        },
+                    ],
+                },
             },
             {
                 id: "exa",
@@ -40,6 +58,29 @@ test("lists the MCP servers exposed through Gen", async () => {
                 description:
                     "Search the live web and fetch clean content from source pages.",
                 url: "https://gen.pollinations.ai/mcp/exa",
+                pricing: {
+                    rates: [
+                        {
+                            name: "exa.search.v1",
+                            label: "Search",
+                            kind: "search_request",
+                            price: "0.007",
+                            currency: "pollen",
+                            quantity: 1,
+                            unit: "request",
+                            suffix: "up to 10 results",
+                        },
+                        {
+                            name: "exa.contents.text.v1",
+                            label: "Fetch",
+                            kind: "page",
+                            price: "0.001",
+                            currency: "pollen",
+                            quantity: 1,
+                            unit: "page",
+                        },
+                    ],
+                },
             },
         ],
     });

--- a/shared/community-endpoints.ts
+++ b/shared/community-endpoints.ts
@@ -530,18 +530,47 @@ export type ListingType = (typeof LISTING_TYPES)[number];
  * Pollinations credential. The only kind that names a price, because it is the
  * only kind whose caller is buying something from the owner.
  */
-export type ProxyListingPayload = {
-    bearerTokenCiphertext: string;
-    // Owner-set: callers may only spend Paid Pollen on this model.
-    paidOnly: boolean;
-    modality: CommunityEndpointModality;
-    imagePricing: CommunityEndpointImagePricing;
-    inputModalities: ModelInputModality[];
-    perUserRpm: number | null;
-    fallbacks: string[];
-    advertised?: CommunityEndpointAdvertised;
-    prices: CommunityEndpointPrices;
-};
+const StoredCommunityEndpointPricesSchema = z.object(
+    Object.fromEntries(
+        COMMUNITY_ENDPOINT_PRICE_FIELDS.map((field) => [
+            field.key,
+            z.number().finite().min(0).default(0),
+        ]),
+    ) as Record<CommunityEndpointPriceKey, z.ZodDefault<z.ZodNumber>>,
+);
+
+export const ProxyListingPayloadSchema = z
+    .object({
+        bearerTokenCiphertext: z.string().min(1),
+        // Owner-set: callers may only spend Paid Pollen on this model. Rows
+        // from before paid-only support are public-spend by default.
+        paidOnly: z.boolean().default(false),
+        modality: z.enum(COMMUNITY_ENDPOINT_MODALITIES),
+        imagePricing: z.enum(COMMUNITY_ENDPOINT_IMAGE_PRICING_MODES),
+        inputModalities: z.array(z.enum(MODEL_INPUT_MODALITIES)).min(1),
+        perUserRpm: z.number().finite().positive().nullable(),
+        fallbacks: z
+            .array(z.string().min(1))
+            .transform((fallbacks) => fallbacks.slice(0, MAX_FALLBACK_TARGETS)),
+        advertised: CommunityEndpointAdvertisedSchema.optional(),
+        prices: StoredCommunityEndpointPricesSchema,
+    })
+    .transform(({ advertised: storedAdvertised, ...payload }) => {
+        const advertised = normalizeCommunityEndpointAdvertised(
+            storedAdvertised,
+            payload.modality,
+        );
+        return {
+            ...payload,
+            inputModalities: normalizeCommunityEndpointInputModalities(
+                payload.inputModalities,
+                payload.modality,
+            ),
+            ...(Object.keys(advertised).length ? { advertised } : {}),
+        };
+    });
+
+export type ProxyListingPayload = z.infer<typeof ProxyListingPayloadSchema>;
 
 /**
  * An agent Enter runs itself. Its row id is also the model sent to the shared
@@ -584,6 +613,12 @@ export type ListingPayloadByType = {
     endpoint_agent: EndpointAgentListingPayload;
 };
 
+const LISTING_PAYLOAD_SCHEMA_BY_TYPE = {
+    proxy: ProxyListingPayloadSchema,
+    prompt_agent: PromptAgentConfigSchema,
+    endpoint_agent: EndpointAgentListingPayloadSchema,
+} as const;
+
 /**
  * Read a stored payload back into its typed shape.
  *
@@ -602,58 +637,8 @@ export function parseListingPayload<K extends ListingType>(
     } catch {
         return null;
     }
-    if (parsed === null || typeof parsed !== "object") return null;
-    const source = parsed as Record<string, unknown>;
-
-    if (type === "endpoint_agent") {
-        const result = EndpointAgentListingPayloadSchema.safeParse(source);
-        return result.success ? (result.data as ListingPayloadByType[K]) : null;
-    }
-    if (type === "prompt_agent") {
-        const result = PromptAgentConfigSchema.safeParse(source);
-        return result.success ? (result.data as ListingPayloadByType[K]) : null;
-    }
-
-    const bearerTokenCiphertext =
-        typeof source.bearerTokenCiphertext === "string"
-            ? source.bearerTokenCiphertext
-            : "";
-    if (!bearerTokenCiphertext) return null;
-    const modality = normalizeCommunityEndpointModality(
-        typeof source.modality === "string" ? source.modality : null,
-    );
-    return {
-        bearerTokenCiphertext,
-        paidOnly: source.paidOnly === true,
-        modality,
-        imagePricing: normalizeCommunityEndpointImagePricing(
-            typeof source.imagePricing === "string"
-                ? source.imagePricing
-                : null,
-        ),
-        inputModalities: normalizeCommunityEndpointInputModalities(
-            Array.isArray(source.inputModalities)
-                ? (source.inputModalities as ModelInputModality[])
-                : undefined,
-            modality,
-        ),
-        perUserRpm:
-            typeof source.perUserRpm === "number" ? source.perUserRpm : null,
-        fallbacks: Array.isArray(source.fallbacks)
-            ? source.fallbacks.filter(
-                  (id): id is string => typeof id === "string",
-              )
-            : [],
-        advertised: normalizeCommunityEndpointAdvertised(
-            CommunityEndpointAdvertisedSchema.safeParse(source.advertised).data,
-            modality,
-        ),
-        prices: communityEndpointPrices(
-            (typeof source.prices === "object" && source.prices !== null
-                ? source.prices
-                : {}) as Partial<CommunityEndpointPrices>,
-        ),
-    } as ListingPayloadByType[K];
+    const result = LISTING_PAYLOAD_SCHEMA_BY_TYPE[type].safeParse(parsed);
+    return result.success ? (result.data as ListingPayloadByType[K]) : null;
 }
 
 export function pendingCommunityEndpointChangeIsReady(

--- a/shared/registry/mcp.ts
+++ b/shared/registry/mcp.ts
@@ -1,4 +1,9 @@
 import type { TinybirdEventType } from "../schemas/generation-event.ts";
+import {
+    type BillingRateDefinition,
+    type PublicPriceInfo,
+    publicPriceInfo,
+} from "./public-pricing.ts";
 
 export const MCP_USAGE_HEADERS = {
     cost: "x-pollinations-mcp-cost",
@@ -14,6 +19,17 @@ type McpServerDefinitionBase = {
     name: string;
     description: string;
     binding: McpBindingName;
+    pricing: McpPricingDefinition;
+};
+
+type McpPricingDefinition = {
+    description?: string;
+    rates: readonly BillingRateDefinition[];
+};
+
+export type McpPricingInfo = {
+    description?: string;
+    rates: PublicPriceInfo[];
 };
 
 export type McpBindingName = "POLLINATIONS_MCP" | "FFMPEG_MCP" | "EXA_MCP";
@@ -28,6 +44,12 @@ export type McpServerDefinition = McpServerDefinitionBase &
           }
     );
 
+export const FFMPEG_MCP_PRICE_PER_SECOND =
+    0.25 * 0.00002 + 1 * 0.0000025 + 4 * 0.00000007;
+
+const EXA_SEARCH_PRICE_PER_REQUEST = 0.007;
+const EXA_CONTENTS_PRICE_PER_PAGE = 0.001;
+
 export const MCP_SERVERS = [
     {
         id: "pollinations",
@@ -36,6 +58,11 @@ export const MCP_SERVERS = [
             "Access Pollinations models and API capabilities through agent tools.",
         binding: "POLLINATIONS_MCP",
         billing: "downstream",
+        pricing: {
+            description:
+                "Generation tools use each selected model's listed rate. Discovery and account tools are free.",
+            rates: [],
+        },
     },
     {
         id: "ffmpeg",
@@ -46,6 +73,22 @@ export const MCP_SERVERS = [
         billing: "usage_receipt",
         provider: "cloudflare",
         eventType: "tool.media",
+        pricing: {
+            rates: [
+                {
+                    id: "cloudflare.container.basic_runtime.v1",
+                    description: "Cloudflare container runtime",
+                    kind: "compute",
+                    unit: "second",
+                    unitCost: FFMPEG_MCP_PRICE_PER_SECOND,
+                    publicPricing: {
+                        label: "Runtime",
+                        quantity: 1,
+                        unit: "second",
+                    },
+                },
+            ],
+        },
     },
     {
         id: "exa",
@@ -56,6 +99,35 @@ export const MCP_SERVERS = [
         billing: "usage_receipt",
         provider: "exa",
         eventType: "tool.search",
+        pricing: {
+            rates: [
+                {
+                    id: "exa.search.v1",
+                    description: "Exa auto search request",
+                    kind: "search_request",
+                    unit: "request",
+                    unitCost: EXA_SEARCH_PRICE_PER_REQUEST,
+                    publicPricing: {
+                        label: "Search",
+                        quantity: 1,
+                        unit: "request",
+                        suffix: "up to 10 results",
+                    },
+                },
+                {
+                    id: "exa.contents.text.v1",
+                    description: "Exa text contents page",
+                    kind: "page",
+                    unit: "page",
+                    unitCost: EXA_CONTENTS_PRICE_PER_PAGE,
+                    publicPricing: {
+                        label: "Fetch",
+                        quantity: 1,
+                        unit: "page",
+                    },
+                },
+            ],
+        },
     },
 ] as const satisfies readonly McpServerDefinition[];
 
@@ -69,4 +141,11 @@ export function getMcpServerDefinition(
     id: string,
 ): McpServerDefinition | undefined {
     return MCP_SERVERS.find((server) => server.id === id);
+}
+
+export function getMcpPricingInfo(server: McpServerDefinition): McpPricingInfo {
+    return {
+        description: server.pricing.description,
+        rates: server.pricing.rates.map((rate) => publicPriceInfo(rate)),
+    };
 }

--- a/shared/registry/model-info.ts
+++ b/shared/registry/model-info.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { publicPriceInfo, toFixedPoint } from "./public-pricing";
 import {
     type BillingAdjustmentRule,
     getPriceDefinitionForModel,
@@ -118,14 +119,6 @@ export const ModelInfoSchema = z.object({
 
 export type ModelInfo = z.infer<typeof ModelInfoSchema>;
 
-/**
- * Format a number to fixed-point string, avoiding scientific notation (e.g. 1.65e-7 → "0.000000165").
- * Strips trailing zeros for cleaner output.
- */
-function toFixedPoint(n: number): string {
-    return n.toFixed(12).replace(/\.?0+$/, "");
-}
-
 function getCapabilities(service: ModelDefinition): ModelCapability[] {
     const capabilities: ModelCapability[] = [];
     if (service.tools) capabilities.push("tool_calling");
@@ -158,18 +151,7 @@ function pricingAdjustmentInfoFromRule(
     rule: BillingAdjustmentRule,
     service: ModelDefinition,
 ) {
-    const { label, quantity, unit, suffix, option } = rule.publicPricing;
-    return {
-        name: rule.id,
-        label,
-        kind: rule.kind,
-        price: toFixedPoint(rule.unitCost * quantity * service.priceMultiplier),
-        currency: "pollen" as const,
-        quantity,
-        unit,
-        suffix,
-        option,
-    };
+    return publicPriceInfo(rule, service.priceMultiplier);
 }
 
 export function modelInfoFromDefinition(

--- a/shared/registry/public-pricing.ts
+++ b/shared/registry/public-pricing.ts
@@ -1,0 +1,47 @@
+export type PublicPricingDefinition = {
+    label: string;
+    quantity: number;
+    unit: string;
+    suffix?: string;
+    option?: {
+        group: string;
+        value: string;
+        label: string;
+        default?: boolean;
+    };
+};
+
+export type BillingRateDefinition = {
+    id: string;
+    description: string;
+    kind: string;
+    unit: string;
+    unitCost: number;
+    publicPricing: PublicPricingDefinition;
+};
+
+export type PublicPriceInfo = PublicPricingDefinition & {
+    name: string;
+    kind: string;
+    price: string;
+    currency: "pollen";
+};
+
+export function toFixedPoint(value: number): string {
+    return value.toFixed(12).replace(/\.?0+$/, "");
+}
+
+export function publicPriceInfo(
+    rate: BillingRateDefinition,
+    priceMultiplier = 1,
+): PublicPriceInfo {
+    return {
+        name: rate.id,
+        kind: rate.kind,
+        price: toFixedPoint(
+            rate.unitCost * rate.publicPricing.quantity * priceMultiplier,
+        ),
+        currency: "pollen",
+        ...rate.publicPricing,
+    };
+}

--- a/shared/registry/registry.ts
+++ b/shared/registry/registry.ts
@@ -17,6 +17,7 @@ export {
 import { EMBEDDING_SERVICES, type EmbeddingServiceId } from "./embeddings";
 import { IMAGE_SERVICES, type ImageModelName } from "./image";
 import { MODEL3D_SERVICES, type Model3dName } from "./model3d";
+import type { BillingRateDefinition } from "./public-pricing";
 import { REALTIME_SERVICES, type RealtimeModelName } from "./realtime";
 import { TEXT_SERVICES, type TextModelName } from "./text";
 
@@ -112,24 +113,7 @@ export const VIDEO_CAPABILITIES = [
 
 export type VideoCapability = (typeof VIDEO_CAPABILITIES)[number];
 
-export type BillingAdjustmentRule = {
-    id: string;
-    description: string;
-    kind: string;
-    unit: string;
-    unitCost: number;
-    publicPricing: {
-        label: string;
-        quantity: number;
-        unit: string;
-        suffix?: string;
-        option?: {
-            group: string;
-            value: string;
-            label: string;
-            default?: boolean;
-        };
-    };
+export type BillingAdjustmentRule = BillingRateDefinition & {
     // Counts billable units from the response output (stream outputs carry a
     // `streamEvents` array). Returning 0 skips the rule for this request.
     // Provider-specific parsing lives with the rule's provider module


### PR DESCRIPTION
- Promotes collaborative issue-quest rewards and updated contributor instructions
- Deploys validated community-listing parsing and embedding publishing
- Adds MCP server discovery and public pricing to the model catalog
- Applies D1 migration 0058 before deploying Enter; no Tinybird changes are included