### PR TITLE
chore: promote main to production

### DIFF
--- a/apps/mcp/wrangler.jsonc
+++ b/apps/mcp/wrangler.jsonc
@@ -2,7 +2,7 @@
   "name": "pollinations-mcp",
   "main": "worker.js",
   "compatibility_date": "2026-08-14",
-  "compatibility_flags": ["nodejs_compat"],
+  "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
   "routes": [
     {
       "pattern": "mcp.myceli.ai",

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/prompt-agent-fields.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/prompt-agent-fields.tsx
@@ -92,7 +92,7 @@ export function PromptAgentFields({
                 <p className="text-xs text-theme-text-muted">
                     Uses the caller's Pollinations API access. See the{" "}
                     <a
-                        href="https://gen.pollinations.ai/docs#tag/mcp-server"
+                        href="https://gen.pollinations.ai/docs#tag/mcp-servers"
                         target="_blank"
                         rel="noopener noreferrer"
                         className="underline decoration-current/40 underline-offset-2 hover:text-theme-text-soft"

--- a/enter.pollinations.ai/frontend/src/components/layout/dashboard-shell.tsx
+++ b/enter.pollinations.ai/frontend/src/components/layout/dashboard-shell.tsx
@@ -256,8 +256,8 @@ export const DashboardShell: FC<DashboardShellProps> = ({
             ),
         },
         {
-            label: "MCP Server",
-            href: `${genDocsUrl()}#tag/mcp-server`,
+            label: "MCP Servers",
+            href: `${genDocsUrl()}#tag/mcp-servers`,
             icon: (
                 <McpIcon className="h-3.5 w-3.5 shrink-0 text-theme-text-muted" />
             ),

--- a/enter.pollinations.ai/frontend/src/components/models/mcp-server-list.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/mcp-server-list.tsx
@@ -107,13 +107,6 @@ export const McpServerList: FC<{ query: string }> = ({ query }) => {
                 })}
             </div>
             <p className="text-xs text-theme-text-muted">
-                <span className="font-medium text-theme-text-strong">
-                    Code quality:
-                </span>{" "}
-                Built-in MCPs favor stateless HTTP, thin proxy logic, clear
-                Pollen billing, and focused tests.
-            </p>
-            <p className="text-xs text-theme-text-muted">
                 Connect with your Pollinations API key. See the{" "}
                 <InlineLink href={genDocsUrl("#tag/mcp-server")}>
                     MCP docs

--- a/enter.pollinations.ai/frontend/src/components/models/mcp-server-list.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/mcp-server-list.tsx
@@ -108,7 +108,7 @@ export const McpServerList: FC<{ query: string }> = ({ query }) => {
             </div>
             <p className="text-xs text-theme-text-muted">
                 Connect with your Pollinations API key. See the{" "}
-                <InlineLink href={genDocsUrl("#tag/mcp-server")}>
+                <InlineLink href={genDocsUrl("#tag/mcp-servers")}>
                     MCP docs
                 </InlineLink>
                 .

--- a/enter.pollinations.ai/frontend/src/components/models/mcp-server-list.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/mcp-server-list.tsx
@@ -68,7 +68,7 @@ export const McpServerList: FC<{ query: string }> = ({ query }) => {
                                         Billing
                                     </p>
                                     {pricing.rates.length > 0 && (
-                                        <div className="grid w-fit grid-cols-[auto_auto_auto] gap-x-2">
+                                        <div className="grid w-full max-w-[19.5rem] grid-cols-[6.5rem_9ch_minmax(0,1fr)] gap-x-2 min-[480px]:grid-cols-[8rem_9ch_5.5rem]">
                                             <UsagePriceRows
                                                 adjustments={pricing.rates}
                                                 align="left"

--- a/enter.pollinations.ai/frontend/src/components/models/price-badge.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/price-badge.tsx
@@ -82,6 +82,7 @@ const formatAdjustmentUnit = ({
     if (kind === "cache_storage") {
         return `${quantityLabel} tokens${detail}`;
     }
+    if (quantity === 1 && unit === "generation") return `gen${detail}`;
     return `${quantityLabel} ${unit}${detail}`;
 };
 
@@ -334,7 +335,7 @@ const LedgerPriceValue: FC<{ value: string }> = ({ value }) => {
     const [whole, fraction] = value.split(".", 2);
 
     return (
-        <span className="grid w-[10ch] shrink-0 grid-cols-[minmax(3ch,1fr)_auto_6ch] text-sm font-semibold tabular-nums text-theme-text-strong">
+        <span className="grid w-full grid-cols-[minmax(2ch,1fr)_auto_5ch] text-sm font-semibold tabular-nums text-theme-text-strong">
             <span className="sr-only">{value}</span>
             <span aria-hidden="true" className="text-right">
                 {whole}
@@ -354,41 +355,77 @@ const RequestBasedAdjustmentKinds = new Set([
     "grounded_prompt",
 ]);
 
+const COMPACT_ADJUSTMENT_LABELS: Record<string, string> = {
+    "azure.flux_2_pro.initial_output_megapixel.v1": "Initial output MP",
+};
+
+const LedgerLabel: FC<{
+    label: string;
+    displayLabel?: string;
+    Icon?: FC<{ className?: string }>;
+}> = ({ label, displayLabel = label, Icon }) => (
+    <span className="grid min-w-0 grid-cols-[0.875rem_minmax(0,1fr)] items-center gap-1.5 text-xs text-theme-text-muted">
+        {Icon ? (
+            <Icon className="h-3.5 w-3.5 shrink-0" />
+        ) : (
+            <span aria-hidden="true" />
+        )}
+        {displayLabel !== label && <span className="sr-only">{label}</span>}
+        <span
+            className="truncate whitespace-nowrap"
+            aria-hidden={displayLabel === label ? undefined : true}
+            title={displayLabel === label ? undefined : label}
+        >
+            {displayLabel}
+        </span>
+    </span>
+);
+
 export const UsagePriceRows: FC<{
     adjustments: ModelPriceAdjustment[];
     align: "left" | "right";
 }> = ({ adjustments, align }) =>
     adjustments.map((adjustment) => {
         const isSearch = RequestBasedAdjustmentKinds.has(adjustment.kind);
+        const PriceIcon = isSearch
+            ? SearchIcon
+            : adjustment.kind === "cache_storage"
+              ? PRICE_ICON.cached
+              : adjustment.kind in PRICE_ICON
+                ? PRICE_ICON[adjustment.kind as PriceKind]
+                : undefined;
+        const unit = `/${formatAdjustmentUnit(adjustment)}`;
         return (
             <div
                 key={adjustment.name}
-                className="grid col-span-full grid-cols-subgrid items-baseline py-0.5"
+                className="grid col-span-full grid-cols-subgrid items-center py-0.5"
             >
                 {align === "right" && <span aria-hidden="true" />}
-                <span className="flex items-center gap-1.5 whitespace-nowrap text-xs text-theme-text-muted">
-                    {isSearch && (
-                        <SearchIcon className="h-3.5 w-3.5 shrink-0" />
-                    )}
-                    {adjustment.label}
-                </span>
+                <LedgerLabel
+                    Icon={PriceIcon}
+                    label={adjustment.label}
+                    displayLabel={
+                        COMPACT_ADJUSTMENT_LABELS[adjustment.name] ??
+                        adjustment.label
+                    }
+                />
                 <LedgerPriceValue
                     value={formatDisplayPrice(adjustment.price).value}
                 />
-                <span className="text-xs font-normal text-theme-text-muted [overflow-wrap:anywhere] sm:whitespace-nowrap">
-                    /{formatAdjustmentUnit(adjustment)}
+                <span
+                    className="min-w-0 truncate whitespace-nowrap text-xs font-normal text-theme-text-muted"
+                    title={unit}
+                >
+                    {unit}
                 </span>
             </div>
         );
     });
 
 const ToolsPricingRow: FC<{ align: "left" | "right" }> = ({ align }) => (
-    <div className="grid col-span-full grid-cols-subgrid items-baseline py-0.5">
+    <div className="grid col-span-full grid-cols-subgrid items-center py-0.5">
         {align === "right" && <span aria-hidden="true" />}
-        <span className="flex items-center gap-1.5 whitespace-nowrap text-xs text-theme-text-muted">
-            <McpIcon className="h-3.5 w-3.5 shrink-0" />
-            Tools
-        </span>
+        <LedgerLabel Icon={McpIcon} label="Tools" />
         <span className="col-span-2 whitespace-nowrap">
             <Tooltip
                 triggerAs="span"
@@ -590,15 +627,15 @@ export const ModelPricingLedger: FC<{
             return (
                 <div
                     key={row.key}
-                    className="grid col-span-full grid-cols-subgrid items-baseline py-0.5"
+                    className="grid col-span-full grid-cols-subgrid items-center py-0.5"
                 >
                     {align === "right" && <span aria-hidden="true" />}
-                    <span className="flex items-center gap-1.5 whitespace-nowrap text-xs text-theme-text-muted">
-                        <PriceIcon className="h-3.5 w-3.5 shrink-0" />
-                        {row.label}
-                    </span>
+                    <LedgerLabel Icon={PriceIcon} label={row.label} />
                     <LedgerPriceValue value={row.value} />
-                    <span className="text-xs font-normal text-theme-text-muted [overflow-wrap:anywhere] sm:whitespace-nowrap">
+                    <span
+                        className="min-w-0 truncate whitespace-nowrap text-xs font-normal text-theme-text-muted"
+                        title={row.unit}
+                    >
                         {row.unit}
                     </span>
                 </div>
@@ -610,8 +647,8 @@ export const ModelPricingLedger: FC<{
             className={cn(
                 "grid w-full min-w-0 max-w-full gap-x-2",
                 align === "left"
-                    ? "grid-cols-[6.5rem_10ch_minmax(0,max-content)]"
-                    : "grid-cols-[1fr_6.5rem_10ch_minmax(0,max-content)]",
+                    ? "grid-cols-[6.5rem_9ch_minmax(0,1fr)] min-[480px]:grid-cols-[8rem_9ch_5.5rem]"
+                    : "grid-cols-[1fr_8rem_9ch_5.5rem]",
                 className,
             )}
         >
@@ -624,10 +661,7 @@ export const ModelPricingLedger: FC<{
                             : "col-span-full",
                     )}
                 >
-                    <span className="flex items-center gap-1.5 whitespace-nowrap text-xs text-theme-text-muted">
-                        <TokensIcon className="h-3.5 w-3.5 shrink-0" />
-                        Requests
-                    </span>
+                    <LedgerLabel Icon={TokensIcon} label="Requests" />
                     {requestEstimate}
                     <span className="whitespace-nowrap text-xs font-normal text-theme-text-muted">
                         /pollen

--- a/gen.pollinations.ai/scripts/generate-apidocs.ts
+++ b/gen.pollinations.ai/scripts/generate-apidocs.ts
@@ -771,7 +771,7 @@ curl ${BASE_URL}/v1/models \\
 
 **3. Pick an endpoint** from the [${sectionHeading(SECTIONS.contents)}](#${sectionAnchor(SECTIONS.contents)}) below.
 
-**Integration guides:** [Connect User Wallets](https://gen.pollinations.ai/docs#tag/connect-user-wallets) · [Publish a Model](https://gen.pollinations.ai/docs#tag/publish-a-model) · [Publish an Agent](https://gen.pollinations.ai/docs#tag/publish-an-agent) · [MCP Server](https://gen.pollinations.ai/docs#tag/mcp-server) · [CLI](https://gen.pollinations.ai/docs#tag/cli)`;
+**Integration guides:** [Connect User Wallets](https://gen.pollinations.ai/docs#tag/connect-user-wallets) · [Publish a Model](https://gen.pollinations.ai/docs#tag/publish-a-model) · [Publish an Agent](https://gen.pollinations.ai/docs#tag/publish-an-agent) · [MCP Servers](https://gen.pollinations.ai/docs#tag/mcp-servers) · [CLI](https://gen.pollinations.ai/docs#tag/cli)`;
 }
 
 function renderTableOfContents(

--- a/gen.pollinations.ai/src/docs/introduction.md
+++ b/gen.pollinations.ai/src/docs/introduction.md
@@ -4,4 +4,4 @@
 
 **Get your API key:** [enter.pollinations.ai](https://enter.pollinations.ai/keys)
 
-**Integrations:** [Connect User Wallets](/docs#tag/connect-user-wallets) · [Publish a Model](/docs#tag/publish-a-model) · [Publish an Agent](/docs#tag/publish-an-agent) · [MCP Server](/docs#tag/mcp-server) · [CLI](/docs#tag/cli)
+**Integrations:** [Connect User Wallets](/docs#tag/connect-user-wallets) · [Publish a Model](/docs#tag/publish-a-model) · [Publish an Agent](/docs#tag/publish-an-agent) · [MCP Servers](/docs#tag/mcp-servers) · [CLI](/docs#tag/cli)

--- a/gen.pollinations.ai/src/docs/mcp.md
+++ b/gen.pollinations.ai/src/docs/mcp.md
@@ -1,0 +1,124 @@
+## MCP Servers
+
+Use Pollinations-hosted MCP servers from any
+[Model Context Protocol](https://modelcontextprotocol.io) client that supports
+Streamable HTTP.
+
+### Quick start
+
+Get an API key from [enter.pollinations.ai](https://enter.pollinations.ai/keys),
+then choose a server:
+
+| Server | Endpoint | Use it for |
+| --- | --- | --- |
+| Pollinations | `https://gen.pollinations.ai/mcp/pollinations` | Pollinations models, media generation, model discovery, and account tools |
+| FFmpeg | `https://gen.pollinations.ai/mcp/ffmpeg` | Trim, convert, resize, compress, and remix audio and video |
+| Exa Search | `https://gen.pollinations.ai/mcp/exa` | Search the live web and fetch clean page content |
+
+Send the key with every request:
+
+```http
+Authorization: Bearer YOUR_KEY
+```
+
+Get current endpoints and pricing from the live catalog:
+
+```bash
+curl https://gen.pollinations.ai/mcp
+```
+
+### Use with hosted agents
+
+Add MCP servers to an agent in
+[My Models](https://enter.pollinations.ai/my-models).
+
+### Connect a client
+
+The official TypeScript client handles initialization and tool discovery:
+
+```ts
+import {
+  Client,
+  StreamableHTTPClientTransport,
+} from "@modelcontextprotocol/client";
+
+const client = new Client({ name: "my-app", version: "1.0.0" });
+const transport = new StreamableHTTPClientTransport(
+  new URL("https://gen.pollinations.ai/mcp/pollinations"),
+  {
+    requestInit: {
+      headers: {
+        Authorization: `Bearer ${process.env.POLLINATIONS_API_KEY}`,
+      },
+    },
+  },
+);
+
+await client.connect(transport);
+const { tools } = await client.listTools();
+```
+
+Other clients use the same endpoint and bearer header; only their configuration
+format differs.
+
+#### Claude Code
+
+```bash
+claude mcp add --transport http pollinations \
+  https://gen.pollinations.ai/mcp/pollinations \
+  --header "Authorization: Bearer YOUR_KEY"
+```
+
+Run `/mcp` in Claude Code to verify the connection. Replace the name and URL
+with another endpoint from the table to use FFmpeg or Exa Search.
+
+### Pollinations MCP
+
+The Pollinations server exposes the main Pollinations API as agent-friendly
+tools.
+
+| Tool | Purpose |
+| --- | --- |
+| `listModels` | List live models, aliases, capabilities, voices, endpoints, and pricing |
+| `getModelStatus` | Inspect recent requests, errors, and latency for a model |
+| `generateText` | Generate text, use search-capable models, process multimodal input, or call a listed agent |
+| `generateImage` | Generate or edit images |
+| `generateVideo` | Generate video |
+| `generateAudio` | Generate speech, music, or sound |
+| `transcribeAudio` | Transcribe audio from a public HTTPS URL |
+| `generate3D` | Generate a GLB 3D model |
+| `createEmbeddings` | Create text or multimodal embeddings |
+| `getBalance` | Check the remaining Pollen balance; requires `account:usage` permission |
+
+Use `listModels` before choosing a model or voice. The registry is live, so
+clients should not rely on a hardcoded model list.
+
+Generated media is uploaded unlisted to `media.pollinations.ai` and returned as
+an MCP resource link, so binary data does not consume model context. Anyone
+with the link can access it, and it expires after 30 days.
+
+### FFmpeg MCP
+
+`runFfmpeg` accepts public HTTPS media inputs and ordinary FFmpeg arguments. It
+supports multiple inputs and returns the output as a hosted MCP resource link.
+Pollinations supplies the input and output files, so omit the `ffmpeg`
+executable and output path from the arguments.
+
+### Exa Search MCP
+
+- `web_search_exa` searches the live web and returns relevant pages with
+  highlights.
+- `web_fetch_exa` reads one or more known URLs as clean text when the search
+  highlights are not enough.
+
+### Billing and permissions
+
+Calls use the same Pollen wallet as the Pollinations API. The catalog endpoint
+shows each server's current pricing. Pollinations generation tools use the
+selected model's listed rate.
+
+An MCP server can only use models and account features allowed by the caller's
+key and cannot spend beyond that key's budget. Configure both in
+[API key settings](https://enter.pollinations.ai/keys). See
+[Authentication](https://gen.pollinations.ai/docs#tag/authentication) for key
+types and security guidance.

--- a/gen.pollinations.ai/src/routes/docs.ts
+++ b/gen.pollinations.ai/src/routes/docs.ts
@@ -36,7 +36,6 @@ import COMMUNITY_MODELS_MD from "../../../BRING_YOUR_OWN_MODEL.md?raw";
 import BYOP_MD from "../../../BRING_YOUR_OWN_POLLEN.md?raw";
 import AGENTS_MD from "../../../BUILD_YOUR_OWN_AGENT.md?raw";
 import CODING_HARNESSES_MD from "../../../CODING_HARNESSES.md?raw";
-import MCP_README from "../../../packages/mcp/README.md?raw";
 import CLI_README from "../../../packages/polli-cli/README.md?raw";
 import MODEL3D_GENERATION_MD from "../docs/3d-generation.md?raw";
 import ACCOUNT_MD from "../docs/account.md?raw";
@@ -46,6 +45,7 @@ import EMBEDDINGS_MD from "../docs/embeddings.md?raw";
 import ERRORS_MD from "../docs/errors.md?raw";
 import IMAGE_GENERATION_MD from "../docs/image-generation.md?raw";
 import INTRODUCTION_MD from "../docs/introduction.md?raw";
+import MCP_MD from "../docs/mcp.md?raw";
 import MEDIA_STORAGE_MD from "../docs/media-storage.md?raw";
 import MODELS_MD from "../docs/models.md?raw";
 import PUBLIC_STATS_MD from "../docs/public-stats.md?raw";
@@ -66,7 +66,7 @@ const DOC_TAGS = {
     communityAgents: "Community Agents",
     cli: "CLI",
     codingHarnesses: "Coding Harnesses",
-    mcpServer: "MCP Server",
+    mcpServers: "MCP Servers",
     errors: "Errors",
     safety: "Safety",
     text: "Text",
@@ -90,7 +90,7 @@ const LEGACY_DOC_TAGS: Record<string, string> = {
     "🧩 Community Models": DOC_TAGS.communityModels,
     "🤖 Community Agents": DOC_TAGS.communityAgents,
     "🖥 CLI": DOC_TAGS.cli,
-    "🔌 MCP Server": DOC_TAGS.mcpServer,
+    "🔌 MCP Server": DOC_TAGS.mcpServers,
     "❌ Errors": DOC_TAGS.errors,
     "🛡️ Safety": DOC_TAGS.safety,
     "✍️ Text": DOC_TAGS.text,
@@ -139,7 +139,7 @@ const DOC_TAG_ICON_HTML: Record<string, string> = {
     [DOC_TAGS.codingHarnesses]: docsIcon(
         '<path d="M4 7h16" /><path d="M4 17h16" /><circle cx="9" cy="7" r="2" fill="currentColor" /><circle cx="15" cy="17" r="2" fill="currentColor" />',
     ),
-    [DOC_TAGS.mcpServer]: docsIcon(
+    [DOC_TAGS.mcpServers]: docsIcon(
         '<rect x="2" y="7" width="8" height="10" rx="1.5" /><rect x="14" y="7" width="8" height="10" rx="1.5" /><path d="M10 12h4" />',
     ),
     [DOC_TAGS.errors]: docsIcon('<path d="M18 6 6 18M6 6l12 12" />'),
@@ -194,13 +194,12 @@ const DOC_TAG_NAV_ICON_HTML: Record<string, string> = Object.fromEntries(
 
 const CLI_DOCS = CLI_README.replace(/^# .*\n+/, "").trim();
 
-const MCP_DOCS = MCP_README.replace(/^# .*\n+/, "").trim();
-
 // Strip the leading H1/H2 heading line so the markdown can be embedded under
 // a Scalar tag (which already renders its own title) without double headings.
 const stripLeadingHeading = (md: string) =>
     md.replace(/^#{1,2}\s.*\n+/, "").trim();
 
+const MCP_DOCS = stripLeadingHeading(MCP_MD.trim());
 const USER_WALLETS_DOCS = stripLeadingHeading(BYOP_MD.trim());
 const PUBLISH_MODEL_DOCS = stripLeadingHeading(COMMUNITY_MODELS_MD.trim());
 const PUBLISH_AGENT_DOCS = stripLeadingHeading(AGENTS_MD.trim());
@@ -359,7 +358,7 @@ const PUBLISH_MODEL_SECTION = `## Publish a Model\n\n${PUBLISH_MODEL_DOCS}`;
 const PUBLISH_AGENT_SECTION = `## Publish an Agent\n\n${PUBLISH_AGENT_DOCS}`;
 const CLI_SECTION = `## CLI\n\n${CLI_DOCS}`;
 const CODING_HARNESSES_SECTION = `## Coding Harnesses\n\n${CODING_HARNESSES_DOCS}`;
-const MCP_SECTION = `## MCP Server\n\n${MCP_DOCS}`;
+const MCP_SECTION = `## MCP Servers\n\n${MCP_DOCS}`;
 
 const LLM_DOC_TEXT = [
     GEN_API_DOCS,
@@ -389,7 +388,7 @@ const GUIDE_REDIRECT_TAGS: Record<string, string> = {
     agents: "publish-an-agent",
     "community-agents": "publish-an-agent",
     cli: "cli",
-    mcp: "mcp-server",
+    mcp: "mcp-servers",
 };
 
 function pollinationsHeaderHtml(): string {
@@ -499,7 +498,7 @@ function generationDocumentation(): OpenApiSchema {
                     DOC_TAGS.userWallets,
                     DOC_TAGS.publishModel,
                     DOC_TAGS.publishAgent,
-                    DOC_TAGS.mcpServer,
+                    DOC_TAGS.mcpServers,
                     DOC_TAGS.cli,
                     DOC_TAGS.codingHarnesses,
                 ],
@@ -571,7 +570,7 @@ function generationDocumentation(): OpenApiSchema {
                 description: CODING_HARNESSES_DOCS,
             },
             {
-                name: DOC_TAGS.mcpServer,
+                name: DOC_TAGS.mcpServers,
                 description: MCP_DOCS,
             },
             {

--- a/gen.pollinations.ai/test/docs.test.ts
+++ b/gen.pollinations.ai/test/docs.test.ts
@@ -258,7 +258,7 @@ describe("docs routes", () => {
             schema.tags.find((tag) => tag.name === "Coding Harnesses")
                 ?.description,
         ).toContain("polli harness dsh on");
-        expect(schema.tags.map((tag) => tag.name)).toContain("MCP Server");
+        expect(schema.tags.map((tag) => tag.name)).toContain("MCP Servers");
         expect(schema.tags.map((tag) => tag.name)).toContain("Quests");
         expect(schema.tags.map((tag) => tag.name)).toContain("Media Storage");
         expect(schema.tags.map((tag) => tag.name)).toContain("Account");
@@ -434,7 +434,7 @@ describe("docs routes", () => {
             ctx,
         );
         expect(mcpRes.status).toBe(301);
-        expect(mcpRes.headers.get("Location")).toBe("/docs#tag/mcp-server");
+        expect(mcpRes.headers.get("Location")).toBe("/docs#tag/mcp-servers");
 
         const agentsRes = await worker.fetch(
             new Request("https://gen.pollinations.ai/docs/guides/agents", {
@@ -546,8 +546,21 @@ describe("docs routes", () => {
         );
         expect(mcpRes.status).toBe(200);
         const mcpBody = await mcpRes.text();
-        expect(mcpBody).toContain("## MCP Server");
-        expect(mcpBody).toContain("https://gen.pollinations.ai/mcp");
+        expect(mcpBody).toContain("## MCP Servers");
+        expect(mcpBody).toContain(
+            "https://gen.pollinations.ai/mcp/pollinations",
+        );
+        expect(mcpBody).toContain("https://gen.pollinations.ai/mcp/ffmpeg");
+        expect(mcpBody).toContain("https://gen.pollinations.ai/mcp/exa");
+        expect(mcpBody).toContain("### Pollinations MCP");
+        expect(mcpBody).toContain("### FFmpeg MCP");
+        expect(mcpBody).toContain("### Exa Search MCP");
+        expect(mcpBody).toContain("https://enter.pollinations.ai/my-models");
+        expect(mcpBody).not.toContain("## Other built-in MCPs");
+        expect(mcpBody).toContain("`generateImage`");
+        expect(mcpBody).toContain("`runFfmpeg`");
+        expect(mcpBody).toContain("`web_search_exa`");
+        expect(mcpBody).not.toContain("mcp.pollinations.ai");
         expect(mcpBody).toContain("Streamable HTTP");
         expect(mcpBody).not.toContain("stdio");
         expect(mcpBody).not.toContain("npx @pollinations/mcp");

--- a/operations/social/prompts/brand/links.md
+++ b/operations/social/prompts/brand/links.md
@@ -20,7 +20,7 @@
 - **Contributor Guide:** https://github.com/pollinations/pollinations/blob/master/CONTRIBUTING.md
 - **React SDK & UI:** https://react.pollinations.ai
 - **Connect User Wallets:** https://gen.pollinations.ai/docs#tag/connect-user-wallets
-- **MCP Server Docs:** https://gen.pollinations.ai/docs#tag/mcp-server
+- **MCP Servers Docs:** https://gen.pollinations.ai/docs#tag/mcp-servers
 - **MCP Protocol (contribute):** https://mcp.sequa.ai/v1/pollinations/contribute
 
 ## Apps & Community

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,84 +1,29 @@
 # pollinations.ai MCP Server
 
-A [Model Context Protocol](https://modelcontextprotocol.io) server for generating
-text, images, video, audio, embeddings, and 3D models with Pollinations. It also
-provides live model discovery, health information, and Pollen balance.
+A [Model Context Protocol](https://modelcontextprotocol.io) server that exposes
+Pollinations models and API capabilities as agent tools.
 
-## Quick Start
+## Connect
 
-Connect any Streamable HTTP client to `https://mcp.pollinations.ai` with:
+Connect a Streamable HTTP client to:
+
+```text
+https://gen.pollinations.ai/mcp/pollinations
+```
+
+Send a Pollinations API key with every request:
 
 ```http
 Authorization: Bearer YOUR_KEY
 ```
 
-The server can only use models and account features allowed by that key's
-permissions, and it cannot spend beyond the key's budget. Configure both in
-[API key settings](https://enter.pollinations.ai/keys); see
-[Authentication](https://gen.pollinations.ai/docs#tag/-authentication).
+Get a key from [enter.pollinations.ai](https://enter.pollinations.ai/keys).
+Calls use that key's Pollen wallet, permissions, and budget.
 
-## Hosted MCP catalog
+For all Pollinations-hosted MCP servers, see the
+[MCP Servers documentation](https://gen.pollinations.ai/docs#tag/mcp-servers).
 
-Pollinations also hosts other MCP servers. List their Streamable HTTP URLs and
-pricing:
-
-```bash
-curl https://gen.pollinations.ai/mcp
-```
-
-Connect any MCP client directly to a returned `url` with the same bearer
-header. Creating a Pollinations agent is not required, and API keys must not be
-put in the URL. Calls use the same Pollen wallet and key permissions as the
-Pollinations API; generation tools use the selected model's listed rate.
-
-For example, with the official TypeScript client:
-
-```ts
-import {
-  Client,
-  StreamableHTTPClientTransport,
-} from "@modelcontextprotocol/client";
-
-const client = new Client({ name: "my-app", version: "1.0.0" });
-const transport = new StreamableHTTPClientTransport(
-  new URL("https://gen.pollinations.ai/mcp/pollinations"),
-  {
-    requestInit: {
-      headers: {
-        Authorization: `Bearer ${process.env.POLLINATIONS_API_KEY}`,
-      },
-    },
-  },
-);
-
-await client.connect(transport);
-const { tools } = await client.listTools();
-```
-
-The client handles MCP initialization and tool discovery. Other clients use the
-same endpoint and header; only their configuration format differs.
-
-### Claude Code
-
-```bash
-claude mcp add --transport http pollinations https://mcp.pollinations.ai \
-  --header "Authorization: Bearer YOUR_KEY"
-```
-
-Run `/mcp` in Claude Code to verify the connection.
-
-## Authentication
-
-Get a key at [enter.pollinations.ai](https://enter.pollinations.ai/keys), or use
-[BYOP](../../BRING_YOUR_OWN_POLLEN.md) to let users connect their own wallet
-through a web or device flow.
-
-**Key types:**
-
-- `pk_` — client-safe and rate-limited to 1 Pollen per IP per hour
-- `sk_` — server-side only and not rate-limited
-
-## Available Tools
+## Tools
 
 | Tool | Purpose | API route |
 | --- | --- | --- |
@@ -94,12 +39,11 @@ through a web or device flow.
 | `getBalance` | Check remaining Pollen; requires `account:usage` | `/account/balance` |
 
 Generated media is uploaded unlisted to `media.pollinations.ai` and returned as
-an MCP resource link, so binary data does not consume model context. Links are
-public to anyone who has them and expire after 30 days. Pass an image's HTTPS
-URL to edit it, and use separate tool calls for multiple images.
+an MCP resource link, so binary data does not consume model context. Anyone
+with the link can access it, and it expires after 30 days.
 
-Models, voices, capabilities, and pricing come from the live registry rather
-than hardcoded lists. Use `listModels` before selecting a model or voice.
+Models, voices, capabilities, and pricing come from the live registry. Use
+`listModels` before selecting a model or voice.
 
 ## Development
 
@@ -109,16 +53,11 @@ Requires Node.js 20 or newer. Run the tests with:
 npm test
 ```
 
-Set `POLLINATIONS_API_KEY` to add live model, auth, text, image, and balance
-checks.
+Set `POLLINATIONS_API_KEY` to add live model, authentication, generation, and
+balance checks.
 
 The hosted Cloudflare Worker lives in [`apps/mcp/`](../../apps/mcp/) and is
-deployed from `production` by
-[`Deploy / Applications`](../../.github/workflows/deploy-applications.yml)
-whenever `apps/mcp/` or `packages/mcp/` changes. It has no separate staging
-deployment because it is a thin Gen proxy. Use the workflow's `mcp` target for
-a manual redeploy.
+routed through Gen.
 
-API reference: [gen.pollinations.ai/docs](https://gen.pollinations.ai/docs) ·
 Issues: [GitHub](https://github.com/pollinations/pollinations/issues) · License:
 MIT


### PR DESCRIPTION
- Promotes the latest `main` changes to production.
- Includes the MCP strict-public fetch fix from #14280.
- Deploys the hosted MCP Worker through the production Applications workflow.