### PR TITLE
feat(video): route Wan inputs across T2V, I2V, and R2V upstreams

### DIFF
--- a/gen.pollinations.ai/src/image/models/wan3FalVideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/wan3FalVideoModel.ts
@@ -10,6 +10,8 @@ const WAN_3_TEXT_ENDPOINT =
     "https://queue.fal.run/alibaba/wan-3.0-prime/text-to-video";
 const WAN_3_IMAGE_ENDPOINT =
     "https://queue.fal.run/alibaba/wan-3.0-prime/image-to-video";
+const WAN_3_R2V_ENDPOINT =
+    "https://queue.fal.run/alibaba/wan-3.0-prime/reference-to-video";
 const WAN_3_DURATION_SECONDS = 5;
 const WAN_3_TIMEOUT_MS = 5 * 60 * 1000;
 const WAN_3_POLL_INTERVAL_MS = 2_000;
@@ -60,30 +62,84 @@ export async function callWan3FalAPI(
         throw new HttpError("Wan 3.0 supports exactly 5 seconds", 400);
     }
 
-    const startImage = safeParams.image[0];
-    const endpoint = startImage ? WAN_3_IMAGE_ENDPOINT : WAN_3_TEXT_ENDPOINT;
+    const images = safeParams.image ?? [];
+    const hasFrames = images.length > 0;
+    const hasReference =
+        (safeParams.reference_images?.length ?? 0) > 0 ||
+        (safeParams.reference_videos?.length ?? 0) > 0 ||
+        (safeParams.reference_audios?.length ?? 0) > 0;
+
+    if (hasFrames && hasReference) {
+        throw new HttpError(
+            "Frame inputs (image[]) and reference media (reference_images, reference_videos, reference_audios) cannot be combined.",
+            400,
+        );
+    }
+
+    const resolution = safeParams.resolution ?? "480p";
     const deadline = Date.now() + WAN_3_TIMEOUT_MS;
     const authorization = { Authorization: `Key ${apiKey}` };
-    const submissionResponse = await fetchUpstream(endpoint, {
-        method: "POST",
-        headers: { ...authorization, "Content-Type": "application/json" },
-        body: JSON.stringify({
+
+    let endpoint: string;
+    let body: Record<string, unknown>;
+
+    if (hasReference) {
+        endpoint = WAN_3_R2V_ENDPOINT;
+        body = {
             prompt,
-            resolution: safeParams.resolution ?? "480p",
-            aspect_ratio: startImage
-                ? "adaptive"
-                : closestRatioLogSpace(
-                      safeParams.width,
-                      safeParams.height,
-                      WAN_3_ASPECT_RATIOS,
-                  ),
+            resolution,
+            duration,
+            enable_prompt_expansion: true,
+            enable_safety_checker: true,
+            seed: safeParams.seed,
+            ...(safeParams.reference_images?.length
+                ? { reference_images: safeParams.reference_images }
+                : {}),
+            ...(safeParams.reference_videos?.length
+                ? { reference_videos: safeParams.reference_videos }
+                : {}),
+            ...(safeParams.reference_audios?.length
+                ? { reference_audios: safeParams.reference_audios }
+                : {}),
+        };
+    } else if (hasFrames) {
+        const startImage = images[0];
+        const endImage = images[1];
+        endpoint = WAN_3_IMAGE_ENDPOINT;
+        body = {
+            prompt,
+            resolution,
+            aspect_ratio: "adaptive",
             duration,
             audio: safeParams.audio,
             enable_prompt_expansion: true,
             enable_safety_checker: true,
             seed: safeParams.seed,
-            ...(startImage ? { start_image_url: startImage } : {}),
-        }),
+            start_image_url: startImage,
+            ...(endImage ? { end_image_url: endImage } : {}),
+        };
+    } else {
+        endpoint = WAN_3_TEXT_ENDPOINT;
+        body = {
+            prompt,
+            resolution,
+            aspect_ratio: closestRatioLogSpace(
+                safeParams.width,
+                safeParams.height,
+                WAN_3_ASPECT_RATIOS,
+            ),
+            duration,
+            audio: safeParams.audio,
+            enable_prompt_expansion: true,
+            enable_safety_checker: true,
+            seed: safeParams.seed,
+        };
+    }
+
+    const submissionResponse = await fetchUpstream(endpoint, {
+        method: "POST",
+        headers: { ...authorization, "Content-Type": "application/json" },
+        body: JSON.stringify(body),
         signal: AbortSignal.timeout(remainingTime(deadline)),
         errorLabel: "Wan 3.0 submission failed",
     });

--- a/gen.pollinations.ai/src/image/models/wanVideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/wanVideoModel.ts
@@ -7,14 +7,15 @@
  * supplied:
  *   - wan-fast → wan-2.2-t2v-fast / wan-2.2-i2v-fast  (480p, ~5s, silent)
  *   - wan      → wan-2.6-t2v      / wan-2.6-i2v       (720p, native audio)
- *   - wan-pro  → wan-2.7-t2v      / wan-2.7-i2v       (720p, native audio)
+ *   - wan-pro  → wan-2.7-t2v / wan-2.7-i2v / wan-2.7-r2v (720p or 1080p)
  *
- * Replicate prices Wan video per-second by mode and resolution. Each public
- * wan-pro exposes 720p and 1080p through one public model. Billing selects the
- * matching rate from the request resolution and whether an input frame routed
- * the call to I2V.
+ * Replicate prices Wan video per-second by mode and resolution. wan-pro exposes
+ * T2V, I2V, and R2V through one public model ID. Billing selects the matching
+ * rate from the request resolution and whether an input frame routed to I2V.
+ * R2V (reference_images / reference_videos) is $0.10/s same as T2V.
  */
 
+import { HttpError } from "@shared/http-error.ts";
 import debug from "debug";
 import type { VideoGenerationResult } from "../createAndReturnVideos.ts";
 import type { ImageParams } from "../params.ts";
@@ -32,6 +33,7 @@ const logError = debug("pollinations:wan:error");
 interface WanVariantConfig {
     t2vModel: string;
     i2vModel: string;
+    r2vModel?: string;
     trackingName: string;
     displayName: string;
     predictionDeadlineMinutes?: number;
@@ -59,6 +61,8 @@ const WAN_FAST_FIXED_SECONDS = 5;
 const WAN_26_DURATIONS = [5, 10, 15] as const;
 const WAN_PRO_MIN_DURATION = 2;
 const WAN_PRO_MAX_DURATION = 15;
+// Wan 2.7 R2V has a tighter duration ceiling than T2V/I2V.
+const WAN_PRO_R2V_MAX_DURATION = 10;
 const WAN_PRO_PREDICTION_DEADLINE_MINUTES = 15;
 
 /** Pick the supported aspect ratio closest to the request. */
@@ -162,6 +166,7 @@ function makeWan27Config(
     return {
         t2vModel: "wan-video/wan-2.7-t2v",
         i2vModel: "wan-video/wan-2.7-i2v",
+        r2vModel: "wan-video/wan-2.7-r2v",
         trackingName,
         displayName: `Wan 2.7${resolution === "1080p" ? " 1080p" : ""}`,
         predictionDeadlineMinutes: WAN_PRO_PREDICTION_DEADLINE_MINUTES,
@@ -206,15 +211,66 @@ async function generateWanVideo(
     safeParams: ImageParams,
 ): Promise<VideoGenerationResult> {
     const images = safeParams.image ?? [];
-    const mode: "t2v" | "i2v" = images.length > 0 ? "i2v" : "t2v";
-    const model = mode === "i2v" ? config.i2vModel : config.t2vModel;
+    const hasFrames = images.length > 0;
+    const hasReference =
+        (safeParams.reference_images?.length ?? 0) > 0 ||
+        (safeParams.reference_videos?.length ?? 0) > 0;
 
-    const frames =
-        images.length > 0 ? await Promise.all(images.map(toDataUri)) : [];
-    const input = config.buildInput(mode, prompt, safeParams, frames);
-    const requestedDuration = config.resolveDuration(safeParams);
+    if (hasFrames && hasReference) {
+        throw new HttpError(
+            "Frame inputs (image[]) and reference media (reference_images, reference_videos) cannot be combined.",
+            400,
+        );
+    }
 
-    logOps(`${config.displayName} (${mode}) input:`, {
+    let model: string;
+    let input: Record<string, unknown>;
+    let requestedDuration: number;
+    let logMode: string;
+
+    if (hasReference) {
+        if (!config.r2vModel) {
+            throw new HttpError(
+                `${config.displayName} does not support reference-to-video.`,
+                400,
+            );
+        }
+        model = config.r2vModel;
+        requestedDuration = Math.max(
+            WAN_PRO_MIN_DURATION,
+            Math.min(
+                WAN_PRO_R2V_MAX_DURATION,
+                Math.floor(safeParams.duration ?? 5),
+            ),
+        );
+        logMode = "r2v";
+        input = withSeed(
+            {
+                prompt,
+                resolution: safeParams.resolution ?? "720p",
+                aspect_ratio: pickAspect(safeParams, WAN_PRO_RATIOS),
+                duration: requestedDuration,
+                ...(safeParams.reference_images?.length
+                    ? { reference_images: safeParams.reference_images }
+                    : {}),
+                ...(safeParams.reference_videos?.length
+                    ? { reference_videos: safeParams.reference_videos }
+                    : {}),
+            },
+            safeParams,
+        );
+    } else {
+        const frameMode: "t2v" | "i2v" = hasFrames ? "i2v" : "t2v";
+        model = frameMode === "i2v" ? config.i2vModel : config.t2vModel;
+        logMode = frameMode;
+        const frames = hasFrames
+            ? await Promise.all(images.map(toDataUri))
+            : [];
+        input = config.buildInput(frameMode, prompt, safeParams, frames);
+        requestedDuration = config.resolveDuration(safeParams);
+    }
+
+    logOps(`${config.displayName} (${logMode}) input:`, {
         ...input,
         prompt: prompt.slice(0, 80),
         image: input.image ? "[data uri]" : undefined,

--- a/gen.pollinations.ai/test/image/videoFrameValidation.test.ts
+++ b/gen.pollinations.ai/test/image/videoFrameValidation.test.ts
@@ -19,7 +19,7 @@ const VIDEO_FRAME_LIMITS = [
     ["seedance-2.0-mini", 2],
     ["seedance-2.0-fast", 2],
     ["wan", 1],
-    ["wan-3.0", 1],
+    ["wan-3.0", 2],
     ["wan-fast", 2],
     ["wan-pro", 2],
     ["grok-video-pro", 1],

--- a/gen.pollinations.ai/test/image/wan3FalVideoModel.test.ts
+++ b/gen.pollinations.ai/test/image/wan3FalVideoModel.test.ts
@@ -7,11 +7,16 @@ const TEXT_ENDPOINT =
     "https://queue.fal.run/alibaba/wan-3.0-prime/text-to-video";
 const IMAGE_ENDPOINT =
     "https://queue.fal.run/alibaba/wan-3.0-prime/image-to-video";
+const R2V_ENDPOINT =
+    "https://queue.fal.run/alibaba/wan-3.0-prime/reference-to-video";
 const STATUS_URL =
     "https://queue.fal.run/alibaba/wan-3.0-prime/requests/test/status";
 const RESULT_URL = "https://queue.fal.run/alibaba/wan-3.0-prime/requests/test";
 const VIDEO_URL = "https://fal.media/wan-3-test.mp4";
 const VIDEO_BYTES = new Uint8Array([0, 0, 0, 20, 102, 116, 121, 112]);
+const REF_IMAGE_URL = "https://media.pollinations.ai/ref-style.png";
+const REF_VIDEO_URL = "https://media.pollinations.ai/ref-motion.mp4";
+const REF_AUDIO_URL = "https://media.pollinations.ai/ref-sound.mp3";
 
 const baseParams: ImageParams = {
     model: "wan-3.0",
@@ -51,7 +56,11 @@ function mockFalFetch(
                       >)
                     : undefined,
             });
-            if (href === TEXT_ENDPOINT || href === IMAGE_ENDPOINT) {
+            if (
+                href === TEXT_ENDPOINT ||
+                href === IMAGE_ENDPOINT ||
+                href === R2V_ENDPOINT
+            ) {
                 return Response.json({
                     status_url: STATUS_URL,
                     response_url: RESULT_URL,
@@ -155,6 +164,72 @@ describe("Wan 3.0 Prime via Fal", () => {
             callWan3FalAPI("a sailboat crossing a calm bay", {
                 ...baseParams,
                 duration: 4,
+            }),
+        ).rejects.toMatchObject({ status: 400 });
+        expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("I2V forwards end_image_url when image[1] is present", async () => {
+        const requests: ProviderRequest[] = [];
+        mockFalFetch(requests);
+        const START = "https://media.pollinations.ai/start.png";
+        const END = "https://media.pollinations.ai/end.png";
+
+        await callWan3FalAPI("smooth transition", {
+            ...baseParams,
+            image: [START, END],
+        });
+
+        expect(requests[0].url).toBe(IMAGE_ENDPOINT);
+        expect(requests[0].body?.start_image_url).toBe(START);
+        expect(requests[0].body?.end_image_url).toBe(END);
+        expect(requests[0].body?.aspect_ratio).toBe("adaptive");
+    });
+
+    it("R2V routes to reference-to-video endpoint with reference fields", async () => {
+        const requests: ProviderRequest[] = [];
+        mockFalFetch(requests);
+
+        const result = await callWan3FalAPI("artistic style", {
+            ...baseParams,
+            reference_images: [REF_IMAGE_URL],
+            reference_videos: [REF_VIDEO_URL],
+            reference_audios: [REF_AUDIO_URL],
+        });
+
+        expect(requests[0].url).toBe(R2V_ENDPOINT);
+        expect(requests[0].body?.reference_images).toEqual([REF_IMAGE_URL]);
+        expect(requests[0].body?.reference_videos).toEqual([REF_VIDEO_URL]);
+        expect(requests[0].body?.reference_audios).toEqual([REF_AUDIO_URL]);
+        expect(requests[0].body?.prompt).toBe("artistic style");
+        expect(result.trackingData).toEqual({
+            actualModel: "wan-3.0",
+            usage: { completionVideoSeconds: 5 },
+        });
+    });
+
+    it("R2V omits absent reference fields from the request body", async () => {
+        const requests: ProviderRequest[] = [];
+        mockFalFetch(requests);
+
+        await callWan3FalAPI("artistic style", {
+            ...baseParams,
+            reference_images: [REF_IMAGE_URL],
+        });
+
+        expect(requests[0].url).toBe(R2V_ENDPOINT);
+        expect(requests[0].body).not.toHaveProperty("reference_videos");
+        expect(requests[0].body).not.toHaveProperty("reference_audios");
+    });
+
+    it("rejects frame + reference combination with 400", async () => {
+        const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+        await expect(
+            callWan3FalAPI("conflict", {
+                ...baseParams,
+                image: ["https://media.pollinations.ai/start.png"],
+                reference_images: [REF_IMAGE_URL],
             }),
         ).rejects.toMatchObject({ status: 400 });
         expect(fetchSpy).not.toHaveBeenCalled();

--- a/gen.pollinations.ai/test/image/wanVideoModel.test.ts
+++ b/gen.pollinations.ai/test/image/wanVideoModel.test.ts
@@ -7,6 +7,9 @@ import {
 } from "../../src/image/models/wanVideoModel.ts";
 import type { ImageParams } from "../../src/image/params.ts";
 
+const REF_IMAGE_URL = "https://media.pollinations.ai/ref-style.png";
+const REF_VIDEO_URL = "https://media.pollinations.ai/ref-motion.mp4";
+
 const REPLICATE_PREDICTIONS =
     /^https:\/\/api\.replicate\.com\/v1\/models\/(.+)\/predictions$/;
 const VIDEO_URL = "https://video.example.com/wan-output.mp4";
@@ -253,5 +256,90 @@ describe("wanVideoModel image-to-video routing", () => {
         expect(calls[0].input.resolution).toBe("480p");
         expect(calls[0].input.image as string).toMatch(EXPECTED_DATA_URI);
         expect(calls[0].input.last_image as string).toMatch(EXPECTED_DATA_URI);
+    });
+});
+
+describe("wanVideoModel reference-to-video routing", () => {
+    it("wan-pro R2V routes to wan-2.7-r2v and passes reference_images", async () => {
+        setReplicateEnv();
+        const calls: ReplicateCall[] = [];
+        mockReplicateFetch(calls, 5);
+
+        const result = await callWanProAPI("cinematic style", {
+            ...baseParams,
+            reference_images: [REF_IMAGE_URL],
+        });
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0].model).toBe("wan-video/wan-2.7-r2v");
+        expect(calls[0].input.reference_images).toEqual([REF_IMAGE_URL]);
+        expect(calls[0].input.resolution).toBe("720p");
+        expect(calls[0].input.duration).toBe(5);
+        expect(result.trackingData).toEqual({
+            actualModel: "wan-pro",
+            usage: { completionVideoSeconds: 5 },
+        });
+    });
+
+    it("wan-pro R2V passes reference_videos alongside reference_images", async () => {
+        setReplicateEnv();
+        const calls: ReplicateCall[] = [];
+        mockReplicateFetch(calls, 7);
+
+        await callWanProAPI("match this motion", {
+            ...baseParams,
+            reference_images: [REF_IMAGE_URL],
+            reference_videos: [REF_VIDEO_URL],
+            duration: 7,
+        });
+
+        expect(calls[0].model).toBe("wan-video/wan-2.7-r2v");
+        expect(calls[0].input.reference_images).toEqual([REF_IMAGE_URL]);
+        expect(calls[0].input.reference_videos).toEqual([REF_VIDEO_URL]);
+        expect(calls[0].input.duration).toBe(7);
+    });
+
+    it("wan-pro R2V clamps duration to 10s maximum", async () => {
+        setReplicateEnv();
+        const calls: ReplicateCall[] = [];
+        mockReplicateFetch(calls, 10);
+
+        await callWanProAPI("cinematic style", {
+            ...baseParams,
+            reference_images: [REF_IMAGE_URL],
+            duration: 15, // above R2V ceiling
+        });
+
+        expect(calls[0].model).toBe("wan-video/wan-2.7-r2v");
+        expect(calls[0].input.duration).toBe(10);
+    });
+
+    it("wan-pro R2V at 1080p uses the 1080p resolution", async () => {
+        setReplicateEnv();
+        const calls: ReplicateCall[] = [];
+        mockReplicateFetch(calls, 5);
+
+        await callWanProAPI("cinematic style", {
+            ...baseParams,
+            resolution: "1080p",
+            reference_images: [REF_IMAGE_URL],
+        });
+
+        expect(calls[0].model).toBe("wan-video/wan-2.7-r2v");
+        expect(calls[0].input.resolution).toBe("1080p");
+    });
+
+    it("wan-pro rejects frame + reference combination with 400", async () => {
+        setReplicateEnv();
+        const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+        await expect(
+            callWanProAPI("cinematic style", {
+                ...baseParams,
+                image: [INPUT_IMAGE_URL],
+                reference_images: [REF_IMAGE_URL],
+            }),
+        ).rejects.toMatchObject({ status: 400 });
+        expect(fetchSpy).not.toHaveBeenCalled();
     });
 });

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -772,10 +772,17 @@ const IMAGE_BASE_SERVICES = {
         ),
         resolutions: ["720p", "1080p"],
         title: "Wan 2.7",
-        description: "Keyframe-controlled video with sound at 720p or 1080p",
-        inputModalities: ["text", "image"],
+        description:
+            "Keyframe-controlled video with sound at 720p or 1080p; also accepts reference images and videos",
+        inputModalities: ["text", "image", "video"],
         outputModalities: ["video", "audio"],
-        videoCapabilities: ["start_frame", "end_frame", "audio_output"],
+        videoCapabilities: [
+            "start_frame",
+            "end_frame",
+            "audio_output",
+            "reference_images",
+            "reference_videos",
+        ],
         maxReferenceImages: 2, // Video keyframe slots: start + end.
         minDuration: 2,
         maxDuration: 15,
@@ -820,11 +827,18 @@ const IMAGE_BASE_SERVICES = {
         resolutions: ["480p", "720p", "1080p"],
         title: "Wan 3.0",
         description:
-            "Five-second video from text or a start image with optional audio at 480p, 720p, or 1080p",
-        inputModalities: ["text", "image"],
+            "Five-second video from text, start/end frames, or reference media with optional audio at 480p, 720p, or 1080p",
+        inputModalities: ["text", "image", "video", "audio"],
         outputModalities: ["video", "audio"],
-        videoCapabilities: ["start_frame", "audio_output"],
-        maxReferenceImages: 1, // Video keyframe slots: start only.
+        videoCapabilities: [
+            "start_frame",
+            "end_frame",
+            "audio_output",
+            "reference_images",
+            "reference_videos",
+            "reference_audios",
+        ],
+        maxReferenceImages: 2, // Video keyframe slots: start + end.
         minDuration: 5,
         maxDuration: 5,
         defaultDuration: 5,


### PR DESCRIPTION
Fixes #14021

## What this does

Extends the existing Wan T2V/I2V adapter routing to include reference-to-video (R2V), keeping one public model ID per Wan version.

| Public model | Request inputs | Upstream route |
|---|---|---|
| `wan-pro` / `wan-3.0` | no frame or reference media | T2V |
| `image[0]` and optional `image[1]` | frame input | I2V |
| any `reference_images`, `reference_videos`, or `reference_audios` | reference media | R2V |

## Changes

- **`gen.pollinations.ai/src/image/models/wanVideoModel.ts`** — adds R2V mode to `generateWanVideo`: detects `reference_images`/`reference_videos`, routes to `wan-video/wan-2.7-r2v`, enforces 2–10 s duration ceiling, rejects frame + reference combinations with HTTP 400
- **`gen.pollinations.ai/src/image/models/wan3FalVideoModel.ts`** — adds R2V endpoint (`/reference-to-video`), forwards `reference_images`/`reference_videos`/`reference_audios`, forwards `image[1]` as `end_image_url` for I2V, rejects frame + reference combinations
- **`shared/registry/image.ts`** — adds `reference_images`, `reference_videos` to `wan-pro` videoCapabilities; adds `reference_images`, `reference_videos`, `reference_audios`, `end_frame` to `wan-3.0`; bumps `wan-3.0` `maxReferenceImages` to 2
- **Tests** — routing, field mapping, duration clamping, invalid-combination rejection for both adapters

## Billing

No changes to billing logic: Wan 2.7 R2V is $0.10/s (same base rate as T2V, existing cost variant for 1080p T2V applies unchanged). Wan 3.0 uses the same resolution rates across all modes.