### PR TITLE
feat(video): route Wan inputs across T2V, I2V, and R2V upstreams

### DIFF
--- a/gen.pollinations.ai/src/image/models/wan3FalVideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/wan3FalVideoModel.ts
@@ -10,6 +10,8 @@ const WAN_3_TEXT_ENDPOINT =
     "https://queue.fal.run/alibaba/wan-3.0-prime/text-to-video";
 const WAN_3_IMAGE_ENDPOINT =
     "https://queue.fal.run/alibaba/wan-3.0-prime/image-to-video";
+const WAN_3_REFERENCE_ENDPOINT =
+    "https://queue.fal.run/alibaba/wan-3.0-prime/reference-to-video";
 const WAN_3_DURATION_SECONDS = 5;
 const WAN_3_TIMEOUT_MS = 5 * 60 * 1000;
 const WAN_3_POLL_INTERVAL_MS = 2_000;
@@ -61,7 +63,23 @@ export async function callWan3FalAPI(
     }
 
     const startImage = safeParams.image[0];
-    const endpoint = startImage ? WAN_3_IMAGE_ENDPOINT : WAN_3_TEXT_ENDPOINT;
+    const endImage = safeParams.image[1];
+    const hasReferences = Boolean(
+        safeParams.reference_images?.length ||
+            safeParams.reference_videos?.length ||
+            safeParams.reference_audios?.length,
+    );
+    if (hasReferences && safeParams.image.length > 0) {
+        throw new HttpError(
+            "Wan 3.0 cannot combine frame images with reference media.",
+            400,
+        );
+    }
+    const endpoint = hasReferences
+        ? WAN_3_REFERENCE_ENDPOINT
+        : startImage
+          ? WAN_3_IMAGE_ENDPOINT
+          : WAN_3_TEXT_ENDPOINT;
     const deadline = Date.now() + WAN_3_TIMEOUT_MS;
     const authorization = { Authorization: `Key ${apiKey}` };
     const submissionResponse = await fetchUpstream(endpoint, {
@@ -70,19 +88,32 @@ export async function callWan3FalAPI(
         body: JSON.stringify({
             prompt,
             resolution: safeParams.resolution ?? "480p",
-            aspect_ratio: startImage
-                ? "adaptive"
-                : closestRatioLogSpace(
-                      safeParams.width,
-                      safeParams.height,
-                      WAN_3_ASPECT_RATIOS,
-                  ),
+            aspect_ratio:
+                startImage || hasReferences
+                    ? "adaptive"
+                    : closestRatioLogSpace(
+                          safeParams.width,
+                          safeParams.height,
+                          WAN_3_ASPECT_RATIOS,
+                      ),
             duration,
             audio: safeParams.audio,
             enable_prompt_expansion: true,
             enable_safety_checker: true,
             seed: safeParams.seed,
-            ...(startImage ? { start_image_url: startImage } : {}),
+            ...(startImage
+                ? {
+                      start_image_url: startImage,
+                      ...(endImage ? { end_image_url: endImage } : {}),
+                  }
+                : {}),
+            ...(hasReferences
+                ? {
+                      reference_image_urls: safeParams.reference_images ?? [],
+                      reference_video_urls: safeParams.reference_videos ?? [],
+                      reference_audio_urls: safeParams.reference_audios ?? [],
+                  }
+                : {}),
         }),
         signal: AbortSignal.timeout(remainingTime(deadline)),
         errorLabel: "Wan 3.0 submission failed",

--- a/gen.pollinations.ai/src/image/models/wanVideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/wanVideoModel.ts
@@ -2,12 +2,12 @@
  * Alibaba Wan video generation via Replicate.
  *
  * Moved off Alibaba DashScope (provider consolidation onto Replicate, which we
- * already use for Seedance). Replicate splits text-to-video and image-to-video
- * into separate models, so each variant routes by whether a first frame is
- * supplied:
+ * already use for Seedance). Replicate splits text-to-video, image-to-video,
+ * and (for Wan 2.7) reference-to-video into separate models, so each variant
+ * routes by the request inputs:
  *   - wan-fast → wan-2.2-t2v-fast / wan-2.2-i2v-fast  (480p, ~5s, silent)
  *   - wan      → wan-2.6-t2v      / wan-2.6-i2v       (720p, native audio)
- *   - wan-pro  → wan-2.7-t2v      / wan-2.7-i2v       (720p, native audio)
+ *   - wan-pro  → wan-2.7-t2v / wan-2.7-i2v / wan-2.7-r2v (720p, native audio)
  *
  * Replicate prices Wan video per-second by mode and resolution. Each public
  * wan-pro exposes 720p and 1080p through one public model. Billing selects the
@@ -15,6 +15,7 @@
  * the call to I2V.
  */
 
+import { HttpError } from "@shared/http-error.ts";
 import debug from "debug";
 import type { VideoGenerationResult } from "../createAndReturnVideos.ts";
 import type { ImageParams } from "../params.ts";
@@ -29,9 +30,13 @@ import {
 const logOps = debug("pollinations:wan:ops");
 const logError = debug("pollinations:wan:error");
 
+type WanMode = "t2v" | "i2v" | "r2v";
+
 interface WanVariantConfig {
     t2vModel: string;
     i2vModel: string;
+    /** Reference-to-video slug; only Wan 2.7 exposes one on Replicate. */
+    r2vModel?: string;
     trackingName: string;
     displayName: string;
     predictionDeadlineMinutes?: number;
@@ -40,13 +45,13 @@ interface WanVariantConfig {
      * already-downloaded data URIs: frames[0] = first frame, frames[1] = last.
      */
     buildInput(
-        mode: "t2v" | "i2v",
+        mode: WanMode,
         prompt: string,
         safeParams: ImageParams,
         frames: string[],
     ): Record<string, unknown>;
     /** Resolve the duration to request AND bill (seconds). */
-    resolveDuration(safeParams: ImageParams): number;
+    resolveDuration(safeParams: ImageParams, mode: WanMode): number;
 }
 
 // wan-2.2-fast: aspect_ratio enum is landscape/portrait only.
@@ -59,6 +64,8 @@ const WAN_FAST_FIXED_SECONDS = 5;
 const WAN_26_DURATIONS = [5, 10, 15] as const;
 const WAN_PRO_MIN_DURATION = 2;
 const WAN_PRO_MAX_DURATION = 15;
+// Replicate wan-2.7-r2v caps output at 10 seconds (T2V/I2V allow 15).
+const WAN_PRO_R2V_MAX_DURATION = 10;
 const WAN_PRO_PREDICTION_DEADLINE_MINUTES = 15;
 
 /** Pick the supported aspect ratio closest to the request. */
@@ -162,16 +169,35 @@ function makeWan27Config(
     return {
         t2vModel: "wan-video/wan-2.7-t2v",
         i2vModel: "wan-video/wan-2.7-i2v",
+        r2vModel: "wan-video/wan-2.7-r2v",
         trackingName,
         displayName: `Wan 2.7${resolution === "1080p" ? " 1080p" : ""}`,
         predictionDeadlineMinutes: WAN_PRO_PREDICTION_DEADLINE_MINUTES,
-        resolveDuration: (p) =>
+        resolveDuration: (p, mode) =>
             Math.max(
                 WAN_PRO_MIN_DURATION,
-                Math.min(WAN_PRO_MAX_DURATION, Math.floor(p.duration ?? 5)),
+                Math.min(
+                    mode === "r2v"
+                        ? WAN_PRO_R2V_MAX_DURATION
+                        : WAN_PRO_MAX_DURATION,
+                    Math.floor(p.duration ?? 5),
+                ),
             ),
         buildInput(mode, prompt, safeParams, frames) {
-            const duration = this.resolveDuration(safeParams);
+            if (mode === "r2v") {
+                return withSeed(
+                    {
+                        prompt,
+                        resolution,
+                        aspect_ratio: pickAspect(safeParams, WAN_PRO_RATIOS),
+                        duration: this.resolveDuration(safeParams, "r2v"),
+                        reference_images: safeParams.reference_images ?? [],
+                        reference_videos: safeParams.reference_videos ?? [],
+                    },
+                    safeParams,
+                );
+            }
+            const duration = this.resolveDuration(safeParams, mode);
             if (mode === "i2v") {
                 return withSeed(
                     {
@@ -206,13 +232,37 @@ async function generateWanVideo(
     safeParams: ImageParams,
 ): Promise<VideoGenerationResult> {
     const images = safeParams.image ?? [];
-    const mode: "t2v" | "i2v" = images.length > 0 ? "i2v" : "t2v";
-    const model = mode === "i2v" ? config.i2vModel : config.t2vModel;
+    const referenceCount =
+        (safeParams.reference_images?.length ?? 0) +
+        (safeParams.reference_videos?.length ?? 0) +
+        (safeParams.reference_audios?.length ?? 0);
+
+    let mode: WanMode;
+    let model: string;
+    if (referenceCount > 0) {
+        if (images.length > 0) {
+            throw new HttpError(
+                `${config.displayName} cannot combine frame images with reference media.`,
+                400,
+            );
+        }
+        if (!config.r2vModel || safeParams.reference_audios?.length) {
+            throw new HttpError(
+                `${config.displayName} does not support the requested reference media.`,
+                400,
+            );
+        }
+        mode = "r2v";
+        model = config.r2vModel;
+    } else {
+        mode = images.length > 0 ? "i2v" : "t2v";
+        model = mode === "i2v" ? config.i2vModel : config.t2vModel;
+    }
 
     const frames =
-        images.length > 0 ? await Promise.all(images.map(toDataUri)) : [];
+        mode === "i2v" ? await Promise.all(images.map(toDataUri)) : [];
     const input = config.buildInput(mode, prompt, safeParams, frames);
-    const requestedDuration = config.resolveDuration(safeParams);
+    const requestedDuration = config.resolveDuration(safeParams, mode);
 
     logOps(`${config.displayName} (${mode}) input:`, {
         ...input,
@@ -221,6 +271,8 @@ async function generateWanVideo(
         first_frame: input.first_frame ? "[data uri]" : undefined,
         last_image: input.last_image ? "[data uri]" : undefined,
         last_frame: input.last_frame ? "[data uri]" : undefined,
+        reference_images: input.reference_images ? "[urls]" : undefined,
+        reference_videos: input.reference_videos ? "[urls]" : undefined,
     });
 
     let videoUrl: string;

--- a/gen.pollinations.ai/src/schemas/image.ts
+++ b/gen.pollinations.ai/src/schemas/image.ts
@@ -84,7 +84,7 @@ const GenerateImageRequestQueryParamsBaseSchema = z.object({
         )
         .meta({
             description:
-                "Reference image URL(s) for image editing or video generation. Separate multiple URLs with `|` or `,`. **Image models:** Used for editing/style reference (kontext, flux-2-pro, flux-2-flex, gptimage, seedream, klein, nanobanana). **Video models:** `image[0]` = starting frame (I2V); `image[1]` = ending frame for first+last-frame interpolation. End-frame supported by `veo`, the `seedance-2.0` family, `seedance-2.5`, `wan-fast`, and `wan-pro`. Requests exceeding the selected model's `max_reference_images` return 400. See `video_capabilities` on `/image/models` or `/models` for per-model support.",
+                "Reference image URL(s) for image editing or video generation. Separate multiple URLs with `|` or `,`. **Image models:** Used for editing/style reference (kontext, flux-2-pro, flux-2-flex, gptimage, seedream, klein, nanobanana). **Video models:** `image[0]` = starting frame (I2V); `image[1]` = ending frame for first+last-frame interpolation. End-frame supported by `veo`, the `seedance-2.0` family, `seedance-2.5`, `wan-fast`, `wan-pro`, and `wan-3.0`. Requests exceeding the selected model's `max_reference_images` return 400. See `video_capabilities` on `/image/models` or `/models` for per-model support.",
         }),
     reference_images: z
         .string()
@@ -97,7 +97,7 @@ const GenerateImageRequestQueryParamsBaseSchema = z.object({
         .optional()
         .meta({
             description:
-                "Video models only: public HTTP(S) image URLs for visual guidance, separate from first/last-frame controls. Separate multiple URLs with `|`; commas inside URLs are preserved. Supported only by Seedance 2.0 and 2.5.",
+                "Video models only: public HTTP(S) image URLs for visual guidance, separate from first/last-frame controls. Separate multiple URLs with `|`; commas inside URLs are preserved. Supported by Seedance 2.0, Seedance 2.5, `wan-pro`, and `wan-3.0`.",
         }),
     reference_videos: z
         .string()
@@ -110,7 +110,7 @@ const GenerateImageRequestQueryParamsBaseSchema = z.object({
         .optional()
         .meta({
             description:
-                "Video models only: public HTTP(S) video URLs for motion or style guidance. Separate multiple URLs with `|`; commas inside URLs are preserved. Supported only by Seedance 2.0 and 2.5.",
+                "Video models only: public HTTP(S) video URLs for motion or style guidance. Separate multiple URLs with `|`; commas inside URLs are preserved. Supported by Seedance 2.0, Seedance 2.5, `wan-pro`, and `wan-3.0`.",
         }),
     reference_audios: z
         .string()
@@ -123,7 +123,7 @@ const GenerateImageRequestQueryParamsBaseSchema = z.object({
         .optional()
         .meta({
             description:
-                "Video models only: public HTTP(S) audio URLs for audio-driven generation. Separate multiple URLs with `|`; commas inside URLs are preserved. Supported only by Seedance 2.0 and 2.5.",
+                "Video models only: public HTTP(S) audio URLs for audio-driven generation. Separate multiple URLs with `|`; commas inside URLs are preserved. Supported by Seedance 2.0, Seedance 2.5, and `wan-3.0`.",
         }),
     transparent: z.coerce.boolean().optional().default(false).meta({
         description:

--- a/gen.pollinations.ai/test/image/videoFrameValidation.test.ts
+++ b/gen.pollinations.ai/test/image/videoFrameValidation.test.ts
@@ -19,7 +19,7 @@ const VIDEO_FRAME_LIMITS = [
     ["seedance-2.0-mini", 2],
     ["seedance-2.0-fast", 2],
     ["wan", 1],
-    ["wan-3.0", 1],
+    ["wan-3.0", 2],
     ["wan-fast", 2],
     ["wan-pro", 2],
     ["grok-video-pro", 1],

--- a/gen.pollinations.ai/test/image/wan3FalVideoModel.test.ts
+++ b/gen.pollinations.ai/test/image/wan3FalVideoModel.test.ts
@@ -7,6 +7,8 @@ const TEXT_ENDPOINT =
     "https://queue.fal.run/alibaba/wan-3.0-prime/text-to-video";
 const IMAGE_ENDPOINT =
     "https://queue.fal.run/alibaba/wan-3.0-prime/image-to-video";
+const REFERENCE_ENDPOINT =
+    "https://queue.fal.run/alibaba/wan-3.0-prime/reference-to-video";
 const STATUS_URL =
     "https://queue.fal.run/alibaba/wan-3.0-prime/requests/test/status";
 const RESULT_URL = "https://queue.fal.run/alibaba/wan-3.0-prime/requests/test";
@@ -51,7 +53,11 @@ function mockFalFetch(
                       >)
                     : undefined,
             });
-            if (href === TEXT_ENDPOINT || href === IMAGE_ENDPOINT) {
+            if (
+                href === TEXT_ENDPOINT ||
+                href === IMAGE_ENDPOINT ||
+                href === REFERENCE_ENDPOINT
+            ) {
                 return Response.json({
                     status_url: STATUS_URL,
                     response_url: RESULT_URL,
@@ -155,6 +161,61 @@ describe("Wan 3.0 Prime via Fal", () => {
             callWan3FalAPI("a sailboat crossing a calm bay", {
                 ...baseParams,
                 duration: 4,
+            }),
+        ).rejects.toMatchObject({ status: 400 });
+        expect(fetchSpy).not.toHaveBeenCalled();
+    });
+});
+
+describe("Wan 3.0 Prime reference and end-frame routing", () => {
+    it("routes reference media to the reference-to-video endpoint", async () => {
+        const requests: ProviderRequest[] = [];
+        mockFalFetch(requests);
+
+        await callWan3FalAPI("the subject in Image 1 walks past Video 1", {
+            ...baseParams,
+            reference_images: ["https://media.example.com/ref.png"],
+            reference_videos: ["https://media.example.com/clip.mp4"],
+            reference_audios: ["https://media.example.com/voice.mp3"],
+        });
+
+        expect(requests[0].url).toBe(REFERENCE_ENDPOINT);
+        expect(requests[0].body).toMatchObject({
+            aspect_ratio: "adaptive",
+            reference_image_urls: ["https://media.example.com/ref.png"],
+            reference_video_urls: ["https://media.example.com/clip.mp4"],
+            reference_audio_urls: ["https://media.example.com/voice.mp3"],
+        });
+        expect(requests[0].body).not.toHaveProperty("start_image_url");
+    });
+
+    it("forwards image[1] as the end frame on image-to-video", async () => {
+        const requests: ProviderRequest[] = [];
+        mockFalFetch(requests);
+
+        await callWan3FalAPI("morph between the frames", {
+            ...baseParams,
+            image: [
+                "https://media.example.com/start.png",
+                "https://media.example.com/end.png",
+            ],
+        });
+
+        expect(requests[0].url).toBe(IMAGE_ENDPOINT);
+        expect(requests[0].body).toMatchObject({
+            start_image_url: "https://media.example.com/start.png",
+            end_image_url: "https://media.example.com/end.png",
+        });
+    });
+
+    it("rejects frame images combined with reference media before any fetch", async () => {
+        const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+        await expect(
+            callWan3FalAPI("ambiguous request", {
+                ...baseParams,
+                image: ["https://media.example.com/start.png"],
+                reference_images: ["https://media.example.com/ref.png"],
             }),
         ).rejects.toMatchObject({ status: 400 });
         expect(fetchSpy).not.toHaveBeenCalled();

--- a/gen.pollinations.ai/test/image/wanVideoModel.test.ts
+++ b/gen.pollinations.ai/test/image/wanVideoModel.test.ts
@@ -255,3 +255,101 @@ describe("wanVideoModel image-to-video routing", () => {
         expect(calls[0].input.last_image as string).toMatch(EXPECTED_DATA_URI);
     });
 });
+
+describe("wanVideoModel reference-to-video routing", () => {
+    const REF_IMAGE = "https://img.example.com/character.png";
+    const REF_VIDEO = "https://vid.example.com/motion.mp4";
+
+    it("wan-pro routes reference images to wan-2.7-r2v with url passthrough", async () => {
+        setReplicateEnv();
+        const calls: ReplicateCall[] = [];
+        mockReplicateFetch(calls, 5);
+
+        const result = await callWanProAPI("the subject turns to the camera", {
+            ...baseParams,
+            reference_images: [REF_IMAGE],
+        });
+
+        expect(calls[0].model).toBe("wan-video/wan-2.7-r2v");
+        expect(calls[0].input.reference_images).toEqual([REF_IMAGE]);
+        expect(calls[0].input.reference_videos).toEqual([]);
+        expect(calls[0].input.first_frame).toBeUndefined();
+        expect(calls[0].input.duration).toBe(5);
+        expect(calls[0].input.resolution).toBe("720p");
+        expect(result.trackingData).toEqual({
+            actualModel: "wan-pro",
+            usage: { completionVideoSeconds: 5 },
+        });
+    });
+
+    it("clamps wan-pro R2V duration to the 10-second upstream maximum", async () => {
+        setReplicateEnv();
+        const calls: ReplicateCall[] = [];
+        mockReplicateFetch(calls, 10);
+
+        await callWanProAPI("the subject turns to the camera", {
+            ...baseParams,
+            duration: 12,
+            reference_videos: [REF_VIDEO],
+        });
+
+        expect(calls[0].model).toBe("wan-video/wan-2.7-r2v");
+        expect(calls[0].input.duration).toBe(10);
+        expect(calls[0].input.reference_videos).toEqual([REF_VIDEO]);
+    });
+
+    it("keeps wan-pro T2V durations above the R2V cap", async () => {
+        setReplicateEnv();
+        const calls: ReplicateCall[] = [];
+        mockReplicateFetch(calls, 12);
+
+        await callWanProAPI("a calm ocean at sunset", {
+            ...baseParams,
+            duration: 12,
+        });
+
+        expect(calls[0].model).toBe("wan-video/wan-2.7-t2v");
+        expect(calls[0].input.duration).toBe(12);
+    });
+
+    it("rejects frame images combined with reference media", async () => {
+        setReplicateEnv();
+        const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+        await expect(
+            callWanProAPI("ambiguous request", {
+                ...baseParams,
+                image: [INPUT_IMAGE_URL],
+                reference_images: [REF_IMAGE],
+            }),
+        ).rejects.toMatchObject({ status: 400 });
+        expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("rejects reference media on variants without an R2V upstream", async () => {
+        setReplicateEnv();
+        const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+        await expect(
+            callWanAPI("a cat walking", {
+                ...baseParams,
+                model: "wan",
+                reference_images: [REF_IMAGE],
+            }),
+        ).rejects.toMatchObject({ status: 400 });
+        expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("rejects reference audio on wan-pro (Replicate R2V has no audio input)", async () => {
+        setReplicateEnv();
+        const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+        await expect(
+            callWanProAPI("the subject speaks", {
+                ...baseParams,
+                reference_audios: ["https://aud.example.com/voice.mp3"],
+            }),
+        ).rejects.toMatchObject({ status: 400 });
+        expect(fetchSpy).not.toHaveBeenCalled();
+    });
+});

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -772,10 +772,17 @@ const IMAGE_BASE_SERVICES = {
         ),
         resolutions: ["720p", "1080p"],
         title: "Wan 2.7",
-        description: "Keyframe-controlled video with sound at 720p or 1080p",
+        description:
+            "Keyframe- or reference-controlled video with sound at 720p or 1080p",
         inputModalities: ["text", "image"],
         outputModalities: ["video", "audio"],
-        videoCapabilities: ["start_frame", "end_frame", "audio_output"],
+        videoCapabilities: [
+            "start_frame",
+            "end_frame",
+            "audio_output",
+            "reference_images",
+            "reference_videos",
+        ],
         maxReferenceImages: 2, // Video keyframe slots: start + end.
         minDuration: 2,
         maxDuration: 15,
@@ -820,11 +827,18 @@ const IMAGE_BASE_SERVICES = {
         resolutions: ["480p", "720p", "1080p"],
         title: "Wan 3.0",
         description:
-            "Five-second video from text or a start image with optional audio at 480p, 720p, or 1080p",
+            "Five-second video from text, start and end frames, or reference media with optional audio at 480p, 720p, or 1080p",
         inputModalities: ["text", "image"],
         outputModalities: ["video", "audio"],
-        videoCapabilities: ["start_frame", "audio_output"],
-        maxReferenceImages: 1, // Video keyframe slots: start only.
+        videoCapabilities: [
+            "start_frame",
+            "end_frame",
+            "audio_output",
+            "reference_images",
+            "reference_videos",
+            "reference_audios",
+        ],
+        maxReferenceImages: 2, // Video keyframe slots: start + end.
         minDuration: 5,
         maxDuration: 5,
         defaultDuration: 5,


### PR DESCRIPTION
Fixes #14021

Routes each Wan request to the upstream mode that matches its inputs while keeping one public model ID per Wan version. Routing stays inside the two existing Wan adapters — no generic mode router, no new endpoints, no new dependencies.

## What changes

**`wanVideoModel.ts` (wan-pro → Replicate Wan 2.7)**
- Adds an explicit `WanMode` (`t2v` / `i2v` / `r2v`) resolved from request inputs: reference media → R2V, `image[0]` → I2V, otherwise T2V.
- R2V maps `reference_images` / `reference_videos` to the `wan-video/wan-2.7-r2v` inputs and enforces that mode's 2–10s duration cap (T2V/I2V keep 15s).
- Frame + reference combinations return a clear 400 instead of silently dropping inputs; `reference_audios` on wan-pro returns 400 since Wan 2.7 R2V has no audio input.
- Reference URLs are passed through as-is (already validated in `params.ts`); request logs redact media fields.

**`wan3FalVideoModel.ts` (wan-3.0 → Fal Wan 3.0 Prime)**
- Any reference media routes to `alibaba/wan-3.0-prime/reference-to-video`, forwarding `reference_image_urls` / `reference_video_urls` / `reference_audio_urls`.
- `image[1]` now maps to the existing `end_image_url` input on the I2V route.
- Same frame + reference rejection; duration/resolution handling unchanged so billing keeps using the existing per-second rates.

**Registry & OpenAPI**
- `wan-pro` advertises `reference_images` + `reference_videos`; `wan-3.0` advertises `end_frame` + all three reference capabilities (`maxReferenceImages` 1 → 2).
- Updated the matching OpenAPI description strings.

Billing needed no changes: R2V requests carry no frame, so the existing `hasImage` logic already selects the $0.10/sec (Wan 2.7) and resolution-tiered (Wan 3.0) rates.

## How I verified

- Focused tests: `wanVideoModel.test.ts` (14), `wan3FalVideoModel.test.ts` (8), `videoFrameValidation.test.ts` (35) — 57/57 pass, covering routing, field mapping, invalid combinations, duration limits and billing inputs.
- Full `gen.pollinations.ai` suite: 115 files, 1433 passed / 6 skipped, 0 failures.
- `npx biome check --write` run on all modified files.

7 files changed, +289 / −33.
