### PR TITLE
docs: clarify hosted MCP servers

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/prompt-agent-fields.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/prompt-agent-fields.tsx
@@ -92,7 +92,7 @@ export function PromptAgentFields({
                 <p className="text-xs text-theme-text-muted">
                     Uses the caller's Pollinations API access. See the{" "}
                     <a
-                        href="https://gen.pollinations.ai/docs#tag/mcp-server"
+                        href="https://gen.pollinations.ai/docs#tag/mcp-servers"
                         target="_blank"
                         rel="noopener noreferrer"
                         className="underline decoration-current/40 underline-offset-2 hover:text-theme-text-soft"

--- a/enter.pollinations.ai/frontend/src/components/layout/dashboard-shell.tsx
+++ b/enter.pollinations.ai/frontend/src/components/layout/dashboard-shell.tsx
@@ -256,8 +256,8 @@ export const DashboardShell: FC<DashboardShellProps> = ({
             ),
         },
         {
-            label: "MCP Server",
-            href: `${genDocsUrl()}#tag/mcp-server`,
+            label: "MCP Servers",
+            href: `${genDocsUrl()}#tag/mcp-servers`,
             icon: (
                 <McpIcon className="h-3.5 w-3.5 shrink-0 text-theme-text-muted" />
             ),

--- a/enter.pollinations.ai/frontend/src/components/models/mcp-server-list.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/mcp-server-list.tsx
@@ -108,7 +108,7 @@ export const McpServerList: FC<{ query: string }> = ({ query }) => {
             </div>
             <p className="text-xs text-theme-text-muted">
                 Connect with your Pollinations API key. See the{" "}
-                <InlineLink href={genDocsUrl("#tag/mcp-server")}>
+                <InlineLink href={genDocsUrl("#tag/mcp-servers")}>
                     MCP docs
                 </InlineLink>
                 .

--- a/gen.pollinations.ai/scripts/generate-apidocs.ts
+++ b/gen.pollinations.ai/scripts/generate-apidocs.ts
@@ -771,7 +771,7 @@ curl ${BASE_URL}/v1/models \\
 
 **3. Pick an endpoint** from the [${sectionHeading(SECTIONS.contents)}](#${sectionAnchor(SECTIONS.contents)}) below.
 
-**Integration guides:** [Connect User Wallets](https://gen.pollinations.ai/docs#tag/connect-user-wallets) · [Publish a Model](https://gen.pollinations.ai/docs#tag/publish-a-model) · [Publish an Agent](https://gen.pollinations.ai/docs#tag/publish-an-agent) · [MCP Server](https://gen.pollinations.ai/docs#tag/mcp-server) · [CLI](https://gen.pollinations.ai/docs#tag/cli)`;
+**Integration guides:** [Connect User Wallets](https://gen.pollinations.ai/docs#tag/connect-user-wallets) · [Publish a Model](https://gen.pollinations.ai/docs#tag/publish-a-model) · [Publish an Agent](https://gen.pollinations.ai/docs#tag/publish-an-agent) · [MCP Servers](https://gen.pollinations.ai/docs#tag/mcp-servers) · [CLI](https://gen.pollinations.ai/docs#tag/cli)`;
 }
 
 function renderTableOfContents(

--- a/gen.pollinations.ai/src/docs/introduction.md
+++ b/gen.pollinations.ai/src/docs/introduction.md
@@ -4,4 +4,4 @@
 
 **Get your API key:** [enter.pollinations.ai](https://enter.pollinations.ai/keys)
 
-**Integrations:** [Connect User Wallets](/docs#tag/connect-user-wallets) · [Publish a Model](/docs#tag/publish-a-model) · [Publish an Agent](/docs#tag/publish-an-agent) · [MCP Server](/docs#tag/mcp-server) · [CLI](/docs#tag/cli)
+**Integrations:** [Connect User Wallets](/docs#tag/connect-user-wallets) · [Publish a Model](/docs#tag/publish-a-model) · [Publish an Agent](/docs#tag/publish-an-agent) · [MCP Servers](/docs#tag/mcp-servers) · [CLI](/docs#tag/cli)

--- a/gen.pollinations.ai/src/docs/mcp.md
+++ b/gen.pollinations.ai/src/docs/mcp.md
@@ -1,0 +1,124 @@
+## MCP Servers
+
+Use Pollinations-hosted MCP servers from any
+[Model Context Protocol](https://modelcontextprotocol.io) client that supports
+Streamable HTTP.
+
+### Quick start
+
+Get an API key from [enter.pollinations.ai](https://enter.pollinations.ai/keys),
+then choose a server:
+
+| Server | Endpoint | Use it for |
+| --- | --- | --- |
+| Pollinations | `https://gen.pollinations.ai/mcp/pollinations` | Pollinations models, media generation, model discovery, and account tools |
+| FFmpeg | `https://gen.pollinations.ai/mcp/ffmpeg` | Trim, convert, resize, compress, and remix audio and video |
+| Exa Search | `https://gen.pollinations.ai/mcp/exa` | Search the live web and fetch clean page content |
+
+Send the key with every request:
+
+```http
+Authorization: Bearer YOUR_KEY
+```
+
+Get current endpoints and pricing from the live catalog:
+
+```bash
+curl https://gen.pollinations.ai/mcp
+```
+
+### Use with hosted agents
+
+Add MCP servers to an agent in
+[My Models](https://enter.pollinations.ai/my-models).
+
+### Connect a client
+
+The official TypeScript client handles initialization and tool discovery:
+
+```ts
+import {
+  Client,
+  StreamableHTTPClientTransport,
+} from "@modelcontextprotocol/client";
+
+const client = new Client({ name: "my-app", version: "1.0.0" });
+const transport = new StreamableHTTPClientTransport(
+  new URL("https://gen.pollinations.ai/mcp/pollinations"),
+  {
+    requestInit: {
+      headers: {
+        Authorization: `Bearer ${process.env.POLLINATIONS_API_KEY}`,
+      },
+    },
+  },
+);
+
+await client.connect(transport);
+const { tools } = await client.listTools();
+```
+
+Other clients use the same endpoint and bearer header; only their configuration
+format differs.
+
+#### Claude Code
+
+```bash
+claude mcp add --transport http pollinations \
+  https://gen.pollinations.ai/mcp/pollinations \
+  --header "Authorization: Bearer YOUR_KEY"
+```
+
+Run `/mcp` in Claude Code to verify the connection. Replace the name and URL
+with another endpoint from the table to use FFmpeg or Exa Search.
+
+### Pollinations MCP
+
+The Pollinations server exposes the main Pollinations API as agent-friendly
+tools.
+
+| Tool | Purpose |
+| --- | --- |
+| `listModels` | List live models, aliases, capabilities, voices, endpoints, and pricing |
+| `getModelStatus` | Inspect recent requests, errors, and latency for a model |
+| `generateText` | Generate text, use search-capable models, process multimodal input, or call a listed agent |
+| `generateImage` | Generate or edit images |
+| `generateVideo` | Generate video |
+| `generateAudio` | Generate speech, music, or sound |
+| `transcribeAudio` | Transcribe audio from a public HTTPS URL |
+| `generate3D` | Generate a GLB 3D model |
+| `createEmbeddings` | Create text or multimodal embeddings |
+| `getBalance` | Check the remaining Pollen balance; requires `account:usage` permission |
+
+Use `listModels` before choosing a model or voice. The registry is live, so
+clients should not rely on a hardcoded model list.
+
+Generated media is uploaded unlisted to `media.pollinations.ai` and returned as
+an MCP resource link, so binary data does not consume model context. Anyone
+with the link can access it, and it expires after 30 days.
+
+### FFmpeg MCP
+
+`runFfmpeg` accepts public HTTPS media inputs and ordinary FFmpeg arguments. It
+supports multiple inputs and returns the output as a hosted MCP resource link.
+Pollinations supplies the input and output files, so omit the `ffmpeg`
+executable and output path from the arguments.
+
+### Exa Search MCP
+
+- `web_search_exa` searches the live web and returns relevant pages with
+  highlights.
+- `web_fetch_exa` reads one or more known URLs as clean text when the search
+  highlights are not enough.
+
+### Billing and permissions
+
+Calls use the same Pollen wallet as the Pollinations API. The catalog endpoint
+shows each server's current pricing. Pollinations generation tools use the
+selected model's listed rate.
+
+An MCP server can only use models and account features allowed by the caller's
+key and cannot spend beyond that key's budget. Configure both in
+[API key settings](https://enter.pollinations.ai/keys). See
+[Authentication](https://gen.pollinations.ai/docs#tag/authentication) for key
+types and security guidance.

--- a/gen.pollinations.ai/src/routes/docs.ts
+++ b/gen.pollinations.ai/src/routes/docs.ts
@@ -36,7 +36,6 @@ import COMMUNITY_MODELS_MD from "../../../BRING_YOUR_OWN_MODEL.md?raw";
 import BYOP_MD from "../../../BRING_YOUR_OWN_POLLEN.md?raw";
 import AGENTS_MD from "../../../BUILD_YOUR_OWN_AGENT.md?raw";
 import CODING_HARNESSES_MD from "../../../CODING_HARNESSES.md?raw";
-import MCP_README from "../../../packages/mcp/README.md?raw";
 import CLI_README from "../../../packages/polli-cli/README.md?raw";
 import MODEL3D_GENERATION_MD from "../docs/3d-generation.md?raw";
 import ACCOUNT_MD from "../docs/account.md?raw";
@@ -46,6 +45,7 @@ import EMBEDDINGS_MD from "../docs/embeddings.md?raw";
 import ERRORS_MD from "../docs/errors.md?raw";
 import IMAGE_GENERATION_MD from "../docs/image-generation.md?raw";
 import INTRODUCTION_MD from "../docs/introduction.md?raw";
+import MCP_MD from "../docs/mcp.md?raw";
 import MEDIA_STORAGE_MD from "../docs/media-storage.md?raw";
 import MODELS_MD from "../docs/models.md?raw";
 import PUBLIC_STATS_MD from "../docs/public-stats.md?raw";
@@ -66,7 +66,7 @@ const DOC_TAGS = {
     communityAgents: "Community Agents",
     cli: "CLI",
     codingHarnesses: "Coding Harnesses",
-    mcpServer: "MCP Server",
+    mcpServers: "MCP Servers",
     errors: "Errors",
     safety: "Safety",
     text: "Text",
@@ -90,7 +90,7 @@ const LEGACY_DOC_TAGS: Record<string, string> = {
     "🧩 Community Models": DOC_TAGS.communityModels,
     "🤖 Community Agents": DOC_TAGS.communityAgents,
     "🖥 CLI": DOC_TAGS.cli,
-    "🔌 MCP Server": DOC_TAGS.mcpServer,
+    "🔌 MCP Server": DOC_TAGS.mcpServers,
     "❌ Errors": DOC_TAGS.errors,
     "🛡️ Safety": DOC_TAGS.safety,
     "✍️ Text": DOC_TAGS.text,
@@ -139,7 +139,7 @@ const DOC_TAG_ICON_HTML: Record<string, string> = {
     [DOC_TAGS.codingHarnesses]: docsIcon(
         '<path d="M4 7h16" /><path d="M4 17h16" /><circle cx="9" cy="7" r="2" fill="currentColor" /><circle cx="15" cy="17" r="2" fill="currentColor" />',
     ),
-    [DOC_TAGS.mcpServer]: docsIcon(
+    [DOC_TAGS.mcpServers]: docsIcon(
         '<rect x="2" y="7" width="8" height="10" rx="1.5" /><rect x="14" y="7" width="8" height="10" rx="1.5" /><path d="M10 12h4" />',
     ),
     [DOC_TAGS.errors]: docsIcon('<path d="M18 6 6 18M6 6l12 12" />'),
@@ -194,13 +194,12 @@ const DOC_TAG_NAV_ICON_HTML: Record<string, string> = Object.fromEntries(
 
 const CLI_DOCS = CLI_README.replace(/^# .*\n+/, "").trim();
 
-const MCP_DOCS = MCP_README.replace(/^# .*\n+/, "").trim();
-
 // Strip the leading H1/H2 heading line so the markdown can be embedded under
 // a Scalar tag (which already renders its own title) without double headings.
 const stripLeadingHeading = (md: string) =>
     md.replace(/^#{1,2}\s.*\n+/, "").trim();
 
+const MCP_DOCS = stripLeadingHeading(MCP_MD.trim());
 const USER_WALLETS_DOCS = stripLeadingHeading(BYOP_MD.trim());
 const PUBLISH_MODEL_DOCS = stripLeadingHeading(COMMUNITY_MODELS_MD.trim());
 const PUBLISH_AGENT_DOCS = stripLeadingHeading(AGENTS_MD.trim());
@@ -359,7 +358,7 @@ const PUBLISH_MODEL_SECTION = `## Publish a Model\n\n${PUBLISH_MODEL_DOCS}`;
 const PUBLISH_AGENT_SECTION = `## Publish an Agent\n\n${PUBLISH_AGENT_DOCS}`;
 const CLI_SECTION = `## CLI\n\n${CLI_DOCS}`;
 const CODING_HARNESSES_SECTION = `## Coding Harnesses\n\n${CODING_HARNESSES_DOCS}`;
-const MCP_SECTION = `## MCP Server\n\n${MCP_DOCS}`;
+const MCP_SECTION = `## MCP Servers\n\n${MCP_DOCS}`;
 
 const LLM_DOC_TEXT = [
     GEN_API_DOCS,
@@ -389,7 +388,7 @@ const GUIDE_REDIRECT_TAGS: Record<string, string> = {
     agents: "publish-an-agent",
     "community-agents": "publish-an-agent",
     cli: "cli",
-    mcp: "mcp-server",
+    mcp: "mcp-servers",
 };
 
 function pollinationsHeaderHtml(): string {
@@ -499,7 +498,7 @@ function generationDocumentation(): OpenApiSchema {
                     DOC_TAGS.userWallets,
                     DOC_TAGS.publishModel,
                     DOC_TAGS.publishAgent,
-                    DOC_TAGS.mcpServer,
+                    DOC_TAGS.mcpServers,
                     DOC_TAGS.cli,
                     DOC_TAGS.codingHarnesses,
                 ],
@@ -571,7 +570,7 @@ function generationDocumentation(): OpenApiSchema {
                 description: CODING_HARNESSES_DOCS,
             },
             {
-                name: DOC_TAGS.mcpServer,
+                name: DOC_TAGS.mcpServers,
                 description: MCP_DOCS,
             },
             {

--- a/gen.pollinations.ai/test/docs.test.ts
+++ b/gen.pollinations.ai/test/docs.test.ts
@@ -258,7 +258,7 @@ describe("docs routes", () => {
             schema.tags.find((tag) => tag.name === "Coding Harnesses")
                 ?.description,
         ).toContain("polli harness dsh on");
-        expect(schema.tags.map((tag) => tag.name)).toContain("MCP Server");
+        expect(schema.tags.map((tag) => tag.name)).toContain("MCP Servers");
         expect(schema.tags.map((tag) => tag.name)).toContain("Quests");
         expect(schema.tags.map((tag) => tag.name)).toContain("Media Storage");
         expect(schema.tags.map((tag) => tag.name)).toContain("Account");
@@ -434,7 +434,7 @@ describe("docs routes", () => {
             ctx,
         );
         expect(mcpRes.status).toBe(301);
-        expect(mcpRes.headers.get("Location")).toBe("/docs#tag/mcp-server");
+        expect(mcpRes.headers.get("Location")).toBe("/docs#tag/mcp-servers");
 
         const agentsRes = await worker.fetch(
             new Request("https://gen.pollinations.ai/docs/guides/agents", {
@@ -546,15 +546,15 @@ describe("docs routes", () => {
         );
         expect(mcpRes.status).toBe(200);
         const mcpBody = await mcpRes.text();
-        expect(mcpBody).toContain("## MCP Server");
+        expect(mcpBody).toContain("## MCP Servers");
         expect(mcpBody).toContain(
             "https://gen.pollinations.ai/mcp/pollinations",
         );
         expect(mcpBody).toContain("https://gen.pollinations.ai/mcp/ffmpeg");
         expect(mcpBody).toContain("https://gen.pollinations.ai/mcp/exa");
-        expect(mcpBody).toContain("## Pollinations MCP");
-        expect(mcpBody).toContain("## FFmpeg MCP");
-        expect(mcpBody).toContain("## Exa Search MCP");
+        expect(mcpBody).toContain("### Pollinations MCP");
+        expect(mcpBody).toContain("### FFmpeg MCP");
+        expect(mcpBody).toContain("### Exa Search MCP");
         expect(mcpBody).toContain("https://enter.pollinations.ai/my-models");
         expect(mcpBody).not.toContain("## Other built-in MCPs");
         expect(mcpBody).toContain("`generateImage`");

--- a/gen.pollinations.ai/test/docs.test.ts
+++ b/gen.pollinations.ai/test/docs.test.ts
@@ -547,7 +547,17 @@ describe("docs routes", () => {
         expect(mcpRes.status).toBe(200);
         const mcpBody = await mcpRes.text();
         expect(mcpBody).toContain("## MCP Server");
-        expect(mcpBody).toContain("https://gen.pollinations.ai/mcp");
+        expect(mcpBody).toContain(
+            "https://gen.pollinations.ai/mcp/pollinations",
+        );
+        expect(mcpBody).toContain("https://gen.pollinations.ai/mcp/ffmpeg");
+        expect(mcpBody).toContain("https://gen.pollinations.ai/mcp/exa");
+        expect(mcpBody).toContain("## Pollinations MCP");
+        expect(mcpBody).toContain("## Other built-in MCPs");
+        expect(mcpBody).toContain("`generateImage`");
+        expect(mcpBody).toContain("`runFfmpeg`");
+        expect(mcpBody).toContain("`web_search_exa`");
+        expect(mcpBody).not.toContain("mcp.pollinations.ai");
         expect(mcpBody).toContain("Streamable HTTP");
         expect(mcpBody).not.toContain("stdio");
         expect(mcpBody).not.toContain("npx @pollinations/mcp");

--- a/gen.pollinations.ai/test/docs.test.ts
+++ b/gen.pollinations.ai/test/docs.test.ts
@@ -553,7 +553,9 @@ describe("docs routes", () => {
         expect(mcpBody).toContain("https://gen.pollinations.ai/mcp/ffmpeg");
         expect(mcpBody).toContain("https://gen.pollinations.ai/mcp/exa");
         expect(mcpBody).toContain("## Pollinations MCP");
-        expect(mcpBody).toContain("## Other built-in MCPs");
+        expect(mcpBody).toContain("## FFmpeg MCP");
+        expect(mcpBody).toContain("## Exa Search MCP");
+        expect(mcpBody).not.toContain("## Other built-in MCPs");
         expect(mcpBody).toContain("`generateImage`");
         expect(mcpBody).toContain("`runFfmpeg`");
         expect(mcpBody).toContain("`web_search_exa`");

--- a/gen.pollinations.ai/test/docs.test.ts
+++ b/gen.pollinations.ai/test/docs.test.ts
@@ -555,6 +555,7 @@ describe("docs routes", () => {
         expect(mcpBody).toContain("## Pollinations MCP");
         expect(mcpBody).toContain("## FFmpeg MCP");
         expect(mcpBody).toContain("## Exa Search MCP");
+        expect(mcpBody).toContain("https://enter.pollinations.ai/my-models");
         expect(mcpBody).not.toContain("## Other built-in MCPs");
         expect(mcpBody).toContain("`generateImage`");
         expect(mcpBody).toContain("`runFfmpeg`");

--- a/operations/social/prompts/brand/links.md
+++ b/operations/social/prompts/brand/links.md
@@ -20,7 +20,7 @@
 - **Contributor Guide:** https://github.com/pollinations/pollinations/blob/master/CONTRIBUTING.md
 - **React SDK & UI:** https://react.pollinations.ai
 - **Connect User Wallets:** https://gen.pollinations.ai/docs#tag/connect-user-wallets
-- **MCP Server Docs:** https://gen.pollinations.ai/docs#tag/mcp-server
+- **MCP Servers Docs:** https://gen.pollinations.ai/docs#tag/mcp-servers
 - **MCP Protocol (contribute):** https://mcp.sequa.ai/v1/pollinations/contribute
 
 ## Apps & Community

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,129 +1,49 @@
-# Pollinations MCP
+# pollinations.ai MCP Server
 
-Use Pollinations tools from any
-[Model Context Protocol](https://modelcontextprotocol.io) client that supports
-Streamable HTTP. All hosted MCP servers are exposed through
-`gen.pollinations.ai`.
+A [Model Context Protocol](https://modelcontextprotocol.io) server that exposes
+Pollinations models and API capabilities as agent tools.
 
-## Quick start
+## Connect
 
-Get an API key from [enter.pollinations.ai](https://enter.pollinations.ai/keys),
-then choose a built-in server:
+Connect a Streamable HTTP client to:
 
-| Server | Streamable HTTP endpoint | Use it for |
-| --- | --- | --- |
-| Pollinations | `https://gen.pollinations.ai/mcp/pollinations` | Pollinations models, media generation, model discovery, and account tools |
-| FFmpeg | `https://gen.pollinations.ai/mcp/ffmpeg` | Trim, convert, resize, compress, and remix audio and video |
-| Exa Search | `https://gen.pollinations.ai/mcp/exa` | Search the live web and fetch clean page content |
+```text
+https://gen.pollinations.ai/mcp/pollinations
+```
 
-Send the key with every request:
+Send a Pollinations API key with every request:
 
 ```http
 Authorization: Bearer YOUR_KEY
 ```
 
-The live catalog returns the same endpoints with current descriptions and
-pricing:
+Get a key from [enter.pollinations.ai](https://enter.pollinations.ai/keys).
+Calls use that key's Pollen wallet, permissions, and budget.
 
-```bash
-curl https://gen.pollinations.ai/mcp
-```
+For all Pollinations-hosted MCP servers, see the
+[MCP Servers documentation](https://gen.pollinations.ai/docs#tag/mcp-servers).
 
-## Use with hosted agents
+## Tools
 
-Add MCP servers to an agent in
-[My Models](https://enter.pollinations.ai/my-models).
-
-## Connect a client
-
-The official TypeScript client handles initialization and tool discovery:
-
-```ts
-import {
-  Client,
-  StreamableHTTPClientTransport,
-} from "@modelcontextprotocol/client";
-
-const client = new Client({ name: "my-app", version: "1.0.0" });
-const transport = new StreamableHTTPClientTransport(
-  new URL("https://gen.pollinations.ai/mcp/pollinations"),
-  {
-    requestInit: {
-      headers: {
-        Authorization: `Bearer ${process.env.POLLINATIONS_API_KEY}`,
-      },
-    },
-  },
-);
-
-await client.connect(transport);
-const { tools } = await client.listTools();
-```
-
-Other clients use the same endpoint and bearer header; only their configuration
-format differs.
-
-### Claude Code
-
-```bash
-claude mcp add --transport http pollinations \
-  https://gen.pollinations.ai/mcp/pollinations \
-  --header "Authorization: Bearer YOUR_KEY"
-```
-
-Run `/mcp` in Claude Code to verify the connection. Replace the name and URL
-with another endpoint from the table to use FFmpeg or Exa Search.
-
-## Pollinations MCP
-
-The Pollinations server exposes the main Pollinations API as agent-friendly
-tools.
-
-| Tool | Purpose |
-| --- | --- |
-| `listModels` | List live models, aliases, capabilities, voices, endpoints, and pricing |
-| `getModelStatus` | Inspect recent requests, errors, and latency for a model |
-| `generateText` | Generate text, use search-capable models, process multimodal input, or call a listed agent |
-| `generateImage` | Generate or edit images |
-| `generateVideo` | Generate video |
-| `generateAudio` | Generate speech, music, or sound |
-| `transcribeAudio` | Transcribe audio from a public HTTPS URL |
-| `generate3D` | Generate a GLB 3D model |
-| `createEmbeddings` | Create text or multimodal embeddings |
-| `getBalance` | Check the remaining Pollen balance; requires `account:usage` permission |
-
-Use `listModels` before choosing a model or voice. The registry is live, so
-clients should not rely on a hardcoded model list.
+| Tool | Purpose | API route |
+| --- | --- | --- |
+| `generateText` | Text, search, multimodal input, and tool calling | `/v1/chat/completions` |
+| `generateImage` | Generate or edit images | `/v1/images/generations` |
+| `generateVideo` | Generate video | `/video/{prompt}` |
+| `generateAudio` | Generate speech, music, or sound | `/audio/{text}` |
+| `transcribeAudio` | Transcribe a public HTTPS audio URL | `/v1/audio/transcriptions` |
+| `generate3D` | Generate a GLB model | `/3d/{prompt}` |
+| `createEmbeddings` | Create text or multimodal embeddings | `/v1/embeddings` |
+| `listModels` | List live models, capabilities, voices, and pricing | Model registry routes |
+| `getModelStatus` | Inspect recent requests, errors, and latency | `/v1/models/status` |
+| `getBalance` | Check remaining Pollen; requires `account:usage` | `/account/balance` |
 
 Generated media is uploaded unlisted to `media.pollinations.ai` and returned as
 an MCP resource link, so binary data does not consume model context. Anyone
 with the link can access it, and it expires after 30 days.
 
-## FFmpeg MCP
-
-`runFfmpeg` accepts public HTTPS media inputs and ordinary FFmpeg arguments. It
-supports multiple inputs and returns the output as a hosted MCP resource link.
-Pollinations supplies the input and output files, so omit the `ffmpeg`
-executable and output path from the arguments.
-
-## Exa Search MCP
-
-- `web_search_exa` searches the live web and returns relevant pages with
-  highlights.
-- `web_fetch_exa` reads one or more known URLs as clean text when the search
-  highlights are not enough.
-
-## Billing and permissions
-
-Calls use the same Pollen wallet as the Pollinations API. The catalog endpoint
-shows each server's current pricing. Pollinations generation tools use the
-selected model's listed rate.
-
-The server can only use models and account features allowed by the caller's key
-and cannot spend beyond that key's budget. Configure both in
-[API key settings](https://enter.pollinations.ai/keys). See
-[Authentication](https://gen.pollinations.ai/docs#tag/authentication) for key
-types and security guidance.
+Models, voices, capabilities, and pricing come from the live registry. Use
+`listModels` before selecting a model or voice.
 
 ## Development
 
@@ -136,10 +56,8 @@ npm test
 Set `POLLINATIONS_API_KEY` to add live model, authentication, generation, and
 balance checks.
 
-The Pollinations MCP implementation lives in [`packages/mcp/`](./), with its
-Cloudflare Worker in [`apps/mcp/`](../../apps/mcp/). Hosted MCP traffic is
+The hosted Cloudflare Worker lives in [`apps/mcp/`](../../apps/mcp/) and is
 routed through Gen.
 
-API reference: [gen.pollinations.ai/docs](https://gen.pollinations.ai/docs) ·
 Issues: [GitHub](https://github.com/pollinations/pollinations/issues) · License:
 MIT

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -74,20 +74,10 @@ with another endpoint from the table to use FFmpeg or Exa Search.
 The Pollinations server exposes the main Pollinations API as agent-friendly
 tools.
 
-### Discover models
-
 | Tool | Purpose |
 | --- | --- |
 | `listModels` | List live models, aliases, capabilities, voices, endpoints, and pricing |
 | `getModelStatus` | Inspect recent requests, errors, and latency for a model |
-
-Use `listModels` before choosing a model or voice. The registry is live, so
-clients should not rely on a hardcoded model list.
-
-### Generate and transform
-
-| Tool | Purpose |
-| --- | --- |
 | `generateText` | Generate text, use search-capable models, process multimodal input, or call a listed agent |
 | `generateImage` | Generate or edit images |
 | `generateVideo` | Generate video |
@@ -95,16 +85,14 @@ clients should not rely on a hardcoded model list.
 | `transcribeAudio` | Transcribe audio from a public HTTPS URL |
 | `generate3D` | Generate a GLB 3D model |
 | `createEmbeddings` | Create text or multimodal embeddings |
+| `getBalance` | Check the remaining Pollen balance; requires `account:usage` permission |
+
+Use `listModels` before choosing a model or voice. The registry is live, so
+clients should not rely on a hardcoded model list.
 
 Generated media is uploaded unlisted to `media.pollinations.ai` and returned as
 an MCP resource link, so binary data does not consume model context. Anyone
 with the link can access it, and it expires after 30 days.
-
-### Account
-
-| Tool | Purpose |
-| --- | --- |
-| `getBalance` | Check the remaining Pollen balance; requires `account:usage` permission |
 
 ## FFmpeg MCP
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,37 +1,37 @@
-# pollinations.ai MCP Server
+# Pollinations MCP
 
-A [Model Context Protocol](https://modelcontextprotocol.io) server for generating
-text, images, video, audio, embeddings, and 3D models with Pollinations. It also
-provides live model discovery, health information, and Pollen balance.
+Use Pollinations tools from any
+[Model Context Protocol](https://modelcontextprotocol.io) client that supports
+Streamable HTTP. All hosted MCP servers are exposed through
+`gen.pollinations.ai`.
 
-## Quick Start
+## Quick start
 
-Connect any Streamable HTTP client to `https://mcp.pollinations.ai` with:
+Get an API key from [enter.pollinations.ai](https://enter.pollinations.ai/keys),
+then choose a built-in server:
+
+| Server | Streamable HTTP endpoint | Use it for |
+| --- | --- | --- |
+| Pollinations | `https://gen.pollinations.ai/mcp/pollinations` | Pollinations models, media generation, model discovery, and account tools |
+| FFmpeg | `https://gen.pollinations.ai/mcp/ffmpeg` | Trim, convert, resize, compress, and remix audio and video |
+| Exa Search | `https://gen.pollinations.ai/mcp/exa` | Search the live web and fetch clean page content |
+
+Send the key with every request:
 
 ```http
 Authorization: Bearer YOUR_KEY
 ```
 
-The server can only use models and account features allowed by that key's
-permissions, and it cannot spend beyond the key's budget. Configure both in
-[API key settings](https://enter.pollinations.ai/keys); see
-[Authentication](https://gen.pollinations.ai/docs#tag/-authentication).
-
-## Hosted MCP catalog
-
-Pollinations also hosts other MCP servers. List their Streamable HTTP URLs and
+The live catalog returns the same endpoints with current descriptions and
 pricing:
 
 ```bash
 curl https://gen.pollinations.ai/mcp
 ```
 
-Connect any MCP client directly to a returned `url` with the same bearer
-header. Creating a Pollinations agent is not required, and API keys must not be
-put in the URL. Calls use the same Pollen wallet and key permissions as the
-Pollinations API; generation tools use the selected model's listed rate.
+## Connect a client
 
-For example, with the official TypeScript client:
+The official TypeScript client handles initialization and tool discovery:
 
 ```ts
 import {
@@ -55,51 +55,84 @@ await client.connect(transport);
 const { tools } = await client.listTools();
 ```
 
-The client handles MCP initialization and tool discovery. Other clients use the
-same endpoint and header; only their configuration format differs.
+Other clients use the same endpoint and bearer header; only their configuration
+format differs.
 
 ### Claude Code
 
 ```bash
-claude mcp add --transport http pollinations https://mcp.pollinations.ai \
+claude mcp add --transport http pollinations \
+  https://gen.pollinations.ai/mcp/pollinations \
   --header "Authorization: Bearer YOUR_KEY"
 ```
 
-Run `/mcp` in Claude Code to verify the connection.
+Run `/mcp` in Claude Code to verify the connection. Replace the name and URL
+with another endpoint from the table to use FFmpeg or Exa Search.
 
-## Authentication
+## Pollinations MCP
 
-Get a key at [enter.pollinations.ai](https://enter.pollinations.ai/keys), or use
-[BYOP](../../BRING_YOUR_OWN_POLLEN.md) to let users connect their own wallet
-through a web or device flow.
+The Pollinations server exposes the main Pollinations API as agent-friendly
+tools.
 
-**Key types:**
+### Discover models
 
-- `pk_` — client-safe and rate-limited to 1 Pollen per IP per hour
-- `sk_` — server-side only and not rate-limited
+| Tool | Purpose |
+| --- | --- |
+| `listModels` | List live models, aliases, capabilities, voices, endpoints, and pricing |
+| `getModelStatus` | Inspect recent requests, errors, and latency for a model |
 
-## Available Tools
+Use `listModels` before choosing a model or voice. The registry is live, so
+clients should not rely on a hardcoded model list.
 
-| Tool | Purpose | API route |
-| --- | --- | --- |
-| `generateText` | Text, search, multimodal input, and tool calling | `/v1/chat/completions` |
-| `generateImage` | Generate or edit images | `/v1/images/generations` |
-| `generateVideo` | Generate video | `/video/{prompt}` |
-| `generateAudio` | Generate speech, music, or sound | `/audio/{text}` |
-| `transcribeAudio` | Transcribe a public HTTPS audio URL | `/v1/audio/transcriptions` |
-| `generate3D` | Generate a GLB model | `/3d/{prompt}` |
-| `createEmbeddings` | Create text or multimodal embeddings | `/v1/embeddings` |
-| `listModels` | List live models, capabilities, voices, and pricing | Model registry routes |
-| `getModelStatus` | Inspect recent requests, errors, and latency | `/v1/models/status` |
-| `getBalance` | Check remaining Pollen; requires `account:usage` | `/account/balance` |
+### Generate and transform
+
+| Tool | Purpose |
+| --- | --- |
+| `generateText` | Generate text, use search-capable models, process multimodal input, or call a listed agent |
+| `generateImage` | Generate or edit images |
+| `generateVideo` | Generate video |
+| `generateAudio` | Generate speech, music, or sound |
+| `transcribeAudio` | Transcribe audio from a public HTTPS URL |
+| `generate3D` | Generate a GLB 3D model |
+| `createEmbeddings` | Create text or multimodal embeddings |
 
 Generated media is uploaded unlisted to `media.pollinations.ai` and returned as
-an MCP resource link, so binary data does not consume model context. Links are
-public to anyone who has them and expire after 30 days. Pass an image's HTTPS
-URL to edit it, and use separate tool calls for multiple images.
+an MCP resource link, so binary data does not consume model context. Anyone
+with the link can access it, and it expires after 30 days.
 
-Models, voices, capabilities, and pricing come from the live registry rather
-than hardcoded lists. Use `listModels` before selecting a model or voice.
+### Account
+
+| Tool | Purpose |
+| --- | --- |
+| `getBalance` | Check the remaining Pollen balance; requires `account:usage` permission |
+
+## Other built-in MCPs
+
+### FFmpeg
+
+`runFfmpeg` accepts public HTTPS media inputs and ordinary FFmpeg arguments. It
+supports multiple inputs and returns the output as a hosted MCP resource link.
+Pollinations supplies the input and output files, so omit the `ffmpeg`
+executable and output path from the arguments.
+
+### Exa Search
+
+- `web_search_exa` searches the live web and returns relevant pages with
+  highlights.
+- `web_fetch_exa` reads one or more known URLs as clean text when the search
+  highlights are not enough.
+
+## Billing and permissions
+
+Calls use the same Pollen wallet as the Pollinations API. The catalog endpoint
+shows each server's current pricing. Pollinations generation tools use the
+selected model's listed rate.
+
+The server can only use models and account features allowed by the caller's key
+and cannot spend beyond that key's budget. Configure both in
+[API key settings](https://enter.pollinations.ai/keys). See
+[Authentication](https://gen.pollinations.ai/docs#tag/authentication) for key
+types and security guidance.
 
 ## Development
 
@@ -109,15 +142,12 @@ Requires Node.js 20 or newer. Run the tests with:
 npm test
 ```
 
-Set `POLLINATIONS_API_KEY` to add live model, auth, text, image, and balance
-checks.
+Set `POLLINATIONS_API_KEY` to add live model, authentication, generation, and
+balance checks.
 
-The hosted Cloudflare Worker lives in [`apps/mcp/`](../../apps/mcp/) and is
-deployed from `production` by
-[`Deploy / Applications`](../../.github/workflows/deploy-applications.yml)
-whenever `apps/mcp/` or `packages/mcp/` changes. It has no separate staging
-deployment because it is a thin Gen proxy. Use the workflow's `mcp` target for
-a manual redeploy.
+The Pollinations MCP implementation lives in [`packages/mcp/`](./), with its
+Cloudflare Worker in [`apps/mcp/`](../../apps/mcp/). Hosted MCP traffic is
+routed through Gen.
 
 API reference: [gen.pollinations.ai/docs](https://gen.pollinations.ai/docs) ·
 Issues: [GitHub](https://github.com/pollinations/pollinations/issues) · License:

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -29,6 +29,12 @@ pricing:
 curl https://gen.pollinations.ai/mcp
 ```
 
+## Use with hosted agents
+
+Built-in MCP servers can be attached to Pollinations-hosted agents. Create or
+edit an agent in [My Models](https://enter.pollinations.ai/my-models), then
+select the MCP servers it can use.
+
 ## Connect a client
 
 The official TypeScript client handles initialization and tool discovery:

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -31,9 +31,8 @@ curl https://gen.pollinations.ai/mcp
 
 ## Use with hosted agents
 
-Built-in MCP servers can be attached to Pollinations-hosted agents. Create or
-edit an agent in [My Models](https://enter.pollinations.ai/my-models), then
-select the MCP servers it can use.
+Add MCP servers to an agent in
+[My Models](https://enter.pollinations.ai/my-models).
 
 ## Connect a client
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -106,16 +106,14 @@ with the link can access it, and it expires after 30 days.
 | --- | --- |
 | `getBalance` | Check the remaining Pollen balance; requires `account:usage` permission |
 
-## Other built-in MCPs
-
-### FFmpeg
+## FFmpeg MCP
 
 `runFfmpeg` accepts public HTTPS media inputs and ordinary FFmpeg arguments. It
 supports multiple inputs and returns the output as a hosted MCP resource link.
 Pollinations supplies the input and output files, so omit the `ffmpeg`
 executable and output path from the arguments.
 
-### Exa Search
+## Exa Search MCP
 
 - `web_search_exa` searches the live web and returns relevant pages with
   highlights.


### PR DESCRIPTION
- Uses Gen-hosted MCP endpoints as the canonical URLs
- Lists Pollinations, FFmpeg, and Exa Search with their purpose and tools
- Groups Pollinations tools into discovery, generation, and account sections
- Clarifies shared authentication, permissions, billing, and resource-link behavior

Tests:
- `npm run typecheck` in `gen.pollinations.ai`
- Biome and `git diff --check`