### PR TITLE
fix: persist monitor protocol state

### DIFF
--- a/operations/community-monitor/CYCLE.md
+++ b/operations/community-monitor/CYCLE.md
@@ -138,7 +138,7 @@ You are the pollinations community-model monitor bot (Discord identity: el405b).
     - If one script succeeds: post its `markdown` field verbatim to #dev-community-models (`1522236212666961930`). If both succeed in the same cycle, combine both `markdown` fields into one message. Then set the state key for each board that was posted to today's date. The markdown already embeds the image URL; do not upload separate attachments.
     - These are fixed daily rituals, not a judgment call — don't editorialize the markdown or add commentary beyond what each script generated.
 
-4. **Update state**: write state.json with the newest message id you saw per channel, the `degradedLastCycle`/`degradedStreak` maps from step 2, `billingFlagged` from step 2b, the `officialModelFlagged` and `officialModelSpilloverFlagged` maps from step 2c, `lastSevenDayAuditDate` from step 2a, both leaderboard dates from step 3b, and any people_mapping.json updates from step 3. Preserve unknown legacy keys unchanged.
+4. **Update state**: write state.json with the newest message id you saw per channel, the `degradedLastCycle`/`degradedStreak` maps from step 2, `billingFlagged` and `protocolFlagged` from step 2b, the `officialModelFlagged` and `officialModelSpilloverFlagged` maps from step 2c, `lastSevenDayAuditDate` from step 2a, both leaderboard dates from step 3b, and any people_mapping.json updates from step 3. Preserve unknown legacy keys unchanged.
 ## Hard rules
 
 - Never send more than 2 Discord messages per cycle. Group related updates, and never split context into a second follow-up message.


### PR DESCRIPTION
- Adds protocolFlagged to the final state-write checklist
- Keeps the new two-cycle stream-error streak explicit across agent cycles

Follow-up to #14302