### PR TITLE
fix: restore Claude Sonnet 5 AWS pricing

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -88,16 +88,16 @@ exports[`effective cost and price per model — snapshot 1`] = `
   },
   "claude-sonnet-5": {
     "cost": {
-      "completionTextTokens": 0.000015,
+      "completionTextTokens": 0.00001,
       "promptCacheWriteTokens": 0.0000025,
       "promptCachedTokens": 0.0000002,
-      "promptTextTokens": 0.000003,
+      "promptTextTokens": 0.000002,
     },
     "price": {
-      "completionTextTokens": 0.000015,
+      "completionTextTokens": 0.00001,
       "promptCacheWriteTokens": 0.0000025,
       "promptCachedTokens": 0.0000002,
-      "promptTextTokens": 0.000003,
+      "promptTextTokens": 0.000002,
     },
   },
   "cohere-embed-v4": {

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -1047,12 +1047,11 @@ export const TEXT_SERVICES = {
         paidOnly: true,
         priceMultiplier: 1,
         cost: {
-            // Bedrock global.anthropic.claude-sonnet-5 standard rates effective 2026-09-01.
-            // Cache meters remain at AWS's currently published rates pending post-promo evidence.
-            promptTextTokens: perMillion(3),
+            // AWS Price List global standard meters, published 2026-09-01T18:36:49Z.
+            promptTextTokens: perMillion(2),
             promptCachedTokens: perMillion(0.2),
             promptCacheWriteTokens: perMillion(2.5),
-            completionTextTokens: perMillion(15),
+            completionTextTokens: perMillion(10),
         },
         title: "Claude Sonnet 5",
         description:


### PR DESCRIPTION
- Restores Claude Sonnet 5 provider costs to $2/M input and $10/M output for the exact AWS Bedrock Global Standard route.
- Keeps cache read at $0.20/M, five-minute cache write at $2.50/M, multiplier 1, paid-only access, aliases, and routing unchanged.
- Corrects the premature rollover merged in #13618; AWS's price-list offer published 2026-09-01T18:36:49Z still carries the promotional meters.
- Verified the exact route with text and image input; 528 focused pricing/alias tests and both Enter and Gen typechecks pass.

Source: https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonBedrockFoundationModels/current/index.json
