### PR TITLE
fix: handle upstream Cloudflare timeouts

### DIFF
--- a/gen.pollinations.ai/src/fallback.ts
+++ b/gen.pollinations.ai/src/fallback.ts
@@ -43,7 +43,7 @@ export function attachFallbackTarget<T extends object>(
  * survive.
  */
 export const FALLBACK_ON_STATUS_CODES = [
-    401, 402, 403, 404, 408, 429, 500, 502, 503, 504,
+    401, 402, 403, 404, 408, 429, 500, 502, 503, 504, 524,
 ];
 
 /**

--- a/gen.pollinations.ai/test/community-endpoints.test.ts
+++ b/gen.pollinations.ai/test/community-endpoints.test.ts
@@ -6920,9 +6920,9 @@ fixtureTest(
                 upstreamHosts.push(host);
                 if (host === primaryHostname) {
                     return Response.json(
-                        { error: "upstream down" },
+                        { error: "upstream timed out" },
                         {
-                            status: 500,
+                            status: 524,
                         },
                     );
                 }

--- a/gen.pollinations.ai/test/fallback.test.ts
+++ b/gen.pollinations.ai/test/fallback.test.ts
@@ -328,6 +328,7 @@ describe("isRetryableFallbackError", () => {
     it("fails over on a rate-limited or broken upstream", () => {
         expect(isRetryableFallbackError(textFailure(429))).toBe(true);
         expect(isRetryableFallbackError(textFailure(503))).toBe(true);
+        expect(isRetryableFallbackError(textFailure(524))).toBe(true);
         expect(isRetryableFallbackError(new HttpError("down", 500))).toBe(true);
         expect(isRetryableFallbackError(new HttpError("no quota", 402))).toBe(
             true,

--- a/gen.pollinations.ai/test/upstream-status.test.ts
+++ b/gen.pollinations.ai/test/upstream-status.test.ts
@@ -4,3 +4,7 @@ import { expect, test } from "vitest";
 test("maps upstream payment failures to bad gateway", () => {
     expect(remapUpstreamStatus(402)).toBe(502);
 });
+
+test("maps upstream Cloudflare timeouts to bad gateway", () => {
+    expect(remapUpstreamStatus(524)).toBe(502);
+});

--- a/shared/error.ts
+++ b/shared/error.ts
@@ -369,12 +369,13 @@ function createUpstreamErrorResponse(
 }
 
 /**
- * Remap upstream 4xx statuses that are our operational concern (auth, routing,
- * quota, conflicts) to 502 Bad Gateway. Leaves input-content errors
- * (400/413/422) as-is since those can reflect user input we failed to validate.
+ * Remap upstream statuses that are our operational concern (auth, routing,
+ * quota, conflicts, proxy timeouts) to 502 Bad Gateway. Leaves input-content
+ * errors (400/413/422) as-is since those can reflect user input we failed to
+ * validate.
  */
 export function remapUpstreamStatus(status: number): ContentfulStatusCode {
-    const remapTo502 = new Set([401, 402, 403, 404, 409, 415, 429]);
+    const remapTo502 = new Set([401, 402, 403, 404, 409, 415, 429, 524]);
     if (remapTo502.has(status)) return 502;
     return status as ContentfulStatusCode;
 }


### PR DESCRIPTION
- Maps upstream Cloudflare 524 responses to the standard 502 error envelope
- Tries declared model fallbacks after an upstream 524
- Keeps the existing 300-second durable-generation contract
- Covers status mapping, fallback selection, and the community image fallback route

Fixes #14300