### PR TITLE
feat: add Mercury 2.5 Preview

### DIFF
--- a/MODEL_SLUGS.md
+++ b/MODEL_SLUGS.md
@@ -154,6 +154,7 @@ Only the names are changing. Model behavior and pricing stay the same.
 | Model | Existing ID | New ID |
 | --- | --- | --- |
 | Mercury 2 | `mercury` | `inception/mercury-2` |
+| Mercury 2.5 Preview | — | `inception/mercury-2.5-preview` |
 
 ## Krea
 

--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -837,6 +837,18 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "completionImageTokens": 0.03,
     },
   },
+  "inception/mercury-2.5-preview": {
+    "cost": {
+      "completionTextTokens": 0.00000015,
+      "promptCachedTokens": 0.000000004,
+      "promptTextTokens": 0.00000004,
+    },
+    "price": {
+      "completionTextTokens": 0.00000015,
+      "promptCachedTokens": 0.000000004,
+      "promptTextTokens": 0.00000004,
+    },
+  },
   "inkling": {
     "cost": {
       "completionTextTokens": 0.0000012,

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -95,6 +95,11 @@ const models: ModelDefinition[] = [
         transform: stripReasoning,
     },
     {
+        name: "inception/mercury-2.5-preview",
+        config: portkeyConfig["inception/mercury-2.5-preview"],
+        transform: createReasoningEffortTransform("toggle"),
+    },
+    {
         name: "command-a-plus",
         config: portkeyConfig["Cohere-command-a-plus-05-2026"],
     },

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -279,6 +279,11 @@ export const portkeyConfig: PortkeyConfigMap = {
                 },
             },
         }),
+    "inception/mercury-2.5-preview": createPinnedOpenRouterConfig(
+        "inception/mercury-2.5-preview",
+        "Inception",
+        64000,
+    ),
 
     // -- Fireworks AI (DeepSeek) ---------------------------------------------
     "accounts/fireworks/models/deepseek-v4-flash-0731": () =>

--- a/gen.pollinations.ai/test/text/transforms/createReasoningEffortTransform.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/createReasoningEffortTransform.test.ts
@@ -94,6 +94,7 @@ describe("reasoning_effort model wiring", () => {
         "nemotron-3.5-lightning",
         "minimax",
         "muse-glimmer",
+        "inception/mercury-2.5-preview",
     ])("disables thinking via reasoning_effort=none on %s", async (modelName) => {
         const transform = findModelByName(modelName)?.transform;
         if (!transform) throw new Error(`${modelName} transform missing`);

--- a/gen.pollinations.ai/test/text/transforms/providerTransformPassthrough.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/providerTransformPassthrough.test.ts
@@ -27,6 +27,7 @@ describe("provider transform passthrough", () => {
         "glm",
         "glm-5.3",
         "z-ai/glm-5.3-flash",
+        "inception/mercury-2.5-preview",
     ])("preserves cache_control for %s", async (modelName) => {
         const transform = findModelByName(modelName)?.transform;
         if (!transform) throw new Error(`${modelName} transform missing`);

--- a/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
+++ b/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
@@ -83,6 +83,19 @@ describe("resolveModelConfig", () => {
         });
     });
 
+    it("pins Mercury 2.5 Preview to Inception on OpenRouter without fallback", () => {
+        const result = resolveModelConfig(messages, {
+            model: "inception/mercury-2.5-preview",
+        });
+
+        expect(result.options.model).toBe("inception/mercury-2.5-preview");
+        expect(result.options.max_tokens).toBe(64000);
+        expect(result.options.provider).toEqual({
+            only: ["Inception"],
+            allow_fallbacks: false,
+        });
+    });
+
     it("routes Nemotron directly to DeepInfra without fallback", () => {
         const result = resolveModelConfig(messages, { model: "nemotron" });
 

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -379,6 +379,30 @@ export const TEXT_SERVICES = {
         contextLength: 128000,
         isSpecialized: false,
     },
+    "inception/mercury-2.5-preview": {
+        aliases: [],
+        provider: "openrouter",
+        brand: "Inception",
+        category: "text",
+        addedDate: new Date("2026-09-01").getTime(),
+        paidOnly: true,
+        priceMultiplier: 1,
+        // OpenRouter's exact Inception route rates (2026-09-01).
+        cost: {
+            promptTextTokens: perMillion(0.04),
+            promptCachedTokens: perMillion(0.004),
+            completionTextTokens: perMillion(0.15),
+        },
+        title: "Mercury 2.5 Preview",
+        description:
+            "Ultra-fast diffusion reasoning for coding, tool use, and structured outputs",
+        inputModalities: ["text"],
+        outputModalities: ["text"],
+        tools: true,
+        reasoning: true,
+        contextLength: 260000,
+        isSpecialized: false,
+    },
     "command-a-plus": {
         aliases: [
             "cohere-command-a-plus",


### PR DESCRIPTION
- Adds canonical `inception/mercury-2.5-preview` as paid-only with multiplier `1`; no aliases, Pollinations GPU, or fallback.
- Pins OpenRouter to Inception with provider fallback disabled and the exact upstream route. Keeps the existing `mercury` model unchanged.
- Bills the live route rates: $0.04/M prompt, $0.004/M cached prompt, and $0.15/M completion. Inception Direct does not currently expose Mercury 2.5.
- Adds reasoning/tool/cache-control routing coverage, effective-price snapshot, and the canonical row in `MODEL_SLUGS.md`.
- Verified direct and local E2E: text, multi-turn, tools, structured output, streaming, native route, malformed input, 10-request burst, cache replay, one wallet debit, and one reconciled Tinybird event. OpenRouter did not report a prompt-cache hit in repeated-prefix probes.