### PR TITLE
refactor: harden model fallback routing

### DIFF
--- a/gen.pollinations.ai/src/fallback.ts
+++ b/gen.pollinations.ai/src/fallback.ts
@@ -34,17 +34,15 @@ export function attachFallbackTarget<T extends object>(
 }
 
 /**
- * Upstream statuses that make a request move on to the model's next fallback
- * target.
+ * Non-5xx upstream statuses that make a request move on to the model's next
+ * fallback target. Every upstream 5xx retries without needing to be listed.
  *
  * 400 and 422 are left out on purpose: those are caller errors and retrying
  * them elsewhere cannot succeed. 401/402/403/404 are included because they mean
  * the primary's credentials or upstream model are broken, which the fallback may
  * survive.
  */
-export const FALLBACK_ON_STATUS_CODES = [
-    401, 402, 403, 404, 408, 429, 500, 502, 503, 504, 524,
-];
+export const FALLBACK_ON_STATUS_CODES = [401, 402, 403, 404, 408, 429];
 
 /**
  * Network-level failures — unreachable host, expired cert, refused connection —
@@ -64,8 +62,9 @@ export function isNetworkFailure(error: unknown): boolean {
  * The upstream failure shapes the generation clients throw. The image client
  * throws the provider's status as-is; the text client remaps it before throwing
  * (429 → 502, see remapUpstreamStatus) and keeps the original in
- * `upstreamStatus`, so the unremapped one is preferred and the list above can
- * name the statuses providers actually send.
+ * `upstreamStatus`, so the unremapped one is normally preferred. A successful
+ * upstream status is the exception: if its body is malformed, the client wraps
+ * that provider failure in a retryable status such as 502.
  */
 type UpstreamFailure = {
     status?: unknown;
@@ -117,8 +116,15 @@ function isGatewayRoutingFailure(failure: UpstreamFailure): boolean {
 }
 
 function upstreamStatus(failure: UpstreamFailure): number | undefined {
-    const status = failure.upstreamStatus ?? failure.status;
-    return typeof status === "number" ? status : undefined;
+    const upstream = failure.upstreamStatus;
+    if (typeof upstream === "number" && (upstream < 200 || upstream >= 300)) {
+        return upstream;
+    }
+    return typeof failure.status === "number"
+        ? failure.status
+        : typeof upstream === "number"
+          ? upstream
+          : undefined;
 }
 
 /** The deadline we send to Portkey is the request's terminal time budget. */
@@ -172,10 +178,7 @@ function upstreamFailureText(failure: UpstreamFailure): (string | null)[] {
  * delegating endpoint, a failed secret decryption all reach here as a plain
  * Error and are rethrown untouched.
  */
-export function isRetryableFallbackError(
-    error: unknown,
-    allowedStatusCodes: readonly number[] = FALLBACK_ON_STATUS_CODES,
-): boolean {
+export function isRetryableFallbackError(error: unknown): boolean {
     if (isNetworkFailure(error)) return true;
     if (!(error instanceof Error)) return false;
     const failure = error as UpstreamFailure;
@@ -187,10 +190,13 @@ export function isRetryableFallbackError(
     if (isPortkeyRequestTimeout(failure)) return false;
     // A dead endpoint reaches us as the gateway's own 400 rather than as a
     // network error, because the gateway is the one that could not connect.
-    const gatewayRoutingFailure =
-        allowedStatusCodes === FALLBACK_ON_STATUS_CODES &&
-        isGatewayRoutingFailure(failure);
-    if (!allowedStatusCodes.includes(status) && !gatewayRoutingFailure) {
+    const gatewayRoutingFailure = isGatewayRoutingFailure(failure);
+    const serverError = status >= 500 && status <= 599;
+    if (
+        !serverError &&
+        !FALLBACK_ON_STATUS_CODES.includes(status) &&
+        !gatewayRoutingFailure
+    ) {
         return false;
     }
     return !firstContentPolicyMessage(upstreamFailureText(failure));
@@ -335,7 +341,6 @@ export async function withModelFallback<T>(
     attempts?: FallbackAttempt[],
     beforeAttempt?: (candidate: FallbackCandidate) => Promise<void>,
 ): Promise<{ result: T; candidate: FallbackCandidate; index: number }> {
-    const allowedStatusCodes = candidates[0]?.definition?.fallbackOnStatusCodes;
     for (const [index, candidate] of candidates.entries()) {
         // Local gates are not upstream failures and must not trigger or be
         // attributed to another fallback candidate.
@@ -356,7 +361,7 @@ export async function withModelFallback<T>(
         } catch (error) {
             const terminal =
                 index === candidates.length - 1 ||
-                !isRetryableFallbackError(error, allowedStatusCodes);
+                !isRetryableFallbackError(error);
             attempts?.push({
                 candidate,
                 error,

--- a/gen.pollinations.ai/src/middleware/model.ts
+++ b/gen.pollinations.ai/src/middleware/model.ts
@@ -95,6 +95,14 @@ export async function resolveModelDefinition(
         });
     }
 
+    // Provider routes are registry entries so fallback linking and billing can
+    // use them, but callers must select the public model they belong to.
+    if (entry.definition.fallbackOnly === true) {
+        throw new HTTPException(400, {
+            message: `Invalid model or alias: "${model}". Must be a valid model name or alias.`,
+        });
+    }
+
     // A private community endpoint is owner-only: to everyone else it doesn't
     // exist. Reuse the same "invalid model" response as an unknown name so
     // private models aren't discoverable by probing.
@@ -216,7 +224,7 @@ export function resolveModel(
             c.var.auth?.user?.id,
             options?.supportedEndpoint,
         );
-        // Hidden registry fallbacks are provider implementations of the public
+        // Fallback-only entries are provider implementations of the public
         // model the caller selected, so they inherit that model's permission.
         // Visible and community targets remain independently scoped: a key can
         // never be served — or billed for — a model it could not call directly.
@@ -224,7 +232,7 @@ export function resolveModel(
         if (allowedModels && resolved.fallbackEntries) {
             resolved.fallbackEntries = resolved.fallbackEntries.filter(
                 (entry) =>
-                    (entry.definition.hidden === true &&
+                    (entry.definition.fallbackOnly === true &&
                         !entry.communityEndpoint) ||
                     allowedModels.includes(entry.id),
             );

--- a/gen.pollinations.ai/src/model-registry.ts
+++ b/gen.pollinations.ai/src/model-registry.ts
@@ -15,6 +15,7 @@ import {
     type Category,
     getModels,
     getRegistryModelDefinition,
+    isVisibleModelDefinition,
     type ModelDefinition,
 } from "@shared/registry/registry.ts";
 import { DEFAULT_TEXT_MODEL } from "@shared/registry/text.ts";
@@ -122,7 +123,7 @@ const STATIC_ENTRIES: GenerationModelEntry[] = getModels().map((modelName) => {
             supportedEndpointsForEventType(eventType),
         definition,
         info: modelInfoFromDefinition(modelName, definition),
-        visible: definition.hidden !== true,
+        visible: isVisibleModelDefinition(definition),
     };
 });
 

--- a/gen.pollinations.ai/src/routes/docs.ts
+++ b/gen.pollinations.ai/src/routes/docs.ts
@@ -11,6 +11,11 @@ import {
     DEFAULT_REALTIME_MODEL,
     REALTIME_MODEL_NAMES,
 } from "@shared/registry/realtime.ts";
+import {
+    getVisibleAudioModels,
+    getVisibleImageModels,
+    getVisibleTextModels,
+} from "@shared/registry/registry.ts";
 import { TEXT_SERVICES } from "@shared/registry/text.ts";
 import type { Context } from "hono";
 import { Hono } from "hono";
@@ -238,12 +243,17 @@ const ALL_ALIASES = new Set([
     ...AUDIO_ALIASES,
     ...EMBEDDING_ALIASES,
 ]);
-const imageModelDisplayNames = getImageModelIds().join(", ");
+const visibleImageIds = new Set<string>(getVisibleImageModels());
+const imageModelDisplayNames = getImageModelIds()
+    .filter((id) => visibleImageIds.has(id))
+    .join(", ");
 
-const videoModelDisplayNames = getVideoModelIds().join(", ");
+const videoModelDisplayNames = getVideoModelIds()
+    .filter((id) => visibleImageIds.has(id))
+    .join(", ");
 
-const textModelDisplayNames = Object.keys(TEXT_SERVICES).join(", ");
-const audioModelDisplayNames = Object.keys(AUDIO_SERVICES).join(", ");
+const textModelDisplayNames = getVisibleTextModels().join(", ");
+const audioModelDisplayNames = getVisibleAudioModels().join(", ");
 const embeddingModelDisplayNames = Object.keys(EMBEDDING_SERVICES).join(", ");
 const realtimeModelDisplayNames = REALTIME_MODEL_NAMES.join(", ");
 const model3dModelDisplayNames = getModel3dModelsInfo()

--- a/gen.pollinations.ai/test/fallback.test.ts
+++ b/gen.pollinations.ai/test/fallback.test.ts
@@ -1,6 +1,10 @@
 import { communityEndpointPrices } from "@shared/community-endpoints.ts";
 import { HttpError } from "@shared/http-error.ts";
-import type { ModelDefinition } from "@shared/registry/registry.ts";
+import { IMAGE_SERVICES } from "@shared/registry/image.ts";
+import {
+    getVisibleImageModels,
+    type ModelDefinition,
+} from "@shared/registry/registry.ts";
 import { FALLBACK_TARGET_HEADER } from "@shared/registry/usage-headers.ts";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -72,6 +76,17 @@ function communityEntry(
 }
 
 describe("registry fallback linking", () => {
+    it("marks provider routes as hidden, fallback-only registry entries", () => {
+        expect(IMAGE_SERVICES.zimage.fallbacks).toContain("zimage-fal");
+        expect(IMAGE_SERVICES["zimage-fal"]).toMatchObject({
+            aliases: [],
+            hidden: true,
+            fallbackOnly: true,
+            provider: "fal",
+        });
+        expect(getVisibleImageModels()).not.toContain("zimage-fal");
+    });
+
     it("uses registry declarations without applying community price rules", () => {
         const primary = registryEntry("primary", ["target-alias", "target"]);
         const target = registryEntry("target", ["primary"], 10);
@@ -329,37 +344,22 @@ describe("isRetryableFallbackError", () => {
         expect(isRetryableFallbackError(textFailure(429))).toBe(true);
         expect(isRetryableFallbackError(textFailure(503))).toBe(true);
         expect(isRetryableFallbackError(textFailure(524))).toBe(true);
+        expect(isRetryableFallbackError(textFailure(599))).toBe(true);
         expect(isRetryableFallbackError(new HttpError("down", 500))).toBe(true);
         expect(isRetryableFallbackError(new HttpError("no quota", 402))).toBe(
             true,
         );
     });
 
-    it("honors a model-specific fallback status list", () => {
-        expect(
-            isRetryableFallbackError(new HttpError("queue full", 503), [503]),
-        ).toBe(true);
+    it("uses the wrapper status for a malformed successful response", () => {
         expect(
             isRetryableFallbackError(
-                new HttpError("backend failed", 500),
-                [503],
-            ),
-        ).toBe(false);
-        expect(
-            isRetryableFallbackError(
-                new TypeError("fetch failed: connection refused"),
-                [503],
-            ),
-        ).toBe(true);
-        expect(
-            isRetryableFallbackError(
-                new HttpError("gateway failed", 400, {
-                    status: "failure",
-                    message: "Invalid custom host",
+                Object.assign(new Error("upstream returned no output"), {
+                    status: 502,
+                    upstreamStatus: 200,
                 }),
-                [503],
             ),
-        ).toBe(false);
+        ).toBe(true);
     });
 
     it("does not multiply the owned Portkey timeout across fallbacks", () => {
@@ -546,10 +546,9 @@ describe("withModelFallback", () => {
         expect(seen(attempts)).toEqual(["primary!"]);
     });
 
-    it("uses the primary model's configured fallback status list", async () => {
+    it("tries the next model for any upstream 5xx", async () => {
         const primary = registryEntry("primary", ["second"]);
         const second = registryEntry("second");
-        primary.definition.fallbackOnStatusCodes = [503];
         primary.fallbackEntries = [second];
         const candidates = fallbackCandidates({
             resolved: primary.id,
@@ -557,12 +556,14 @@ describe("withModelFallback", () => {
             fallbackEntries: primary.fallbackEntries,
         });
         const attempt = vi.fn(async () => "served");
-        attempt.mockRejectedValueOnce(new HttpError("backend failed", 500));
+        attempt.mockRejectedValueOnce(new HttpError("gateway timeout", 524));
 
-        await expect(withModelFallback(candidates, attempt)).rejects.toThrow(
-            "backend failed",
-        );
-        expect(attempt).toHaveBeenCalledTimes(1);
+        await expect(withModelFallback(candidates, attempt)).resolves.toEqual({
+            result: "served",
+            candidate: expect.objectContaining({ id: "second" }),
+            index: 1,
+        });
+        expect(attempt).toHaveBeenCalledTimes(2);
     });
 
     it("reports the failed and serving attempts in order", async () => {

--- a/gen.pollinations.ai/test/image/zImageFalFallback.test.ts
+++ b/gen.pollinations.ai/test/image/zImageFalFallback.test.ts
@@ -157,3 +157,25 @@ test("uses Fal only after the Vast Z-Image pool exhausts its 503s", async ({
         10,
     );
 });
+
+test("rejects direct calls to the internal Fal route", async ({
+    paidApiKey,
+    mocks,
+}) => {
+    await mocks.enable("tinybird", "fal");
+    const { response, wait } = await fetchWorker(
+        "/image/a%20red%20apple?model=zimage-fal",
+        { headers: { authorization: `Bearer ${paidApiKey}` } },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+        error: {
+            code: "BAD_REQUEST",
+            message:
+                'Invalid model or alias: "zimage-fal". Must be a valid model name or alias.',
+        },
+    });
+    await wait();
+    expect(mocks.fal.state.falRequests).toHaveLength(0);
+});

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -422,10 +422,6 @@ const IMAGE_BASE_SERVICES = {
     "zimage": {
         aliases: ["z-image", "z-image-turbo", "tongyi-mai/z-image-turbo"],
         provider: "vast",
-        // Routes live in image-fallbacks.ts. Narrower than the default
-        // status list: only a 503 (no capacity) overflows to Fal, so every
-        // other Vast failure surfaces instead of being served elsewhere.
-        fallbackOnStatusCodes: [503],
         brand: "Alibaba",
         category: "image",
         addedDate: new Date("2025-12-08").getTime(),

--- a/shared/registry/merge-fallbacks.ts
+++ b/shared/registry/merge-fallbacks.ts
@@ -9,16 +9,12 @@ import type { ModelDefinition } from "./registry";
  * asked for. `provider` is required because it is the one thing a route must
  * not inherit: it is what makes the route a route, and what the spend is
  * attributed to. The omitted fields are owned by the merge — a route is always
- * hidden, carries no aliases of its own, and never chains further.
+ * hidden and fallback-only, carries no aliases, and never chains further.
  */
 export type FallbackDefinition = Partial<
     Omit<
         ModelDefinition,
-        | "aliases"
-        | "fallbacks"
-        | "fallbackOnStatusCodes"
-        | "hidden"
-        | "provider"
+        "aliases" | "fallbacks" | "fallbackOnly" | "hidden" | "provider"
     >
 > & { provider: string };
 
@@ -69,7 +65,8 @@ export function mergeFallbacks<
         const {
             aliases: _aliases,
             fallbacks: _fallbacks,
-            fallbackOnStatusCodes: _statusCodes,
+            fallbackOnly: _fallbackOnly,
+            hidden: _hidden,
             ...inherited
         } = parent;
         for (const [routeId, overrides] of Object.entries(routes)) {
@@ -78,6 +75,7 @@ export function mergeFallbacks<
                 ...overrides,
                 aliases: [],
                 hidden: true,
+                fallbackOnly: true,
             };
         }
     }

--- a/shared/registry/registry.ts
+++ b/shared/registry/registry.ts
@@ -155,8 +155,6 @@ export type ModelDefinition = {
     perUserRpm?: number | null;
     /** Ordered model ids to try when this model's upstream fails. */
     fallbacks?: string[];
-    /** Override the shared fallback status list for this model. Network failures always retry. */
-    fallbackOnStatusCodes?: number[];
     /** Input safety features callers cannot disable for this model. */
     requiredSafetyFeatures?: SafetyFeature[];
     brand: string;
@@ -211,6 +209,8 @@ export type ModelDefinition = {
     // audio (e.g. Stable Audio) from per-character TTS, which share cost fields.
     flatRate?: boolean;
     hidden?: boolean; // Hidden from /models endpoints and dashboard, but still usable via API
+    /** Internal provider route: hidden from discovery and rejected when selected by a caller. */
+    fallbackOnly?: boolean;
     supportedEndpoints?: string[]; // Override the default endpoints for specialized models
     // Supported output resolutions; first entry is the default.
     resolutions?: string[];
@@ -535,7 +535,7 @@ export function resolveModelName(model: string): ModelName {
 }
 
 /**
- * Get all public model names
+ * Get all bundled registry model names, including hidden provider routes.
  */
 export function getModels(): ModelName[] {
     return Object.keys(MODEL_REGISTRY) as ModelName[];
@@ -572,8 +572,14 @@ function getModel3dModels(): Model3dName[] {
 function filterVisible<TModelName extends ModelName>(
     ids: TModelName[],
 ): TModelName[] {
-    return ids.filter((id) => !MODEL_REGISTRY[id]?.hidden);
+    return ids.filter((id) =>
+        isVisibleModelDefinition(MODEL_REGISTRY[id] as ModelDefinition),
+    );
 }
+
+export const isVisibleModelDefinition = (
+    definition: ModelDefinition,
+): boolean => definition.hidden !== true && definition.fallbackOnly !== true;
 
 export const getVisibleTextModels = () => filterVisible(getTextModels());
 export const getVisibleImageModels = () => filterVisible(getImageModels());

--- a/shared/registry/visible-model-ids.ts
+++ b/shared/registry/visible-model-ids.ts
@@ -5,7 +5,12 @@ import {
     effectiveCommunityEndpointVisibility,
 } from "../community-endpoints.ts";
 import * as schema from "../db/better-auth.ts";
-import { getModels, resolveModelName } from "./registry.ts";
+import {
+    getModels,
+    getRegistryModelDefinition,
+    isVisibleModelDefinition,
+    resolveModelName,
+} from "./registry.ts";
 
 export function canonicalizeModelPermissionIds(
     modelIds: readonly string[],
@@ -31,7 +36,11 @@ export async function getVisibleModelIdsForUser(
     dbBinding: D1Database,
     userId: string,
 ): Promise<Set<string>> {
-    const modelIds = new Set<string>(getModels());
+    const modelIds = new Set<string>(
+        getModels().filter((model) =>
+            isVisibleModelDefinition(getRegistryModelDefinition(model)),
+        ),
+    );
     const db = drizzle(dbBinding, { schema });
     const communityModels = await db
         .select({


### PR DESCRIPTION
- Marks generated provider routes as internal fallback-only models
- Keeps fallback routes out of catalogs, docs, and API-key model lists
- Retries every upstream 5xx while preserving caller, moderation, and total-timeout exclusions
- Covers internal Z-Image fallback routing and direct-call rejection