### PR TITLE
fix: parse chat content arrays in Play

### DIFF
--- a/pollinations.ai/src/ui/components/play/PlayGenerator.tsx
+++ b/pollinations.ai/src/ui/components/play/PlayGenerator.tsx
@@ -387,9 +387,11 @@ export function PlayGenerator({
                 },
                 async (response) => {
                     const data = await response.json();
-                    const text =
-                        data.choices?.[0]?.message?.content || copy.noResponse;
-                    setResult(text);
+                    const content = data.choices?.[0]?.message?.content;
+                    const text = Array.isArray(content)
+                        ? content.find((part) => part.type === "text")?.text
+                        : content;
+                    setResult(text || copy.noResponse);
                     setResultType("text");
                     setIsLoading(false);
                 },


### PR DESCRIPTION
- Extracts text from OpenAI content-parts arrays before rendering chat results.
- Keeps existing string-content behavior unchanged.
- Supports Floret responses containing text plus linked media parts.

Split from #14294.