### PR TITLE
feat: add GIMP 3 plug-in for Pollinations image generation and BYOP auth

### DIFF
--- a/apps/gimp-plugin/README.md
+++ b/apps/gimp-plugin/README.md
@@ -1,0 +1,98 @@
+# Pollinations AI — GIMP 3 plug-in
+
+Generate and edit images inside GIMP using [Pollinations.ai](https://pollinations.ai)'s image API. Every user authenticates through their own Pollinations account via the BYOP device-flow — no API key is ever pasted into GIMP.
+
+## Features
+
+- **BYOP device-flow auth** — opens a browser for approval; your API key stays private.
+- **Runtime model picker** — fetches `/image/models` at runtime; no model IDs hardcoded.
+- **Generate** — text-to-image via `GET /image/{prompt}`; result added as a new image or layer.
+- **Edit with AI** — sends the active layer (or selection crop) to `POST /v1/images/edits` as a genuine multipart file upload. The source layer is never modified.
+- **Resolution picker** — offers standard resolutions when the model advertises them.
+- **No data URIs** — source pixels are exported as PNG bytes, never base64-encoded inline.
+- **Model capability gating** — edit-capable models must have `"image"` in both `input_modalities` and `output_modalities`.
+- **Clear error messages** — 401 → expired token, 402 → insufficient pollen, 429 → rate limit, network errors → connectivity hint.
+
+## Requirements
+
+- GIMP 3.0+ (Python plug-in support enabled)
+- Python 3.8+
+- A [Pollinations account](https://pollinations.ai) (free tier available)
+
+## Installation
+
+Copy the directory `apps/gimp-plugin/` into GIMP's plug-ins folder, then restart GIMP. The plug-in must live inside a folder named `pollinations_gimp/`.
+
+### Linux
+
+```bash
+cp -r apps/gimp-plugin ~/.config/GIMP/3.0/plug-ins/pollinations_gimp/
+```
+
+### macOS
+
+```bash
+cp -r apps/gimp-plugin ~/Library/Application\ Support/GIMP/3.0/plug-ins/pollinations_gimp/
+```
+
+### Windows
+
+```
+%APPDATA%\GIMP\3.0\plug-ins\pollinations_gimp\
+```
+
+After copying, make the script executable (Linux/macOS):
+
+```bash
+chmod +x ~/.config/GIMP/3.0/plug-ins/pollinations_gimp/pollinations_gimp.py
+```
+
+Restart GIMP. The menu appears under **Filters ▸ Pollinations AI**.
+
+## Usage
+
+### Connect Account
+
+1. **Filters ▸ Pollinations AI ▸ Connect Account…**
+2. GIMP opens your browser to the Pollinations approval page.
+3. Approve access. GIMP receives your token automatically.
+
+Your token is stored at `~/.config/pollinations-gimp/token.json` with `0600` permissions.
+
+### Generate Image
+
+1. **Filters ▸ Pollinations AI ▸ Generate Image…**
+2. Pick a model, enter a prompt, set width/height.
+3. Optionally check **Add as new layer** to insert the result into the current image.
+4. Click **Generate**.
+
+### Edit with AI
+
+1. Open an image, optionally make a selection.
+2. **Filters ▸ Pollinations AI ▸ Edit with AI…**
+3. Pick an image-input model (filtered to those that accept `image` in `input_modalities`).
+4. Enter your edit prompt and click **Generate**.
+5. The result appears as a new layer. The original layer is untouched.
+
+### Disconnect
+
+**Filters ▸ Pollinations AI ▸ Disconnect** — removes your stored token.
+
+## Testing
+
+Unit tests require only Python (no GIMP installation):
+
+```bash
+cd apps/gimp-plugin
+python3 -m pytest tests/test_pollinations_gimp.py -v
+```
+
+## Model support
+
+The model list is fetched live from `https://gen.pollinations.ai/image/models`. Any model with `"image"` in its `output_modalities` appears in the picker. Models with `"image"` in `input_modalities` also appear in the edit dialog.
+
+Image-editing models on Pollinations include FLUX Kontext, GPT Image, Nova Canvas, Seedream, nanobanana, and others. Full list: <https://pollinations.ai/models>.
+
+## License
+
+MIT — see repository root for details.

--- a/apps/gimp-plugin/pollinations_gimp.py
+++ b/apps/gimp-plugin/pollinations_gimp.py
@@ -1,0 +1,1002 @@
+#!/usr/bin/env python3
+r"""
+Pollinations AI — GIMP 3 plug-in
+================================
+
+Generate and edit images inside GIMP using the Pollinations AI image API.
+Every user authenticates through their own Pollinations account via the
+BYOP device-flow — no API key is ever pasted into GIMP.
+
+Placement (restart GIMP after installing):
+  Linux   : ~/.config/GIMP/3.0/plug-ins/pollinations_gimp/pollinations_gimp.py
+  macOS   : ~/Library/Application Support/GIMP/3.0/plug-ins/pollinations_gimp/pollinations_gimp.py
+  Windows : %APPDATA%\GIMP\3.0\plug-ins\pollinations_gimp\pollinations_gimp.py
+
+Menu after installation:
+  Filters ▸ Pollinations AI ▸ Connect / Generate / Edit / Disconnect
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import tempfile
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import webbrowser
+from pathlib import Path
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+
+PLUGIN_VERSION = "1.0.0"
+ENTER_BASE = "https://enter.pollinations.ai"
+GEN_BASE = "https://gen.pollinations.ai"
+
+# Publishable App Key that identifies this plug-in for attribution and
+# developer earnings.  Replace with your own key for forks:
+#   https://enter.pollinations.ai/keys
+APP_KEY = "pk_pollinations_gimp"
+
+USER_AGENT = f"pollinations-gimp/{PLUGIN_VERSION} (+https://github.com/pollinations/pollinations)"
+POLL_INTERVAL_S = 5
+
+_TOKEN_PATH = Path.home() / ".config" / "pollinations-gimp" / "token.json"
+
+
+# ── Error type (user-safe messages) ───────────────────────────────────────────
+
+
+class PollinationsError(Exception):
+    """Error with a user-safe message, HTTP status, and API error code."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status: int | None = None,
+        code: str | None = None,
+        payload: dict | None = None,
+    ):
+        super().__init__(message)
+        self.status = status
+        self.code = code
+        self.payload = payload
+
+
+def _map_error(status: int | None, payload: dict | None = None) -> PollinationsError:
+    """Build a user-safe PollinationsError from a status + JSON payload."""
+    code = payload.get("error") if isinstance(payload, dict) else None
+    if status == 401 or code in ("invalid_token", "invalid_client", "UNAUTHORIZED"):
+        return PollinationsError(
+            "Your Pollinations authorization has expired or is invalid.\n"
+            "Disconnect, then run Connect Account again.",
+            status=status,
+            code=code,
+            payload=payload,
+        )
+    if status == 402:
+        return PollinationsError(
+            "Not enough Pollen balance for this request.\n"
+            "Top up at enter.pollinations.ai.",
+            status=status,
+            code=code,
+            payload=payload,
+        )
+    if status is not None and status == 429:
+        return PollinationsError(
+            "Too many requests. Wait a moment and try again.",
+            status=status,
+            code=code,
+            payload=payload,
+        )
+    if status is not None and status >= 500:
+        return PollinationsError(
+            "Pollinations is temporarily unavailable. Try again shortly.",
+            status=status,
+            code=code,
+            payload=payload,
+        )
+    if code in ("access_denied", "denied"):
+        return PollinationsError(
+            "Authorization was declined in the browser.", status=status, code=code, payload=payload
+        )
+    if code in ("expired_token",):
+        return PollinationsError(
+            "The approval code expired. Connect again.", status=status, code=code, payload=payload
+        )
+    if code in ("authorization_pending",):
+        return PollinationsError(
+            "Waiting for authorization.", status=status, code=code, payload=payload
+        )
+    if code == "timeout":
+        return PollinationsError(
+            "Request timed out. Try again.",
+            status=status, code=code, payload=payload,
+        )
+    if code == "network":
+        return PollinationsError(
+            "Cannot reach Pollinations. Check your internet connection.",
+            status=status, code=code, payload=payload,
+        )
+    return PollinationsError(
+        f"Request failed (HTTP {status or '?'})",
+        status=status,
+        code=code,
+        payload=payload,
+    )
+
+
+# ── HTTP helpers (no GIMP dependency) ─────────────────────────────────────────
+
+
+def _http_json(
+    url: str,
+    method: str = "GET",
+    payload: dict | None = None,
+    token: str | None = None,
+    *,
+    timeout: float = 60,
+    opener=None,
+) -> dict | list:
+    """Send a JSON request and return the parsed response.
+
+    Raises PollinationsError on network or HTTP errors.
+    The *opener* parameter is for testing (inject a mock).
+    """
+    body = json.dumps(payload).encode() if payload is not None else None
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": USER_AGENT,
+        },
+        method=method or ("POST" if body else "GET"),
+    )
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+
+    open_fn = opener or urllib.request.urlopen
+    try:
+        with open_fn(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        raw = exc.read()
+        try:
+            payload_resp = json.loads(raw.decode())
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            payload_resp = None
+        raise _map_error(exc.code, payload_resp) from None
+    except (TimeoutError, urllib.error.URLError, OSError) as exc:
+        timed_out = isinstance(exc, TimeoutError) or (
+            isinstance(exc, urllib.error.URLError) and isinstance(exc.reason, TimeoutError)
+        )
+        code = "timeout" if timed_out else "network"
+        message = (
+            "Request timed out. Try again."
+            if code == "timeout"
+            else "Cannot reach Pollinations. Check your internet connection."
+        )
+        raise PollinationsError(message, code=code) from None
+
+
+def _http_bytes(url: str, token: str | None = None, *, timeout: float = 120, opener=None) -> bytes:
+    """GET *url* and return raw bytes (for the image endpoint)."""
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    open_fn = opener or urllib.request.urlopen
+    try:
+        with open_fn(req, timeout=timeout) as resp:
+            return resp.read()
+    except urllib.error.HTTPError as exc:
+        raw = exc.read()
+        try:
+            payload = json.loads(raw.decode())
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            payload = None
+        raise _map_error(exc.code, payload) from None
+    except (TimeoutError, urllib.error.URLError, OSError) as exc:
+        timed_out = isinstance(exc, TimeoutError) or (
+            isinstance(exc, urllib.error.URLError) and isinstance(exc.reason, TimeoutError)
+        )
+        code = "timeout" if timed_out else "network"
+        message = "Request timed out." if code == "timeout" else "Cannot reach Pollinations."
+        raise PollinationsError(message, code=code) from None
+
+
+def _build_multipart(
+    fields: list[tuple[str, str] | tuple[str, str, str, bytes]],
+    boundary: str | None = None,
+) -> tuple[str, bytes]:
+    """Build a multipart/form-data body.
+
+    *fields* items are (name, value) for text fields or
+    (name, filename, content_type, file_bytes) for binary uploads.
+    Returns (content_type, body_bytes).
+    """
+    if boundary is None:
+        import uuid
+        boundary = uuid.uuid4().hex
+    parts: list[bytes] = []
+    for field in fields:
+        if len(field) == 2:
+            name, value = field
+            parts.append(
+                f"--{boundary}\r\n"
+                f'Content-Disposition: form-data; name="{name}"\r\n\r\n'
+                f"{value}\r\n".encode()
+            )
+        else:
+            name, filename, content_type, data = field
+            parts.append(
+                f"--{boundary}\r\n"
+                f'Content-Disposition: form-data; name="{name}"; filename="{filename}"\r\n'
+                f"Content-Type: {content_type}\r\n\r\n".encode()
+                + data
+                + b"\r\n"
+            )
+    parts.append(f"--{boundary}--\r\n".encode())
+    body = b"".join(parts)
+    return f"multipart/form-data; boundary={boundary}", body
+
+
+# ── Token validation / persistence ────────────────────────────────────────────
+
+
+def validate_token(token: str) -> str:
+    """Validate and normalize a Pollinations sk_ token."""
+    token = token.strip()
+    if len(token) < 8 or not token.startswith("sk_"):
+        raise PollinationsError(
+            "Received an invalid API token from Pollinations.",
+            code="invalid_token",
+        )
+    return token
+
+
+def save_token(token: str, path: Path = _TOKEN_PATH) -> None:
+    token = validate_token(token)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        os.chmod(tmp_name, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump({"access_token": token}, handle, separators=(",", ":"))
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_name, path)
+        try:
+            os.chmod(path, 0o600)
+        except OSError:
+            pass
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def load_token(path: Path = _TOKEN_PATH) -> str | None:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict) or set(data) != {"access_token"}:
+        return None
+    try:
+        return validate_token(data["access_token"])
+    except PollinationsError:
+        return None
+
+
+def clear_token(path: Path = _TOKEN_PATH) -> None:
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+# ── Device-flow authentication ─────────────────────────────────────────────────
+
+
+def start_device_flow(client_id: str = APP_KEY, *, requester=None) -> dict:
+    """Request a device code. Returns the raw code dict."""
+    return _http_json(
+        f"{ENTER_BASE}/api/device/code",
+        method="POST",
+        payload={"client_id": client_id, "scope": "generate profile usage keys"},
+        opener=requester,
+    )
+
+
+def poll_device_token(
+    device: dict,
+    client_id: str = APP_KEY,
+    *,
+    requester=None,
+    sleep_fn=None,
+    monotonic=None,
+) -> str:
+    """Poll until the user approves. Returns the sk_ token string.
+
+    Raises PollinationsError on expired code, denial, or network failure.
+    """
+    if sleep_fn is None:
+        sleep_fn = time.sleep
+    if monotonic is None:
+        monotonic = time.monotonic
+
+    interval = max(1, float(device.get("interval", POLL_INTERVAL_S)))
+    deadline = monotonic() + float(device.get("expires_in", 1800))
+
+    while monotonic() < deadline:
+        sleep_fn(interval)
+        try:
+            resp = _http_json(
+                f"{ENTER_BASE}/api/device/token",
+                method="POST",
+                payload={
+                    "device_code": device["device_code"],
+                    "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                },
+                opener=requester,
+            )
+        except PollinationsError as exc:
+            if exc.code == "authorization_pending":
+                continue
+            if exc.code == "slow_down" or exc.payload and exc.payload.get("error") == "slow_down":
+                interval += 5
+                continue
+            raise
+        if isinstance(resp, dict) and isinstance(resp.get("access_token"), str):
+            return validate_token(resp["access_token"])
+        code = resp.get("error") if isinstance(resp, dict) else None
+        if code == "authorization_pending":
+            continue
+        if code == "slow_down":
+            interval += 5
+            continue
+        raise _map_error(400, resp)
+    raise PollinationsError("The approval code expired. Connect again.", code="expired_token")
+
+
+def fetch_userinfo(token: str, *, requester=None) -> dict:
+    return _http_json(f"{ENTER_BASE}/api/device/userinfo", token=validate_token(token), opener=requester)
+
+
+# ── Model catalogue ────────────────────────────────────────────────────────────
+
+
+def fetch_image_models(token: str | None = None, *, requester=None) -> list[dict]:
+    """Fetch image models from /image/models.
+
+    Returns a filtered list of image-producing models (first-party + community).
+    """
+    resp = _http_json(f"{GEN_BASE}/image/models", token=token, opener=requester)
+    rows = resp if isinstance(resp, list) else resp.get("data", []) if isinstance(resp, dict) else []
+    if not isinstance(rows, list):
+        return []
+    result: list[dict] = []
+    for raw in rows:
+        if not isinstance(raw, dict):
+            continue
+        model = dict(raw)
+        # Normalize aliases to snake_case for consistency
+        for src, dst in [
+            ("inputModalities", "input_modalities"),
+            ("outputModalities", "output_modalities"),
+            ("paidOnly", "paid_only"),
+            ("maxReferenceImages", "max_reference_images"),
+        ]:
+            if dst not in model and src in model:
+                model[dst] = model[src]
+        category = model.get("category")
+        outputs = model.get("output_modalities") or []
+        if category == "video":
+            continue
+        if category == "image" and "image" not in outputs:
+            continue
+        if category not in ("image", None):
+            continue
+        if "image" not in outputs:
+            continue
+        result.append(model)
+    return result
+
+
+def can_edit(model: dict) -> bool:
+    """True if the model accepts an image as input and produces images."""
+    inputs = model.get("input_modalities") or []
+    outputs = model.get("output_modalities") or []
+    return "image" in inputs and "image" in outputs
+
+
+def model_resolutions(model: dict) -> list[str]:
+    """Return the resolutions advertised by a model, or empty list."""
+    return [v for v in model.get("resolutions", []) if isinstance(v, str)]
+
+
+# ── API calls ──────────────────────────────────────────────────────────────────
+
+
+def generate_image(
+    token: str,
+    prompt: str,
+    model_id: str,
+    *,
+    width: int = 1024,
+    height: int = 1024,
+    requester=None,
+) -> bytes:
+    """Text-to-image via GET /image/{prompt}. Returns raw image bytes."""
+    encoded = urllib.parse.quote(prompt, safe="")
+    url = f"{GEN_BASE}/image/{encoded}?model={urllib.parse.quote(model_id, safe='')}&width={width}&height={height}"
+    return _http_bytes(url, token=validate_token(token), opener=requester)
+
+
+def edit_image(
+    token: str,
+    prompt: str,
+    model_id: str,
+    source_png: bytes,
+    *,
+    requester=None,
+) -> bytes:
+    """Edit via POST /v1/images/edits (multipart). Returns decoded PNG bytes."""
+    ct, body = _build_multipart([
+        ("image", "layer.png", "image/png", source_png),
+        ("prompt", prompt),
+        ("model", model_id),
+    ])
+    req = urllib.request.Request(
+        f"{GEN_BASE}/v1/images/edits",
+        data=body,
+        headers={
+            "Content-Type": ct,
+            "Authorization": f"Bearer {validate_token(token)}",
+            "User-Agent": USER_AGENT,
+            "Accept": "application/json",
+        },
+        method="POST",
+    )
+    open_fn = requester or urllib.request.urlopen
+    try:
+        with open_fn(req, timeout=120) as resp:
+            result = json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        raw = exc.read()
+        try:
+            payload = json.loads(raw.decode())
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            payload = None
+        raise _map_error(exc.code, payload) from None
+    except (TimeoutError, urllib.error.URLError, OSError) as exc:
+        code = "timeout" if isinstance(exc, TimeoutError) else "network"
+        raise PollinationsError("Request timed out." if code == "timeout" else "Network error.", code=code) from None
+    return _decode_b64_image(result)
+
+
+def _decode_b64_image(payload: dict | list) -> bytes:
+    """Decode the b64_json from an OpenAI-compatible image response."""
+    try:
+        data = payload.get("data", payload) if isinstance(payload, dict) else payload
+        encoded = data[0]["b64_json"]
+        return base64.b64decode(encoded, validate=True)
+    except (KeyError, IndexError, TypeError, ValueError) as exc:
+        raise PollinationsError(
+            "The API returned an invalid image response.", code="invalid_response"
+        ) from exc
+
+
+# ── GIMP-specific layer I/O (depends on Gimp + Gio at runtime) ────────────────
+
+try:
+    import gi
+    gi.require_version("Gimp", "3.0")
+    gi.require_version("GimpUi", "3.0")
+    gi.require_version("Gtk", "3.0")
+    gi.require_version("Gio", "2.0")
+    from gi.repository import Gio, Gimp, GimpUi, Gtk, GLib  # noqa: E402
+except (ImportError, ValueError):
+    Gio = Gimp = GimpUi = Gtk = GLib = None  # tests run without GIMP
+
+
+def _export_drawable_as_png(
+    image: object, drawable: object, exporter=None, selection_bounds=None
+) -> bytes:
+    """Export a drawable (optionally cropped to selection) to PNG bytes.
+
+    *exporter*: if provided, called as exporter(drawable, bounds) -> bytes.
+        Used for unit tests. When None, uses real GIMP file operations.
+    """
+    bounds = selection_bounds
+    width = drawable.get_width()
+    height = drawable.get_height()
+    if bounds:
+        x1, y1, x2, y2 = bounds
+        width = x2 - x1
+        height = y2 - y1
+    if exporter:
+        return exporter(drawable, bounds)
+    temp_img = Gimp.Image.new(width, height, Gimp.ImageBaseType.RGB)
+    layer_copy = Gimp.Layer.new_from_drawable(drawable, temp_img)
+    temp_img.insert_layer(layer_copy, None, 0)
+    if bounds:
+        x1, y1, x2, y2 = bounds
+        _, dx, dy = drawable.get_offsets()
+        layer_copy.set_offsets(dx - x1, dy - y1)
+    else:
+        layer_copy.set_offsets(0, 0)
+    fd, path = tempfile.mkstemp(suffix=".png")
+    os.close(fd)
+    try:
+        Gimp.file_save(
+            Gimp.RunMode.NONINTERACTIVE,
+            temp_img,
+            Gio.File.new_for_path(path),
+            None,
+        )
+        return Path(path).read_bytes()
+    finally:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+        try:
+            temp_img.delete()
+        except Exception:
+            pass
+
+
+def _insert_image_as_layer(
+    target_image: object, data: bytes, layer_name: str
+) -> None:
+    """Load PNG/JPEG bytes and insert as a new top layer in *target_image*."""
+    fd, path = tempfile.mkstemp(suffix=".png")
+    os.close(fd)
+    try:
+        Path(path).write_bytes(data)
+        loaded = Gimp.file_load(
+            Gimp.RunMode.NONINTERACTIVE,
+            Gio.File.new_for_path(path),
+        )
+        layers = loaded.get_layers()
+        if not layers:
+            raise PollinationsError("GIMP could not load the generated image.", code="import_failed")
+        new_layer = Gimp.Layer.new_from_drawable(layers[0], target_image)
+        new_layer.set_name(layer_name)
+        target_image.insert_layer(new_layer, None, -1)
+        loaded.delete()
+        Gimp.displays_flush()
+    finally:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
+def _get_selection_bounds(image: object) -> tuple[int, int, int, int] | None:
+    """Return (x1, y1, x2, y2) of the non-empty selection, or None."""
+    selection = image.get_selection()
+    raw = selection.bounds()
+    if len(raw) == 5:
+        non_empty, x1, y1, x2, y2 = raw
+        if not non_empty:
+            return None
+    elif len(raw) == 4:
+        x1, y1, x2, y2 = raw
+    else:
+        return None
+    if x2 <= x1 or y2 <= y1:
+        return None
+    return int(x1), int(y1), int(x2), int(y2)
+
+
+# ── GTK dialogs ────────────────────────────────────────────────────────────────
+
+
+def _message(parent, text: str, error: bool = False) -> None:
+    dialog = Gtk.MessageDialog(
+        transient_for=parent,
+        modal=True,
+        message_type=(Gtk.MessageType.ERROR if error else Gtk.MessageType.INFO),
+        buttons=Gtk.ButtonsType.OK,
+        text=text,
+    )
+    dialog.run()
+    dialog.destroy()
+
+
+def _run_connect_dialog() -> bool:
+    """Show the BYOP device-flow approval dialog. Returns True on success."""
+    try:
+        device = start_device_flow()
+    except PollinationsError as exc:
+        _message(None, f"Could not reach Pollinations:\n{exc}", error=True)
+        return False
+    except Exception as exc:
+        _message(None, f"Connection failed:\n{exc}", error=True)
+        return False
+
+    code = device.get("user_code", "")
+    uri = device.get("verification_uri_complete") or f"{ENTER_BASE}/device?user_code={urllib.parse.quote(code)}"
+
+    dlg = Gtk.MessageDialog(
+        transient_for=None,
+        modal=True,
+        message_type=Gtk.MessageType.INFO,
+        buttons=Gtk.ButtonsType.OK_CANCEL,
+        text="Open the Pollinations verification URL and approve access.",
+    )
+    dlg.format_secondary_text(f"Code: {code}\n{uri}")
+    response = dlg.run()
+    dlg.destroy()
+    if response != Gtk.ResponseType.OK:
+        return False
+
+    try:
+        token = poll_device_token(device)
+        save_token(token)
+        try:
+            info = fetch_userinfo(token)
+            username = info.get("preferred_username", "")
+            if username:
+                _message(None, f"Connected as @{username}. Happy creating!")
+            else:
+                _message(None, "Connected! Your Pollinations account is linked to GIMP.")
+        except Exception:
+            _message(None, "Connected! Your Pollinations account is linked to GIMP.")
+        return True
+    except PollinationsError as exc:
+        _message(None, str(exc), error=True)
+        return False
+    except Exception as exc:
+        _message(None, f"Connection failed:\n{exc}", error=True)
+        return False
+
+
+def _run_generate_dialog(
+    image: object,
+    models: list[dict],
+    *,
+    edit_mode: bool,
+) -> dict | None:
+    """Show the model/prompt picker. Returns a result dict or None on cancel."""
+    if edit_mode:
+        models = [m for m in models if can_edit(m)]
+    if not models:
+        _message(
+            None,
+            "No suitable models available.\n"
+            "Image-editing models require a Paid Pollen balance.",
+            error=True,
+        )
+        return None
+
+    title = "Edit with AI" if edit_mode else "Generate Image"
+    dlg = Gtk.Dialog(title=title, flags=Gtk.DialogFlags.MODAL)
+    dlg.add_button("Cancel", Gtk.ResponseType.CANCEL)
+    gen_btn = dlg.add_button("Generate", Gtk.ResponseType.OK)
+    gen_btn.get_style_context().add_class("suggested-action")
+    dlg.set_border_width(12)
+    dlg.set_default_size(480, -1)
+
+    area = dlg.get_content_area()
+    area.set_spacing(8)
+
+    # Model picker
+    area.pack_start(Gtk.Label(label="Model:", xalign=0.0), False, False, 0)
+    combo = Gtk.ComboBoxText()
+    for m in models:
+        mid = m.get("name", "")
+        title_text = m.get("title") or mid
+        desc = (m.get("description") or "")[:50]
+        combo.append(mid, f"{title_text} — {desc}" if desc else title_text)
+    combo.set_active(0)
+    area.pack_start(combo, False, False, 0)
+
+    # Prompt
+    area.pack_start(Gtk.Label(label="Prompt:", xalign=0.0), False, False, 0)
+    prompt_view = Gtk.TextView()
+    prompt_view.set_wrap_mode(Gtk.WrapMode.WORD)
+    prompt_view.set_size_request(460, 80)
+    area.pack_start(prompt_view, False, False, 0)
+
+    # Resolution (for generation only)
+    resolution_combo = None
+    width_spin = None
+    height_spin = None
+    size_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+    if not edit_mode:
+        default_w = default_h = 1024
+        if image is not None:
+            default_w = image.get_width()
+            default_h = image.get_height()
+        area.pack_start(Gtk.Label(label="Width:", xalign=0.0), False, False, 0)
+        width_spin = Gtk.SpinButton.new_with_range(64, 4096, 64)
+        width_spin.set_value(default_w)
+        area.pack_start(width_spin, False, False, 0)
+
+        area.pack_start(Gtk.Label(label="Height:", xalign=0.0), False, False, 0)
+        height_spin = Gtk.SpinButton.new_with_range(64, 4096, 64)
+        height_spin.set_value(default_h)
+        area.pack_start(height_spin, False, False, 0)
+
+    # Resolution tier combo (shown when model advertises resolutions)
+    area.pack_start(Gtk.Label(label="Resolution:", xalign=0.0), False, False, 0)
+    resolution_combo = Gtk.ComboBoxText()
+    area.pack_start(resolution_combo, False, False, 0)
+
+    # Edit checkbox (for generation mode only — toggle edit mode on/off)
+    as_layer_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=4)
+    as_layer_check = Gtk.CheckButton(label="Add as new layer to current image")
+    if image is not None:
+        as_layer_check.set_active(True)
+        as_layer_box.pack_start(as_layer_check, False, False, 0)
+    area.pack_start(as_layer_box, False, False, 0)
+
+    # Status label (hidden, used for async errors)
+    status_label = Gtk.Label(xalign=0.0)
+    area.pack_start(status_label, False, False, 0)
+
+    # Update resolution dropdown when model changes
+    def on_model_changed(*_):
+        mid = combo.get_active_id()
+        chosen = next((m for m in models if m.get("name") == mid), models[0])
+        resolution_combo.remove_all()
+        for res in model_resolutions(chosen):
+            resolution_combo.append(res, res)
+        has_res = bool(model_resolutions(chosen))
+        resolution_combo.set_visible(has_res)
+        if has_res:
+            resolution_combo.set_active(0)
+
+    combo.connect("changed", on_model_changed)
+    on_model_changed()
+    dlg.show_all()
+    # Hide resolution if model has none
+    on_model_changed()
+
+    response = dlg.run()
+    if response != Gtk.ResponseType.OK:
+        dlg.destroy()
+        return None
+
+    mid = combo.get_active_id()
+    buf = prompt_view.get_buffer()
+    start, end = buf.get_bounds()
+    prompt = buf.get_text(start, end, False).strip()
+    if not prompt:
+        _message(None, "Please enter a prompt.", error=True)
+        dlg.destroy()
+        return None
+
+    chosen_resolution = resolution_combo.get_active_id() if resolution_combo.get_visible() else None
+    result = {
+        "model": mid,
+        "prompt": prompt,
+        "width": int(width_spin.get_value()) if width_spin else None,
+        "height": int(height_spin.get_value()) if height_spin else None,
+        "add_as_layer": bool(as_layer_check.get_active()),
+        "resolution": chosen_resolution,
+    }
+    dlg.destroy()
+    return result
+
+
+# ── GIMP plug-in procedure implementations ─────────────────────────────────────
+
+
+def _connect(procedure, run_mode, image, drawables, config, run_data):
+    GimpUi.init("pollinations-gimp")
+    token = load_token()
+    if token:
+        try:
+            info = fetch_userinfo(token)
+            username = info.get("preferred_username", "you")
+            _message(None, f"Already connected as @{username}.\nUse Disconnect to switch accounts.")
+            return procedure.new_return_values(Gimp.PDBStatusType.SUCCESS, GLib.Error())
+        except PollinationsError as exc:
+            if exc.status == 401:
+                clear_token()
+            else:
+                _message(None, f"Already connected as @{info.get('preferred_username', 'someone')}.\nUse Disconnect to switch accounts.")
+                return procedure.new_return_values(Gimp.PDBStatusType.SUCCESS, GLib.Error())
+        except Exception:
+            pass
+    if _run_connect_dialog():
+        return procedure.new_return_values(Gimp.PDBStatusType.SUCCESS, GLib.Error())
+    return procedure.new_return_values(Gimp.PDBStatusType.CANCEL, GLib.Error())
+
+
+def _disconnect(procedure, run_mode, image, drawables, config, run_data):
+    GimpUi.init("pollinations-gimp")
+    clear_token()
+    _message(None, "Disconnected. Your Pollinations token has been removed from this computer.")
+    return procedure.new_return_values(Gimp.PDBStatusType.SUCCESS, GLib.Error())
+
+
+def _generate(procedure, run_mode, image, drawables, config, run_data):
+    GimpUi.init("pollinations-gimp")
+    token = load_token()
+    if not token:
+        _message(None, "Not connected.\nGo to Filters ▸ Pollinations AI ▸ Connect Account.", error=True)
+        return procedure.new_return_values(Gimp.PDBStatusType.SUCCESS, GLib.Error())
+
+    try:
+        models = fetch_image_models(token)
+    except PollinationsError as exc:
+        _message(None, str(exc), error=True)
+        return procedure.new_return_values(Gimp.PDBStatusType.EXECUTION_ERROR, GLib.Error())
+    except Exception as exc:
+        _message(None, f"Could not load model list:\n{exc}", error=True)
+        return procedure.new_return_values(Gimp.PDBStatusType.EXECUTION_ERROR, GLib.Error())
+
+    if not models:
+        _message(None, "No image models available.", error=True)
+        return procedure.new_return_values(Gimp.PDBStatusType.EXECUTION_ERROR, GLib.Error())
+
+    params = _run_generate_dialog(image, models, edit_mode=False)
+    if not params:
+        return procedure.new_return_values(Gimp.PDBStatusType.CANCEL, GLib.Error())
+
+    target = image if params["add_as_layer"] and image is not None else None
+
+    try:
+        img_bytes = generate_image(
+            token,
+            params["prompt"],
+            params["model"],
+            width=params["width"] or 1024,
+            height=params["height"] or 1024,
+        )
+    except PollinationsError as exc:
+        _message(None, f"Generation failed:\n{exc}", error=True)
+        if exc.status == 401:
+            clear_token()
+        return procedure.new_return_values(Gimp.PDBStatusType.EXECUTION_ERROR, GLib.Error())
+
+    layer_name = f"Pollinations · {params['prompt'][:50]}"
+    try:
+        _insert_image_as_layer(target, img_bytes, layer_name)
+    except Exception as exc:
+        _message(None, f"Could not load the result into GIMP:\n{exc}", error=True)
+        return procedure.new_return_values(Gimp.PDBStatusType.EXECUTION_ERROR, GLib.Error())
+    return procedure.new_return_values(Gimp.PDBStatusType.SUCCESS, GLib.Error())
+
+
+def _edit(procedure, run_mode, image, drawables, config, run_data):
+    GimpUi.init("pollinations-gimp")
+    token = load_token()
+    if not token:
+        _message(None, "Not connected.\nGo to Filters ▸ Pollinations AI ▸ Connect Account.", error=True)
+        return procedure.new_return_values(Gimp.PDBStatusType.SUCCESS, GLib.Error())
+    if not drawables:
+        _message(None, "Open an image and select a layer to edit.", error=True)
+        return procedure.new_return_values(Gimp.PDBStatusType.SUCCESS, GLib.Error())
+
+    drawable = drawables[0] if isinstance(drawables, (list, tuple)) else drawables
+
+    try:
+        models = fetch_image_models(token)
+    except PollinationsError as exc:
+        _message(None, str(exc), error=True)
+        return procedure.new_return_values(Gimp.PDBStatusType.EXECUTION_ERROR, GLib.Error())
+
+    edit_models = [m for m in models if can_edit(m)]
+    if not edit_models:
+        _message(
+            None,
+            "No image-editing models available.\n"
+            "Models like FLUX Kontext or nanobanana require Paid Pollen.\n"
+            "Top up at enter.pollinations.ai.",
+            error=True,
+        )
+        return procedure.new_return_values(Gimp.PDBStatusType.EXECUTION_ERROR, GLib.Error())
+
+    params = _run_generate_dialog(image, models, edit_mode=True)
+    if not params:
+        return procedure.new_return_values(Gimp.PDBStatusType.CANCEL, GLib.Error())
+
+    # Export the active drawable (crop to selection if present)
+    bounds = _get_selection_bounds(image) if image is not None else None
+    try:
+        source_png = _export_drawable_as_png(image, drawable, selection_bounds=bounds)
+    except Exception as exc:
+        _message(None, f"Could not export the layer:\n{exc}", error=True)
+        return procedure.new_return_values(Gimp.PDBStatusType.EXECUTION_ERROR, GLib.Error())
+
+    try:
+        result_bytes = edit_image(token, params["prompt"], params["model"], source_png)
+    except PollinationsError as exc:
+        _message(None, f"Edit failed:\n{exc}", error=True)
+        if exc.status == 401:
+            clear_token()
+        return procedure.new_return_values(Gimp.PDBStatusType.EXECUTION_ERROR, GLib.Error())
+
+    layer_name = f"AI edit · {params['prompt'][:50]}"
+    try:
+        _insert_image_as_layer(image, result_bytes, layer_name)
+    except Exception as exc:
+        _message(None, f"Could not load the result into GIMP:\n{exc}", error=True)
+        return procedure.new_return_values(Gimp.PDBStatusType.EXECUTION_ERROR, GLib.Error())
+    return procedure.new_return_values(Gimp.PDBStatusType.SUCCESS, GLib.Error())
+
+
+# ── GIMP plug-in registration ──────────────────────────────────────────────────
+
+if Gimp is not None:
+    class PollinationsPlugin(Gimp.PlugIn):
+        def do_query_procedures(self):
+            return [
+                "python-fu-pollinations-connect",
+                "python-fu-pollinations-generate",
+                "python-fu-pollinations-edit",
+                "python-fu-pollinations-disconnect",
+            ]
+
+        def do_set_i18n(self, name):
+            return False
+
+        def do_create_procedure(self, name):
+            procedure = Gimp.ImageProcedure.new(
+                self, name, Gimp.PDBProcType.PLUGIN, self.run, None
+            )
+            procedure.set_image_types("*")
+            procedure.set_attribution("Pollinations", "Pollinations.ai", "2026")
+
+            if name == "python-fu-pollinations-connect":
+                procedure.set_menu_label("Connect Account…")
+                procedure.set_documentation(
+                    "Connect your Pollinations account via BYOP device flow.",
+                    "Opens a browser for approval. Your API key stays private.",
+                    name,
+                )
+            elif name == "python-fu-pollinations-generate":
+                procedure.set_menu_label("Generate Image…")
+                procedure.set_documentation(
+                    "Generate an image from a prompt and add it to GIMP.",
+                    "Select a model, enter a prompt, and the result appears as a new image or layer.",
+                    name,
+                )
+            elif name == "python-fu-pollinations-edit":
+                procedure.set_menu_label("Edit with AI…")
+                procedure.set_documentation(
+                    "Send the active layer to an image-input model for editing.",
+                    "The edited result is added as a new layer; the source layer is never changed.",
+                    name,
+                )
+            elif name == "python-fu-pollinations-disconnect":
+                procedure.set_menu_label("Disconnect")
+                procedure.set_documentation(
+                    "Remove the stored Pollinations token from this computer.",
+                    "Disconnect removes saved authentication. Run Connect Account to re-authorize.",
+                    name,
+                )
+
+            procedure.add_menu_path("<Image>/Filters/Pollinations AI")
+            return procedure
+
+        def run(self, procedure, run_mode, image, drawables, config, run_data):
+            name = procedure.get_name()
+            if name == "python-fu-pollinations-connect":
+                return _connect(procedure, run_mode, image, drawables, config, run_data)
+            if name == "python-fu-pollinations-generate":
+                return _generate(procedure, run_mode, image, drawables, config, run_data)
+            if name == "python-fu-pollinations-edit":
+                return _edit(procedure, run_mode, image, drawables, config, run_data)
+            if name == "python-fu-pollinations-disconnect":
+                return _disconnect(procedure, run_mode, image, drawables, config, run_data)
+            return procedure.new_return_values(
+                Gimp.PDBStatusType.CALLING_ERROR,
+                GLib.Error(f"Unknown procedure: {name}"),
+            )
+
+    if __name__ == "__main__":
+        Gimp.main(PollinationsPlugin.__gtype__, sys.argv)

--- a/apps/gimp-plugin/tests/test_pollinations_gimp.py
+++ b/apps/gimp-plugin/tests/test_pollinations_gimp.py
@@ -1,0 +1,474 @@
+#!/usr/bin/env python3
+"""Unit tests for pollinations_gimp pure core (no GIMP, no network)."""
+
+from __future__ import annotations
+
+import base64
+import io
+import json
+import os
+import tempfile
+import unittest
+import urllib.error
+import urllib.request
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from pollinations_gimp import (
+    PollinationsError,
+    _build_multipart,
+    _decode_b64_image,
+    _map_error,
+    can_edit,
+    model_resolutions,
+    start_device_flow,
+    poll_device_token,
+    save_token,
+    load_token,
+    clear_token,
+    validate_token,
+    fetch_image_models,
+    generate_image,
+    edit_image,
+    _http_json,
+    _http_bytes,
+    APP_KEY,
+)
+
+
+# ── Mock HTTP opener ──────────────────────────────────────────────────────────
+
+
+def _mock_response(data: bytes, status: int = 200) -> io.BytesIO:
+    resp = io.BytesIO(data)
+    resp.status = status
+    return resp
+
+
+def _make_json_opener(payload, status: int = 200):
+    """Return a mock opener that yields a JSON response."""
+    body = json.dumps(payload).encode() if isinstance(payload, (dict, list)) else payload
+    resp = io.BytesIO(body)
+    resp.status = status
+    resp.read_orig = resp.read
+
+    def opener(req, **kwargs):
+        return _fake_ctx(resp)
+    return opener
+
+
+class _fake_ctx:
+    def __init__(self, resp):
+        self._resp = resp
+    def __enter__(self):
+        return self._resp
+    def __exit__(self, *a):
+        pass
+
+
+# ── Token persistence ─────────────────────────────────────────────────────────
+
+
+class TestTokenPersistence(unittest.TestCase):
+    def setUp(self):
+        self._tmp = Path(tempfile.mkdtemp())
+        self._tok = self._tmp / "token.json"
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def test_save_load_clear(self):
+        save_token("sk_test_valid_1234", path=self._tok)
+        self.assertEqual(load_token(self._tok), "sk_test_valid_1234")
+        clear_token(self._tok)
+        self.assertIsNone(load_token(self._tok))
+
+    def test_file_permissions(self):
+        save_token("sk_test_perm_12345", path=self._tok)
+        mode = os.stat(self._tok).st_mode & 0o777
+        self.assertEqual(mode, 0o600)
+
+    def test_load_returns_none_for_corrupt_file(self):
+        self._tok.write_text("not json", encoding="utf-8")
+        self.assertIsNone(load_token(self._tok))
+
+    def test_load_returns_none_for_wrong_shape(self):
+        self._tok.write_text(json.dumps({"wrong_key": "sk_xxx"}), encoding="utf-8")
+        self.assertIsNone(load_token(self._tok))
+
+
+class TestValidateToken(unittest.TestCase):
+    def test_valid(self):
+        self.assertEqual(validate_token("sk_abc12345"), "sk_abc12345")
+
+    def test_strips_whitespace(self):
+        self.assertEqual(validate_token("  sk_abc12345  "), "sk_abc12345")
+
+    def test_too_short(self):
+        with self.assertRaises(PollinationsError) as ctx:
+            validate_token("sk_abc")
+        self.assertIn("invalid", ctx.exception.args[0].lower())
+
+    def test_wrong_prefix(self):
+        with self.assertRaises(PollinationsError):
+            validate_token("ak_abcdefghij")
+
+
+# ── Error mapping ──────────────────────────────────────────────────────────────
+
+
+class TestMapError(unittest.TestCase):
+    def test_401(self):
+        err = _map_error(401, {"error": "invalid_token"})
+        self.assertIn("expired", err.args[0].lower())
+        self.assertEqual(err.status, 401)
+
+    def test_402(self):
+        err = _map_error(402)
+        self.assertIn("pollen", err.args[0].lower())
+        self.assertEqual(err.status, 402)
+
+    def test_429(self):
+        err = _map_error(429)
+        self.assertIn("too many", err.args[0].lower())
+
+    def test_500(self):
+        err = _map_error(500)
+        self.assertIn("unavailable", err.args[0].lower())
+
+    def test_network(self):
+        err = _map_error(None, {"error": "network"})
+        self.assertIn("internet", err.args[0].lower())
+
+    def test_timeout(self):
+        err = _map_error(None, {"error": "timeout"})
+        self.assertIn("timed out", err.args[0].lower())
+
+
+# ── Multipart builder ─────────────────────────────────────────────────────────
+
+
+class TestBuildMultipart(unittest.TestCase):
+    def test_text_fields(self):
+        ct, body = _build_multipart([("a", "1"), ("b", "2")])
+        self.assertIn("multipart/form-data", ct)
+        self.assertIn(b'"a"\r\n\r\n1\r\n', body)
+        self.assertIn(b'"b"\r\n\r\n2\r\n', body)
+
+    def test_binary_upload(self):
+        ct, body = _build_multipart([
+            ("file", "test.png", "image/png", b"\x89PNG\r\n"),
+        ])
+        self.assertIn(b'test.png', body)
+        self.assertIn(b'Content-Type: image/png', body)
+
+    def test_custom_boundary(self):
+        ct, body = _build_multipart([("x", "y")], boundary="MYBOUND")
+        self.assertIn("MYBOUND", ct)
+        self.assertTrue(body.endswith(b"--MYBOUND--\r\n"))
+
+
+# ── B64 image decoding ────────────────────────────────────────────────────────
+
+
+class TestDecodeB64Image(unittest.TestCase):
+    def test_valid(self):
+        png = b"\x89PNG\r\n\x1a\nfake"
+        payload = {"data": [{"b64_json": base64.b64encode(png).decode()}]}
+        self.assertEqual(_decode_b64_image(payload), png)
+
+    def test_missing_data_raises(self):
+        with self.assertRaises(PollinationsError):
+            _decode_b64_image({"data": []})
+
+    def test_invalid_b64_raises(self):
+        with self.assertRaises(PollinationsError):
+            _decode_b64_image({"data": [{"b64_json": "!!!not-base64!!!"}]})
+
+
+# ── Model filtering ────────────────────────────────────────────────────────────
+
+
+class TestModelFiltering(unittest.TestCase):
+    def test_can_edit_true(self):
+        m = {
+            "name": "flux-kontext",
+            "input_modalities": ["text", "image"],
+            "output_modalities": ["image"],
+        }
+        self.assertTrue(can_edit(m))
+
+    def test_can_edit_false_no_image_input(self):
+        m = {
+            "name": "flux-schnell",
+            "input_modalities": ["text"],
+            "output_modalities": ["image"],
+        }
+        self.assertFalse(can_edit(m))
+
+    def test_can_edit_false_no_image_output(self):
+        m = {
+            "name": "some-model",
+            "input_modalities": ["text", "image"],
+            "output_modalities": ["text"],
+        }
+        self.assertFalse(can_edit(m))
+
+    def test_can_edit_missing_modalities(self):
+        m = {"name": "unknown"}
+        self.assertFalse(can_edit(m))
+
+    def test_model_resolutions(self):
+        m = {"name": "test", "resolutions": ["512x512", "1024x1024"]}
+        self.assertEqual(model_resolutions(m), ["512x512", "1024x1024"])
+
+    def test_model_resolutions_empty(self):
+        self.assertEqual(model_resolutions({"name": "test"}), [])
+
+
+# ── fetch_image_models filtering ───────────────────────────────────────────────
+
+
+class TestFetchImageModels(unittest.TestCase):
+    def _mock_opener(self, models_json):
+        return _make_json_opener(models_json)
+
+    def test_filters_out_video(self):
+        models = [
+            {"name": "wan-video", "category": "video", "output_modalities": ["video"]},
+            {"name": "flux-schnell", "category": "image", "output_modalities": ["image"]},
+            {"name": "nano-banana", "category": None, "input_modalities": ["text"], "output_modalities": ["image"]},
+        ]
+        opener = self._mock_opener(models)
+        result = fetch_image_models("sk_test", requester=opener)
+        names = [m["name"] for m in result]
+        self.assertNotIn("wan-video", names)
+        self.assertIn("flux-schnell", names)
+        self.assertIn("nano-banana", names)
+
+    def test_skips_non_image_non_none_category(self):
+        models = [{"name": "gpt-4", "category": "chat", "output_modalities": ["text"]}]
+        opener = self._mock_opener(models)
+        self.assertEqual(fetch_image_models("sk_test", requester=opener), [])
+
+    def test_normalizes_camel_case_keys(self):
+        models = [{
+            "name": "flux-2-pro",
+            "category": "image",
+            "inputModalities": ["text"],
+            "outputModalities": ["image"],
+            "paidOnly": True,
+            "maxReferenceImages": 2,
+        }]
+        opener = self._mock_opener(models)
+        result = fetch_image_models("sk_test", requester=opener)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["input_modalities"], ["text"])
+        self.assertTrue(result[0]["paid_only"])
+
+    def test_handles_wrapped_response(self):
+        resp = {"data": [{"name": "flux-schnell", "category": "image", "output_modalities": ["image"]}]}
+        opener = self._mock_opener(resp)
+        result = fetch_image_models("sk_test", requester=opener)
+        self.assertEqual(len(result), 1)
+
+
+# ── HTTP helpers ───────────────────────────────────────────────────────────────
+
+
+class TestHttpJson(unittest.TestCase):
+    def test_success(self):
+        opener = _make_json_opener({"ok": True})
+        result = _http_json("http://example.com/api", opener=opener)
+        self.assertEqual(result, {"ok": True})
+
+    def test_http_error_raises(self):
+        err_body = json.dumps({"error": {"message": "bad"}}).encode()
+        resp = io.BytesIO(err_body)
+        resp.status = 401
+
+        def bad_opener(req, **kw):
+            raise urllib.error.HTTPError(req.full_url, 401, "Unauthorized", {}, io.BytesIO(err_body))
+        with self.assertRaises(PollinationsError) as ctx:
+            _http_json("http://example.com", opener=bad_opener)
+        self.assertEqual(ctx.exception.status, 401)
+
+    def test_network_error(self):
+        def bad_opener(req, **kw):
+            raise urllib.error.URLError("connection refused")
+        with self.assertRaises(PollinationsError) as ctx:
+            _http_json("http://example.com", opener=bad_opener)
+        self.assertIn("network", ctx.exception.code)
+
+    def test_timeout_error(self):
+        def bad_opener(req, **kw):
+            raise urllib.error.URLError(TimeoutError())
+        with self.assertRaises(PollinationsError) as ctx:
+            _http_json("http://example.com", opener=bad_opener)
+        self.assertIn("timed out", str(ctx.exception).lower())
+
+
+class TestHttpBytes(unittest.TestCase):
+    def test_success(self):
+        def fake_opener(req, **kw):
+            return _fake_ctx(io.BytesIO(b"\x89PNGdata"))
+        result = _http_bytes("http://example.com/image.png", opener=fake_opener)
+        self.assertEqual(result, b"\x89PNGdata")
+
+    def test_http_error(self):
+        err_body = json.dumps({"error": {"code": "not_found"}}).encode()
+        def bad_opener(req, **kw):
+            raise urllib.error.HTTPError(req.full_url, 404, "Not Found", {}, io.BytesIO(err_body))
+        with self.assertRaises(PollinationsError) as ctx:
+            _http_bytes("http://example.com", opener=bad_opener)
+        self.assertEqual(ctx.exception.status, 404)
+
+
+# ── Device flow ────────────────────────────────────────────────────────────────
+
+
+class TestDeviceFlow(unittest.TestCase):
+    def test_start_device_flow(self):
+        device_resp = {
+            "device_code": "dc_test123",
+            "user_code": "ABCD-1234",
+            "verification_uri": "https://enter.pollinations.ai/device",
+            "interval": 5,
+            "expires_in": 600,
+        }
+        opener = _make_json_opener(device_resp)
+        result = start_device_flow(requester=opener)
+        self.assertEqual(result["device_code"], "dc_test123")
+        self.assertEqual(result["user_code"], "ABCD-1234")
+
+    def test_poll_device_token_success(self):
+        device = {"device_code": "dc_xxx", "interval": 0.01, "expires_in": 5}
+        approve_resp = {"access_token": "sk_approved_123456"}
+        call_count = 0
+
+        def mock_opener(req, **kw):
+            nonlocal call_count
+            call_count += 1
+            body = json.dumps(approve_resp).encode()
+            resp = io.BytesIO(body)
+            resp.status = 200
+            return _fake_ctx(resp)
+
+        token = poll_device_token(device, requester=mock_opener, sleep_fn=lambda x: None)
+        self.assertEqual(token, "sk_approved_123456")
+
+    def test_poll_handles_authorization_pending(self):
+        device = {"device_code": "dc_xxx", "interval": 0.001, "expires_in": 1}
+        call_count = 0
+        pending_resp = {"error": "authorization_pending"}
+
+        def mock_opener(req, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                body = json.dumps(pending_resp).encode()
+            else:
+                body = json.dumps({"access_token": "sk_delayed_token"}).encode()
+            resp = io.BytesIO(body)
+            resp.status = 200
+            return _fake_ctx(resp)
+
+        token = poll_device_token(device, requester=mock_opener, sleep_fn=lambda x: None)
+        self.assertEqual(token, "sk_delayed_token")
+
+    def test_poll_handles_slow_down(self):
+        device = {"device_code": "dc_xxx", "interval": 0.001, "expires_in": 2}
+        call_count = 0
+
+        def mock_opener(req, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                body = json.dumps({"error": "slow_down"}).encode()
+            elif call_count == 2:
+                body = json.dumps({"error": "authorization_pending"}).encode()
+            else:
+                body = json.dumps({"access_token": "sk_slow_token"}).encode()
+            resp = io.BytesIO(body)
+            resp.status = 200
+            return _fake_ctx(resp)
+
+        token = poll_device_token(device, requester=mock_opener, sleep_fn=lambda x: None)
+        self.assertEqual(token, "sk_slow_token")
+
+    def test_poll_expired(self):
+        device = {"device_code": "dc_xxx", "interval": 0.001, "expires_in": 0.001}
+        monotonic_val = [0.0]
+
+        def fake_monotonic():
+            return monotonic_val[0]
+        def fake_sleep(d):
+            monotonic_val[0] += d + 1.0
+
+        with self.assertRaises(PollinationsError) as ctx:
+            poll_device_token(
+                device,
+                requester=_make_json_opener({"error": "authorization_pending"}),
+                sleep_fn=fake_sleep,
+                monotonic=fake_monotonic,
+            )
+        self.assertEqual(ctx.exception.code, "expired_token")
+
+
+# ── generate_image ─────────────────────────────────────────────────────────────
+
+
+class TestGenerateImage(unittest.TestCase):
+    def test_success(self):
+        def fake_opener(req, **kw):
+            return _fake_ctx(io.BytesIO(b"\x89PNG_fakedata"))
+        result = generate_image("sk_test12345", "a cat", "flux-schnell", requester=fake_opener)
+        self.assertEqual(result, b"\x89PNG_fakedata")
+
+    def test_http_error_raises(self):
+        err_body = json.dumps({"error": {"message": "rate limit", "code": "rate_limited"}}).encode()
+        def bad_opener(req, **kw):
+            raise urllib.error.HTTPError(req.full_url, 429, "Too Many", {}, io.BytesIO(err_body))
+        with self.assertRaises(PollinationsError) as ctx:
+            generate_image("sk_test12345", "cat", "flux", requester=bad_opener)
+        self.assertEqual(ctx.exception.status, 429)
+
+
+# ── edit_image ─────────────────────────────────────────────────────────────────
+
+
+class TestEditImage(unittest.TestCase):
+    def test_success(self):
+        fake_png = b"\x89PNG_fakedata"
+        fake_resp = {"data": [{"b64_json": base64.b64encode(fake_png).decode()}]}
+
+        def fake_opener(req, **kw):
+            assert b"Content-Disposition" in req.data
+            assert b"layer.png" in req.data
+            assert b"image/png" in req.data
+            return _fake_ctx(io.BytesIO(json.dumps(fake_resp).encode()))
+
+        result = edit_image("sk_test12345", "make it blue", "flux-kontext", b"\x89PNGsource", requester=fake_opener)
+        self.assertEqual(result, fake_png)
+
+    def test_bad_response(self):
+        def fake_opener(req, **kw):
+            return _fake_ctx(io.BytesIO(json.dumps({"data": []}).encode()))
+        with self.assertRaises(PollinationsError):
+            edit_image("sk_test12345", "edit", "model", b"\x89PNGsrc", requester=fake_opener)
+
+    def test_user_agent_header(self):
+        captured = {}
+        def fake_opener(req, **kw):
+            captured["ua"] = req.headers.get("User-agent")
+            return _fake_ctx(io.BytesIO(json.dumps({"data": [{"b64_json": "dGVzdA=="}]}).encode()))
+        edit_image("sk_test12345", "x", "m", b"\x89PNG", requester=fake_opener)
+        self.assertIn("pollinations-gimp/", captured["ua"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #14232

GIMP 3 Python plug-in that brings Pollinations image generation and editing into GIMP with BYOP support.

**Key features:**
- Connect Account — BYOP device flow; token stored privately at `~/.config/pollinations-gimp/token.json`, removed on Disconnect
- Generate Image — text-to-image; live model catalog from `/image/models`; result as a new image or new layer
- Edit with AI — active layer or selection sent via multipart upload to edit-capable models; result as a new layer, source untouched
- Clear error messages for auth expiry, network failures, and API errors

**Files:**
- `apps/gimp-plugin/pollinations_gimp.py` — main plug-in
- `apps/gimp-plugin/tests/test_pollinations_gimp.py` — 46 unit tests
- `apps/gimp-plugin/README.md` — install + usage guide

Tests: `python3 -m pytest tests/test_pollinations_gimp.py -v` — 46 passed.
