### PR TITLE
feat(apps): add Pollinations AI GIMP 3 plug-in with BYOP auth

### DIFF
--- a/apps/gimp-plugin/README.md
+++ b/apps/gimp-plugin/README.md
@@ -1,0 +1,137 @@
+# Pollinations AI — GIMP 3 Plug-in
+
+Generate and edit images inside GIMP using the [Pollinations AI](https://pollinations.ai/) API.
+Each user authenticates through their own Pollinations account via the BYOP device-flow — no API
+key is ever typed into GIMP.
+
+## Features
+
+- **Connect Account** — one-time browser authorization; token is stored locally and survives GIMP restarts.
+- **Generate Image** — pick any image model loaded at runtime from `/image/models`, enter a prompt, and receive the result as a new GIMP image or an additional layer.
+- **Edit with AI** — send the active layer to an image-to-image model (e.g. FLUX Kontext) and receive the result as a new layer; the source layer is never modified.
+- **Disconnect** — removes the stored token at any time.
+
+Model capabilities (whether a model accepts image input) are read from the API, so controls are shown or hidden automatically — nothing is hardcoded.
+
+## Requirements
+
+| Requirement | Notes |
+|---|---|
+| GIMP 3.0 or later | Python-Fu / GObject-Introspection enabled |
+| Python 3.10 or later | Bundled with GIMP 3 on all platforms |
+| Pollinations account | Free at [pollinations.ai](https://pollinations.ai/) |
+| Pollen balance | Free Pollen covers standard models; paid models (FLUX Kontext, FLUX.2 Pro) require a Paid Pollen balance |
+
+No third-party Python packages are needed.
+
+## Installation
+
+GIMP 3 loads plug-ins from a directory whose name matches the plug-in filename.
+Install by copying the `pollinations_gimp` folder to your platform's plug-in directory.
+
+### Linux
+
+```bash
+PLUGIN_DIR="$HOME/.config/GIMP/3.0/plug-ins/pollinations_gimp"
+mkdir -p "$PLUGIN_DIR"
+cp apps/gimp-plugin/pollinations_gimp.py "$PLUGIN_DIR/"
+chmod +x "$PLUGIN_DIR/pollinations_gimp.py"
+```
+
+### macOS
+
+```bash
+PLUGIN_DIR="$HOME/Library/Application Support/GIMP/3.0/plug-ins/pollinations_gimp"
+mkdir -p "$PLUGIN_DIR"
+cp apps/gimp-plugin/pollinations_gimp.py "$PLUGIN_DIR/"
+chmod +x "$PLUGIN_DIR/pollinations_gimp.py"
+```
+
+### Windows
+
+1. Open File Explorer and navigate to `%APPDATA%\GIMP\3.0\plug-ins\`.
+2. Create a folder named `pollinations_gimp`.
+3. Copy `pollinations_gimp.py` into that folder.
+
+GIMP on Windows uses its bundled Python interpreter; no separate installation is needed.
+
+### Restart GIMP
+
+After installation (or after upgrading the plug-in) restart GIMP.
+The menu **Filters ▸ Pollinations AI** should appear.
+
+## Usage
+
+### 1. Connect your Pollinations account
+
+Go to **Filters ▸ Pollinations AI ▸ Connect Account…**
+
+A dialog appears showing:
+- A verification URL (`enter.pollinations.ai/device`)
+- A short approval code
+
+Click **Open Browser**. Approve the plug-in in the browser tab that opens.
+The dialog detects approval automatically and closes.
+Your token is saved to `~/.config/GIMP/3.0/pollinations/token.json` (Linux/macOS)
+or the equivalent Windows path.
+
+### 2. Generate an image
+
+Go to **Filters ▸ Pollinations AI ▸ Generate Image…**
+
+- **Model** — dropdown populated at runtime from the Pollinations API.
+- **Prompt** — describe the image you want.
+- **Width / Height** — output dimensions (default matches the open canvas, or 1024 × 1024).
+- **Insert as new layer** — checked by default when a canvas is open; uncheck to open the result as a standalone image.
+
+### 3. Edit the active layer
+
+Open an image, select a layer, then go to **Filters ▸ Pollinations AI ▸ Edit with AI…**
+
+Only models that advertise image input (e.g. FLUX Kontext, FLUX.2 Pro) are listed.
+Enter a plain-English edit instruction and click **Generate**.
+The edited result is added as a new layer above the original; nothing is overwritten.
+
+### 4. Disconnect
+
+**Filters ▸ Pollinations AI ▸ Disconnect** removes the saved token from your computer.
+
+## App Key
+
+The plug-in ships with a placeholder App Key (`pk_gimp_plugin`) for attribution.
+If you maintain a fork or distribution of this plug-in, replace `APP_KEY` in
+`pollinations_gimp.py` with your own publishable key from
+[enter.pollinations.ai/keys](https://enter.pollinations.ai/keys).
+
+## Error reference
+
+| Message | Cause | Fix |
+|---|---|---|
+| "Not connected" | No stored token | Run Connect Account |
+| "Could not load the model list" | Network error | Check internet, try again |
+| "No image-editing models available" | No Paid Pollen balance | Add balance at enter.pollinations.ai |
+| "HTTP 401" | Token expired | Disconnect then Connect Account again |
+| "HTTP 402" | Insufficient Pollen | Add balance at enter.pollinations.ai |
+
+## Development
+
+```bash
+# Run the unit tests (no GIMP or network required)
+python -m pytest apps/gimp-plugin/tests/ -v
+
+# Or with the standard library runner
+python -m unittest discover -s apps/gimp-plugin/tests -v
+```
+
+Tests cover token persistence, model filtering, URL encoding, and data-URI construction.
+The GIMP API calls and GTK dialogs are excluded from automated tests; see the
+end-to-end demonstration section below.
+
+## End-to-end demonstration
+
+1. Install into GIMP 3 as described above.
+2. Open **Filters ▸ Pollinations AI ▸ Connect Account…** and authorize in the browser.
+3. With a blank canvas open, run **Generate Image…**, choose `flux`, and enter `a sunset over mountains`.
+4. A new layer "Pollinations: a sunset over mountains" appears on the canvas.
+5. With that layer selected, run **Edit with AI…**, choose `kontext`, and enter `make the mountains snow-capped`.
+6. A new layer "AI edit: make the mountains snow-capped" appears above the original.

--- a/apps/gimp-plugin/pollinations_gimp.py
+++ b/apps/gimp-plugin/pollinations_gimp.py
@@ -1,0 +1,754 @@
+#!/usr/bin/env python3
+"""
+Pollinations AI — GIMP 3 plug-in
+
+Brings Pollinations image generation and editing into GIMP with BYOP device-flow
+authorization.  Every user authenticates through their own Pollinations account;
+no API key is ever pasted into GIMP.
+
+Installation (place the whole directory at the plug-ins path for your platform):
+  Linux   : ~/.config/GIMP/3.0/plug-ins/pollinations_gimp/pollinations_gimp.py
+  macOS   : ~/Library/Application Support/GIMP/3.0/plug-ins/pollinations_gimp/pollinations_gimp.py
+  Windows : %APPDATA%\\GIMP\\3.0\\plug-ins\\pollinations_gimp\\pollinations_gimp.py
+
+The file must be executable:
+  chmod +x pollinations_gimp.py
+
+After restarting GIMP, the menu Filters ▸ Pollinations AI appears.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import sys
+import tempfile
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import webbrowser
+from pathlib import Path
+
+import gi
+
+gi.require_version("Gimp", "3.0")
+gi.require_version("GimpUi", "3.0")
+gi.require_version("Gtk", "3.0")
+gi.require_version("GLib", "2.0")
+gi.require_version("Gio", "2.0")
+
+from gi.repository import Gio, GimpUi, GLib, Gtk
+from gi.repository import Gimp  # noqa: E402  (must come after gi.require_version calls)
+
+# ── Public constants ──────────────────────────────────────────────────────────
+
+PLUGIN_VERSION = "1.0.0"
+
+ENTER_BASE = "https://enter.pollinations.ai"
+GEN_BASE = "https://gen.pollinations.ai"
+
+# Publishable App Key that identifies this plug-in for attribution and developer
+# earnings.  Obtain or replace your own at enter.pollinations.ai/keys.
+APP_KEY = "pk_gimp_plugin"
+
+POLL_INTERVAL_S = 5  # seconds between device-token polls
+
+# Token is stored per-user in the GIMP config directory so it survives restarts.
+_TOKEN_DIR = Path(GLib.get_user_config_dir()) / "GIMP" / "3.0" / "pollinations"
+_TOKEN_FILE = _TOKEN_DIR / "token.json"
+
+
+# ── Auth helpers ──────────────────────────────────────────────────────────────
+
+
+def _json_request(
+    url: str,
+    data: dict | None = None,
+    token: str | None = None,
+    method: str | None = None,
+) -> dict:
+    """Minimal JSON HTTP helper — no third-party dependencies required."""
+    body = json.dumps(data).encode() if data is not None else None
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+        method=method or ("POST" if body else "GET"),
+    )
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    with urllib.request.urlopen(req, timeout=20) as resp:
+        return json.loads(resp.read().decode())
+
+
+def load_token() -> str | None:
+    """Return the stored user sk_ token, or None if not connected."""
+    try:
+        payload = json.loads(_TOKEN_FILE.read_text())
+        return payload.get("access_token") or None
+    except Exception:
+        return None
+
+
+def save_token(token: str) -> None:
+    _TOKEN_DIR.mkdir(parents=True, exist_ok=True)
+    _TOKEN_FILE.write_text(json.dumps({"access_token": token}))
+
+
+def delete_token() -> None:
+    try:
+        _TOKEN_FILE.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def request_device_code() -> dict:
+    """Start a BYOP device-flow session and return the code response."""
+    return _json_request(
+        f"{ENTER_BASE}/api/device/code",
+        {"client_id": APP_KEY},
+    )
+
+
+def poll_device_token(device_code: str) -> str | None:
+    """
+    Poll for the user-authorized sk_ token.
+    Returns the token string when approved, None while still pending.
+    Raises on hard errors (expired code, network failure, etc.).
+    """
+    resp = _json_request(
+        f"{ENTER_BASE}/api/device/token",
+        {"device_code": device_code},
+    )
+    error = resp.get("error", "")
+    if error in ("authorization_pending", "slow_down"):
+        return None
+    if "access_token" in resp:
+        return resp["access_token"]
+    raise RuntimeError(resp.get("error_description") or error or "Unknown error")
+
+
+def get_userinfo(token: str) -> dict:
+    """Fetch the OIDC userinfo for a connected account."""
+    return _json_request(f"{ENTER_BASE}/api/device/userinfo", token=token)
+
+
+def fetch_models(token: str | None = None) -> list[dict]:
+    """
+    Fetch the image model catalogue from /image/models.
+    Returns a list of model dicts, each with at least 'id' and 'title'.
+    Falls back to an empty list on network errors.
+    """
+    try:
+        resp = _json_request(
+            f"{GEN_BASE}/image/models",
+            token=token,
+        )
+        if isinstance(resp, dict):
+            return resp.get("data", [])
+        return resp if isinstance(resp, list) else []
+    except Exception:
+        return []
+
+
+def models_with_image_input(models: list[dict]) -> list[dict]:
+    """Filter model list to those that accept an image as additional input."""
+    return [m for m in models if "image" in m.get("inputModalities", [])]
+
+
+# ── GIMP image I/O helpers ───────────────────────────────────────────────────
+
+
+def _load_result_into_gimp(
+    image_bytes: bytes,
+    target_image: "Gimp.Image | None",
+    layer_name: str,
+) -> None:
+    """
+    Load raw image bytes into GIMP.
+    target_image=None  → open as a new standalone image
+    target_image=image → insert as a new layer on top of that image
+    """
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as fh:
+        fh.write(image_bytes)
+        tmp_path = fh.name
+
+    try:
+        tmp_file = Gio.File.new_for_path(tmp_path)
+        loaded = Gimp.file_load(Gimp.RunMode.NONINTERACTIVE, tmp_file)
+
+        if target_image is None:
+            Gimp.display_new(loaded)
+        else:
+            src_layer = loaded.get_active_drawable()
+            new_layer = Gimp.Layer.new_from_drawable(src_layer, target_image)
+            new_layer.set_name(layer_name)
+            target_image.insert_layer(new_layer, None, -1)
+            Gimp.image_delete(loaded)
+            Gimp.displays_flush()
+    finally:
+        os.unlink(tmp_path)
+
+
+def _export_drawable_png_bytes(
+    image: "Gimp.Image",
+    drawable: "Gimp.Drawable",
+) -> bytes:
+    """
+    Export a GIMP drawable to PNG bytes via a temp file.
+    The image is not modified — a throwaway duplicate is flattened instead.
+    """
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as fh:
+        tmp_path = fh.name
+
+    try:
+        tmp_file = Gio.File.new_for_path(tmp_path)
+        # Duplicate so we can flatten without altering the source
+        dup_image = image.duplicate()
+        try:
+            dup_image.flatten()
+            flat = dup_image.get_active_drawable()
+            Gimp.file_overwrite(
+                Gimp.RunMode.NONINTERACTIVE,
+                dup_image,
+                [flat],
+                tmp_file,
+            )
+        finally:
+            Gimp.image_delete(dup_image)
+        return Path(tmp_path).read_bytes()
+    finally:
+        os.unlink(tmp_path)
+
+
+# ── Generation request ────────────────────────────────────────────────────────
+
+
+def generate_image(
+    prompt: str,
+    model: str,
+    token: str,
+    *,
+    width: int | None = None,
+    height: int | None = None,
+    input_image_b64: str | None = None,
+) -> bytes:
+    """
+    Call the Pollinations image API and return the raw image bytes.
+
+    If input_image_b64 is provided it is sent as a data URI in the 'image'
+    parameter — supported by models whose inputModalities include 'image'.
+    """
+    encoded_prompt = urllib.parse.quote(prompt, safe="")
+    url = f"{GEN_BASE}/image/{encoded_prompt}"
+
+    body: dict = {"model": model}
+    if width:
+        body["width"] = width
+    if height:
+        body["height"] = height
+    if input_image_b64:
+        body["image"] = f"data:image/png;base64,{input_image_b64}"
+
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode(),
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {token}",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        return resp.read()
+
+
+# ── GTK dialog helpers ────────────────────────────────────────────────────────
+
+
+def _message_dialog(
+    parent: "Gtk.Window | None",
+    message_type: Gtk.MessageType,
+    text: str,
+    secondary: str = "",
+) -> None:
+    dlg = Gtk.MessageDialog(
+        transient_for=parent,
+        modal=True,
+        message_type=message_type,
+        buttons=Gtk.ButtonsType.OK,
+        text=text,
+    )
+    if secondary:
+        dlg.format_secondary_text(secondary)
+    dlg.run()
+    dlg.destroy()
+
+
+def _error(parent: "Gtk.Window | None", msg: str) -> None:
+    _message_dialog(parent, Gtk.MessageType.ERROR, "Pollinations AI", msg)
+
+
+def _info(parent: "Gtk.Window | None", msg: str) -> None:
+    _message_dialog(parent, Gtk.MessageType.INFO, "Pollinations AI", msg)
+
+
+# ── Auth dialog ───────────────────────────────────────────────────────────────
+
+
+def run_auth_dialog() -> bool:
+    """
+    Run the BYOP device-flow dialog.
+    Opens a browser to the approval page and polls for the token.
+    Returns True when the token is saved, False on cancel.
+    """
+    try:
+        code_resp = request_device_code()
+    except Exception as exc:
+        _error(None, f"Could not reach Pollinations: {exc}")
+        return False
+
+    device_code = code_resp["device_code"]
+    user_code = code_resp.get("user_code", "")
+    verify_uri = code_resp.get("verification_uri", f"{ENTER_BASE}/device")
+    full_uri = code_resp.get("verification_uri_complete") or f"{verify_uri}?user_code={urllib.parse.quote(user_code)}"
+
+    dlg = GimpUi.Dialog(title="Connect Pollinations Account", role="pollinations-auth")
+    dlg.add_button("Cancel", Gtk.ResponseType.CANCEL)
+    dlg.set_border_width(12)
+    dlg.set_default_size(400, -1)
+
+    box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=10)
+    box.set_border_width(6)
+
+    instructions = Gtk.Label(xalign=0.0, use_markup=True)
+    instructions.set_markup(
+        "1. Click <b>Open Browser</b> to approve access for this plug-in.\n"
+        "2. If no browser opens, visit the URL below and enter the code."
+    )
+    box.pack_start(instructions, False, False, 0)
+
+    url_row = Gtk.Box(spacing=6)
+    url_entry = Gtk.Entry(text=verify_uri, editable=False, can_focus=False)
+    url_entry.set_hexpand(True)
+    open_btn = Gtk.Button(label="Open Browser")
+    open_btn.connect("clicked", lambda _btn: webbrowser.open(full_uri))
+    url_row.pack_start(url_entry, True, True, 0)
+    url_row.pack_start(open_btn, False, False, 0)
+    box.pack_start(url_row, False, False, 0)
+
+    code_lbl = Gtk.Label(xalign=0.0, use_markup=True)
+    code_lbl.set_markup(f"Approval code: <b><tt>{user_code}</tt></b>")
+    box.pack_start(code_lbl, False, False, 0)
+
+    status_lbl = Gtk.Label(label="Waiting for your approval in the browser…", xalign=0.0)
+    box.pack_start(status_lbl, False, False, 0)
+
+    spinner = Gtk.Spinner()
+    spinner.start()
+    box.pack_start(spinner, False, False, 0)
+
+    dlg.vbox.pack_start(box, True, True, 0)
+    dlg.show_all()
+
+    state: dict = {"token": None, "done": False}
+
+    def _poll():
+        while not state["done"]:
+            time.sleep(POLL_INTERVAL_S)
+            if state["done"]:
+                break
+            try:
+                tok = poll_device_token(device_code)
+                if tok:
+                    state["token"] = tok
+                    state["done"] = True
+                    GLib.idle_add(_on_approved)
+            except Exception:
+                # Hard error from the device endpoint — stop polling
+                state["done"] = True
+                GLib.idle_add(lambda: dlg.response(Gtk.ResponseType.CANCEL) or False)
+
+    def _on_approved():
+        spinner.stop()
+        status_lbl.set_text("Approved!")
+        dlg.response(Gtk.ResponseType.OK)
+        return False  # GLib.idle_add: do not reschedule
+
+    thread = threading.Thread(target=_poll, daemon=True)
+    thread.start()
+
+    response = dlg.run()
+    state["done"] = True  # signal poll thread to stop
+    dlg.destroy()
+
+    if state["token"]:
+        save_token(state["token"])
+        return True
+    return False
+
+
+# ── Generate / Edit dialog ────────────────────────────────────────────────────
+
+
+def run_generate_dialog(
+    models: list[dict],
+    *,
+    image_input_mode: bool,
+    current_image_size: tuple[int, int] | None,
+) -> dict | None:
+    """
+    Show the model + prompt dialog.
+
+    image_input_mode=True  → filter to image-input models; skip size controls.
+    Returns a dict with keys: model, prompt, width, height, add_as_layer
+    or None when cancelled.
+    """
+    if image_input_mode:
+        models = models_with_image_input(models)
+
+    if not models:
+        _error(
+            None,
+            "No suitable models are available on your account.\n"
+            "Image-editing models (such as FLUX Kontext) require a Paid Pollen balance.",
+        )
+        return None
+
+    title = "Edit with AI" if image_input_mode else "Generate Image"
+    dlg = GimpUi.Dialog(title=title, role="pollinations-generate")
+    dlg.add_button("Cancel", Gtk.ResponseType.CANCEL)
+    gen_btn = dlg.add_button("Generate", Gtk.ResponseType.OK)
+    gen_btn.get_style_context().add_class("suggested-action")
+    dlg.set_border_width(12)
+    dlg.set_default_size(460, -1)
+
+    grid = Gtk.Grid(column_spacing=12, row_spacing=8, border_width=6)
+    row = 0
+
+    # Model picker
+    grid.attach(Gtk.Label(label="Model:", xalign=1.0), 0, row, 1, 1)
+    model_store = Gtk.ListStore(str, str)  # (id, display label)
+    for m in models:
+        mid = m.get("id") or m.get("name", "")
+        label = m.get("title") or mid
+        desc = m.get("description", "")
+        display = f"{label} — {desc[:60]}" if desc else label
+        model_store.append([mid, display])
+
+    model_combo = Gtk.ComboBox(model=model_store)
+    cell = Gtk.CellRendererText()
+    model_combo.pack_start(cell, True)
+    model_combo.add_attribute(cell, "text", 1)
+    model_combo.set_active(0)
+    model_combo.set_hexpand(True)
+    grid.attach(model_combo, 1, row, 1, 1)
+    row += 1
+
+    # Prompt
+    grid.attach(Gtk.Label(label="Prompt:", xalign=1.0), 0, row, 1, 1)
+    prompt_entry = Gtk.Entry(placeholder_text="Describe the image you want…")
+    prompt_entry.set_hexpand(True)
+    prompt_entry.connect("activate", lambda _e: dlg.response(Gtk.ResponseType.OK))
+    grid.attach(prompt_entry, 1, row, 1, 1)
+    row += 1
+
+    width_spin = height_spin = as_layer_check = None
+
+    if not image_input_mode:
+        # Width
+        grid.attach(Gtk.Label(label="Width:", xalign=1.0), 0, row, 1, 1)
+        default_w = current_image_size[0] if current_image_size else 1024
+        width_spin = Gtk.SpinButton.new_with_range(64, 2048, 64)
+        width_spin.set_value(default_w)
+        grid.attach(width_spin, 1, row, 1, 1)
+        row += 1
+
+        # Height
+        grid.attach(Gtk.Label(label="Height:", xalign=1.0), 0, row, 1, 1)
+        default_h = current_image_size[1] if current_image_size else 1024
+        height_spin = Gtk.SpinButton.new_with_range(64, 2048, 64)
+        height_spin.set_value(default_h)
+        grid.attach(height_spin, 1, row, 1, 1)
+        row += 1
+
+        # Insert destination
+        grid.attach(Gtk.Label(label="Insert as:", xalign=1.0), 0, row, 1, 1)
+        as_layer_check = Gtk.CheckButton(label="New layer on current image")
+        as_layer_check.set_active(current_image_size is not None)
+        grid.attach(as_layer_check, 1, row, 1, 1)
+
+    dlg.vbox.pack_start(grid, True, True, 0)
+    dlg.show_all()
+    response = dlg.run()
+    dlg.hide()
+
+    if response != Gtk.ResponseType.OK:
+        dlg.destroy()
+        return None
+
+    it = model_combo.get_active_iter()
+    selected_id = model_store[it][0] if it else (models[0].get("id") or "")
+
+    result = {
+        "model": selected_id,
+        "prompt": prompt_entry.get_text().strip(),
+        "width": int(width_spin.get_value()) if width_spin else None,
+        "height": int(height_spin.get_value()) if height_spin else None,
+        "add_as_layer": bool(as_layer_check and as_layer_check.get_active()),
+    }
+    dlg.destroy()
+    return result
+
+
+# ── Procedure implementations ─────────────────────────────────────────────────
+
+
+def _proc_connect(procedure, run_mode, image, drawables, config, data):
+    GimpUi.init("pollinations_gimp")
+
+    existing = load_token()
+    if existing:
+        try:
+            info = get_userinfo(existing)
+            username = info.get("preferred_username", "you")
+            _info(None, f"Already connected as @{username}.\nUse 'Disconnect' to switch accounts.")
+            return procedure.new_return_values(Gimp.PDBStatusType.SUCCESS, GLib.Error())
+        except Exception:
+            pass  # token expired — fall through to re-auth
+
+    if run_auth_dialog():
+        try:
+            info = get_userinfo(load_token())
+            username = info.get("preferred_username", "you")
+            _info(None, f"Connected as @{username}. Happy creating!")
+        except Exception:
+            _info(None, "Connected! Your Pollinations account is now linked to GIMP.")
+    else:
+        _error(None, "Authorization was not completed. Run 'Connect Account' to try again.")
+
+    return procedure.new_return_values(Gimp.PDBStatusType.SUCCESS, GLib.Error())
+
+
+def _proc_disconnect(procedure, run_mode, image, drawables, config, data):
+    GimpUi.init("pollinations_gimp")
+    delete_token()
+    _info(None, "Disconnected. Your Pollinations token has been removed from this computer.")
+    return procedure.new_return_values(Gimp.PDBStatusType.SUCCESS, GLib.Error())
+
+
+def _proc_generate(procedure, run_mode, image, drawables, config, data):
+    GimpUi.init("pollinations_gimp")
+
+    token = load_token()
+    if not token:
+        _error(None, "Not connected.\nGo to Filters ▸ Pollinations AI ▸ Connect Account.")
+        return procedure.new_return_values(Gimp.PDBStatusType.SUCCESS, GLib.Error())
+
+    models = fetch_models(token)
+    if not models:
+        _error(None, "Could not load the model list.\nCheck your internet connection and try again.")
+        return procedure.new_return_values(Gimp.PDBStatusType.SUCCESS, GLib.Error())
+
+    current_size = (image.get_width(), image.get_height()) if image else None
+    params = run_generate_dialog(models, image_input_mode=False, current_image_size=current_size)
+    if not params:
+        return procedure.new_return_values(Gimp.PDBStatusType.CANCEL, GLib.Error())
+    if not params["prompt"]:
+        _error(None, "Please enter a prompt.")
+        return procedure.new_return_values(Gimp.PDBStatusType.CANCEL, GLib.Error())
+
+    target = image if params["add_as_layer"] else None
+
+    try:
+        img_bytes = generate_image(
+            prompt=params["prompt"],
+            model=params["model"],
+            token=token,
+            width=params["width"],
+            height=params["height"],
+        )
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode(errors="replace")
+        _error(None, f"Generation failed (HTTP {exc.code}):\n{body[:300]}")
+        return procedure.new_return_values(Gimp.PDBStatusType.EXECUTION_ERROR, GLib.Error())
+    except Exception as exc:
+        _error(None, f"Generation failed:\n{exc}")
+        return procedure.new_return_values(Gimp.PDBStatusType.EXECUTION_ERROR, GLib.Error())
+
+    layer_name = f"Pollinations: {params['prompt'][:50]}"
+    _load_result_into_gimp(img_bytes, target, layer_name)
+    return procedure.new_return_values(Gimp.PDBStatusType.SUCCESS, GLib.Error())
+
+
+def _proc_edit(procedure, run_mode, image, drawables, config, data):
+    GimpUi.init("pollinations_gimp")
+
+    token = load_token()
+    if not token:
+        _error(None, "Not connected.\nGo to Filters ▸ Pollinations AI ▸ Connect Account.")
+        return procedure.new_return_values(Gimp.PDBStatusType.SUCCESS, GLib.Error())
+
+    # Resolve the active drawable from whatever GIMP passes
+    if not drawables:
+        _error(None, "Open an image and select a layer to edit.")
+        return procedure.new_return_values(Gimp.PDBStatusType.SUCCESS, GLib.Error())
+
+    drawable = drawables[0] if isinstance(drawables, (list, tuple)) else drawables.item(0)
+
+    models = fetch_models(token)
+    edit_models = models_with_image_input(models)
+    if not edit_models:
+        _error(
+            None,
+            "No image-editing models are available on your account.\n"
+            "Models such as FLUX Kontext or FLUX.2 Pro require Paid Pollen.\n"
+            "Visit enter.pollinations.ai to add a balance.",
+        )
+        return procedure.new_return_values(Gimp.PDBStatusType.SUCCESS, GLib.Error())
+
+    params = run_generate_dialog(
+        edit_models,
+        image_input_mode=True,
+        current_image_size=None,
+    )
+    if not params:
+        return procedure.new_return_values(Gimp.PDBStatusType.CANCEL, GLib.Error())
+    if not params["prompt"]:
+        _error(None, "Please enter an edit instruction.")
+        return procedure.new_return_values(Gimp.PDBStatusType.CANCEL, GLib.Error())
+
+    try:
+        png_bytes = _export_drawable_png_bytes(image, drawable)
+    except Exception as exc:
+        _error(None, f"Could not read the active layer:\n{exc}")
+        return procedure.new_return_values(Gimp.PDBStatusType.EXECUTION_ERROR, GLib.Error())
+
+    image_b64 = base64.b64encode(png_bytes).decode()
+
+    try:
+        result_bytes = generate_image(
+            prompt=params["prompt"],
+            model=params["model"],
+            token=token,
+            input_image_b64=image_b64,
+        )
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode(errors="replace")
+        _error(None, f"Edit request failed (HTTP {exc.code}):\n{body[:300]}")
+        return procedure.new_return_values(Gimp.PDBStatusType.EXECUTION_ERROR, GLib.Error())
+    except Exception as exc:
+        _error(None, f"Edit request failed:\n{exc}")
+        return procedure.new_return_values(Gimp.PDBStatusType.EXECUTION_ERROR, GLib.Error())
+
+    layer_name = f"AI edit: {params['prompt'][:50]}"
+    _load_result_into_gimp(result_bytes, image, layer_name)
+    return procedure.new_return_values(Gimp.PDBStatusType.SUCCESS, GLib.Error())
+
+
+# ── Plug-in class ─────────────────────────────────────────────────────────────
+
+
+class PollinationsPlugin(Gimp.PlugIn):
+    """
+    Registers four PDB procedures under Filters ▸ Pollinations AI:
+      • Connect Account   — BYOP device-flow auth
+      • Disconnect        — clear stored token
+      • Generate Image    — text-to-image; adds result as new image or layer
+      • Edit with AI      — image-to-image; active layer → new layer
+    """
+
+    def do_set_i18n(self, procname):
+        return False, None, None
+
+    def do_query_procedures(self):
+        return [
+            "python-fu-pollinations-connect",
+            "python-fu-pollinations-disconnect",
+            "python-fu-pollinations-generate",
+            "python-fu-pollinations-edit",
+        ]
+
+    def do_create_procedure(self, name):
+        MENU_PATH = "<Image>/Filters/Pollinations AI"
+        CREDIT = ("Pollinations AI", "Pollinations AI", "2026")
+
+        if name == "python-fu-pollinations-connect":
+            proc = Gimp.ImageProcedure.new(
+                self, name, Gimp.PDBProcType.PLUGIN, _proc_connect, None
+            )
+            proc.set_sensitivity_mask(Gimp.ProcedureSensitivityMask.ALWAYS)
+            proc.set_menu_label("Connect Account…")
+            proc.set_documentation(
+                "Connect your Pollinations account",
+                "Opens the BYOP device-flow dialog.  Users authorize the plug-in "
+                "in their browser; no API key is ever entered manually.",
+                name,
+            )
+            proc.set_attribution(*CREDIT)
+            proc.add_menu_path(MENU_PATH)
+            return proc
+
+        if name == "python-fu-pollinations-disconnect":
+            proc = Gimp.ImageProcedure.new(
+                self, name, Gimp.PDBProcType.PLUGIN, _proc_disconnect, None
+            )
+            proc.set_sensitivity_mask(Gimp.ProcedureSensitivityMask.ALWAYS)
+            proc.set_menu_label("Disconnect")
+            proc.set_documentation(
+                "Disconnect your Pollinations account",
+                "Removes the stored authorization token from this computer.",
+                name,
+            )
+            proc.set_attribution(*CREDIT)
+            proc.add_menu_path(MENU_PATH)
+            return proc
+
+        if name == "python-fu-pollinations-generate":
+            proc = Gimp.ImageProcedure.new(
+                self, name, Gimp.PDBProcType.PLUGIN, _proc_generate, None
+            )
+            proc.set_sensitivity_mask(
+                Gimp.ProcedureSensitivityMask.NO_IMAGE
+                | Gimp.ProcedureSensitivityMask.DRAWABLE
+                | Gimp.ProcedureSensitivityMask.DRAWABLES
+            )
+            proc.set_menu_label("Generate Image…")
+            proc.set_documentation(
+                "Generate an image with Pollinations AI",
+                "Shows a model picker and prompt field.  Generates an image via "
+                "the Pollinations API and loads it into GIMP as a new image or layer.",
+                name,
+            )
+            proc.set_attribution(*CREDIT)
+            proc.add_menu_path(MENU_PATH)
+            return proc
+
+        if name == "python-fu-pollinations-edit":
+            proc = Gimp.ImageProcedure.new(
+                self, name, Gimp.PDBProcType.PLUGIN, _proc_edit, None
+            )
+            proc.set_sensitivity_mask(
+                Gimp.ProcedureSensitivityMask.DRAWABLE
+                | Gimp.ProcedureSensitivityMask.DRAWABLES
+            )
+            proc.set_menu_label("Edit with AI…")
+            proc.set_documentation(
+                "Edit the active layer using an image-to-image model",
+                "Exports the active layer, sends it to a Pollinations image-editing "
+                "model (e.g. FLUX Kontext), and adds the result as a new layer — "
+                "the original layer is never modified.",
+                name,
+            )
+            proc.set_attribution(*CREDIT)
+            proc.add_menu_path(MENU_PATH)
+            return proc
+
+        return None
+
+
+if __name__ == "__main__":
+    Gimp.main(PollinationsPlugin.__gtype__, sys.argv)

--- a/apps/gimp-plugin/tests/test_helpers.py
+++ b/apps/gimp-plugin/tests/test_helpers.py
@@ -1,0 +1,298 @@
+"""
+Unit tests for the pure-Python helper functions in pollinations_gimp.py.
+
+These tests run without GIMP or a network connection.
+Run with:
+    python -m pytest apps/gimp-plugin/tests/ -v
+    # or
+    python -m unittest discover -s apps/gimp-plugin/tests -v
+"""
+
+from __future__ import annotations
+
+import base64
+import importlib.util
+import json
+import sys
+import types
+import unittest
+import urllib.error
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Stub out the gi / GIMP bindings so the module can be imported without GIMP
+# ---------------------------------------------------------------------------
+
+_gi_stub = types.ModuleType("gi")
+_gi_stub.require_version = lambda *a, **k: None
+sys.modules["gi"] = _gi_stub
+
+for _mod in (
+    "gi.repository",
+    "gi.repository.Gimp",
+    "gi.repository.GimpUi",
+    "gi.repository.Gtk",
+    "gi.repository.GLib",
+    "gi.repository.Gio",
+):
+    sys.modules[_mod] = MagicMock()
+
+# GLib.get_user_config_dir must return a real string path
+sys.modules["gi.repository.GLib"].get_user_config_dir = lambda: "/tmp/test_gimp_config"
+
+# ---------------------------------------------------------------------------
+# Import the module under test
+# ---------------------------------------------------------------------------
+
+_plugin_path = Path(__file__).parent.parent / "pollinations_gimp.py"
+_spec = importlib.util.spec_from_file_location("pollinations_gimp", _plugin_path)
+_mod = importlib.util.module_from_spec(_spec)
+# Prevent Gimp.main() at module level from executing during import
+with patch.object(_mod, "__name__", "pollinations_gimp"):
+    # Pre-populate sys.modules so relative imports resolve
+    sys.modules["pollinations_gimp"] = _mod
+    _spec.loader.exec_module(_mod)
+
+# Convenient re-exports
+load_token = _mod.load_token
+save_token = _mod.save_token
+delete_token = _mod.delete_token
+fetch_models = _mod.fetch_models
+models_with_image_input = _mod.models_with_image_input
+generate_image = _mod.generate_image
+ENTER_BASE = _mod.ENTER_BASE
+GEN_BASE = _mod.GEN_BASE
+APP_KEY = _mod.APP_KEY
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestTokenPersistence(unittest.TestCase):
+    """save_token / load_token / delete_token round-trip."""
+
+    def setUp(self):
+        import tempfile
+
+        self._tmp = tempfile.mkdtemp()
+        token_dir = Path(self._tmp) / "pollinations"
+        # Patch the private module-level paths
+        self._orig_dir = _mod._TOKEN_DIR
+        self._orig_file = _mod._TOKEN_FILE
+        _mod._TOKEN_DIR = token_dir
+        _mod._TOKEN_FILE = token_dir / "token.json"
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self._tmp, ignore_errors=True)
+        _mod._TOKEN_DIR = self._orig_dir
+        _mod._TOKEN_FILE = self._orig_file
+
+    def test_no_token_returns_none(self):
+        self.assertIsNone(load_token())
+
+    def test_save_and_load_roundtrip(self):
+        save_token("sk_test_abc123")
+        self.assertEqual(load_token(), "sk_test_abc123")
+
+    def test_delete_removes_token(self):
+        save_token("sk_test_abc123")
+        delete_token()
+        self.assertIsNone(load_token())
+
+    def test_delete_nonexistent_does_not_raise(self):
+        delete_token()  # must not raise FileNotFoundError
+
+    def test_token_file_contains_access_token_key(self):
+        save_token("sk_hello")
+        raw = json.loads(_mod._TOKEN_FILE.read_text())
+        self.assertIn("access_token", raw)
+        self.assertEqual(raw["access_token"], "sk_hello")
+
+    def test_corrupted_file_returns_none(self):
+        _mod._TOKEN_DIR.mkdir(parents=True, exist_ok=True)
+        _mod._TOKEN_FILE.write_text("not-json{{")
+        self.assertIsNone(load_token())
+
+
+class TestModelFiltering(unittest.TestCase):
+    """models_with_image_input filters to image-capable models."""
+
+    _SAMPLE = [
+        {"id": "flux", "title": "FLUX", "inputModalities": ["text"], "outputModalities": ["image"]},
+        {"id": "kontext", "title": "FLUX Kontext", "inputModalities": ["text", "image"], "outputModalities": ["image"]},
+        {"id": "flux-2-pro", "title": "FLUX.2 Pro", "inputModalities": ["text", "image"], "outputModalities": ["image"]},
+        {"id": "veo", "title": "Veo", "inputModalities": ["text"], "outputModalities": ["video"]},
+    ]
+
+    def test_returns_only_image_input_models(self):
+        result = models_with_image_input(self._SAMPLE)
+        ids = [m["id"] for m in result]
+        self.assertIn("kontext", ids)
+        self.assertIn("flux-2-pro", ids)
+        self.assertNotIn("flux", ids)
+        self.assertNotIn("veo", ids)
+
+    def test_empty_list_returns_empty(self):
+        self.assertEqual(models_with_image_input([]), [])
+
+    def test_no_image_input_models_returns_empty(self):
+        text_only = [{"id": "flux", "inputModalities": ["text"]}]
+        self.assertEqual(models_with_image_input(text_only), [])
+
+    def test_model_without_inputModalities_key_is_excluded(self):
+        models = [{"id": "mystery"}]
+        self.assertEqual(models_with_image_input(models), [])
+
+
+class TestFetchModels(unittest.TestCase):
+    """fetch_models parses the OpenAI-compatible /image/models response."""
+
+    _RESPONSE = {
+        "object": "list",
+        "data": [
+            {"id": "flux", "title": "FLUX", "inputModalities": ["text"]},
+            {"id": "kontext", "title": "FLUX Kontext", "inputModalities": ["text", "image"]},
+        ],
+    }
+
+    def _fake_urlopen(self, req, timeout=20):
+        body = json.dumps(self._RESPONSE).encode()
+        resp = MagicMock()
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        resp.read = lambda: body
+        return resp
+
+    def test_parses_data_array(self):
+        with patch("urllib.request.urlopen", side_effect=self._fake_urlopen):
+            models = fetch_models("sk_test")
+        self.assertEqual(len(models), 2)
+        self.assertEqual(models[0]["id"], "flux")
+
+    def test_network_error_returns_empty_list(self):
+        def _raise(*a, **k):
+            raise OSError("no network")
+
+        with patch("urllib.request.urlopen", side_effect=_raise):
+            models = fetch_models("sk_test")
+        self.assertEqual(models, [])
+
+    def test_request_carries_authorization_header(self):
+        captured = {}
+
+        def _capture(req, timeout=20):
+            captured["auth"] = req.get_header("Authorization")
+            resp = MagicMock()
+            resp.__enter__ = lambda s: s
+            resp.__exit__ = MagicMock(return_value=False)
+            resp.read = lambda: json.dumps(self._RESPONSE).encode()
+            return resp
+
+        with patch("urllib.request.urlopen", side_effect=_capture):
+            fetch_models("sk_mytoken")
+        self.assertEqual(captured["auth"], "Bearer sk_mytoken")
+
+
+class TestGenerateImageRequest(unittest.TestCase):
+    """generate_image builds the correct POST request."""
+
+    def _make_fake_urlopen(self, response_bytes=b"\x89PNG\r\n"):
+        def _fake(req, timeout=120):
+            self._captured_req = req
+            resp = MagicMock()
+            resp.__enter__ = lambda s: s
+            resp.__exit__ = MagicMock(return_value=False)
+            resp.read = lambda: response_bytes
+            return resp
+
+        return _fake
+
+    def test_prompt_is_url_encoded_in_path(self):
+        fake = self._make_fake_urlopen()
+        with patch("urllib.request.urlopen", side_effect=fake):
+            generate_image("a cat & dog", "flux", "sk_tok")
+        self.assertIn("a%20cat%20%26%20dog", self._captured_req.full_url)
+
+    def test_model_in_json_body(self):
+        fake = self._make_fake_urlopen()
+        with patch("urllib.request.urlopen", side_effect=fake):
+            generate_image("test", "kontext", "sk_tok")
+        body = json.loads(self._captured_req.data)
+        self.assertEqual(body["model"], "kontext")
+
+    def test_size_included_when_provided(self):
+        fake = self._make_fake_urlopen()
+        with patch("urllib.request.urlopen", side_effect=fake):
+            generate_image("test", "flux", "sk_tok", width=512, height=768)
+        body = json.loads(self._captured_req.data)
+        self.assertEqual(body["width"], 512)
+        self.assertEqual(body["height"], 768)
+
+    def test_size_omitted_when_not_provided(self):
+        fake = self._make_fake_urlopen()
+        with patch("urllib.request.urlopen", side_effect=fake):
+            generate_image("test", "flux", "sk_tok")
+        body = json.loads(self._captured_req.data)
+        self.assertNotIn("width", body)
+        self.assertNotIn("height", body)
+
+    def test_data_uri_sent_for_image_input(self):
+        fake = self._make_fake_urlopen()
+        png_bytes = b"\x89PNG\r\n\x1a\n"
+        b64 = base64.b64encode(png_bytes).decode()
+        with patch("urllib.request.urlopen", side_effect=fake):
+            generate_image("stylize", "kontext", "sk_tok", input_image_b64=b64)
+        body = json.loads(self._captured_req.data)
+        self.assertTrue(body["image"].startswith("data:image/png;base64,"))
+        decoded = base64.b64decode(body["image"].split(",", 1)[1])
+        self.assertEqual(decoded, png_bytes)
+
+    def test_no_image_field_when_no_input_image(self):
+        fake = self._make_fake_urlopen()
+        with patch("urllib.request.urlopen", side_effect=fake):
+            generate_image("test", "flux", "sk_tok")
+        body = json.loads(self._captured_req.data)
+        self.assertNotIn("image", body)
+
+    def test_authorization_header_set(self):
+        fake = self._make_fake_urlopen()
+        with patch("urllib.request.urlopen", side_effect=fake):
+            generate_image("test", "flux", "sk_mykey")
+        self.assertEqual(
+            self._captured_req.get_header("Authorization"), "Bearer sk_mykey"
+        )
+
+    def test_http_error_propagates(self):
+        def _raise(*a, **k):
+            raise urllib.error.HTTPError(
+                url="x", code=402, msg="Payment Required", hdrs={}, fp=BytesIO(b"need pollen")
+            )
+
+        with patch("urllib.request.urlopen", side_effect=_raise):
+            with self.assertRaises(urllib.error.HTTPError) as ctx:
+                generate_image("test", "flux", "sk_tok")
+        self.assertEqual(ctx.exception.code, 402)
+
+
+class TestAppKeyAndUrls(unittest.TestCase):
+    """Smoke-check constants."""
+
+    def test_enter_base_is_https(self):
+        self.assertTrue(ENTER_BASE.startswith("https://"))
+
+    def test_gen_base_is_https(self):
+        self.assertTrue(GEN_BASE.startswith("https://"))
+
+    def test_app_key_is_publishable(self):
+        # Publishable keys start with pk_
+        self.assertTrue(APP_KEY.startswith("pk_"), f"Expected pk_ prefix, got {APP_KEY!r}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `apps/gimp-plugin/pollinations_gimp.py` — a GIMP 3 Python plug-in that registers four commands under **Filters ▸ Pollinations AI**
- **Connect Account** — BYOP device-flow auth via `enter.pollinations.ai/device`; token persisted in the GIMP config directory
- **Generate Image** — text-to-image; model list fetched live from `/image/models`; result as new GIMP image or new layer
- **Edit with AI** — active layer exported as a PNG data URI and sent to image-to-image models (e.g. FLUX Kontext); result as new layer; source unchanged
- **Disconnect** — removes the stored token
- `apps/gimp-plugin/README.md` — installation instructions for Linux, macOS, and Windows; usage guide; error reference
- `apps/gimp-plugin/tests/test_helpers.py` — 24 unit tests (token persistence, model filtering, URL encoding, data-URI construction, error propagation); no GIMP or network required

## Test plan

- [x] `python3 -m unittest discover -s apps/gimp-plugin/tests -v` — all 24 tests pass
- [ ] Install into GIMP 3 (`~/.config/GIMP/3.0/plug-ins/pollinations_gimp/`), restart GIMP, confirm **Filters ▸ Pollinations AI** menu appears
- [ ] Connect Account → approve in browser → confirm "Connected as @username" dialog
- [ ] Generate Image with `flux` model — result added as layer
- [ ] Edit with AI with `kontext` model — result added as new layer; source layer unchanged
- [ ] Disconnect → token file removed

Fixes #14232

🤖 Generated with [Claude Code](https://claude.ai/claude-code)