### PR TITLE
test: update community relisting fixture

### DIFF
--- a/gen.pollinations.ai/test/community-endpoints.test.ts
+++ b/gen.pollinations.ai/test/community-endpoints.test.ts
@@ -5149,12 +5149,14 @@ fixtureTest(
             hidden: true,
             hiddenReason: "was failing",
         });
+        const elapsedDelayAt = new Date(
+            Date.now() - COMMUNITY_ENDPOINT_CHANGE_DELAY_MS - 1,
+        );
         await db
             .update(communityEndpointTable)
             .set({
-                pendingAt: new Date(
-                    Date.now() - COMMUNITY_ENDPOINT_CHANGE_DELAY_MS - 1,
-                ),
+                pendingAt: elapsedDelayAt,
+                hiddenAt: elapsedDelayAt,
             })
             .where(eq(communityEndpointTable.id, createdId));
 


### PR DESCRIPTION
- Advances the hidden timestamp past the 12-hour relisting delay
- Keeps the existing account API relisting assertion meaningful
- Fixes the Gen suite failure introduced by the new relisting policy