### PR TITLE
feat(cli): add OpenClaw harness

### DIFF
--- a/CODING_HARNESSES.md
+++ b/CODING_HARNESSES.md
@@ -3,6 +3,7 @@
 Use `polli harness` to connect a supported coding harness to Pollinations. It handles Polli login, a dedicated API key, model setup, and any Pollinations capabilities supported by that harness.
 
 > **Available now:** DeepSeek Harness, OpenCode, Pi, and Prime Agent are integrated `polli harness` profiles. OpenClaw is coming soon.
+> **Available now:** DeepSeek Harness, OpenCode, Pi, Prime Agent, and OpenClaw are integrated `polli harness` profiles.
 
 ## Use a harness
 
@@ -29,7 +30,7 @@ If a harness cannot be launched, `on` stops before login, key creation, or confi
 | [OpenCode](https://opencode.ai) | **Available now** — `polli harness opencode on` | Uses the existing [Pollinations OpenCode plugin](https://github.com/fkom13/opencode-pollinations-plugin) for models, media tools, usage, and quests. Defaults to `openai`. |
 | [Pi](https://github.com/earendil-works/pi) | **Available now** — `polli harness pi on` | Uses Pi's native provider support and the Polli skill. Pi intentionally has no built-in MCP support. Defaults to `deepseek`. |
 | [Prime Agent](https://github.com/PrimeIntellect-ai/prime-agent) | **Available now** — `polli harness prime on` | Uses native provider support and the Polli skill while preserving memories, sessions, and unrelated configuration. |
-| [OpenClaw](https://github.com/openclaw/openclaw) | Coming soon | Will bring the [existing Pollinations setup](./apps/openclaw/README.md) into the shared `polli harness` workflow. |
+| [OpenClaw](https://github.com/openclaw/openclaw) | **Available now** — `polli harness openclaw on` | Same provider block as the [existing setup script](./apps/openclaw/README.md), but the model list comes from the live catalog instead of a hardcoded table. Defaults to `kimi`. |
 
 ## DeepSeek Harness
 
@@ -70,3 +71,13 @@ polli harness prime off
 ```
 
 `on` requires Prime Agent to be installed with its official installer. It registers the current compatible Pollinations model catalog in `~/.prime/agent/models.json`, stores a dedicated key in `auth.json`, selects the startup model in `settings.json`, and installs the Polli skill under `skills/polli/`. Choose another default with `--model <id>`.
+
+## OpenClaw
+
+```bash
+npx @pollinations/cli harness openclaw on
+polli harness openclaw status
+polli harness openclaw off
+```
+
+`on` requires OpenClaw to be installed with its official script: `curl -fsSL https://openclaw.ai/install.sh | bash`. It writes the same `models.providers.pollinations` block as the [existing Pollinations setup script](./apps/openclaw/README.md), but fills the model list from the current Pollinations catalog rather than a second hardcoded table. The Polli skill goes under `skills/polli/`, so media tools and quest access come with it. An existing `agents.defaults.model.primary` is left alone and reported instead — set the default yourself with `openclaw models set pollinations/<id>` or start with `--model <id>` on a fresh setup. `off` removes only the Pollinations provider, the default model it wrote, and the skill, leaving other providers, channels, and gateway settings in place; run `openclaw gateway restart` to pick up the change.

--- a/packages/polli-cli/src/harnesses/index.ts
+++ b/packages/polli-cli/src/harnesses/index.ts
@@ -1,7 +1,8 @@
 import { dsh } from "./dsh.js";
+import { openclaw } from "./openclaw.js";
 import { opencode } from "./opencode.js";
 import { pi } from "./pi.js";
 import { prime } from "./prime.js";
 import type { HarnessAdapter } from "./types.js";
 
-export const HARNESSES: HarnessAdapter[] = [dsh, opencode, pi, prime];
+export const HARNESSES: HarnessAdapter[] = [dsh, openclaw, opencode, pi, prime];

--- a/packages/polli-cli/src/harnesses/openclaw.test.ts
+++ b/packages/polli-cli/src/harnesses/openclaw.test.ts
@@ -1,0 +1,273 @@
+import {
+    existsSync,
+    mkdirSync,
+    mkdtempSync,
+    readdirSync,
+    readFileSync,
+    rmSync,
+    statSync,
+    writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+    configureOpenclaw,
+    disableOpenclaw,
+    openclaw,
+    openclawStateDir,
+} from "./openclaw.js";
+import type { HarnessContext } from "./types.js";
+
+const models = [
+    { id: "kimi", contextWindow: 262000, input: ["text", "image"] },
+    { id: "deepseek", contextWindow: 1048576, input: ["text"] },
+];
+
+let home: string;
+let ctx: HarnessContext;
+
+beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "polli-openclaw-harness-"));
+    ctx = { home, env: {} };
+});
+
+afterEach(() => rmSync(home, { recursive: true, force: true }));
+
+const stateDir = () => join(home, ".openclaw");
+const configFile = () => join(stateDir(), "openclaw.json");
+const skillFile = () => join(stateDir(), "skills", "polli", "SKILL.md");
+const read = (path: string) => readFileSync(path, "utf-8");
+const readJson = (path: string) =>
+    JSON.parse(read(path)) as Record<string, unknown>;
+const providers = (path = configFile()) =>
+    (readJson(path).models as Record<string, Record<string, unknown>>)
+        .providers;
+const pollinations = (config: Record<string, unknown>) =>
+    (config.models as Record<string, Record<string, Record<string, unknown>>>)
+        .providers.pollinations as Record<string, unknown>;
+const snapshotFiles = () => {
+    const dir = join(home, ".pollinations", "harnesses");
+    return existsSync(dir)
+        ? readdirSync(dir).filter((file) => file.startsWith("openclaw."))
+        : [];
+};
+
+describe("openclaw harness", () => {
+    it("writes the provider, key, default model, and skill from scratch", () => {
+        const result = configureOpenclaw(ctx, models, "sk_test_key", "kimi");
+        expect(result).toMatchObject({
+            harness: "openclaw",
+            configured: true,
+            model: "kimi",
+        });
+
+        expect(providers().pollinations).toMatchObject({
+            baseUrl: "https://gen.pollinations.ai/v1",
+            api: "openai-completions",
+            apiKey: "sk_test_key",
+        });
+        expect(
+            (providers().pollinations.models as { id: string }[]).map(
+                (model) => model.id,
+            ),
+        ).toEqual(["kimi", "deepseek"]);
+        expect(readJson(configFile()).agents).toMatchObject({
+            defaults: { model: { primary: "pollinations/kimi" } },
+        });
+        expect(read(skillFile())).toContain("name: polli");
+        expect(statSync(configFile()).mode & 0o777).toBe(0o600);
+        expect(openclaw.status(ctx)).toMatchObject({
+            configured: true,
+            model: "kimi",
+        });
+    });
+
+    it("keeps existing providers and unrelated config", () => {
+        mkdirSync(stateDir(), { recursive: true });
+        writeFileSync(
+            configFile(),
+            JSON.stringify(
+                {
+                    models: {
+                        providers: {
+                            ollama: {
+                                baseUrl: "http://localhost:11434/v1",
+                                models: [],
+                            },
+                        },
+                    },
+                    gateway: { port: 36400 },
+                    channels: { telegram: { enabled: true } },
+                },
+                null,
+                2,
+            ),
+        );
+
+        configureOpenclaw(ctx, models, "sk_test_key", "kimi");
+
+        expect(providers().ollama).toBeDefined();
+        expect(providers().pollinations).toBeDefined();
+        const config = readJson(configFile());
+        expect(config.gateway).toEqual({ port: 36400 });
+        expect(config.channels).toEqual({ telegram: { enabled: true } });
+    });
+
+    it("keeps an existing primary model instead of overriding it", () => {
+        mkdirSync(stateDir(), { recursive: true });
+        writeFileSync(
+            configFile(),
+            JSON.stringify({
+                agents: {
+                    defaults: { model: { primary: "anthropic/claude" } },
+                },
+            }),
+        );
+
+        const result = configureOpenclaw(ctx, models, "sk_test_key", "kimi");
+
+        expect(readJson(configFile()).agents).toMatchObject({
+            defaults: { model: { primary: "anthropic/claude" } },
+        });
+        expect(result.configured).toBe(true);
+        expect(result.model).toBeUndefined();
+    });
+
+    it("restores the original file byte-for-byte on off", () => {
+        mkdirSync(stateDir(), { recursive: true });
+        const original = JSON.stringify({
+            models: { providers: { ollama: { models: [] } } },
+        });
+        writeFileSync(configFile(), original);
+
+        configureOpenclaw(ctx, models, "sk_test_key", "kimi");
+        const result = disableOpenclaw(ctx);
+
+        expect(result.outcome).toBe("restored");
+        expect(read(configFile())).toBe(original);
+        expect(existsSync(skillFile())).toBe(false);
+        expect(openclaw.status(ctx).configured).toBe(false);
+    });
+
+    it("strips only the Pollinations entries when config changed since on", () => {
+        configureOpenclaw(ctx, models, "sk_test_key", "kimi");
+        const edited = readJson(configFile());
+        (
+            edited.models as Record<string, Record<string, unknown>>
+        ).providers.ollama = { models: [] };
+        writeFileSync(configFile(), JSON.stringify(edited));
+
+        const result = disableOpenclaw(ctx);
+
+        expect(result.outcome).toBe("stripped");
+        expect(providers().ollama).toBeDefined();
+        expect(providers().pollinations).toBeUndefined();
+        expect(
+            (readJson(configFile()).agents as Record<string, unknown>).defaults,
+        ).toMatchObject({ model: {} });
+        expect(existsSync(skillFile())).toBe(false);
+    });
+
+    it("removes the models block when Pollinations was the only provider", () => {
+        configureOpenclaw(ctx, models, "sk_test_key", "kimi");
+        writeFileSync(
+            configFile(),
+            JSON.stringify({
+                ...readJson(configFile()),
+                gateway: { port: 36400 },
+            }),
+        );
+
+        disableOpenclaw(ctx);
+
+        const config = readJson(configFile());
+        expect(config.models).toBeUndefined();
+        expect(config.gateway).toEqual({ port: 36400 });
+    });
+
+    it("reports unchanged when off runs before on", () => {
+        expect(disableOpenclaw(ctx).outcome).toBe("unchanged");
+    });
+
+    it("re-running on switches the model and keeps the pre-on backup", () => {
+        configureOpenclaw(ctx, models, "sk_test_key", "kimi");
+        configureOpenclaw(ctx, models, "sk_test_key", "deepseek");
+        expect(openclaw.status(ctx).model).toBe("deepseek");
+
+        disableOpenclaw(ctx);
+        expect(existsSync(configFile())).toBe(false);
+    });
+
+    it("honors OPENCLAW_STATE_DIR", () => {
+        const custom = join(home, "custom-openclaw");
+        configureOpenclaw(
+            { home, env: { OPENCLAW_STATE_DIR: custom } },
+            models,
+            "sk_test_key",
+            "kimi",
+        );
+        expect(existsSync(join(custom, "openclaw.json"))).toBe(true);
+        expect(existsSync(configFile())).toBe(false);
+    });
+
+    it("treats an empty OPENCLAW_STATE_DIR as unset", () => {
+        configureOpenclaw(
+            { home, env: { OPENCLAW_STATE_DIR: "  " } },
+            models,
+            "sk",
+            "kimi",
+        );
+        expect(existsSync(configFile())).toBe(true);
+    });
+
+    it("openclawStateDir resolves to default when env is unset", () => {
+        expect(openclawStateDir(ctx)).toBe(join(home, ".openclaw"));
+    });
+
+    it("reports unconfigured when the API key is missing", () => {
+        configureOpenclaw(ctx, models, "sk_test_key", "kimi");
+        const config = readJson(configFile());
+        pollinations(config).apiKey = "";
+        writeFileSync(configFile(), JSON.stringify(config));
+        expect(openclaw.status(ctx).configured).toBe(false);
+    });
+
+    it("reports unconfigured when the provider points elsewhere", () => {
+        configureOpenclaw(ctx, models, "sk_test_key", "kimi");
+        const config = readJson(configFile());
+        pollinations(config).baseUrl = "https://example.com/v1";
+        writeFileSync(configFile(), JSON.stringify(config));
+        expect(openclaw.status(ctx).configured).toBe(false);
+    });
+
+    it("preserves a corrupt snapshot and refuses to disable", () => {
+        configureOpenclaw(ctx, models, "sk_test_key", "kimi");
+        const snapshot = join(
+            home,
+            ".pollinations",
+            "harnesses",
+            snapshotFiles()[0],
+        );
+        writeFileSync(snapshot, "{");
+        expect(() => disableOpenclaw(ctx)).toThrow();
+        expect(snapshotFiles()).toHaveLength(1);
+        expect(openclaw.status(ctx).configured).toBe(true);
+    });
+
+    it("does not overwrite an existing skill file", () => {
+        mkdirSync(join(stateDir(), "skills", "polli"), { recursive: true });
+        writeFileSync(skillFile(), "custom content");
+
+        configureOpenclaw(ctx, models, "sk_test_key", "kimi");
+        expect(read(skillFile())).toBe("custom content");
+    });
+
+    it("stops before configuration when OpenClaw is unavailable", async () => {
+        await expect(openclaw.on(ctx, {})).rejects.toThrow(
+            "OpenClaw was not found",
+        );
+        expect(existsSync(stateDir())).toBe(false);
+        expect(snapshotFiles()).toHaveLength(0);
+    });
+});

--- a/packages/polli-cli/src/harnesses/openclaw.ts
+++ b/packages/polli-cli/src/harnesses/openclaw.ts
@@ -1,0 +1,252 @@
+import { join } from "node:path";
+import polliSkill from "../../SKILL.md?raw";
+import { BASE_URL } from "../lib/config.js";
+import { printInfo } from "../lib/output.js";
+import {
+    commandExists,
+    readTextIfExists,
+    removeIfExists,
+    writeTextAtomic,
+} from "./fs.js";
+import { resolveHarnessKey } from "./keys.js";
+import { fetchHarnessModels } from "./models.js";
+import {
+    applyWithSnapshot,
+    clearSnapshot,
+    restoreSnapshot,
+} from "./snapshot.js";
+import type {
+    HarnessAdapter,
+    HarnessContext,
+    HarnessModel,
+    HarnessResult,
+} from "./types.js";
+
+const ID = "openclaw";
+const LABEL = "OpenClaw";
+const PROVIDER = "pollinations";
+const DEFAULT_MODEL = "kimi";
+const MAX_TOKENS = 8192;
+const INSTALL_HINT = "curl -fsSL https://openclaw.ai/install.sh | bash";
+
+/**
+ * OpenClaw keeps state in OPENCLAW_STATE_DIR (default ~/.openclaw) and reads
+ * its main config from openclaw.json there. `models.providers` merges with the
+ * built-in catalog by default, so no `models.mode` override is written.
+ */
+export const openclawStateDir = (ctx: HarnessContext) =>
+    ctx.env.OPENCLAW_STATE_DIR?.trim() || join(ctx.home, ".openclaw");
+const configPath = (ctx: HarnessContext) =>
+    join(openclawStateDir(ctx), "openclaw.json");
+const skillPath = (ctx: HarnessContext) =>
+    join(openclawStateDir(ctx), "skills", "polli", "SKILL.md");
+
+const files = (ctx: HarnessContext) => [configPath(ctx), skillPath(ctx)];
+
+interface ProviderEntry {
+    baseUrl?: string;
+    api?: string;
+    apiKey?: string;
+}
+
+interface OpenClawConfig {
+    models?: { providers?: Record<string, unknown> } & Record<string, unknown>;
+    agents?: {
+        defaults?: {
+            model?: { primary?: string } & Record<string, unknown>;
+        } & Record<string, unknown>;
+    };
+    [key: string]: unknown;
+}
+
+const loadJson = (path: string): Record<string, unknown> => {
+    const text = readTextIfExists(path);
+    if (!text?.trim()) return {};
+    return JSON.parse(text) as Record<string, unknown>;
+};
+
+const saveJson = (path: string, data: Record<string, unknown>) => {
+    writeTextAtomic(path, `${JSON.stringify(data, null, 2)}\n`, 0o600);
+};
+
+const loadConfig = (path: string): OpenClawConfig =>
+    loadJson(path) as OpenClawConfig;
+
+const modelEntry = (model: HarnessModel) => ({
+    id: model.id,
+    name: model.id,
+    reasoning: false,
+    input: model.input,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: model.contextWindow,
+    maxTokens: MAX_TOKENS,
+});
+
+const providerEntry = (models: HarnessModel[], apiKey: string) => ({
+    baseUrl: `${BASE_URL}/v1`,
+    apiKey,
+    api: "openai-completions",
+    models: models.map(modelEntry),
+});
+
+const readKey = (ctx: HarnessContext): string | null => {
+    const provider = loadConfig(configPath(ctx)).models?.providers?.[
+        PROVIDER
+    ] as ProviderEntry | undefined;
+    return typeof provider?.apiKey === "string" && provider.apiKey
+        ? provider.apiKey
+        : null;
+};
+
+const primaryModel = (config: OpenClawConfig) =>
+    config.agents?.defaults?.model?.primary;
+
+const writeConfig = (
+    ctx: HarnessContext,
+    models: HarnessModel[],
+    apiKey: string,
+    model: string,
+) => {
+    const config = loadConfig(configPath(ctx));
+    config.models = {
+        ...(config.models ?? {}),
+        providers: {
+            ...((config.models?.providers as Record<string, unknown>) ?? {}),
+            [PROVIDER]: providerEntry(models, apiKey),
+        },
+    };
+
+    // OpenClaw treats an existing primary as intentional, so a non-Pollinations
+    // default is kept and only reported (docs/concepts/model-providers.md).
+    let switched = true;
+    const primary = primaryModel(config);
+    if (primary === undefined || primary.startsWith(`${PROVIDER}/`)) {
+        config.agents = {
+            ...(config.agents ?? {}),
+            defaults: {
+                ...((config.agents?.defaults as Record<string, unknown>) ?? {}),
+                model: {
+                    ...((config.agents?.defaults?.model as
+                        | Record<string, unknown>
+                        | undefined) ?? {}),
+                    primary: `${PROVIDER}/${model}`,
+                },
+            },
+        };
+    } else if (primary !== `${PROVIDER}/${model}`) {
+        switched = false;
+    }
+    saveJson(configPath(ctx), config);
+
+    if (readTextIfExists(skillPath(ctx)) === null) {
+        writeTextAtomic(skillPath(ctx), polliSkill, 0o600);
+    }
+    if (!switched) {
+        printInfo(
+            `Kept your existing default model. Switch with: openclaw models set ${PROVIDER}/${model}`,
+        );
+    }
+};
+
+const stripConfig = (ctx: HarnessContext): boolean => {
+    let changed = false;
+    if (readTextIfExists(configPath(ctx)) !== null) {
+        const config = loadConfig(configPath(ctx));
+        const providers = config.models?.providers as
+            | Record<string, unknown>
+            | undefined;
+        if (providers && PROVIDER in providers) {
+            const rest = { ...providers };
+            delete rest[PROVIDER];
+            if (Object.keys(rest).length === 0) delete config.models;
+            else config.models = { ...config.models, providers: rest };
+            changed = true;
+        }
+        if (primaryModel(config)?.startsWith(`${PROVIDER}/`)) {
+            delete config.agents?.defaults?.model?.primary;
+            changed = true;
+        }
+        if (changed) saveJson(configPath(ctx), config);
+    }
+    if (readTextIfExists(skillPath(ctx)) === polliSkill) {
+        removeIfExists(skillPath(ctx));
+        changed = true;
+    }
+    return changed;
+};
+
+const result = (ctx: HarnessContext): HarnessResult => {
+    const config = loadConfig(configPath(ctx));
+    const provider = config.models?.providers?.[PROVIDER] as
+        | ProviderEntry
+        | undefined;
+    const primary = primaryModel(config);
+    const model = primary?.startsWith(`${PROVIDER}/`)
+        ? primary.slice(PROVIDER.length + 1)
+        : undefined;
+    return {
+        harness: ID,
+        label: LABEL,
+        configured:
+            provider?.baseUrl === `${BASE_URL}/v1` &&
+            provider?.api === "openai-completions" &&
+            typeof provider?.apiKey === "string" &&
+            provider.apiKey.length > 0 &&
+            readTextIfExists(skillPath(ctx)) !== null,
+        model,
+        files: files(ctx),
+    };
+};
+
+export const configureOpenclaw = (
+    ctx: HarnessContext,
+    models: HarnessModel[],
+    apiKey: string,
+    model: string,
+): HarnessResult => {
+    applyWithSnapshot(ctx, ID, files(ctx), () =>
+        writeConfig(ctx, models, apiKey, model),
+    );
+    return result(ctx);
+};
+
+export const disableOpenclaw = (ctx: HarnessContext): HarnessResult => {
+    const managedFiles = files(ctx);
+    let outcome: HarnessResult["outcome"] = "restored";
+    if (restoreSnapshot(ctx, ID, managedFiles) !== "restored") {
+        outcome = stripConfig(ctx) ? "stripped" : "unchanged";
+        clearSnapshot(ctx, ID, managedFiles);
+    }
+    return { ...result(ctx), configured: false, outcome };
+};
+
+export const openclaw: HarnessAdapter = {
+    id: ID,
+    label: LABEL,
+    description: "Add Pollinations as a model provider in OpenClaw",
+    restartHint: "Restart OpenClaw or run: openclaw gateway restart",
+
+    async on(ctx, options) {
+        if (!commandExists("openclaw", ctx.env)) {
+            throw new Error(
+                `OpenClaw was not found. Install it first: ${INSTALL_HINT}`,
+            );
+        }
+        const model = options.model ?? DEFAULT_MODEL;
+        const models = await fetchHarnessModels();
+        if (!models.some((candidate) => candidate.id === model)) {
+            throw new Error(
+                `Model "${model}" is not a tool-calling text model. Run: polli models`,
+            );
+        }
+
+        const apiKey = await resolveHarnessKey(
+            { id: ID, label: LABEL, existingKey: readKey(ctx) },
+            { browser: options.browser },
+        );
+        return configureOpenclaw(ctx, models, apiKey, model);
+    },
+
+    off: disableOpenclaw,
+    status: result,
+};


### PR DESCRIPTION
Fixes #14121

- Adds `polli harness openclaw on|status|off` using OpenClaw's native `models.providers.pollinations` block, mirroring the existing `apps/openclaw` setup script but filling the model list from the live catalog instead of a second hardcoded table.
- Checks that OpenClaw is installed before login, key creation, or configuration, and shows the official install command.
- Defaults to `kimi` like the existing setup script; an unrelated `agents.defaults.model.primary` is preserved and reported, and repeated `on --model` switches only within Pollinations models.
- Installs the Polli skill under `skills/polli/`; `off` restores the previous config byte-for-byte and removes only Pollinations-managed entries. Follows the same inline-JSON, no-new-shared-modules pattern as the merged `prime.ts`.

Note: #14121 was closed as completed, but `main` has no OpenClaw profile yet (`harnesses/index.ts` lists dsh/opencode/pi/prime). This PR fills that gap.

Tests: 16 focused lifecycle tests; full CLI suite 83/83 pass; biome clean on modified files. Verified against a real OpenClaw 2026.8.1 install: `on` registers 68 live-catalog models, `openclaw models list` shows them all with `kimi` as default, and `off` restores the config byte-for-byte.
