### PR TITLE
feat: add selectable KPI time range

### DIFF
--- a/operations/kpi/src/App.jsx
+++ b/operations/kpi/src/App.jsx
@@ -18,6 +18,7 @@ import { RetentionTable } from "./components/RetentionTable";
 import { Trend } from "./components/Trend";
 import { SOURCE_LABELS, useKpiData } from "./hooks/useKpiData";
 import { calcChange, formatValue, weekLabel } from "./lib/format";
+import { DEFAULT_WEEKS, WEEK_RANGES, weeksFromSearch } from "./lib/range";
 
 const EXPORT_COLUMNS = [
     ["week", "Week"],
@@ -103,6 +104,18 @@ export default function App() {
     // Both live here so the chart follows the table.
     const [viewIndex, setViewIndex] = useState({});
     const [explored, setExplored] = useState("registrations:0");
+    const [weeks, setWeeks] = useState(() =>
+        weeksFromSearch(window.location.search),
+    );
+
+    const changeWeeks = (event) => {
+        const next = Number(event.target.value);
+        setWeeks(next);
+        const url = new URL(window.location.href);
+        if (next === DEFAULT_WEEKS) url.searchParams.delete("weeks");
+        else url.searchParams.set("weeks", String(next));
+        window.history.replaceState(null, "", url);
+    };
 
     const cycleView = (key) =>
         setViewIndex((prev) => ({ ...prev, [key]: (prev[key] ?? 0) + 1 }));
@@ -126,7 +139,7 @@ export default function App() {
         github,
         currentWeek,
         previousWeek,
-    } = useKpiData();
+    } = useKpiData(weeks);
 
     if (loading) return <LoadingScreen done={done} active={active} />;
 
@@ -171,15 +184,32 @@ export default function App() {
             </AppHeader>
 
             <main className="mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 py-5 sm:px-6 md:py-7">
-                <div className="flex flex-col gap-1">
-                    <Heading as="h1" size="title">
-                        KPI Dashboard
-                    </Heading>
-                    <Text as="p" tone="base">
-                        Weekly KPIs for pollinations.ai. Figures are the last
-                        full week ({weekLabel(currentWeek?.week)}) against the
-                        one before it.
-                    </Text>
+                <div className="flex flex-wrap items-end justify-between gap-3">
+                    <div className="flex flex-col gap-1">
+                        <Heading as="h1" size="title">
+                            KPI Dashboard
+                        </Heading>
+                        <Text as="p" tone="base">
+                            Weekly KPIs for pollinations.ai. Figures are the
+                            last full week ({weekLabel(currentWeek?.week)})
+                            against the one before it.
+                        </Text>
+                    </div>
+                    <label className="flex items-center gap-2 text-sm text-theme-text-muted">
+                        Range
+                        <select
+                            aria-label="KPI time range"
+                            value={weeks}
+                            onChange={changeWeeks}
+                            className="rounded-lg bg-theme-bg-subtle px-2.5 py-1.5 font-medium text-theme-text-strong hover:bg-theme-bg-hover"
+                        >
+                            {WEEK_RANGES.map((range) => (
+                                <option key={range} value={range}>
+                                    {range} weeks
+                                </option>
+                            ))}
+                        </select>
+                    </label>
                 </div>
 
                 {missing.length > 0 && (

--- a/operations/kpi/src/hooks/useKpiData.js
+++ b/operations/kpi/src/hooks/useKpiData.js
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
 import * as api from "../lib/api";
 import { currentWeekStart } from "../lib/format";
+import { DEFAULT_WEEKS } from "../lib/range";
 
-const WEEKS = 12;
 const RETENTION_WEEKS = 8;
 
 /**
@@ -12,17 +12,17 @@ const RETENTION_WEEKS = 8;
 const SOURCES = [
     { label: "GitHub stars", key: "github", load: api.github },
     { label: "Registrations", key: "registrations", load: api.registrations },
-    { label: "Revenue", key: "revenue", load: () => api.revenue(WEEKS) },
+    { label: "Revenue", key: "revenue", load: api.revenue },
     {
         label: "Health stats",
         key: "health",
-        load: () => api.weekly("health", WEEKS),
+        load: (weeks) => api.weekly("health", weeks),
     },
-    { label: "WAU", key: "wau", load: () => api.weekly("wau", WEEKS) },
+    { label: "WAU", key: "wau", load: (weeks) => api.weekly("wau", weeks) },
     {
         label: "Usage stats",
         key: "usage",
-        load: () => api.weekly("usage", WEEKS),
+        load: (weeks) => api.weekly("usage", weeks),
     },
     {
         label: "Retention",
@@ -32,7 +32,7 @@ const SOURCES = [
     {
         label: "User segments",
         key: "segments",
-        load: () => api.weekly("user-segments", WEEKS),
+        load: (weeks) => api.weekly("user-segments", weeks),
     },
     { label: "Activations", key: "activations", load: api.activations },
     {
@@ -66,7 +66,7 @@ function mergeInto(weekMap, rows, project) {
     }
 }
 
-export function useKpiData() {
+export function useKpiData(weeks = DEFAULT_WEEKS) {
     const [state, setState] = useState({
         loading: true,
         done: [],
@@ -82,11 +82,17 @@ export function useKpiData() {
         let cancelled = false;
 
         async function load() {
+            setState((prev) => ({
+                ...prev,
+                loading: true,
+                done: [],
+                active: SOURCES[0].label,
+            }));
             const raw = {};
             for (const source of SOURCES) {
                 if (cancelled) return;
                 setState((prev) => ({ ...prev, active: source.label }));
-                raw[source.key] = await source.load().catch(() => null);
+                raw[source.key] = await source.load(weeks).catch(() => null);
                 if (cancelled) return;
                 setState((prev) => ({
                     ...prev,
@@ -160,12 +166,12 @@ export function useKpiData() {
 
             // Pipes disagree on how far back they reach — registrations and
             // activations run to Oct 2025, the Tinybird pipes only cover the
-            // last WEEKS. The table needs the window every source can fill;
-            // the acquisition chart keeps the whole history.
+            // last selected range. The table needs the window every source
+            // can fill; the acquisition chart keeps the whole history.
             const allWeeks = [...weekMap.values()].sort((a, b) =>
                 a.week.localeCompare(b.week),
             );
-            const weeklyData = allWeeks.slice(-(WEEKS + 1));
+            const weeklyData = allWeeks.slice(-(weeks + 1));
 
             if (cancelled) return;
             setState((prev) => ({
@@ -190,7 +196,7 @@ export function useKpiData() {
         return () => {
             cancelled = true;
         };
-    }, []);
+    }, [weeks]);
 
     const partialWeekStart = currentWeekStart();
     const fullWeeks = state.weeklyData.filter(

--- a/operations/kpi/src/lib/api.js
+++ b/operations/kpi/src/lib/api.js
@@ -9,7 +9,7 @@ async function getRows(path) {
 export const registrations = () => getRows("/api/kpi/registrations");
 export const activations = () => getRows("/api/kpi/activations");
 export const revenue = (weeks) =>
-    getRows("/api/kpi/revenue").then((rows) => rows?.slice(-weeks) ?? null);
+    getRows(`/api/kpi/revenue?weeks_back=${weeks}`);
 export const appSubmissions = () => getRows("/api/kpi/app-submissions");
 
 export const weekly = (pipe, weeks) =>

--- a/operations/kpi/src/lib/range.js
+++ b/operations/kpi/src/lib/range.js
@@ -1,0 +1,7 @@
+export const DEFAULT_WEEKS = 12;
+export const WEEK_RANGES = [12, 20];
+
+export function weeksFromSearch(search) {
+    const weeks = Number(new URLSearchParams(search).get("weeks"));
+    return WEEK_RANGES.includes(weeks) ? weeks : DEFAULT_WEEKS;
+}

--- a/operations/kpi/test/kpis.test.js
+++ b/operations/kpi/test/kpis.test.js
@@ -9,8 +9,23 @@ import {
     kpiViewById,
     kpiViewId,
 } from "../src/lib/kpis";
+import { DEFAULT_WEEKS, WEEK_RANGES, weeksFromSearch } from "../src/lib/range";
 
 const community = KPIS.find((row) => row.key === "communityModels");
+
+describe("dashboard time range", () => {
+    it("defaults to 12 weeks and accepts the supported 20-week view", () => {
+        expect(DEFAULT_WEEKS).toBe(12);
+        expect(WEEK_RANGES).toEqual([12, 20]);
+        expect(weeksFromSearch("")).toBe(12);
+        expect(weeksFromSearch("?weeks=20")).toBe(20);
+    });
+
+    it("ignores unsupported or malformed URL values", () => {
+        expect(weeksFromSearch("?weeks=52")).toBe(12);
+        expect(weeksFromSearch("?weeks=nope")).toBe(12);
+    });
+});
 
 // One week as the dashboard sees it, after useKpiData maps the usage pipe.
 const week = {

--- a/operations/kpi/worker/index.ts
+++ b/operations/kpi/worker/index.ts
@@ -264,8 +264,10 @@ function getWeekStart(date: Date): string {
 // Tinybird: Fetch and aggregate daily Stripe revenue into weekly
 async function fetchStripeRevenue(
     env: Env,
+    weeksBack: number,
 ): Promise<Array<{ week: string; revenue: number; purchases: number }>> {
-    const daysBack = 90;
+    // Include the current partial week plus every requested full week.
+    const daysBack = (weeksBack + 1) * 7;
     const result = await fetchTinybird(env, "daily_stripe_revenue", {
         days_back: daysBack,
     });
@@ -296,10 +298,12 @@ async function fetchStripeRevenue(
 }
 
 app.get("/api/kpi/revenue", async (c) => {
-    const result = (await fetchStripeRevenue(c.env)).map((row) => ({
-        ...row,
-        revenue: Math.round(row.revenue * 100) / 100,
-    }));
+    const result = (await fetchStripeRevenue(c.env, parseWeeksBack(c))).map(
+        (row) => ({
+            ...row,
+            revenue: Math.round(row.revenue * 100) / 100,
+        }),
+    );
 
     return c.json({ data: result });
 });


### PR DESCRIPTION
- Adds a 12/20-week selector to the KPI dashboard, with 12 weeks remaining the default
- Persists the 20-week choice in the URL and reloads the existing serial data sources only when the range changes
- Makes Stripe revenue request the same selected window so older columns stay complete
- Tests URL range parsing; KPI tests and production build pass