### PR TITLE
fix: route MCP generation fetches publicly

### DIFF
--- a/apps/mcp/wrangler.jsonc
+++ b/apps/mcp/wrangler.jsonc
@@ -2,7 +2,7 @@
   "name": "pollinations-mcp",
   "main": "worker.js",
   "compatibility_date": "2026-08-14",
-  "compatibility_flags": ["nodejs_compat"],
+  "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
   "routes": [
     {
       "pattern": "mcp.myceli.ai",


### PR DESCRIPTION
- Adds Cloudflare’s `global_fetch_strictly_public` compatibility flag to the hosted MCP Worker.
- Prevents nested prompt-agent MCP tools from receiving Cloudflare 522 responses when they call Gen.
- Keeps the existing MCP API, authentication, and billing flow unchanged.

Tests:
- `npm test` in `apps/mcp` (7/7)
- `npm run check` in `apps/mcp` (Wrangler dry-run)