### PR TITLE
refactor: use one event type for MCP calls

### DIFF
--- a/gen.pollinations.ai/src/routes/mcp.ts
+++ b/gen.pollinations.ai/src/routes/mcp.ts
@@ -103,7 +103,7 @@ async function settleUsage(
         responseTime: endedAt.getTime() - startedAt.getTime(),
         responseStatus: usage.status,
         environment: c.env.ENVIRONMENT,
-        eventType: server.eventType,
+        eventType: "mcp.call",
         ...requestIdentity(c.var.auth),
         ...(deduction?.payerBucket
             ? payerBucketToMeter(deduction.payerBucket)

--- a/shared/registry/mcp.ts
+++ b/shared/registry/mcp.ts
@@ -1,4 +1,3 @@
-import type { TinybirdEventType } from "../schemas/generation-event.ts";
 import {
     type BillingRateDefinition,
     type PublicPriceInfo,
@@ -40,7 +39,6 @@ export type McpServerDefinition = McpServerDefinitionBase &
         | {
               billing: "usage_receipt";
               provider: string;
-              eventType: TinybirdEventType;
           }
     );
 
@@ -72,7 +70,6 @@ export const MCP_SERVERS = [
         binding: "FFMPEG_MCP",
         billing: "usage_receipt",
         provider: "cloudflare",
-        eventType: "tool.media",
         pricing: {
             rates: [
                 {
@@ -98,7 +95,6 @@ export const MCP_SERVERS = [
         binding: "EXA_MCP",
         billing: "usage_receipt",
         provider: "exa",
-        eventType: "tool.search",
         pricing: {
             rates: [
                 {

--- a/shared/schemas/generation-event.ts
+++ b/shared/schemas/generation-event.ts
@@ -9,7 +9,7 @@ export type EventType =
     | "generate.embedding"
     | "generate.realtime";
 
-export type TinybirdEventType = EventType | "tool.media" | "tool.search";
+export type TinybirdEventType = EventType | "mcp.call";
 
 // Plain TypeScript type for Tinybird events (no D1 table - events sent directly to Tinybird)
 export type TinybirdEvent = {


### PR DESCRIPTION
- Records all receipt-billed MCP operations as `mcp.call`
- Removes capability-specific event types from MCP registry entries
- Keeps server, provider, pricing adjustment, status, and billing attribution unchanged

Tests: `npm run test -- test/mcp-proxy.test.ts`; `npm run typecheck`