### PR TITLE
fix: publish Polli CLI through npm OIDC

### DIFF
--- a/.github/workflows/release-publish-npm-packages.yml
+++ b/.github/workflows/release-publish-npm-packages.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
     paths:
+      - ".github/workflows/release-publish-npm-packages.yml"
       - "packages/sdk/**"
       - "packages/ui/**"
       - "packages/mcp/**"
@@ -36,7 +37,7 @@ jobs:
           echo "sdk=$(echo "$changed" | grep -q '^packages/sdk/' && echo true || echo false)" >> "$GITHUB_OUTPUT"
           echo "ui=$(echo "$changed" | grep -q '^packages/ui/' && echo true || echo false)" >> "$GITHUB_OUTPUT"
           echo "mcp=$(echo "$changed" | grep -q '^packages/mcp/' && echo true || echo false)" >> "$GITHUB_OUTPUT"
-          echo "cli=$(echo "$changed" | grep -q '^packages/polli-cli/' && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "cli=$(echo "$changed" | grep -Eq '^packages/polli-cli/|^\.github/workflows/release-publish-npm-packages\.yml$' && echo true || echo false)" >> "$GITHUB_OUTPUT"
           echo "Changed files:"
           echo "$changed" | grep '^packages/' || true
 
@@ -174,12 +175,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies & build
@@ -205,5 +207,3 @@ jobs:
         if: steps.check.outputs.skip != 'true'
         working-directory: packages/polli-cli
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
- Migrates only `@pollinations/cli` publishing from the expired repository token to npm Trusted Publishing.
- Uses Node 24 and grants the CLI job the required GitHub OIDC permission.
- Retriggers the CLI publisher when this workflow change reaches `main`, allowing unpublished 0.1.12 to ship.
- Requires npm package setting: GitHub Actions publisher `pollinations/pollinations`, workflow `release-publish-npm-packages.yml`, action `npm publish`.

Tests: `actionlint`; `npm run build`; `npm test` (57 passed); `npm pack --dry-run`.