### PR TITLE
refactor: unify safety input preparation

### DIFF
--- a/gen.pollinations.ai/src/middleware/safety.ts
+++ b/gen.pollinations.ai/src/middleware/safety.ts
@@ -32,16 +32,39 @@ export type SafetyVariables = {
     safetyHeaders?: Record<string, string>;
 };
 
-export async function applySafety(
+type SafetyInput = string | string[] | ChatBody;
+
+type PreparedSafetyInput = {
+    texts: string[];
+    safe?: SafeValue;
+    rebuild: (safeTexts: string[]) => SafetyInput;
+};
+
+export function applySafetyToInput(
     c: SafetyContext,
-    text: string,
-    bodySafe?: SafeValue,
-): Promise<string> {
-    const [safeText] = await applySafetyToTexts(c, [text], bodySafe);
-    return safeText;
+    input: string,
+    safe?: SafeValue,
+): Promise<string>;
+export function applySafetyToInput(
+    c: SafetyContext,
+    input: string[],
+    safe?: SafeValue,
+): Promise<string[]>;
+export function applySafetyToInput(
+    c: SafetyContext,
+    input: ChatBody,
+): Promise<ChatBody>;
+export async function applySafetyToInput(
+    c: SafetyContext,
+    input: SafetyInput,
+    safe?: SafeValue,
+): Promise<SafetyInput> {
+    const prepared = prepareSafetyInput(input, safe);
+    const safeTexts = await checkSafetyTexts(c, prepared.texts, prepared.safe);
+    return prepared.rebuild(safeTexts);
 }
 
-export async function applySafetyToTexts(
+async function checkSafetyTexts(
     c: SafetyContext,
     texts: string[],
     bodySafe?: SafeValue,
@@ -187,18 +210,34 @@ function setSafetyHeader(c: SafetyContext, name: string, value: string): void {
     c.set(SAFETY_HEADERS_KEY, current);
 }
 
-export async function applySafetyToChatRequest(
-    c: SafetyContext,
-    body: ChatBody,
-): Promise<ChatBody> {
-    const safeValue = body.safe as SafeValue;
-    const targets = collectChatTextTargets(body);
-    const safeTexts = await applySafetyToTexts(
-        c,
-        targets.map((target) => target.text),
-        safeValue,
-    );
+function prepareSafetyInput(
+    input: SafetyInput,
+    safe?: SafeValue,
+): PreparedSafetyInput {
+    if (typeof input === "string") {
+        return {
+            texts: [input],
+            safe,
+            rebuild: ([safeText]) => safeText,
+        };
+    }
+    if (Array.isArray(input)) {
+        return { texts: input, safe, rebuild: (safeTexts) => safeTexts };
+    }
 
+    const targets = collectChatTextTargets(input);
+    return {
+        texts: targets.map((target) => target.text),
+        safe: input.safe as SafeValue,
+        rebuild: (safeTexts) => rebuildChatInput(input, targets, safeTexts),
+    };
+}
+
+function rebuildChatInput(
+    body: ChatBody,
+    targets: ChatTextTarget[],
+    safeTexts: string[],
+): ChatBody {
     let nextMessages = body.messages;
     let nextSystem = body.system;
     let changed = false;

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -31,11 +31,7 @@ import { audioCache } from "@/middleware/media-cache.ts";
 import { resolveModel } from "@/middleware/model.ts";
 import { frontendKeyRateLimit } from "@/middleware/rate-limit-durable.ts";
 import { edgeRateLimit } from "@/middleware/rate-limit-edge.ts";
-import {
-    applySafety,
-    applySafetyToTexts,
-    withSafetyHeaders,
-} from "@/middleware/safety.ts";
+import { applySafetyToInput, withSafetyHeaders } from "@/middleware/safety.ts";
 import { textCache } from "@/middleware/text-cache.ts";
 import { track } from "@/middleware/track.ts";
 import googleCloudAuth from "@/text/auth/googleCloudAuth.ts";
@@ -2789,7 +2785,7 @@ async function generateAudioFromSpeechRequest(
 
     if (c.var.model.resolved === "eleven-dialogue") {
         const inputs = parseDialogueInput(input);
-        const safeTexts = await applySafetyToTexts(
+        const safeTexts = await applySafetyToInput(
             c,
             inputs.map((turn) => turn.text),
             safe,
@@ -2808,7 +2804,7 @@ async function generateAudioFromSpeechRequest(
         return withSafetyHeaders(c, response);
     }
 
-    const safeInput = await applySafety(c, input, safe);
+    const safeInput = await applySafetyToInput(c, input, safe);
     const referenceAudio = reference_audio
         ? await fetchReferenceAudio(reference_audio)
         : undefined;
@@ -2964,7 +2960,7 @@ export async function handleSpeechWithTimestamps(
                 "Timestamped speech supports mp3, opus, aac, wav, and pcm output.",
         });
     }
-    const safeInput = await applySafety(c, input, safe);
+    const safeInput = await applySafetyToInput(c, input, safe);
     return withAudioFallback(c, (candidate) =>
         generateElevenLabsSpeechWithTimestamps({
             modelName: candidate.id as ElevenLabsTtsModelName,

--- a/gen.pollinations.ai/src/routes/generation-handlers.ts
+++ b/gen.pollinations.ai/src/routes/generation-handlers.ts
@@ -15,12 +15,7 @@ import {
 } from "@/embeddings/handler.ts";
 import type { Env } from "@/env.ts";
 import { handleImagePrompt } from "@/image/handler.ts";
-import {
-    applySafety,
-    applySafetyToChatRequest,
-    applySafetyToTexts,
-    withSafetyHeaders,
-} from "@/middleware/safety.ts";
+import { applySafetyToInput, withSafetyHeaders } from "@/middleware/safety.ts";
 import { handle3dPrompt } from "@/model3d/handler.ts";
 import type { CreateEmbeddingRequestSchema } from "@/schemas/embeddings.ts";
 import type { GenerateTextRequestQueryParams } from "@/schemas/text.ts";
@@ -125,7 +120,7 @@ export type SimpleAudioQuery = z.infer<typeof simpleAudioQuerySchema>;
 
 export async function generateImageVideo(c: Context<Env>): Promise<Response> {
     const query = c.req.valid("query" as never) as { safe?: SafeValue };
-    const prompt = await applySafety(
+    const prompt = await applySafetyToInput(
         c,
         c.req.param("prompt") || "",
         query.safe,
@@ -135,7 +130,7 @@ export async function generateImageVideo(c: Context<Env>): Promise<Response> {
 
 export async function generateModel3d(c: Context<Env>): Promise<Response> {
     const query = c.req.valid("query" as never) as { safe?: SafeValue };
-    const prompt = await applySafety(
+    const prompt = await applySafetyToInput(
         c,
         c.req.param("prompt") || "",
         query.safe,
@@ -178,7 +173,7 @@ export async function generateEmbeddingsResponse(
 export async function generateChatCompletion(
     c: Context<Env>,
 ): Promise<Response> {
-    const requestBody = await applySafetyToChatRequest(c, {
+    const requestBody = await applySafetyToInput(c, {
         ...(c.req.valid("json" as never) as CreateChatCompletionRequest),
         model: c.var.model.resolved,
     });
@@ -220,7 +215,7 @@ export async function generateChatCompletion(
 }
 
 export async function generateTextContent(c: Context<Env>): Promise<Response> {
-    const requestBody = await applySafetyToChatRequest(c, {
+    const requestBody = await applySafetyToInput(c, {
         ...(c.req.valid("json" as never) as CreateChatCompletionRequest),
         model: c.var.model.resolved,
     });
@@ -237,7 +232,7 @@ export async function generateSimpleText(c: Context<Env>): Promise<Response> {
         typeof query.system === "string"
             ? [c.req.param("prompt"), query.system]
             : [c.req.param("prompt")];
-    const [prompt, system] = await applySafetyToTexts(
+    const [prompt, system] = await applySafetyToInput(
         c,
         textInputs,
         query.safe,

--- a/gen.pollinations.ai/src/routes/images.ts
+++ b/gen.pollinations.ai/src/routes/images.ts
@@ -28,7 +28,7 @@ import { createMiddleware } from "hono/factory";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import type { Env } from "@/env.ts";
 import { generateImageOrVideoResponse } from "@/image/handler.ts";
-import { applySafety, withSafetyHeaders } from "@/middleware/safety.ts";
+import { applySafetyToInput, withSafetyHeaders } from "@/middleware/safety.ts";
 import { arrayBufferToBase64 } from "@/util.ts";
 
 // --- Helpers ---
@@ -237,7 +237,7 @@ export const prepareOpenAIImageGeneration = createMiddleware<Env>(
         const model = c.var.model.resolved;
 
         const resolved = resolveParams(body);
-        const safePrompt = await applySafety(
+        const safePrompt = await applySafetyToInput(
             c,
             body.prompt,
             body.safe as SafeValue,
@@ -337,7 +337,7 @@ export async function handleImageGeneration(c: Context<Env>) {
 export async function handleImageEdit(c: Context<Env>) {
     const { prompt, imageUrls, size, quality, seed, safe, extra } =
         await parseEditInput(c);
-    const safePrompt = await applySafety(c, prompt, safe);
+    const safePrompt = await applySafetyToInput(c, prompt, safe);
     const resolved = resolveParams({ size, quality, seed });
 
     const response = await generateImageOrVideoResponse(c, safePrompt, {

--- a/gen.pollinations.ai/test/safety.test.ts
+++ b/gen.pollinations.ai/test/safety.test.ts
@@ -3,6 +3,7 @@ import {
     communityModelDefinition,
     type ProxyCommunityEndpointRuntime,
 } from "@shared/community-endpoints.ts";
+import type { CreateChatCompletionRequest } from "@shared/schemas/openai.ts";
 import {
     parseSafeFeatures,
     SAFETY_HEADER_NAME,
@@ -15,11 +16,7 @@ import type { Env } from "@/env.ts";
 import type { LoggerVariables } from "@/middleware/logger.ts";
 import type { ModelVariables } from "@/middleware/model.ts";
 import { getRequiredSafetyFeatures } from "@/middleware/model.ts";
-import {
-    applySafety,
-    applySafetyToChatRequest,
-    withSafetyHeaders,
-} from "@/middleware/safety.ts";
+import { applySafetyToInput, withSafetyHeaders } from "@/middleware/safety.ts";
 import type { BedrockResponse } from "@/utils/bedrock-guardrail.ts";
 import {
     generateCacheKey as generateMediaCacheKey,
@@ -68,14 +65,22 @@ function safetyApp(
             await next();
         })
         .get("/scan/:text", async (c) => {
-            const text = await applySafety(c, c.req.param("text"));
+            const text = await applySafetyToInput(c, c.req.param("text"));
             return withSafetyHeaders(c, new Response(text));
+        })
+        .post("/texts", async (c) => {
+            const body = await c.req.json<{
+                texts: string[];
+                safe?: "privacy";
+            }>();
+            const texts = await applySafetyToInput(c, body.texts, body.safe);
+            return withSafetyHeaders(c, Response.json(texts));
         })
         .post("/chat", async (c) => {
             const body = await c.req.json();
-            const safeBody = await applySafetyToChatRequest(
+            const safeBody = await applySafetyToInput(
                 c,
-                body as Parameters<typeof applySafetyToChatRequest>[1],
+                body as CreateChatCompletionRequest & Record<string, unknown>,
             );
             return withSafetyHeaders(c, Response.json(safeBody));
         });
@@ -126,7 +131,7 @@ describe("safety schema", () => {
 // The Bedrock-backed tests sign requests with AWS SigV4 (WebCrypto HMAC-SHA256)
 // inside the workerd runtime; that crypto path can take several seconds on a cold
 // or loaded runtime, so give these blocks generous headroom over the 5s default.
-describe("applySafety", { timeout: 30000 }, () => {
+describe("applySafetyToInput text", { timeout: 30000 }, () => {
     beforeEach(() => {
         guardrailResponse = { action: "NONE", assessments: [] };
         fetchMock = vi.fn(async () => Response.json(guardrailResponse));
@@ -320,6 +325,39 @@ describe("applySafety", { timeout: 30000 }, () => {
         expect(fetchMock).toHaveBeenCalledOnce();
     });
 
+    it("prepares multiple text inputs for one guardrail request", async () => {
+        guardrailResponse = intervened(
+            {
+                sensitiveInformationPolicy: {
+                    piiEntities: [
+                        {
+                            action: "ANONYMIZED",
+                            match: "a@example.com",
+                            type: "EMAIL",
+                        },
+                    ],
+                },
+            },
+            [{ text: "first {EMAIL}" }, { text: "second" }],
+        );
+
+        const response = await safetyApp().request(
+            "/texts",
+            {
+                method: "POST",
+                body: JSON.stringify({
+                    texts: ["first a@example.com", "second"],
+                    safe: "privacy",
+                }),
+            },
+            configuredEnv,
+        );
+
+        expect(response.status).toBe(200);
+        expect(fetchMock).toHaveBeenCalledOnce();
+        expect(await response.json()).toEqual(["first {EMAIL}", "second"]);
+    });
+
     it("blocks requested content categories", async () => {
         guardrailResponse = intervened({
             contentPolicy: {
@@ -408,7 +446,7 @@ describe("applySafety", { timeout: 30000 }, () => {
     });
 });
 
-describe("applySafetyToChatRequest", { timeout: 30000 }, () => {
+describe("applySafetyToInput", { timeout: 30000 }, () => {
     beforeEach(() => {
         guardrailResponse = { action: "NONE", assessments: [] };
         fetchMock = vi.fn(async () => Response.json(guardrailResponse));


### PR DESCRIPTION
- Replaces route-specific safety helpers with one typed input preparer
- Preserves existing text, chat, image, video, 3D, and audio prompt behavior
- Keeps guardrail policy, batching, redaction, and failure handling unchanged
- Adds direct coverage for batched text inputs

No public API or model configuration changes.