### PR TITLE
feat: add Discord BYOP bot with device authorization flow

### DIFF
--- a/apps/discord-byop-bot/.gitignore
+++ b/apps/discord-byop-bot/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+data/tokens.json
+.env

--- a/apps/discord-byop-bot/README.md
+++ b/apps/discord-byop-bot/README.md
@@ -1,0 +1,90 @@
+# discord-byop-bot
+
+A Discord bot that demonstrates **Bring Your Own Pollen** (BYOP) device authorization. Users connect their Pollinations wallet directly from Discord — no API key pasting required.
+
+## How it works
+
+1. User runs `/connect` in Discord.
+2. Bot starts a device authorization flow and DMs the user a short code + verification URL.
+3. User opens the URL in their browser, signs in with GitHub, and approves the bot.
+4. Bot receives a scoped user token (`sk_…`) and stores it in `data/tokens.json`.
+5. `/ask` and `/imagine` commands spend Pollen from the connected user's balance.
+6. `/disconnect` removes the stored token.
+
+Tokens survive bot restarts. Expired or revoked tokens are detected on the next API call and the user is prompted to re-authorize.
+
+## Slash commands
+
+| Command | Description |
+|---|---|
+| `/connect` | Link your Pollinations account (device flow) |
+| `/disconnect` | Remove your stored authorization |
+| `/ask <prompt>` | Generate text using your Pollen |
+| `/imagine <prompt>` | Generate an image using your Pollen |
+
+## Setup
+
+### 1. Create a Discord application
+
+- Go to the [Discord developer portal](https://discord.com/developers/applications) → **New Application**.
+- Under **Bot**, create a bot and copy its token (`DISCORD_TOKEN`).
+- Note the **Application ID** (`CLIENT_ID`).
+- Under **OAuth2 → URL Generator**, select scopes `bot` + `applications.commands`, permission `Send Messages`, and invite the bot to your server.
+
+### 2. Create a Pollinations App Key
+
+- Sign in at <https://enter.pollinations.ai/keys> → **Create New App Key**.
+- Copy the `pk_…` key — this is your `APP_KEY`.
+- No redirect URI is needed for the device flow.
+
+### 3. Install dependencies
+
+```bash
+npm install
+```
+
+### 4. Register slash commands
+
+```bash
+DISCORD_TOKEN=... CLIENT_ID=... node register.js
+```
+
+For instant propagation during development, add `GUILD_ID=<your-server-id>`.
+
+### 5. Run the bot
+
+```bash
+DISCORD_TOKEN=... CLIENT_ID=... APP_KEY=pk_... node bot.js
+```
+
+Environment variables:
+
+| Variable | Required | Description |
+|---|---|---|
+| `DISCORD_TOKEN` | Yes | Bot token from the Discord developer portal |
+| `CLIENT_ID` | Yes | Discord application ID |
+| `APP_KEY` | Yes | Pollinations publishable key (`pk_…`) |
+| `ENTER_URL` | No | Auth base URL (default: `https://enter.pollinations.ai`) |
+| `GEN_URL` | No | Generation base URL (default: `https://gen.pollinations.ai`) |
+
+## Reproducible demo (no Discord required)
+
+`test.js` runs the full connect → use → disconnect flow against the real Pollinations API without needing a Discord server:
+
+```bash
+APP_KEY=pk_... node test.js
+```
+
+The script:
+1. Starts a device flow and prints the verification URL + user code.
+2. Polls until you approve in your browser.
+3. Generates text using the issued token.
+4. Generates an image using the issued token.
+5. Revokes the token.
+
+## Privacy
+
+- User tokens are stored only in `data/tokens.json` on the bot's host (gitignored).
+- The authorization code is sent via DM (private) when possible; otherwise via an ephemeral channel message visible only to the user.
+- Token values never appear in public messages or logs.
+- Users can revoke issued tokens at any time from the [Pollinations dashboard](https://enter.pollinations.ai/keys).

--- a/apps/discord-byop-bot/bot.js
+++ b/apps/discord-byop-bot/bot.js
@@ -1,0 +1,320 @@
+/**
+ * Discord BYOP bot — demonstrates Pollinations device authorization flow.
+ *
+ * Users connect their Pollinations wallet via `/connect` (device flow — no API
+ * key pasting). Once connected, `/ask` and `/imagine` spend from their own
+ * Pollen balance. `/disconnect` removes the stored credential.
+ *
+ * Token persistence: data/tokens.json (gitignored). The file maps Discord user
+ * IDs to { token, connectedAt } so connections survive restarts.
+ *
+ * Required env vars:
+ *   DISCORD_TOKEN   — bot token from the Discord developer portal
+ *   CLIENT_ID       — Discord application (client) ID
+ *   APP_KEY         — Pollinations publishable key (pk_…) for attribution
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client, GatewayIntentBits, MessageFlags } from "discord.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const ENTER_URL = process.env.ENTER_URL ?? "https://enter.pollinations.ai";
+const GEN_URL = process.env.GEN_URL ?? "https://gen.pollinations.ai";
+const APP_KEY = process.env.APP_KEY ?? "";
+const DISCORD_TOKEN = process.env.DISCORD_TOKEN ?? "";
+const TOKEN_FILE = join(__dirname, "data", "tokens.json");
+
+// ── Token store ──────────────────────────────────────────────────────────────
+
+function loadTokens() {
+    if (!existsSync(TOKEN_FILE)) return {};
+    try {
+        return JSON.parse(readFileSync(TOKEN_FILE, "utf8"));
+    } catch {
+        return {};
+    }
+}
+
+function saveTokens(map) {
+    mkdirSync(dirname(TOKEN_FILE), { recursive: true });
+    writeFileSync(TOKEN_FILE, JSON.stringify(map, null, 2));
+}
+
+const tokenStore = loadTokens();
+
+function storeToken(userId, token) {
+    tokenStore[userId] = { token, connectedAt: new Date().toISOString() };
+    saveTokens(tokenStore);
+}
+
+function removeToken(userId) {
+    delete tokenStore[userId];
+    saveTokens(tokenStore);
+}
+
+// ── Pollinations device flow ─────────────────────────────────────────────────
+
+async function startDeviceFlow() {
+    const res = await fetch(`${ENTER_URL}/api/device/code`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({ client_id: APP_KEY }).toString(),
+    });
+    if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        throw new Error(`Device flow start failed (${res.status}): ${text}`);
+    }
+    return res.json();
+}
+
+async function pollForToken(deviceCode, signal) {
+    let intervalMs = 5000;
+    while (true) {
+        if (signal?.aborted) throw new Error("Cancelled");
+        await new Promise((r) => setTimeout(r, intervalMs));
+        if (signal?.aborted) throw new Error("Cancelled");
+
+        const res = await fetch(`${ENTER_URL}/api/oauth/token`, {
+            method: "POST",
+            headers: { "Content-Type": "application/x-www-form-urlencoded" },
+            body: new URLSearchParams({
+                grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+                device_code: deviceCode,
+                client_id: APP_KEY,
+            }).toString(),
+            signal,
+        });
+
+        const body = await res.json().catch(() => ({}));
+
+        if (res.ok && body.access_token) return body.access_token;
+        if (body.error === "authorization_pending") continue;
+        if (body.error === "slow_down") {
+            intervalMs += 5000;
+            continue;
+        }
+        if (body.error === "expired_token")
+            throw new Error("Code expired — run /connect again.");
+        if (body.error === "access_denied")
+            throw new Error("Authorization denied.");
+        throw new Error(
+            body.error_description || body.error || "Unknown error",
+        );
+    }
+}
+
+async function getUserInfo(token) {
+    const res = await fetch(`${ENTER_URL}/api/device/userinfo`, {
+        headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) return null;
+    return res.json();
+}
+
+// ── Pollinations generation ──────────────────────────────────────────────────
+
+async function generateText(token, prompt) {
+    const res = await fetch(`${GEN_URL}/v1/chat/completions`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+            model: "openai-fast",
+            messages: [{ role: "user", content: prompt }],
+        }),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+        if (res.status === 401)
+            throw new Error("Token expired — run /connect again.");
+        throw new Error(
+            data.error?.message || `Generation failed (${res.status})`,
+        );
+    }
+    return data.choices?.[0]?.message?.content ?? JSON.stringify(data);
+}
+
+async function generateImage(token, prompt) {
+    const encoded = encodeURIComponent(prompt);
+    const url = `${GEN_URL}/image/${encoded}?model=flux&nologo=true`;
+    const res = await fetch(url, {
+        method: "HEAD",
+        headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) {
+        if (res.status === 401)
+            throw new Error("Token expired — run /connect again.");
+        throw new Error(`Image generation failed (${res.status})`);
+    }
+    // Return the final URL after redirects (which is the image URL)
+    return res.url || url;
+}
+
+// ── Command handlers ─────────────────────────────────────────────────────────
+
+async function handleConnect(interaction) {
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+    if (tokenStore[interaction.user.id]) {
+        await interaction.editReply(
+            "Already connected. Use `/disconnect` first if you want to re-authorize.",
+        );
+        return;
+    }
+
+    let code;
+    try {
+        code = await startDeviceFlow();
+    } catch (err) {
+        await interaction.editReply(
+            `Failed to start authorization: ${err.message}`,
+        );
+        return;
+    }
+
+    const expireMin = Math.round((code.expires_in ?? 300) / 60);
+    const authMessage =
+        `**Connect your Pollinations account**\n\n` +
+        `1. Visit: ${code.verification_uri_complete ?? `${ENTER_URL}/device`}\n` +
+        `2. Enter code: \`${code.user_code}\`\n\n` +
+        `This code expires in ${expireMin} minutes. Waiting…`;
+
+    // Try to DM the code so it stays private
+    let dmSent = false;
+    try {
+        const dm = await interaction.user.createDM();
+        await dm.send(authMessage);
+        dmSent = true;
+    } catch {
+        // DMs disabled — fall through to ephemeral reply
+    }
+
+    await interaction.editReply(
+        dmSent
+            ? "Check your DMs for the authorization link. Waiting for approval… ⏳"
+            : authMessage,
+    );
+
+    // Abort polling when the interaction webhook expires (~14 min)
+    const abort = new AbortController();
+    const timeout = setTimeout(() => abort.abort(), 14 * 60 * 1000);
+
+    try {
+        const token = await pollForToken(code.device_code, abort.signal);
+        clearTimeout(timeout);
+
+        storeToken(interaction.user.id, token);
+
+        const info = await getUserInfo(token).catch(() => null);
+        const username =
+            info?.preferred_username ?? info?.name ?? "your account";
+        await interaction.editReply(
+            `✅ Connected as **${username}**! Your Pollen will be used for \`/ask\` and \`/imagine\`.`,
+        );
+    } catch (err) {
+        clearTimeout(timeout);
+        await interaction.editReply(`❌ ${err.message}`).catch(() => {});
+    }
+}
+
+async function handleDisconnect(interaction) {
+    if (!tokenStore[interaction.user.id]) {
+        await interaction.reply({
+            content:
+                "No Pollinations account connected. Use `/connect` to link one.",
+            flags: MessageFlags.Ephemeral,
+        });
+        return;
+    }
+    removeToken(interaction.user.id);
+    await interaction.reply({
+        content: "✅ Disconnected. Your Pollinations token has been removed.",
+        flags: MessageFlags.Ephemeral,
+    });
+}
+
+async function handleAsk(interaction) {
+    const entry = tokenStore[interaction.user.id];
+    if (!entry) {
+        await interaction.reply({
+            content: "Connect first with `/connect`.",
+            flags: MessageFlags.Ephemeral,
+        });
+        return;
+    }
+
+    const prompt = interaction.options.getString("prompt", true);
+    await interaction.deferReply();
+
+    try {
+        const text = await generateText(entry.token, prompt);
+        const truncated = text.length > 1900 ? `${text.slice(0, 1900)}…` : text;
+        await interaction.editReply(truncated);
+    } catch (err) {
+        if (err.message.includes("expired")) removeToken(interaction.user.id);
+        await interaction.editReply(`❌ ${err.message}`);
+    }
+}
+
+async function handleImagine(interaction) {
+    const entry = tokenStore[interaction.user.id];
+    if (!entry) {
+        await interaction.reply({
+            content: "Connect first with `/connect`.",
+            flags: MessageFlags.Ephemeral,
+        });
+        return;
+    }
+
+    const prompt = interaction.options.getString("prompt", true);
+    await interaction.deferReply();
+
+    try {
+        const imageUrl = await generateImage(entry.token, prompt);
+        await interaction.editReply({ content: imageUrl });
+    } catch (err) {
+        if (err.message.includes("expired")) removeToken(interaction.user.id);
+        await interaction.editReply(`❌ ${err.message}`);
+    }
+}
+
+// ── Discord client ───────────────────────────────────────────────────────────
+
+const client = new Client({ intents: [GatewayIntentBits.Guilds] });
+
+client.once("ready", (c) => {
+    console.log(`Logged in as ${c.user.tag}`);
+});
+
+client.on("interactionCreate", async (interaction) => {
+    if (!interaction.isChatInputCommand()) return;
+
+    switch (interaction.commandName) {
+        case "connect":
+            await handleConnect(interaction).catch(console.error);
+            break;
+        case "disconnect":
+            await handleDisconnect(interaction).catch(console.error);
+            break;
+        case "ask":
+            await handleAsk(interaction).catch(console.error);
+            break;
+        case "imagine":
+            await handleImagine(interaction).catch(console.error);
+            break;
+        default:
+            break;
+    }
+});
+
+if (!DISCORD_TOKEN) {
+    console.error("DISCORD_TOKEN is required");
+    process.exit(1);
+}
+
+client.login(DISCORD_TOKEN);

--- a/apps/discord-byop-bot/package-lock.json
+++ b/apps/discord-byop-bot/package-lock.json
@@ -1,0 +1,317 @@
+{
+  "name": "discord-byop-bot",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "discord-byop-bot",
+      "version": "1.0.0",
+      "dependencies": {
+        "discord.js": "^14.19.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@discordjs/builders": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.14.1.tgz",
+      "integrity": "sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/shapeshift": "^4.0.0",
+        "discord-api-types": "^0.38.40",
+        "fast-deep-equal": "^3.1.3",
+        "ts-mixer": "^6.0.4",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/collection": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.11.0"
+      }
+    },
+    "node_modules/@discordjs/formatters": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.2.tgz",
+      "integrity": "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.3.tgz",
+      "integrity": "sha512-wvOylxNYJkwKjctS/Mn5GP1w9r3/rzyH+ThD1JlAca6zEdlHs8QWBBUQJpU5Q+W6DoIj/Ljh1IPlZs7hTU+UAg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.1",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/async-queue": "^1.5.3",
+        "@sapphire/snowflake": "^3.5.5",
+        "@vladfrangu/async_event_emitter": "^2.4.6",
+        "discord-api-types": "^0.38.50",
+        "magic-bytes.js": "^1.13.0",
+        "tslib": "^2.6.3",
+        "undici": "^6.27.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/util": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
+      "integrity": "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
+      "integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/rest": "^2.5.1",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@types/ws": "^8.5.10",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "^0.38.1",
+        "tslib": "^2.6.2",
+        "ws": "^8.17.0"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@sapphire/async-queue": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+      "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sapphire/shapeshift": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
+      "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=v16"
+      }
+    },
+    "node_modules/@sapphire/snowflake": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
+      "integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.4.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
+      "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vladfrangu/async_event_emitter": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
+      "integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/discord-api-types": {
+      "version": "0.38.54",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.54.tgz",
+      "integrity": "sha512-3704EKdPtVl0Mozoe6uBJQ8GNmUkH8c81nfXkdSBx+Um8GN3FI/003uTY0Pg0A4KjL8g2Q+4v5cHR247kv6vwA==",
+      "license": "MIT",
+      "workspaces": [
+        "scripts/actions/documentation"
+      ]
+    },
+    "node_modules/discord.js": {
+      "version": "14.27.0",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.27.0.tgz",
+      "integrity": "sha512-qHbFlFG2N7y3LjPySYsL6A1+BnX6bkTVgo842EX0CqVPk/KTMwZkojPHEXKsQUpWZNyz5BISNHK1cPpQw0+m4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/builders": "^1.14.1",
+        "@discordjs/collection": "1.5.3",
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/rest": "^2.6.2",
+        "@discordjs/util": "^1.2.0",
+        "@discordjs/ws": "^1.2.3",
+        "@sapphire/snowflake": "3.5.5",
+        "discord-api-types": "^0.38.49",
+        "fast-deep-equal": "3.1.3",
+        "lodash.snakecase": "4.1.1",
+        "magic-bytes.js": "^1.13.0",
+        "tslib": "^2.6.3",
+        "undici": "^6.27.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "license": "MIT"
+    },
+    "node_modules/magic-bytes.js": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.1.tgz",
+      "integrity": "sha512-x5sn4UX2k5gCWlcfmoFwG4TPie8+dctESyqOBdhB5p6MsgWXdBKGmt9nXPObj/JI50TTL928lc5Yt1WntMn1bw==",
+      "license": "MIT"
+    },
+    "node_modules/ts-mixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/apps/discord-byop-bot/package.json
+++ b/apps/discord-byop-bot/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "discord-byop-bot",
+  "version": "1.0.0",
+  "description": "Discord bot demonstrating Pollinations Bring Your Own Pollen device authorization flow",
+  "type": "module",
+  "scripts": {
+    "register": "node register.js",
+    "start": "node bot.js",
+    "test": "node test.js"
+  },
+  "dependencies": {
+    "discord.js": "^14.19.2"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/apps/discord-byop-bot/register.js
+++ b/apps/discord-byop-bot/register.js
@@ -1,0 +1,65 @@
+/**
+ * Register slash commands with Discord.
+ * Run once (or whenever commands change):
+ *
+ *   CLIENT_ID=... DISCORD_TOKEN=... node register.js
+ *
+ * To register to a single guild only (instant propagation):
+ *
+ *   GUILD_ID=... CLIENT_ID=... DISCORD_TOKEN=... node register.js
+ */
+
+import { REST, Routes, SlashCommandBuilder } from "discord.js";
+
+const DISCORD_TOKEN = process.env.DISCORD_TOKEN ?? "";
+const CLIENT_ID = process.env.CLIENT_ID ?? "";
+const GUILD_ID = process.env.GUILD_ID ?? "";
+
+if (!DISCORD_TOKEN || !CLIENT_ID) {
+    console.error("DISCORD_TOKEN and CLIENT_ID are required");
+    process.exit(1);
+}
+
+const commands = [
+    new SlashCommandBuilder()
+        .setName("connect")
+        .setDescription(
+            "Link your Pollinations account via device authorization",
+        ),
+    new SlashCommandBuilder()
+        .setName("disconnect")
+        .setDescription("Remove your stored Pollinations authorization"),
+    new SlashCommandBuilder()
+        .setName("ask")
+        .setDescription("Ask a question using your Pollinations Pollen")
+        .addStringOption((opt) =>
+            opt
+                .setName("prompt")
+                .setDescription("Your question or prompt")
+                .setRequired(true),
+        ),
+    new SlashCommandBuilder()
+        .setName("imagine")
+        .setDescription("Generate an image using your Pollinations Pollen")
+        .addStringOption((opt) =>
+            opt
+                .setName("prompt")
+                .setDescription("Describe the image")
+                .setRequired(true),
+        ),
+].map((c) => c.toJSON());
+
+const rest = new REST().setToken(DISCORD_TOKEN);
+
+const route = GUILD_ID
+    ? Routes.applicationGuildCommands(CLIENT_ID, GUILD_ID)
+    : Routes.applicationCommands(CLIENT_ID);
+
+try {
+    console.log(`Registering ${commands.length} slash commands…`);
+    await rest.put(route, { body: commands });
+    console.log("Done.");
+} catch (err) {
+    console.error(err);
+    process.exit(1);
+}

--- a/apps/discord-byop-bot/test.js
+++ b/apps/discord-byop-bot/test.js
@@ -1,0 +1,183 @@
+/**
+ * Reproducible connect → use → disconnect demo (no Discord required).
+ *
+ * Demonstrates the full BYOP device flow against the real Pollinations API:
+ *   1. Start device flow → print verification URL + user code
+ *   2. Wait for user to approve in browser
+ *   3. Call text generation with the issued token
+ *   4. Call image generation with the issued token
+ *   5. Revoke (disconnect) the token via the account keys API
+ *
+ * Run:
+ *   APP_KEY=pk_... node test.js
+ */
+
+const ENTER_URL = process.env.ENTER_URL ?? "https://enter.pollinations.ai";
+const GEN_URL = process.env.GEN_URL ?? "https://gen.pollinations.ai";
+const APP_KEY = process.env.APP_KEY ?? "";
+
+if (!APP_KEY) {
+    console.error("APP_KEY=pk_... is required");
+    process.exit(1);
+}
+
+// ── Step 1: Start device flow ────────────────────────────────────────────────
+
+console.log("Step 1: Starting device authorization flow…\n");
+
+const codeRes = await fetch(`${ENTER_URL}/api/device/code`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ client_id: APP_KEY }).toString(),
+});
+
+if (!codeRes.ok) {
+    console.error("Failed to start device flow:", await codeRes.text());
+    process.exit(1);
+}
+
+const code = await codeRes.json();
+
+console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+console.log(
+    `  Visit: ${code.verification_uri_complete ?? `${ENTER_URL}/device`}`,
+);
+console.log(`  Code:  ${code.user_code}`);
+console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+console.log("\nWaiting for authorization… (approve in your browser)\n");
+
+// ── Step 2: Poll for token ───────────────────────────────────────────────────
+
+let intervalMs = Math.max(code.interval ?? 5, 5) * 1000;
+const expiresAt = Date.now() + (code.expires_in ?? 300) * 1000;
+let accessToken = null;
+
+while (Date.now() < expiresAt) {
+    await new Promise((r) => setTimeout(r, intervalMs));
+
+    const tokenRes = await fetch(`${ENTER_URL}/api/oauth/token`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+            grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+            device_code: code.device_code,
+            client_id: APP_KEY,
+        }).toString(),
+    });
+
+    const body = await tokenRes.json().catch(() => ({}));
+
+    if (tokenRes.ok && body.access_token) {
+        accessToken = body.access_token;
+        break;
+    }
+    if (body.error === "authorization_pending") {
+        process.stdout.write(".");
+        continue;
+    }
+    if (body.error === "slow_down") {
+        intervalMs += 5000;
+        continue;
+    }
+    console.error(
+        "\nDevice flow error:",
+        body.error,
+        body.error_description ?? "",
+    );
+    process.exit(1);
+}
+
+if (!accessToken) {
+    console.error("\nDevice code expired before authorization.");
+    process.exit(1);
+}
+
+// Identify the user — but never log the token itself
+const userRes = await fetch(`${ENTER_URL}/api/device/userinfo`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+});
+const userInfo = userRes.ok ? await userRes.json() : {};
+console.log(
+    `\n✅ Authorized as: ${userInfo.preferred_username ?? userInfo.name ?? userInfo.sub ?? "unknown"}\n`,
+);
+
+// ── Step 3: Generate text ────────────────────────────────────────────────────
+
+console.log("Step 3: Generating text (spends your Pollen)…\n");
+
+const textRes = await fetch(`${GEN_URL}/v1/chat/completions`, {
+    method: "POST",
+    headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({
+        model: "openai-fast",
+        messages: [
+            {
+                role: "user",
+                content: "Say hello from Pollinations in one sentence.",
+            },
+        ],
+    }),
+});
+
+const textData = await textRes.json().catch(() => ({}));
+if (!textRes.ok) {
+    console.error("Text generation failed:", textData);
+    process.exit(1);
+}
+const reply = textData.choices?.[0]?.message?.content ?? "(empty)";
+console.log("Response:", reply, "\n");
+
+// ── Step 4: Generate image ───────────────────────────────────────────────────
+
+console.log("Step 4: Generating image (spends your Pollen)…\n");
+
+const prompt = "a sunflower field at sunset";
+const imageUrl = `${GEN_URL}/image/${encodeURIComponent(prompt)}?model=flux&nologo=true`;
+const imageRes = await fetch(imageUrl, {
+    method: "HEAD",
+    headers: { Authorization: `Bearer ${accessToken}` },
+});
+if (!imageRes.ok) {
+    console.error("Image generation failed:", imageRes.status);
+    process.exit(1);
+}
+console.log("Image URL:", imageRes.url || imageUrl, "\n");
+
+// ── Step 5: Disconnect ───────────────────────────────────────────────────────
+
+console.log("Step 5: Disconnect — revoking the token…\n");
+
+// List keys to find the one we just issued
+const keysRes = await fetch(`${ENTER_URL}/account/keys`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+});
+if (keysRes.ok) {
+    const keys = await keysRes.json().catch(() => []);
+    const ours = Array.isArray(keys)
+        ? keys.find(
+              (k) =>
+                  k.token === accessToken ||
+                  k.prefix === accessToken.slice(0, 12),
+          )
+        : null;
+    if (ours?.id) {
+        const del = await fetch(`${ENTER_URL}/account/keys/${ours.id}`, {
+            method: "DELETE",
+            headers: { Authorization: `Bearer ${accessToken}` },
+        });
+        console.log(
+            del.ok ? "✅ Token revoked." : `Revoke response: ${del.status}`,
+        );
+    } else {
+        console.log(
+            "Token will expire naturally (revocation endpoint unavailable).",
+        );
+    }
+} else {
+    console.log("Token will expire naturally (could not list keys).");
+}
+
+console.log("\nDemo complete.");


### PR DESCRIPTION
## Summary

- Adds `apps/discord-byop-bot/` — a reusable, self-contained Discord bot that demonstrates **Bring Your Own Pollen** via the OAuth device flow.
- Users run `/connect` and are DM'd a short code + URL; they approve in their browser with no API key pasting.
- `/ask <prompt>` and `/imagine <prompt>` generate text and images spending the connected user's Pollen via their scoped `sk_` token.
- `/disconnect` removes the stored token.
- `register.js` registers the four slash commands via Discord's REST API.
- `test.js` provides a fully reproducible connect → text generation → image generation → disconnect demo that runs against the live Pollinations API without needing a Discord server.

## Design

- Zero-dependency on the Pollinations SDK — raw `fetch` calls so the code is readable and portable.
- Tokens stored in `data/tokens.json` (gitignored): `{ discordUserId: { token, connectedAt } }` — survives restarts.
- Authorization code is sent via DM first (private); ephemeral channel message fallback if DMs are disabled.
- Token values never appear in public messages or logs.
- Expired tokens detected on next API call; user prompted to re-authorize.
- App Key (`pk_…`) passed as `client_id` to attribute usage and enable developer earnings.

## Test plan

- [ ] `node register.js` — registers commands in Discord
- [ ] `node bot.js` — starts the bot
- [ ] `/connect` in Discord → DM received → approve in browser → bot confirms with Pollinations username
- [ ] `/ask hello` → AI response appears in channel
- [ ] `/imagine a sunset` → image URL appears in channel
- [ ] `/disconnect` → confirmation; subsequent `/ask` prompts reconnect
- [ ] Restart bot → `/ask` still works (token loaded from file)
- [ ] `APP_KEY=pk_... node test.js` — non-interactive demo completes

Fixes #14227

🤖 Generated with [Claude Code](https://claude.com/claude-code)