### PR TITLE
feat(video): route Wan inputs across T2V, I2V, and R2V upstreams

### DIFF
--- a/gen.pollinations.ai/src/image/models/wan3FalVideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/wan3FalVideoModel.ts
@@ -10,6 +10,8 @@ const WAN_3_TEXT_ENDPOINT =
     "https://queue.fal.run/alibaba/wan-3.0-prime/text-to-video";
 const WAN_3_IMAGE_ENDPOINT =
     "https://queue.fal.run/alibaba/wan-3.0-prime/image-to-video";
+const WAN_3_REFERENCE_ENDPOINT =
+    "https://queue.fal.run/alibaba/wan-3.0-prime/reference-to-video";
 const WAN_3_DURATION_SECONDS = 5;
 const WAN_3_TIMEOUT_MS = 5 * 60 * 1000;
 const WAN_3_POLL_INTERVAL_MS = 2_000;
@@ -61,29 +63,51 @@ export async function callWan3FalAPI(
     }
 
     const startImage = safeParams.image[0];
-    const endpoint = startImage ? WAN_3_IMAGE_ENDPOINT : WAN_3_TEXT_ENDPOINT;
+    const endImage = safeParams.image[1];
+    const refImages = safeParams.reference_images ?? [];
+    const refVideos = safeParams.reference_videos ?? [];
+    const refAudios = safeParams.reference_audios ?? [];
+    const hasReferences =
+        refImages.length > 0 || refVideos.length > 0 || refAudios.length > 0;
+
+    const endpoint = hasReferences
+        ? WAN_3_REFERENCE_ENDPOINT
+        : startImage
+          ? WAN_3_IMAGE_ENDPOINT
+          : WAN_3_TEXT_ENDPOINT;
     const deadline = Date.now() + WAN_3_TIMEOUT_MS;
     const authorization = { Authorization: `Key ${apiKey}` };
+
+    const body: Record<string, unknown> = {
+        prompt,
+        resolution: safeParams.resolution ?? "480p",
+        aspect_ratio: startImage
+            ? "adaptive"
+            : closestRatioLogSpace(
+                  safeParams.width,
+                  safeParams.height,
+                  WAN_3_ASPECT_RATIOS,
+              ),
+        duration,
+        audio: safeParams.audio,
+        enable_prompt_expansion: true,
+        enable_safety_checker: true,
+        seed: safeParams.seed,
+        ...(startImage ? { start_image_url: startImage } : {}),
+        ...(endImage ? { end_image_url: endImage } : {}),
+    };
+
+    if (hasReferences) {
+        if (refImages.length > 0) body.reference_images = refImages;
+        if (refVideos.length > 0) body.reference_videos = refVideos;
+        if (refAudios.length > 0) body.reference_audios = refAudios;
+        body.aspect_ratio = "adaptive";
+    }
+
     const submissionResponse = await fetchUpstream(endpoint, {
         method: "POST",
         headers: { ...authorization, "Content-Type": "application/json" },
-        body: JSON.stringify({
-            prompt,
-            resolution: safeParams.resolution ?? "480p",
-            aspect_ratio: startImage
-                ? "adaptive"
-                : closestRatioLogSpace(
-                      safeParams.width,
-                      safeParams.height,
-                      WAN_3_ASPECT_RATIOS,
-                  ),
-            duration,
-            audio: safeParams.audio,
-            enable_prompt_expansion: true,
-            enable_safety_checker: true,
-            seed: safeParams.seed,
-            ...(startImage ? { start_image_url: startImage } : {}),
-        }),
+        body: JSON.stringify(body),
         signal: AbortSignal.timeout(remainingTime(deadline)),
         errorLabel: "Wan 3.0 submission failed",
     });

--- a/gen.pollinations.ai/src/image/models/wanVideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/wanVideoModel.ts
@@ -29,24 +29,30 @@ import {
 const logOps = debug("pollinations:wan:ops");
 const logError = debug("pollinations:wan:error");
 
+type WanMode = "t2v" | "i2v" | "r2v";
+
 interface WanVariantConfig {
     t2vModel: string;
     i2vModel: string;
+    r2vModel?: string;
     trackingName: string;
     displayName: string;
     predictionDeadlineMinutes?: number;
+    r2vMaxDuration?: number;
     /**
      * Build the Replicate input for the chosen mode. `frames` holds the
      * already-downloaded data URIs: frames[0] = first frame, frames[1] = last.
+     * `references` holds reference media URLs for R2V mode.
      */
     buildInput(
-        mode: "t2v" | "i2v",
+        mode: WanMode,
         prompt: string,
         safeParams: ImageParams,
         frames: string[],
+        references: { images: string[]; videos: string[] },
     ): Record<string, unknown>;
     /** Resolve the duration to request AND bill (seconds). */
-    resolveDuration(safeParams: ImageParams): number;
+    resolveDuration(safeParams: ImageParams, mode: WanMode): number;
 }
 
 // wan-2.2-fast: aspect_ratio enum is landscape/portrait only.
@@ -59,6 +65,7 @@ const WAN_FAST_FIXED_SECONDS = 5;
 const WAN_26_DURATIONS = [5, 10, 15] as const;
 const WAN_PRO_MIN_DURATION = 2;
 const WAN_PRO_MAX_DURATION = 15;
+const WAN_PRO_R2V_MAX_DURATION = 10;
 const WAN_PRO_PREDICTION_DEADLINE_MINUTES = 15;
 
 /** Pick the supported aspect ratio closest to the request. */
@@ -154,7 +161,7 @@ const WAN_26_CONFIG: WanVariantConfig = {
 };
 
 // Wan 2.7 uses one public model for both supported resolutions. The upstream
-// still has separate T2V and I2V routes, selected from the input frames.
+// still has separate T2V, I2V, and R2V routes, selected from the input.
 function makeWan27Config(
     resolution: "720p" | "1080p",
     trackingName: string,
@@ -162,16 +169,37 @@ function makeWan27Config(
     return {
         t2vModel: "wan-video/wan-2.7-t2v",
         i2vModel: "wan-video/wan-2.7-i2v",
+        r2vModel: "wan-video/wan-2.7-r2v",
+        r2vMaxDuration: WAN_PRO_R2V_MAX_DURATION,
         trackingName,
         displayName: `Wan 2.7${resolution === "1080p" ? " 1080p" : ""}`,
         predictionDeadlineMinutes: WAN_PRO_PREDICTION_DEADLINE_MINUTES,
-        resolveDuration: (p) =>
-            Math.max(
+        resolveDuration: (p, mode) => {
+            const max =
+                mode === "r2v"
+                    ? WAN_PRO_R2V_MAX_DURATION
+                    : WAN_PRO_MAX_DURATION;
+            return Math.max(
                 WAN_PRO_MIN_DURATION,
-                Math.min(WAN_PRO_MAX_DURATION, Math.floor(p.duration ?? 5)),
-            ),
-        buildInput(mode, prompt, safeParams, frames) {
-            const duration = this.resolveDuration(safeParams);
+                Math.min(max, Math.floor(p.duration ?? 5)),
+            );
+        },
+        buildInput(mode, prompt, safeParams, frames, references) {
+            const duration = this.resolveDuration(safeParams, mode);
+            if (mode === "r2v") {
+                return withSeed(
+                    {
+                        prompt,
+                        image: references.images[0],
+                        resolution,
+                        duration,
+                        ...(references.videos.length
+                            ? { reference_videos: references.videos }
+                            : {}),
+                    },
+                    safeParams,
+                );
+            }
             if (mode === "i2v") {
                 return withSeed(
                     {
@@ -206,18 +234,40 @@ async function generateWanVideo(
     safeParams: ImageParams,
 ): Promise<VideoGenerationResult> {
     const images = safeParams.image ?? [];
-    const mode: "t2v" | "i2v" = images.length > 0 ? "i2v" : "t2v";
-    const model = mode === "i2v" ? config.i2vModel : config.t2vModel;
+    const refImages = safeParams.reference_images ?? [];
+    const refVideos = safeParams.reference_videos ?? [];
+    const hasReferences = refImages.length > 0 || refVideos.length > 0;
+
+    const mode: WanMode =
+        images.length > 0
+            ? "i2v"
+            : hasReferences && config.r2vModel
+              ? "r2v"
+              : "t2v";
+
+    const model =
+        mode === "r2v"
+            ? (config.r2vModel ?? config.i2vModel)
+            : mode === "i2v"
+              ? config.i2vModel
+              : config.t2vModel;
 
     const frames =
         images.length > 0 ? await Promise.all(images.map(toDataUri)) : [];
-    const input = config.buildInput(mode, prompt, safeParams, frames);
-    const requestedDuration = config.resolveDuration(safeParams);
+    const references = { images: refImages, videos: refVideos };
+    const input = config.buildInput(
+        mode,
+        prompt,
+        safeParams,
+        frames,
+        references,
+    );
+    const requestedDuration = config.resolveDuration(safeParams, mode);
 
     logOps(`${config.displayName} (${mode}) input:`, {
         ...input,
         prompt: prompt.slice(0, 80),
-        image: input.image ? "[data uri]" : undefined,
+        image: input.image ? "[data uri or ref]" : undefined,
         first_frame: input.first_frame ? "[data uri]" : undefined,
         last_image: input.last_image ? "[data uri]" : undefined,
         last_frame: input.last_frame ? "[data uri]" : undefined,

--- a/gen.pollinations.ai/src/image/params.ts
+++ b/gen.pollinations.ai/src/image/params.ts
@@ -187,20 +187,6 @@ export const ImageParamsSchema = z
                 });
             }
         }
-        // Reject frame + reference combinations for video models
-        if (data.image.length > 0) {
-            const hasRefs =
-                (data.reference_images?.length ?? 0) > 0 ||
-                (data.reference_videos?.length ?? 0) > 0 ||
-                (data.reference_audios?.length ?? 0) > 0;
-            if (hasRefs) {
-                ctx.addIssue({
-                    code: z.ZodIssueCode.custom,
-                    message:
-                        "Cannot combine frame images (image[]) with reference media (reference_images/reference_videos/reference_audios). Use one or the other.",
-                });
-            }
-        }
         if (data.model === "minimax-h3") {
             if (data.duration !== undefined && data.duration !== 5) {
                 ctx.addIssue({

--- a/gen.pollinations.ai/src/image/params.ts
+++ b/gen.pollinations.ai/src/image/params.ts
@@ -187,6 +187,20 @@ export const ImageParamsSchema = z
                 });
             }
         }
+        // Reject frame + reference combinations for video models
+        if (data.image.length > 0) {
+            const hasRefs =
+                (data.reference_images?.length ?? 0) > 0 ||
+                (data.reference_videos?.length ?? 0) > 0 ||
+                (data.reference_audios?.length ?? 0) > 0;
+            if (hasRefs) {
+                ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    message:
+                        "Cannot combine frame images (image[]) with reference media (reference_images/reference_videos/reference_audios). Use one or the other.",
+                });
+            }
+        }
         if (data.model === "minimax-h3") {
             if (data.duration !== undefined && data.duration !== 5) {
                 ctx.addIssue({

--- a/gen.pollinations.ai/test/image/wan3FalVideoModel.test.ts
+++ b/gen.pollinations.ai/test/image/wan3FalVideoModel.test.ts
@@ -7,6 +7,8 @@ const TEXT_ENDPOINT =
     "https://queue.fal.run/alibaba/wan-3.0-prime/text-to-video";
 const IMAGE_ENDPOINT =
     "https://queue.fal.run/alibaba/wan-3.0-prime/image-to-video";
+const REFERENCE_ENDPOINT =
+    "https://queue.fal.run/alibaba/wan-3.0-prime/reference-to-video";
 const STATUS_URL =
     "https://queue.fal.run/alibaba/wan-3.0-prime/requests/test/status";
 const RESULT_URL = "https://queue.fal.run/alibaba/wan-3.0-prime/requests/test";
@@ -51,7 +53,11 @@ function mockFalFetch(
                       >)
                     : undefined,
             });
-            if (href === TEXT_ENDPOINT || href === IMAGE_ENDPOINT) {
+            if (
+                href === TEXT_ENDPOINT ||
+                href === IMAGE_ENDPOINT ||
+                href === REFERENCE_ENDPOINT
+            ) {
                 return Response.json({
                     status_url: STATUS_URL,
                     response_url: RESULT_URL,
@@ -158,5 +164,59 @@ describe("Wan 3.0 Prime via Fal", () => {
             }),
         ).rejects.toMatchObject({ status: 400 });
         expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("routes reference images to the reference-to-video endpoint", async () => {
+        const requests: ProviderRequest[] = [];
+        mockFalFetch(requests);
+
+        const result = await callWan3FalAPI("a serene landscape", {
+            ...baseParams,
+            reference_images: ["https://example.com/ref.png"],
+        });
+
+        expect(requests[0].url).toBe(REFERENCE_ENDPOINT);
+        expect(requests[0].body).toMatchObject({
+            prompt: "a serene landscape",
+            reference_images: ["https://example.com/ref.png"],
+            aspect_ratio: "adaptive",
+        });
+        expect(result.trackingData.actualModel).toBe("wan-3.0");
+    });
+
+    it("routes reference videos and audio to the reference-to-video endpoint", async () => {
+        const requests: ProviderRequest[] = [];
+        mockFalFetch(requests);
+
+        await callWan3FalAPI("a music video", {
+            ...baseParams,
+            reference_videos: ["https://example.com/ref.mp4"],
+            reference_audios: ["https://example.com/ref.mp3"],
+        });
+
+        expect(requests[0].url).toBe(REFERENCE_ENDPOINT);
+        expect(requests[0].body).toMatchObject({
+            reference_videos: ["https://example.com/ref.mp4"],
+            reference_audios: ["https://example.com/ref.mp3"],
+        });
+    });
+
+    it("forwards image[1] as end_image_url in image-to-video mode", async () => {
+        const requests: ProviderRequest[] = [];
+        mockFalFetch(requests);
+
+        await callWan3FalAPI("a cat walking", {
+            ...baseParams,
+            image: [
+                "https://example.com/start.png",
+                "https://example.com/end.png",
+            ],
+        });
+
+        expect(requests[0].url).toBe(IMAGE_ENDPOINT);
+        expect(requests[0].body).toMatchObject({
+            start_image_url: "https://example.com/start.png",
+            end_image_url: "https://example.com/end.png",
+        });
     });
 });

--- a/gen.pollinations.ai/test/image/wanVideoModel.test.ts
+++ b/gen.pollinations.ai/test/image/wanVideoModel.test.ts
@@ -12,6 +12,8 @@ const REPLICATE_PREDICTIONS =
 const VIDEO_URL = "https://video.example.com/wan-output.mp4";
 const INPUT_IMAGE_URL = "https://img.example.com/first-frame.png";
 const LAST_IMAGE_URL = "https://img.example.com/last-frame.png";
+const REF_IMAGE_URL = "https://img.example.com/ref-image.png";
+const REF_VIDEO_URL = "https://video.example.com/ref-video.mp4";
 // PNG magic bytes so downloadUserImage's detectMimeType resolves to image/png.
 const PNG_BYTES = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
 const EXPECTED_DATA_URI = /^data:image\/png;base64,/;
@@ -83,10 +85,20 @@ function mockReplicateFetch(
                     headers: { "Content-Type": "video/mp4" },
                 });
             }
-            if (href === INPUT_IMAGE_URL || href === LAST_IMAGE_URL) {
+            if (
+                href === INPUT_IMAGE_URL ||
+                href === LAST_IMAGE_URL ||
+                href === REF_IMAGE_URL
+            ) {
                 return new Response(PNG_BYTES, {
                     status: 200,
                     headers: { "Content-Type": "image/png" },
+                });
+            }
+            if (href === REF_VIDEO_URL) {
+                return new Response(new Uint8Array([0, 0, 0, 24]), {
+                    status: 200,
+                    headers: { "Content-Type": "video/mp4" },
                 });
             }
             return new Response("unexpected URL", { status: 404 });
@@ -253,5 +265,86 @@ describe("wanVideoModel image-to-video routing", () => {
         expect(calls[0].input.resolution).toBe("480p");
         expect(calls[0].input.image as string).toMatch(EXPECTED_DATA_URI);
         expect(calls[0].input.last_image as string).toMatch(EXPECTED_DATA_URI);
+    });
+});
+
+describe("wanVideoModel reference-to-video routing", () => {
+    it("wan-pro r2v routes to wan-2.7-r2v with reference image", async () => {
+        setReplicateEnv();
+        const calls: ReplicateCall[] = [];
+        mockReplicateFetch(calls, 5);
+
+        await callWanProAPI("a serene landscape", {
+            ...baseParams,
+            reference_images: [REF_IMAGE_URL],
+        });
+
+        expect(calls[0].model).toBe("wan-video/wan-2.7-r2v");
+        expect(calls[0].input.resolution).toBe("720p");
+        expect(calls[0].input.image).toBe(REF_IMAGE_URL);
+        expect(calls[0].input.duration).toBe(5);
+        expect(calls[0].cancelAfter).toBe("15m");
+    });
+
+    it("wan-pro r2v with reference image and video passes both", async () => {
+        setReplicateEnv();
+        const calls: ReplicateCall[] = [];
+        mockReplicateFetch(calls, 5);
+
+        await callWanProAPI("a serene landscape", {
+            ...baseParams,
+            reference_images: [REF_IMAGE_URL],
+            reference_videos: [REF_VIDEO_URL],
+        });
+
+        expect(calls[0].model).toBe("wan-video/wan-2.7-r2v");
+        expect(calls[0].input.image).toBe(REF_IMAGE_URL);
+        expect(calls[0].input.reference_videos).toEqual([REF_VIDEO_URL]);
+    });
+
+    it("wan-pro r2v clamps duration to 10s max", async () => {
+        setReplicateEnv();
+        const calls: ReplicateCall[] = [];
+        mockReplicateFetch(calls, 10);
+
+        await callWanProAPI("a serene landscape", {
+            ...baseParams,
+            duration: 15,
+            reference_images: [REF_IMAGE_URL],
+        });
+
+        expect(calls[0].model).toBe("wan-video/wan-2.7-r2v");
+        expect(calls[0].input.duration).toBe(10);
+    });
+
+    it("wan-pro i2v takes priority over r2v when both frames and references provided", async () => {
+        setReplicateEnv();
+        const calls: ReplicateCall[] = [];
+        mockReplicateFetch(calls, 5);
+
+        await callWanProAPI("a cat walking", {
+            ...baseParams,
+            image: [INPUT_IMAGE_URL],
+            reference_images: [REF_IMAGE_URL],
+        });
+
+        // i2v should win since frames are present
+        expect(calls[0].model).toBe("wan-video/wan-2.7-i2v");
+        expect(calls[0].input.first_frame as string).toMatch(EXPECTED_DATA_URI);
+    });
+
+    it("wan-pro 1080p r2v routes correctly", async () => {
+        setReplicateEnv();
+        const calls: ReplicateCall[] = [];
+        mockReplicateFetch(calls, 5);
+
+        await callWanProAPI("a serene landscape", {
+            ...baseParams,
+            resolution: "1080p",
+            reference_images: [REF_IMAGE_URL],
+        });
+
+        expect(calls[0].model).toBe("wan-video/wan-2.7-r2v");
+        expect(calls[0].input.resolution).toBe("1080p");
     });
 });

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -775,8 +775,15 @@ const IMAGE_BASE_SERVICES = {
         description: "Keyframe-controlled video with sound at 720p or 1080p",
         inputModalities: ["text", "image"],
         outputModalities: ["video", "audio"],
-        videoCapabilities: ["start_frame", "end_frame", "audio_output"],
+        videoCapabilities: [
+            "start_frame",
+            "end_frame",
+            "audio_output",
+            "reference_images",
+            "reference_videos",
+        ],
         maxReferenceImages: 2, // Video keyframe slots: start + end.
+        maxReferenceVideos: 1, // R2V mode accepts one reference video.
         minDuration: 2,
         maxDuration: 15,
         defaultDuration: 5,
@@ -823,8 +830,15 @@ const IMAGE_BASE_SERVICES = {
             "Five-second video from text or a start image with optional audio at 480p, 720p, or 1080p",
         inputModalities: ["text", "image"],
         outputModalities: ["video", "audio"],
-        videoCapabilities: ["start_frame", "audio_output"],
+        videoCapabilities: [
+            "start_frame",
+            "audio_output",
+            "reference_images",
+            "reference_videos",
+            "reference_audios",
+        ],
         maxReferenceImages: 1, // Video keyframe slots: start only.
+        maxReferenceVideos: 1, // R2V mode accepts one reference video.
         minDuration: 5,
         maxDuration: 5,
         defaultDuration: 5,


### PR DESCRIPTION
Fixes #14021

Routes Wan reference media inputs to the correct R2V upstream:

**Wan 2.7 (wan-pro):** When eference_images or eference_videos are provided (without frame images), routes to wan-video/wan-2.7-r2v via Replicate.

**Wan 3.0:** When eference_images, eference_videos, or eference_audios are provided, routes to the Fal eference-to-video endpoint. Also forwards image[1] as end_image_url in I2V mode.

**Validation:** Rejects frame + reference combinations with a clear error message.

**Duration limits:** R2V mode clamped to 2-10s (vs 2-15s for T2V/I2V on Wan 2.7).

**Registry:** Added eference_images, eference_videos capabilities to wan-pro; added eference_images, eference_videos, eference_audios to wan-3.0.

21 tests pass, biome clean.