### PR TITLE
fix: delay community model unhiding

### DIFF
--- a/enter.pollinations.ai/src/routes/community-endpoints.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints.ts
@@ -1,5 +1,6 @@
 import { validateCommunityEndpointUrl } from "@shared/community-endpoint-urls.ts";
 import {
+    COMMUNITY_ENDPOINT_CHANGE_DELAY_MS,
     type CommunityEndpointVisibility,
     communityModelId,
     type EndpointAgentListingPayload,
@@ -779,6 +780,19 @@ export const communityEndpointsRoutes = new Hono<Env>()
                 update.description = input.description || null;
             }
             if (input.hidden !== undefined) {
+                if (
+                    !input.hidden &&
+                    (input.visibility ?? currentVisibility) === "public" &&
+                    endpoint.hiddenAt &&
+                    Date.now() <
+                        endpoint.hiddenAt.getTime() +
+                            COMMUNITY_ENDPOINT_CHANGE_DELAY_MS
+                ) {
+                    throw new HTTPException(400, {
+                        message:
+                            "Community models can be relisted 12 hours after they were hidden",
+                    });
+                }
                 update.hiddenAt = input.hidden ? new Date() : null;
                 update.hiddenReason = input.hidden ? "Hidden by owner" : null;
                 update.hiddenBy = input.hidden ? "owner" : null;

--- a/enter.pollinations.ai/test/integration/community-endpoint-price-delay.test.ts
+++ b/enter.pollinations.ai/test/integration/community-endpoint-price-delay.test.ts
@@ -326,6 +326,56 @@ describe("community endpoint 12-hour price-change delay", () => {
         expect(row?.pendingAt).toBeNull();
     });
 
+    test("unhiding waits for the publication delay", async ({
+        sessionToken,
+    }) => {
+        await approveCommunityModels();
+        const created = await postModel(sessionToken, "", {
+            name: "relisted-model",
+            title: "Relisted model",
+            visibility: "public",
+            baseUrl: "https://text.example.com/v1",
+            bearerToken: "tok",
+        });
+        const id = created.id as string;
+        await publishPendingModel(sessionToken, id);
+        const db = drizzle(env.DB);
+        await db
+            .update(schema.communityEndpoint)
+            .set({
+                hiddenAt: new Date(),
+                hiddenReason: "Hidden by monitor",
+                hiddenBy: "monitor",
+            })
+            .where(eq(schema.communityEndpoint.id, id));
+
+        const early = await SELF.fetch(`${endpointUrl}/${id}/update`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Cookie: `better-auth.session_token=${sessionToken}`,
+            },
+            body: JSON.stringify({ hidden: false }),
+        });
+        expect(early.status).toBe(400);
+        expect(await early.text()).toContain(
+            "can be relisted 12 hours after they were hidden",
+        );
+
+        await db
+            .update(schema.communityEndpoint)
+            .set({
+                hiddenAt: new Date(
+                    Date.now() - COMMUNITY_ENDPOINT_CHANGE_DELAY_MS - 1000,
+                ),
+            })
+            .where(eq(schema.communityEndpoint.id, id));
+        const relisted = await postModel(sessionToken, `/${id}/update`, {
+            hidden: false,
+        });
+        expect(relisted).toMatchObject({ hidden: false, hiddenAt: null });
+    });
+
     test("price change during pending publication restarts the delay", async ({
         sessionToken,
     }) => {

--- a/operations/community-monitor/CYCLE.md
+++ b/operations/community-monitor/CYCLE.md
@@ -52,8 +52,8 @@ You are the pollinations community-model monitor bot (Discord identity: el405b).
       Treat the model as hidden only when the JSON reports `meta.changes = 1`. If it reports zero, re-read the row and leave the concurrent state untouched; do not post or update monitor state. Do not clear the fields in this hide path; the recovery path below is the only monitor-owned exception.
 
    **Recovery check — every cycle:** hidden models remain callable by exact ID, so use that traffic to reverse monitor hides without waiting for a maintainer.
-   1. Query D1 for text/image rows with `hidden_by = 'monitor'` and `hidden_at <= unixepoch() - 43200`, selecting id, `owner/name`, the hidden fields, and category as `CASE WHEN type = 'proxy' THEN json_extract(payload, '$.modality') ELSE 'text' END`. Never select the removed `community_endpoint.modality` column, expose `payload`, or consider owner- or maintainer-hidden rows.
-   2. Match those exact model IDs to the 1-hour Tinybird data. A recovery candidate needs at least 10 non-client requests and at least 90% success, using the same final-outcome and image-provider-4xx rules as hiding. Requiring the row to have been hidden for 12 hours prevents rapid automatic relisting while keeping the recovery signal focused on recent traffic.
+   1. Query D1 for text/image rows with `hidden_by = 'monitor'` and `hidden_at <= unixepoch() - 3600`, selecting id, `owner/name`, the hidden fields, and category as `CASE WHEN type = 'proxy' THEN json_extract(payload, '$.modality') ELSE 'text' END`. Never select the removed `community_endpoint.modality` column, expose `payload`, or consider owner- or maintainer-hidden rows.
+   2. Match those exact model IDs to the 1-hour Tinybird data. A recovery candidate needs at least 10 non-client requests and at least 90% success, using the same final-outcome and image-provider-4xx rules as hiding. Requiring the row to have been hidden for an hour prevents rapid flapping while keeping the recovery signal focused on recent traffic.
    3. Confirm each candidate with one fresh exact-ID probe: `node probe.mjs --model '<owner/name>' --category '<text|image>'`. Relist only when its JSON result has `ok: true`; any failure or inconclusive result vetoes recovery.
    4. Relist atomically:
       ```bash
@@ -123,7 +123,7 @@ You are the pollinations community-model monitor bot (Discord identity: el405b).
    ```
    The 250-char style guidance above still applies to the surrounding commentary (if any) — the panel itself is exempt from the char limit, same as the existing factual-list exemption.
 
-   **If someone asks to relist a hidden model** (or says they fixed it): look up the D1 row. For a monitor-hidden text/image model, run `node probe.mjs --model '<owner/name>' --category '<text|image>'`; one passing result is enough to relist it with the recovery update above. A failed or inconclusive probe leaves it hidden. Owner- and maintainer-hidden rows are never changed. Owners can also use **Relist** in Models → My Models themselves.
+   **If someone asks to relist a hidden model** (or says they fixed it): look up the D1 row. For a monitor-hidden text/image model, run `node probe.mjs --model '<owner/name>' --category '<text|image>'`; one passing result is enough to relist it with the recovery update above. A failed or inconclusive probe leaves it hidden. Owner- and maintainer-hidden rows are never changed. Owners can also use **Relist** in Models → My Models themselves after the normal 12-hour publication delay.
 
    When tagging anyone, resolve their Discord id via people_mapping.json first — never mention a GitHub username's numeric id as if it were a Discord snowflake, and never fabricate a discord_id.
 


### PR DESCRIPTION
- Applies the existing 12-hour publication delay to owner-triggered unhiding of public community models
- Keeps private model unhiding immediate and preserves monitor-managed recovery
- Restores the monitor recovery eligibility window to one hour
- Adds focused integration coverage for before and after the deadline

Test: `npx vitest run test/integration/community-endpoint-price-delay.test.ts` (12 passed)