### PR TITLE
feat(video): route Wan inputs across T2V, I2V, and R2V upstreams

### DIFF
--- a/gen.pollinations.ai/src/image/models/wan3FalVideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/wan3FalVideoModel.ts
@@ -80,67 +80,42 @@ export async function callWan3FalAPI(
     const deadline = Date.now() + WAN_3_TIMEOUT_MS;
     const authorization = { Authorization: `Key ${apiKey}` };
 
-    let endpoint: string;
-    let body: Record<string, unknown>;
-
-    if (hasReference) {
-        endpoint = WAN_3_R2V_ENDPOINT;
-        body = {
-            prompt,
-            resolution,
-            aspect_ratio: closestRatioLogSpace(
-                safeParams.width,
-                safeParams.height,
-                WAN_3_ASPECT_RATIOS,
-            ),
-            duration,
-            audio: safeParams.audio,
-            enable_prompt_expansion: true,
-            enable_safety_checker: true,
-            seed: safeParams.seed,
-            ...(safeParams.reference_images?.length
-                ? { reference_image_urls: safeParams.reference_images }
-                : {}),
-            ...(safeParams.reference_videos?.length
-                ? { reference_video_urls: safeParams.reference_videos }
-                : {}),
-            ...(safeParams.reference_audios?.length
-                ? { reference_audio_urls: safeParams.reference_audios }
-                : {}),
-        };
-    } else if (hasFrames) {
-        const startImage = images[0];
-        const endImage = images[1];
-        endpoint = WAN_3_IMAGE_ENDPOINT;
-        body = {
-            prompt,
-            resolution,
-            aspect_ratio: "adaptive",
-            duration,
-            audio: safeParams.audio,
-            enable_prompt_expansion: true,
-            enable_safety_checker: true,
-            seed: safeParams.seed,
-            start_image_url: startImage,
-            ...(endImage ? { end_image_url: endImage } : {}),
-        };
-    } else {
-        endpoint = WAN_3_TEXT_ENDPOINT;
-        body = {
-            prompt,
-            resolution,
-            aspect_ratio: closestRatioLogSpace(
-                safeParams.width,
-                safeParams.height,
-                WAN_3_ASPECT_RATIOS,
-            ),
-            duration,
-            audio: safeParams.audio,
-            enable_prompt_expansion: true,
-            enable_safety_checker: true,
-            seed: safeParams.seed,
-        };
-    }
+    const endpoint = hasReference
+        ? WAN_3_R2V_ENDPOINT
+        : hasFrames
+          ? WAN_3_IMAGE_ENDPOINT
+          : WAN_3_TEXT_ENDPOINT;
+    const body = {
+        prompt,
+        resolution,
+        aspect_ratio: hasFrames
+            ? "adaptive"
+            : closestRatioLogSpace(
+                  safeParams.width,
+                  safeParams.height,
+                  WAN_3_ASPECT_RATIOS,
+              ),
+        duration,
+        audio: safeParams.audio,
+        enable_prompt_expansion: true,
+        enable_safety_checker: true,
+        seed: safeParams.seed,
+        ...(hasFrames
+            ? {
+                  start_image_url: images[0],
+                  ...(images[1] ? { end_image_url: images[1] } : {}),
+              }
+            : {}),
+        ...(safeParams.reference_images?.length
+            ? { reference_image_urls: safeParams.reference_images }
+            : {}),
+        ...(safeParams.reference_videos?.length
+            ? { reference_video_urls: safeParams.reference_videos }
+            : {}),
+        ...(safeParams.reference_audios?.length
+            ? { reference_audio_urls: safeParams.reference_audios }
+            : {}),
+    };
 
     const submissionResponse = await fetchUpstream(endpoint, {
         method: "POST",

--- a/gen.pollinations.ai/src/image/models/wan3FalVideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/wan3FalVideoModel.ts
@@ -10,6 +10,8 @@ const WAN_3_TEXT_ENDPOINT =
     "https://queue.fal.run/alibaba/wan-3.0-prime/text-to-video";
 const WAN_3_IMAGE_ENDPOINT =
     "https://queue.fal.run/alibaba/wan-3.0-prime/image-to-video";
+const WAN_3_R2V_ENDPOINT =
+    "https://queue.fal.run/alibaba/wan-3.0-prime/reference-to-video";
 const WAN_3_DURATION_SECONDS = 5;
 const WAN_3_TIMEOUT_MS = 5 * 60 * 1000;
 const WAN_3_POLL_INTERVAL_MS = 2_000;
@@ -60,30 +62,90 @@ export async function callWan3FalAPI(
         throw new HttpError("Wan 3.0 supports exactly 5 seconds", 400);
     }
 
-    const startImage = safeParams.image[0];
-    const endpoint = startImage ? WAN_3_IMAGE_ENDPOINT : WAN_3_TEXT_ENDPOINT;
+    const images = safeParams.image ?? [];
+    const hasFrames = images.length > 0;
+    const hasReference =
+        (safeParams.reference_images?.length ?? 0) > 0 ||
+        (safeParams.reference_videos?.length ?? 0) > 0 ||
+        (safeParams.reference_audios?.length ?? 0) > 0;
+
+    if (hasFrames && hasReference) {
+        throw new HttpError(
+            "Frame inputs (image[]) and reference media (reference_images, reference_videos, reference_audios) cannot be combined.",
+            400,
+        );
+    }
+
+    const resolution = safeParams.resolution ?? "480p";
     const deadline = Date.now() + WAN_3_TIMEOUT_MS;
     const authorization = { Authorization: `Key ${apiKey}` };
-    const submissionResponse = await fetchUpstream(endpoint, {
-        method: "POST",
-        headers: { ...authorization, "Content-Type": "application/json" },
-        body: JSON.stringify({
+
+    let endpoint: string;
+    let body: Record<string, unknown>;
+
+    if (hasReference) {
+        endpoint = WAN_3_R2V_ENDPOINT;
+        body = {
             prompt,
-            resolution: safeParams.resolution ?? "480p",
-            aspect_ratio: startImage
-                ? "adaptive"
-                : closestRatioLogSpace(
-                      safeParams.width,
-                      safeParams.height,
-                      WAN_3_ASPECT_RATIOS,
-                  ),
+            resolution,
+            aspect_ratio: closestRatioLogSpace(
+                safeParams.width,
+                safeParams.height,
+                WAN_3_ASPECT_RATIOS,
+            ),
             duration,
             audio: safeParams.audio,
             enable_prompt_expansion: true,
             enable_safety_checker: true,
             seed: safeParams.seed,
-            ...(startImage ? { start_image_url: startImage } : {}),
-        }),
+            ...(safeParams.reference_images?.length
+                ? { reference_image_urls: safeParams.reference_images }
+                : {}),
+            ...(safeParams.reference_videos?.length
+                ? { reference_video_urls: safeParams.reference_videos }
+                : {}),
+            ...(safeParams.reference_audios?.length
+                ? { reference_audio_urls: safeParams.reference_audios }
+                : {}),
+        };
+    } else if (hasFrames) {
+        const startImage = images[0];
+        const endImage = images[1];
+        endpoint = WAN_3_IMAGE_ENDPOINT;
+        body = {
+            prompt,
+            resolution,
+            aspect_ratio: "adaptive",
+            duration,
+            audio: safeParams.audio,
+            enable_prompt_expansion: true,
+            enable_safety_checker: true,
+            seed: safeParams.seed,
+            start_image_url: startImage,
+            ...(endImage ? { end_image_url: endImage } : {}),
+        };
+    } else {
+        endpoint = WAN_3_TEXT_ENDPOINT;
+        body = {
+            prompt,
+            resolution,
+            aspect_ratio: closestRatioLogSpace(
+                safeParams.width,
+                safeParams.height,
+                WAN_3_ASPECT_RATIOS,
+            ),
+            duration,
+            audio: safeParams.audio,
+            enable_prompt_expansion: true,
+            enable_safety_checker: true,
+            seed: safeParams.seed,
+        };
+    }
+
+    const submissionResponse = await fetchUpstream(endpoint, {
+        method: "POST",
+        headers: { ...authorization, "Content-Type": "application/json" },
+        body: JSON.stringify(body),
         signal: AbortSignal.timeout(remainingTime(deadline)),
         errorLabel: "Wan 3.0 submission failed",
     });

--- a/gen.pollinations.ai/src/image/models/wanVideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/wanVideoModel.ts
@@ -7,14 +7,15 @@
  * supplied:
  *   - wan-fast → wan-2.2-t2v-fast / wan-2.2-i2v-fast  (480p, ~5s, silent)
  *   - wan      → wan-2.6-t2v      / wan-2.6-i2v       (720p, native audio)
- *   - wan-pro  → wan-2.7-t2v      / wan-2.7-i2v       (720p, native audio)
+ *   - wan-pro  → wan-2.7-t2v / wan-2.7-i2v / wan-2.7-r2v (720p or 1080p)
  *
- * Replicate prices Wan video per-second by mode and resolution. Each public
- * wan-pro exposes 720p and 1080p through one public model. Billing selects the
- * matching rate from the request resolution and whether an input frame routed
- * the call to I2V.
+ * Replicate prices Wan video per-second by mode and resolution. wan-pro exposes
+ * T2V, I2V, and R2V through one public model ID. Billing selects the matching
+ * rate from the request resolution and whether an input frame routed to I2V.
+ * R2V (reference_images / reference_videos) is $0.10/s, same as T2V.
  */
 
+import { HttpError } from "@shared/http-error.ts";
 import debug from "debug";
 import type { VideoGenerationResult } from "../createAndReturnVideos.ts";
 import type { ImageParams } from "../params.ts";
@@ -32,6 +33,7 @@ const logError = debug("pollinations:wan:error");
 interface WanVariantConfig {
     t2vModel: string;
     i2vModel: string;
+    r2vModel?: string;
     trackingName: string;
     displayName: string;
     predictionDeadlineMinutes?: number;
@@ -59,6 +61,7 @@ const WAN_FAST_FIXED_SECONDS = 5;
 const WAN_26_DURATIONS = [5, 10, 15] as const;
 const WAN_PRO_MIN_DURATION = 2;
 const WAN_PRO_MAX_DURATION = 15;
+const WAN_PRO_R2V_MAX_DURATION = 10;
 const WAN_PRO_PREDICTION_DEADLINE_MINUTES = 15;
 
 /** Pick the supported aspect ratio closest to the request. */
@@ -162,6 +165,7 @@ function makeWan27Config(
     return {
         t2vModel: "wan-video/wan-2.7-t2v",
         i2vModel: "wan-video/wan-2.7-i2v",
+        r2vModel: "wan-video/wan-2.7-r2v",
         trackingName,
         displayName: `Wan 2.7${resolution === "1080p" ? " 1080p" : ""}`,
         predictionDeadlineMinutes: WAN_PRO_PREDICTION_DEADLINE_MINUTES,
@@ -206,13 +210,64 @@ async function generateWanVideo(
     safeParams: ImageParams,
 ): Promise<VideoGenerationResult> {
     const images = safeParams.image ?? [];
-    const mode: "t2v" | "i2v" = images.length > 0 ? "i2v" : "t2v";
-    const model = mode === "i2v" ? config.i2vModel : config.t2vModel;
+    const hasFrames = images.length > 0;
+    const hasReference =
+        (safeParams.reference_images?.length ?? 0) > 0 ||
+        (safeParams.reference_videos?.length ?? 0) > 0;
 
-    const frames =
-        images.length > 0 ? await Promise.all(images.map(toDataUri)) : [];
-    const input = config.buildInput(mode, prompt, safeParams, frames);
-    const requestedDuration = config.resolveDuration(safeParams);
+    if (hasFrames && hasReference) {
+        throw new HttpError(
+            "Frame inputs (image[]) and reference media (reference_images, reference_videos) cannot be combined.",
+            400,
+        );
+    }
+
+    let model: string;
+    let input: Record<string, unknown>;
+    let requestedDuration: number;
+    let mode: string;
+
+    if (hasReference) {
+        if (!config.r2vModel) {
+            throw new HttpError(
+                `${config.displayName} does not support reference-to-video.`,
+                400,
+            );
+        }
+        model = config.r2vModel;
+        mode = "r2v";
+        requestedDuration = Math.max(
+            WAN_PRO_MIN_DURATION,
+            Math.min(
+                WAN_PRO_R2V_MAX_DURATION,
+                Math.floor(safeParams.duration ?? 5),
+            ),
+        );
+        input = withSeed(
+            {
+                prompt,
+                resolution: safeParams.resolution ?? "720p",
+                aspect_ratio: pickAspect(safeParams, WAN_PRO_RATIOS),
+                duration: requestedDuration,
+                ...(safeParams.reference_images?.length
+                    ? { reference_images: safeParams.reference_images }
+                    : {}),
+                ...(safeParams.reference_videos?.length
+                    ? { reference_videos: safeParams.reference_videos }
+                    : {}),
+            },
+            safeParams,
+        );
+    } else {
+        const frameMode: "t2v" | "i2v" = hasFrames ? "i2v" : "t2v";
+        model = frameMode === "i2v" ? config.i2vModel : config.t2vModel;
+        mode = frameMode;
+        const frames = hasFrames
+            ? await Promise.all(images.map(toDataUri))
+            : [];
+        input = config.buildInput(frameMode, prompt, safeParams, frames);
+        requestedDuration = config.resolveDuration(safeParams);
+    }
 
     logOps(`${config.displayName} (${mode}) input:`, {
         ...input,
@@ -221,6 +276,12 @@ async function generateWanVideo(
         first_frame: input.first_frame ? "[data uri]" : undefined,
         last_image: input.last_image ? "[data uri]" : undefined,
         last_frame: input.last_frame ? "[data uri]" : undefined,
+        reference_images: input.reference_images
+            ? `[${(input.reference_images as string[]).length} urls]`
+            : undefined,
+        reference_videos: input.reference_videos
+            ? `[${(input.reference_videos as string[]).length} urls]`
+            : undefined,
     });
 
     let videoUrl: string;

--- a/gen.pollinations.ai/src/schemas/image.ts
+++ b/gen.pollinations.ai/src/schemas/image.ts
@@ -84,7 +84,7 @@ const GenerateImageRequestQueryParamsBaseSchema = z.object({
         )
         .meta({
             description:
-                "Reference image URL(s) for image editing or video generation. Separate multiple URLs with `|` or `,`. **Image models:** Used for editing/style reference (kontext, flux-2-pro, flux-2-flex, gptimage, seedream, klein, nanobanana). **Video models:** `image[0]` = starting frame (I2V); `image[1]` = ending frame for first+last-frame interpolation. End-frame supported by `veo`, the `seedance-2.0` family, `seedance-2.5`, `wan-fast`, and `wan-pro`. Requests exceeding the selected model's `max_reference_images` return 400. See `video_capabilities` on `/image/models` or `/models` for per-model support.",
+                "Reference image URL(s) for image editing or video generation. Separate multiple URLs with `|` or `,`. **Image models:** Used for editing or style reference. **Video models:** `image[0]` is the starting frame; `image[1]` is the optional ending frame. See `video_capabilities` and `max_reference_images` on `/image/models` or `/models` for per-model support.",
         }),
     reference_images: z
         .string()
@@ -97,7 +97,7 @@ const GenerateImageRequestQueryParamsBaseSchema = z.object({
         .optional()
         .meta({
             description:
-                "Video models only: public HTTP(S) image URLs for visual guidance, separate from first/last-frame controls. Separate multiple URLs with `|`; commas inside URLs are preserved. Supported only by Seedance 2.0 and 2.5.",
+                "Video models only: public HTTP(S) image URLs for visual guidance, separate from first/last-frame controls. Separate multiple URLs with `|`; commas inside URLs are preserved. See `video_capabilities` on `/image/models` or `/models` for per-model support.",
         }),
     reference_videos: z
         .string()
@@ -110,7 +110,7 @@ const GenerateImageRequestQueryParamsBaseSchema = z.object({
         .optional()
         .meta({
             description:
-                "Video models only: public HTTP(S) video URLs for motion or style guidance. Separate multiple URLs with `|`; commas inside URLs are preserved. Supported only by Seedance 2.0 and 2.5.",
+                "Video models only: public HTTP(S) video URLs for motion or style guidance. Separate multiple URLs with `|`; commas inside URLs are preserved. See `video_capabilities` on `/image/models` or `/models` for per-model support.",
         }),
     reference_audios: z
         .string()
@@ -123,7 +123,7 @@ const GenerateImageRequestQueryParamsBaseSchema = z.object({
         .optional()
         .meta({
             description:
-                "Video models only: public HTTP(S) audio URLs for audio-driven generation. Separate multiple URLs with `|`; commas inside URLs are preserved. Supported only by Seedance 2.0 and 2.5.",
+                "Video models only: public HTTP(S) audio URLs for audio-driven generation. Separate multiple URLs with `|`; commas inside URLs are preserved. See `video_capabilities` on `/image/models` or `/models` for per-model support.",
         }),
     transparent: z.coerce.boolean().optional().default(false).meta({
         description:

--- a/gen.pollinations.ai/test/image/videoFrameValidation.test.ts
+++ b/gen.pollinations.ai/test/image/videoFrameValidation.test.ts
@@ -19,7 +19,7 @@ const VIDEO_FRAME_LIMITS = [
     ["seedance-2.0-mini", 2],
     ["seedance-2.0-fast", 2],
     ["wan", 1],
-    ["wan-3.0", 1],
+    ["wan-3.0", 2],
     ["wan-fast", 2],
     ["wan-pro", 2],
     ["grok-video-pro", 1],

--- a/gen.pollinations.ai/test/image/wan3FalVideoModel.test.ts
+++ b/gen.pollinations.ai/test/image/wan3FalVideoModel.test.ts
@@ -7,11 +7,16 @@ const TEXT_ENDPOINT =
     "https://queue.fal.run/alibaba/wan-3.0-prime/text-to-video";
 const IMAGE_ENDPOINT =
     "https://queue.fal.run/alibaba/wan-3.0-prime/image-to-video";
+const R2V_ENDPOINT =
+    "https://queue.fal.run/alibaba/wan-3.0-prime/reference-to-video";
 const STATUS_URL =
     "https://queue.fal.run/alibaba/wan-3.0-prime/requests/test/status";
 const RESULT_URL = "https://queue.fal.run/alibaba/wan-3.0-prime/requests/test";
 const VIDEO_URL = "https://fal.media/wan-3-test.mp4";
 const VIDEO_BYTES = new Uint8Array([0, 0, 0, 20, 102, 116, 121, 112]);
+const REF_IMAGE_URL = "https://media.pollinations.ai/ref-style.png";
+const REF_VIDEO_URL = "https://media.pollinations.ai/ref-motion.mp4";
+const REF_AUDIO_URL = "https://media.pollinations.ai/ref-sound.mp3";
 
 const baseParams: ImageParams = {
     model: "wan-3.0",
@@ -51,7 +56,11 @@ function mockFalFetch(
                       >)
                     : undefined,
             });
-            if (href === TEXT_ENDPOINT || href === IMAGE_ENDPOINT) {
+            if (
+                href === TEXT_ENDPOINT ||
+                href === IMAGE_ENDPOINT ||
+                href === R2V_ENDPOINT
+            ) {
                 return Response.json({
                     status_url: STATUS_URL,
                     response_url: RESULT_URL,
@@ -155,6 +164,86 @@ describe("Wan 3.0 Prime via Fal", () => {
             callWan3FalAPI("a sailboat crossing a calm bay", {
                 ...baseParams,
                 duration: 4,
+            }),
+        ).rejects.toMatchObject({ status: 400 });
+        expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("I2V forwards end_image_url when image[1] is present", async () => {
+        const requests: ProviderRequest[] = [];
+        mockFalFetch(requests);
+        const START = "https://media.pollinations.ai/start.png";
+        const END = "https://media.pollinations.ai/end.png";
+
+        await callWan3FalAPI("smooth transition", {
+            ...baseParams,
+            image: [START, END],
+        });
+
+        expect(requests[0].url).toBe(IMAGE_ENDPOINT);
+        expect(requests[0].body?.start_image_url).toBe(START);
+        expect(requests[0].body?.end_image_url).toBe(END);
+        expect(requests[0].body?.aspect_ratio).toBe("adaptive");
+    });
+
+    it("R2V maps Pollinations references to the Fal Prime contract", async () => {
+        const requests: ProviderRequest[] = [];
+        mockFalFetch(requests);
+
+        const result = await callWan3FalAPI("artistic style", {
+            ...baseParams,
+            width: 720,
+            height: 1280,
+            resolution: "1080p",
+            audio: true,
+            reference_images: [REF_IMAGE_URL],
+            reference_videos: [REF_VIDEO_URL],
+            reference_audios: [REF_AUDIO_URL],
+        });
+
+        expect(requests[0].url).toBe(R2V_ENDPOINT);
+        expect(requests[0].body).toMatchObject({
+            prompt: "artistic style",
+            resolution: "1080p",
+            aspect_ratio: "9:16",
+            duration: 5,
+            audio: true,
+            reference_image_urls: [REF_IMAGE_URL],
+            reference_video_urls: [REF_VIDEO_URL],
+            reference_audio_urls: [REF_AUDIO_URL],
+        });
+        expect(requests[0].body).not.toHaveProperty("reference_images");
+        expect(requests[0].body).not.toHaveProperty("reference_videos");
+        expect(requests[0].body).not.toHaveProperty("reference_audios");
+        expect(result.trackingData).toEqual({
+            actualModel: "wan-3.0",
+            usage: { completionVideoSeconds: 5 },
+        });
+    });
+
+    it("R2V omits absent Fal reference fields from the request body", async () => {
+        const requests: ProviderRequest[] = [];
+        mockFalFetch(requests);
+
+        await callWan3FalAPI("artistic style", {
+            ...baseParams,
+            reference_images: [REF_IMAGE_URL],
+        });
+
+        expect(requests[0].url).toBe(R2V_ENDPOINT);
+        expect(requests[0].body?.reference_image_urls).toEqual([REF_IMAGE_URL]);
+        expect(requests[0].body).not.toHaveProperty("reference_video_urls");
+        expect(requests[0].body).not.toHaveProperty("reference_audio_urls");
+    });
+
+    it("rejects frame + reference combination with 400", async () => {
+        const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+        await expect(
+            callWan3FalAPI("conflict", {
+                ...baseParams,
+                image: ["https://media.pollinations.ai/start.png"],
+                reference_images: [REF_IMAGE_URL],
             }),
         ).rejects.toMatchObject({ status: 400 });
         expect(fetchSpy).not.toHaveBeenCalled();

--- a/gen.pollinations.ai/test/image/wanVideoModel.test.ts
+++ b/gen.pollinations.ai/test/image/wanVideoModel.test.ts
@@ -1,3 +1,5 @@
+import { IMAGE_SERVICES } from "@shared/registry/image.ts";
+import { calculateUsageBilling } from "@shared/registry/registry.ts";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { syncImageEnv } from "../../src/image/env.ts";
 import {
@@ -12,6 +14,8 @@ const REPLICATE_PREDICTIONS =
 const VIDEO_URL = "https://video.example.com/wan-output.mp4";
 const INPUT_IMAGE_URL = "https://img.example.com/first-frame.png";
 const LAST_IMAGE_URL = "https://img.example.com/last-frame.png";
+const REF_IMAGE_URL = "https://media.pollinations.ai/ref-style.png";
+const REF_VIDEO_URL = "https://media.pollinations.ai/ref-motion.mp4";
 // PNG magic bytes so downloadUserImage's detectMimeType resolves to image/png.
 const PNG_BYTES = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
 const EXPECTED_DATA_URI = /^data:image\/png;base64,/;
@@ -186,6 +190,38 @@ describe("wanVideoModel billing usage", () => {
             usage: { completionVideoSeconds: 5 },
         });
     });
+
+    it("uses the real cost selector for Wan 2.7 1080p T2V, I2V, and R2V", () => {
+        const service = IMAGE_SERVICES["wan-pro"];
+        const usage = { completionVideoSeconds: 5 };
+        const bill = (hasImage: boolean, hasReferenceVideo = false) =>
+            calculateUsageBilling({
+                model: "wan-pro",
+                usage,
+                servedBy: service,
+                input: {
+                    resolution: "1080p",
+                    hasImage,
+                    hasReferenceVideo,
+                },
+            });
+
+        const t2v = bill(false);
+        const i2v = bill(true);
+        const r2v = bill(false, true);
+
+        expect(t2v.costVariant).toBe("1080p");
+        expect(t2v.priceDefinition.completionVideoSeconds).toBe(0.1);
+        expect(t2v.cost.totalCost).toBe(0.5);
+
+        expect(i2v.costVariant).toBe("1080p_image");
+        expect(i2v.priceDefinition.completionVideoSeconds).toBe(0.15);
+        expect(i2v.cost.totalCost).toBe(0.75);
+
+        expect(r2v.costVariant).toBe("1080p");
+        expect(r2v.priceDefinition.completionVideoSeconds).toBe(0.1);
+        expect(r2v.cost.totalCost).toBe(0.5);
+    });
 });
 
 describe("wanVideoModel image-to-video routing", () => {
@@ -253,5 +289,81 @@ describe("wanVideoModel image-to-video routing", () => {
         expect(calls[0].input.resolution).toBe("480p");
         expect(calls[0].input.image as string).toMatch(EXPECTED_DATA_URI);
         expect(calls[0].input.last_image as string).toMatch(EXPECTED_DATA_URI);
+    });
+});
+
+describe("wanVideoModel reference-to-video routing", () => {
+    it("wan-pro R2V routes to wan-2.7-r2v with reference_images", async () => {
+        setReplicateEnv();
+        const calls: ReplicateCall[] = [];
+        mockReplicateFetch(calls, 5);
+
+        const result = await callWanProAPI("cinematic style", {
+            ...baseParams,
+            resolution: "1080p",
+            reference_images: [REF_IMAGE_URL],
+        });
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0].model).toBe("wan-video/wan-2.7-r2v");
+        expect(calls[0].input.reference_images).toEqual([REF_IMAGE_URL]);
+        expect(calls[0].input.resolution).toBe("1080p");
+        expect(calls[0].input.duration).toBe(5);
+        expect(calls[0].cancelAfter).toBe("15m");
+        expect(result.trackingData).toEqual({
+            actualModel: "wan-pro",
+            usage: { completionVideoSeconds: 5 },
+        });
+    });
+
+    it("wan-pro R2V passes reference_videos alongside reference_images", async () => {
+        setReplicateEnv();
+        const calls: ReplicateCall[] = [];
+        mockReplicateFetch(calls, 7);
+
+        const result = await callWanProAPI("match this motion", {
+            ...baseParams,
+            reference_images: [REF_IMAGE_URL],
+            reference_videos: [REF_VIDEO_URL],
+            duration: 7,
+        });
+
+        expect(calls[0].model).toBe("wan-video/wan-2.7-r2v");
+        expect(calls[0].input.reference_images).toEqual([REF_IMAGE_URL]);
+        expect(calls[0].input.reference_videos).toEqual([REF_VIDEO_URL]);
+        expect(calls[0].input.duration).toBe(7);
+        expect(result.trackingData).toEqual({
+            actualModel: "wan-pro",
+            usage: { completionVideoSeconds: 7 },
+        });
+    });
+
+    it("wan-pro R2V clamps duration to the 10s R2V ceiling", async () => {
+        setReplicateEnv();
+        const calls: ReplicateCall[] = [];
+        mockReplicateFetch(calls, 10);
+
+        await callWanProAPI("cinematic style", {
+            ...baseParams,
+            reference_images: [REF_IMAGE_URL],
+            duration: 15,
+        });
+
+        expect(calls[0].model).toBe("wan-video/wan-2.7-r2v");
+        expect(calls[0].input.duration).toBe(10);
+    });
+
+    it("wan-pro rejects frame + reference combination with 400", async () => {
+        setReplicateEnv();
+        const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+        await expect(
+            callWanProAPI("cinematic style", {
+                ...baseParams,
+                image: [INPUT_IMAGE_URL],
+                reference_images: [REF_IMAGE_URL],
+            }),
+        ).rejects.toMatchObject({ status: 400 });
+        expect(fetchSpy).not.toHaveBeenCalled();
     });
 });

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -737,11 +737,12 @@ const IMAGE_BASE_SERVICES = {
         addedDate: new Date("2026-05-26").getTime(),
         priceMultiplier: 1,
         paidOnly: true,
-        // Replicate wan-2.7. Audio is bundled into the per-second rate. T2V is
-        // $0.10/s at both resolutions; I2V is $0.10/s at 720p and $0.15/s at
-        // 1080p.
+        // Replicate wan-2.7. Audio is bundled into the per-second rate. T2V and
+        // R2V are $0.10/s at both resolutions; I2V is $0.10/s at 720p and
+        // $0.15/s at 1080p. R2V never sets hasImage, so it always lands on the
+        // base or "1080p" sheet and avoids the I2V surcharge.
         cost: {
-            completionVideoSeconds: 0.1, // per sec (720p, includes audio)
+            completionVideoSeconds: 0.1, // per sec (720p, includes audio; also R2V)
         },
         ...defineCostVariants(
             {
@@ -772,10 +773,17 @@ const IMAGE_BASE_SERVICES = {
         ),
         resolutions: ["720p", "1080p"],
         title: "Wan 2.7",
-        description: "Keyframe-controlled video with sound at 720p or 1080p",
-        inputModalities: ["text", "image"],
+        description:
+            "Keyframe-controlled video with sound at 720p or 1080p; also accepts reference images and videos",
+        inputModalities: ["text", "image", "video"],
         outputModalities: ["video", "audio"],
-        videoCapabilities: ["start_frame", "end_frame", "audio_output"],
+        videoCapabilities: [
+            "start_frame",
+            "end_frame",
+            "audio_output",
+            "reference_images",
+            "reference_videos",
+        ],
         maxReferenceImages: 2, // Video keyframe slots: start + end.
         minDuration: 2,
         maxDuration: 15,
@@ -820,11 +828,18 @@ const IMAGE_BASE_SERVICES = {
         resolutions: ["480p", "720p", "1080p"],
         title: "Wan 3.0",
         description:
-            "Five-second video from text or a start image with optional audio at 480p, 720p, or 1080p",
-        inputModalities: ["text", "image"],
+            "Five-second video from text, start/end frames, or reference media with optional audio at 480p, 720p, or 1080p",
+        inputModalities: ["text", "image", "video", "audio"],
         outputModalities: ["video", "audio"],
-        videoCapabilities: ["start_frame", "audio_output"],
-        maxReferenceImages: 1, // Video keyframe slots: start only.
+        videoCapabilities: [
+            "start_frame",
+            "end_frame",
+            "audio_output",
+            "reference_images",
+            "reference_videos",
+            "reference_audios",
+        ],
+        maxReferenceImages: 2, // Video keyframe slots: start + end.
         minDuration: 5,
         maxDuration: 5,
         defaultDuration: 5,


### PR DESCRIPTION
Fixes #14021

## Summary
- route `wan-pro` across T2V, I2V, and Replicate Wan 2.7 R2V while preserving the public model ID
- route `wan-3.0` across T2V, I2V, and Fal Wan 3.0 Prime R2V
- forward Wan 3.0 `image[1]` as `end_image_url` and advertise end-frame/reference capabilities
- reject frame + reference combinations explicitly
- enforce Wan 2.7 R2V's 2–10s duration window while keeping T2V/I2V up to 15s
- preserve tracking, response shape, and existing lifecycle behavior

## Provider contract details
- Replicate R2V uses `wan-video/wan-2.7-r2v` with `reference_images` / `reference_videos`
- Fal Prime R2V uses `alibaba/wan-3.0-prime/reference-to-video` with the provider schema fields `reference_image_urls`, `reference_video_urls`, and `reference_audio_urls`
- Wan 3.0 R2V also forwards resolution, aspect ratio, duration, audio, safety/prompt settings, and seed

## Billing coverage
Added a test that exercises the real cost selector for Wan 2.7 1080p:
- T2V: $0.10/s
- I2V: $0.15/s
- R2V: $0.10/s

This verifies that R2V reference media does not trigger the I2V 1080p surcharge.

## Validation
- `npx vitest run test/image/wanVideoModel.test.ts test/image/wan3FalVideoModel.test.ts test/image/videoFrameValidation.test.ts test/model-registry.test.ts` — 58/58 passed
- `npm run typecheck` — passed
- `npx biome check --write` on the six modified files — passed
- `git diff --check` — clean

The implementation stays within the two existing Wan adapters and registry/tests; no new public endpoints or generic routing layer are introduced.
