### PR TITLE
chore(polli-cli): bump version to 0.1.12

### DIFF
--- a/packages/polli-cli/package-lock.json
+++ b/packages/polli-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pollinations/cli",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pollinations/cli",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/packages/polli-cli/package.json
+++ b/packages/polli-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollinations/cli",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "The Pollinations CLI — for humans, AI agents, and everything in between",
   "type": "module",
   "bin": {


### PR DESCRIPTION
- Bumps `@pollinations/cli` from `0.1.11` to `0.1.12`.
- Updates the standalone CLI lockfile.
- Enables the npm release workflow to publish the merged OpenCode and Pi harness integrations.

Tests:
- `npm test` — 56 passed
- `npm run build`