### PR TITLE
chore(apps): remove GimpToPolli listing

### DIFF
--- a/operations/app-management/app.json
+++ b/operations/app-management/app.json
@@ -754,27 +754,6 @@
     "screenshotUrl": "https://media.pollinations.ai/2e3b778c-335d-433c-87cb-40d0ab82eb2f"
   },
   {
-    "emoji": "🖼️",
-    "name": "GimpToPolli",
-    "url": "https://github.com/GermanIllan/pollinationsai",
-    "description": "### 🌸 App Submission: GimpToPolli - **App Name:** GimpToPolli - **Author / Developer:** [@GermanIllan](https://github.com/GermanIllan) - **Repository URL:** https://github.com/GermanIllan/pollination",
-    "language": "en",
-    "category": "image",
-    "platform": "web",
-    "githubUsername": "GermanIllan",
-    "githubUserId": "187320745",
-    "repositoryUrl": null,
-    "repositoryStars": null,
-    "discordUsername": "GermanIllan",
-    "other": null,
-    "submittedDate": "2026-08-08",
-    "issueUrl": "https://github.com/pollinations/pollinations/issues/13209",
-    "approvedDate": "2026-08-08",
-    "byop": true,
-    "requests24h": 0,
-    "screenshotUrl": "https://media.pollinations.ai/993630b2-ea1a-433e-ab6d-b44c22b83f70"
-  },
-  {
     "emoji": "🎮",
     "name": "NEON SHADOWS: CHRONICLES OF THE CORE",
     "url": "https://habitatai.biz/game",


### PR DESCRIPTION
- Removes GimpToPolli from the community app catalog.
- Its two Python entrypoints only open `https://pollinations.ai/` in the default browser and do not integrate the API.
- Keeps Orange City, the author’s actual Pollinations-powered GIMP plugin, listed.

Validation: `node operations/app-management/app.js validate` and Biome passed.