### PR TITLE
fix: align Enter dashboard pricing

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/mcp-server-list.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/mcp-server-list.tsx
@@ -68,7 +68,7 @@ export const McpServerList: FC<{ query: string }> = ({ query }) => {
                                         Billing
                                     </p>
                                     {pricing.rates.length > 0 && (
-                                        <div className="grid w-fit grid-cols-[auto_auto_auto] gap-x-2">
+                                        <div className="grid w-full max-w-[19.5rem] grid-cols-[6.5rem_9ch_minmax(0,1fr)] gap-x-2 min-[480px]:grid-cols-[8rem_9ch_5.5rem]">
                                             <UsagePriceRows
                                                 adjustments={pricing.rates}
                                                 align="left"

--- a/enter.pollinations.ai/frontend/src/components/models/price-badge.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/price-badge.tsx
@@ -82,6 +82,7 @@ const formatAdjustmentUnit = ({
     if (kind === "cache_storage") {
         return `${quantityLabel} tokens${detail}`;
     }
+    if (quantity === 1 && unit === "generation") return `gen${detail}`;
     return `${quantityLabel} ${unit}${detail}`;
 };
 
@@ -334,7 +335,7 @@ const LedgerPriceValue: FC<{ value: string }> = ({ value }) => {
     const [whole, fraction] = value.split(".", 2);
 
     return (
-        <span className="grid w-[10ch] shrink-0 grid-cols-[minmax(3ch,1fr)_auto_6ch] text-sm font-semibold tabular-nums text-theme-text-strong">
+        <span className="grid w-full grid-cols-[minmax(2ch,1fr)_auto_5ch] text-sm font-semibold tabular-nums text-theme-text-strong">
             <span className="sr-only">{value}</span>
             <span aria-hidden="true" className="text-right">
                 {whole}
@@ -354,41 +355,77 @@ const RequestBasedAdjustmentKinds = new Set([
     "grounded_prompt",
 ]);
 
+const COMPACT_ADJUSTMENT_LABELS: Record<string, string> = {
+    "azure.flux_2_pro.initial_output_megapixel.v1": "Initial output MP",
+};
+
+const LedgerLabel: FC<{
+    label: string;
+    displayLabel?: string;
+    Icon?: FC<{ className?: string }>;
+}> = ({ label, displayLabel = label, Icon }) => (
+    <span className="grid min-w-0 grid-cols-[0.875rem_minmax(0,1fr)] items-center gap-1.5 text-xs text-theme-text-muted">
+        {Icon ? (
+            <Icon className="h-3.5 w-3.5 shrink-0" />
+        ) : (
+            <span aria-hidden="true" />
+        )}
+        {displayLabel !== label && <span className="sr-only">{label}</span>}
+        <span
+            className="truncate whitespace-nowrap"
+            aria-hidden={displayLabel === label ? undefined : true}
+            title={displayLabel === label ? undefined : label}
+        >
+            {displayLabel}
+        </span>
+    </span>
+);
+
 export const UsagePriceRows: FC<{
     adjustments: ModelPriceAdjustment[];
     align: "left" | "right";
 }> = ({ adjustments, align }) =>
     adjustments.map((adjustment) => {
         const isSearch = RequestBasedAdjustmentKinds.has(adjustment.kind);
+        const PriceIcon = isSearch
+            ? SearchIcon
+            : adjustment.kind === "cache_storage"
+              ? PRICE_ICON.cached
+              : adjustment.kind in PRICE_ICON
+                ? PRICE_ICON[adjustment.kind as PriceKind]
+                : undefined;
+        const unit = `/${formatAdjustmentUnit(adjustment)}`;
         return (
             <div
                 key={adjustment.name}
-                className="grid col-span-full grid-cols-subgrid items-baseline py-0.5"
+                className="grid col-span-full grid-cols-subgrid items-center py-0.5"
             >
                 {align === "right" && <span aria-hidden="true" />}
-                <span className="flex items-center gap-1.5 whitespace-nowrap text-xs text-theme-text-muted">
-                    {isSearch && (
-                        <SearchIcon className="h-3.5 w-3.5 shrink-0" />
-                    )}
-                    {adjustment.label}
-                </span>
+                <LedgerLabel
+                    Icon={PriceIcon}
+                    label={adjustment.label}
+                    displayLabel={
+                        COMPACT_ADJUSTMENT_LABELS[adjustment.name] ??
+                        adjustment.label
+                    }
+                />
                 <LedgerPriceValue
                     value={formatDisplayPrice(adjustment.price).value}
                 />
-                <span className="text-xs font-normal text-theme-text-muted [overflow-wrap:anywhere] sm:whitespace-nowrap">
-                    /{formatAdjustmentUnit(adjustment)}
+                <span
+                    className="min-w-0 truncate whitespace-nowrap text-xs font-normal text-theme-text-muted"
+                    title={unit}
+                >
+                    {unit}
                 </span>
             </div>
         );
     });
 
 const ToolsPricingRow: FC<{ align: "left" | "right" }> = ({ align }) => (
-    <div className="grid col-span-full grid-cols-subgrid items-baseline py-0.5">
+    <div className="grid col-span-full grid-cols-subgrid items-center py-0.5">
         {align === "right" && <span aria-hidden="true" />}
-        <span className="flex items-center gap-1.5 whitespace-nowrap text-xs text-theme-text-muted">
-            <McpIcon className="h-3.5 w-3.5 shrink-0" />
-            Tools
-        </span>
+        <LedgerLabel Icon={McpIcon} label="Tools" />
         <span className="col-span-2 whitespace-nowrap">
             <Tooltip
                 triggerAs="span"
@@ -590,15 +627,15 @@ export const ModelPricingLedger: FC<{
             return (
                 <div
                     key={row.key}
-                    className="grid col-span-full grid-cols-subgrid items-baseline py-0.5"
+                    className="grid col-span-full grid-cols-subgrid items-center py-0.5"
                 >
                     {align === "right" && <span aria-hidden="true" />}
-                    <span className="flex items-center gap-1.5 whitespace-nowrap text-xs text-theme-text-muted">
-                        <PriceIcon className="h-3.5 w-3.5 shrink-0" />
-                        {row.label}
-                    </span>
+                    <LedgerLabel Icon={PriceIcon} label={row.label} />
                     <LedgerPriceValue value={row.value} />
-                    <span className="text-xs font-normal text-theme-text-muted [overflow-wrap:anywhere] sm:whitespace-nowrap">
+                    <span
+                        className="min-w-0 truncate whitespace-nowrap text-xs font-normal text-theme-text-muted"
+                        title={row.unit}
+                    >
                         {row.unit}
                     </span>
                 </div>
@@ -610,8 +647,8 @@ export const ModelPricingLedger: FC<{
             className={cn(
                 "grid w-full min-w-0 max-w-full gap-x-2",
                 align === "left"
-                    ? "grid-cols-[6.5rem_10ch_minmax(0,max-content)]"
-                    : "grid-cols-[1fr_6.5rem_10ch_minmax(0,max-content)]",
+                    ? "grid-cols-[6.5rem_9ch_minmax(0,1fr)] min-[480px]:grid-cols-[8rem_9ch_5.5rem]"
+                    : "grid-cols-[1fr_8rem_9ch_5.5rem]",
                 className,
             )}
         >
@@ -624,10 +661,7 @@ export const ModelPricingLedger: FC<{
                             : "col-span-full",
                     )}
                 >
-                    <span className="flex items-center gap-1.5 whitespace-nowrap text-xs text-theme-text-muted">
-                        <TokensIcon className="h-3.5 w-3.5 shrink-0" />
-                        Requests
-                    </span>
+                    <LedgerLabel Icon={TokensIcon} label="Requests" />
                     {requestEstimate}
                     <span className="whitespace-nowrap text-xs font-normal text-theme-text-muted">
                         /pollen


### PR DESCRIPTION
- Aligns pricing labels, icons, decimal values, and units with consistent fixed columns across Enter model cards.
- Shortens the FLUX.2 Pro premium label to `Initial output MP` while preserving the full accessible label and standardizes single-generation units to `/gen`.
- Applies the same responsive pricing columns to built-in MCP billing rows.

Tests:
- `npx biome check --write frontend/src/components/models/price-badge.tsx frontend/src/components/models/mcp-server-list.tsx`
- `npm run typecheck` in `enter.pollinations.ai`
- `npm run build:frontend` in `enter.pollinations.ai`
- Local browser verification at `/models?sort=newest`