### PR TITLE
fix(polli-cli): configure Pi provider API key

### DIFF
--- a/packages/polli-cli/src/harnesses/pi.test.ts
+++ b/packages/polli-cli/src/harnesses/pi.test.ts
@@ -59,6 +59,7 @@ describe("pi harness", () => {
             .pollinations as Record<string, unknown>;
         expect(provider).toMatchObject({
             api: "openai-completions",
+            apiKey: "pollinations",
             baseUrl: "https://gen.pollinations.ai/v1",
         });
         expect((provider.models as { id: string }[]).map((m) => m.id)).toEqual([
@@ -208,6 +209,17 @@ describe("pi harness", () => {
     it("reports unconfigured when the API key is missing", () => {
         configurePi(ctx, settings);
         rmSync(authFile());
+        expect(pi.status(ctx).configured).toBe(false);
+    });
+
+    it("reports unconfigured when the provider API key marker is missing", () => {
+        configurePi(ctx, settings);
+        const data = readJson(modelsFile());
+        const provider = (
+            data.providers as Record<string, Record<string, unknown>>
+        ).pollinations;
+        delete provider.apiKey;
+        writeFileSync(modelsFile(), `${JSON.stringify(data, null, 2)}\n`);
         expect(pi.status(ctx).configured).toBe(false);
     });
 

--- a/packages/polli-cli/src/harnesses/pi.ts
+++ b/packages/polli-cli/src/harnesses/pi.ts
@@ -75,6 +75,8 @@ const readKey = (ctx: HarnessContext): string | null => {
 const providerConfig = (models: HarnessModel[]) => ({
     baseUrl: `${BASE_URL}/v1`,
     api: "openai-completions",
+    // Pi validates custom providers before resolving their auth.json entry.
+    apiKey: PROVIDER,
     compat: {
         supportsStore: false,
         supportsDeveloperRole: false,
@@ -179,7 +181,10 @@ const result = (ctx: HarnessContext): HarnessResult => {
     const providers = modelsData.providers as
         | Record<string, unknown>
         | undefined;
-    const hasProvider = !!providers?.[PROVIDER];
+    const provider = providers?.[PROVIDER] as
+        | Record<string, unknown>
+        | undefined;
+    const hasProvider = provider?.apiKey === PROVIDER;
 
     const authEntry = authData[PROVIDER] as Record<string, unknown> | undefined;
     const hasKey =


### PR DESCRIPTION
- Adds Pi's required custom-provider API key marker
- Keeps the real credential in `auth.json`
- Reports older incomplete Pi configs as unconfigured so rerunning setup repairs them
- Tests: `npm run test` (57 passed), `npm run build`