### PR TITLE
feat: add DeepSeek V4 Flash Vision

### DIFF
--- a/MODEL_SLUGS.md
+++ b/MODEL_SLUGS.md
@@ -86,6 +86,7 @@ Only the names are changing. Model behavior and pricing stay the same.
 | Model | Existing ID | New ID |
 | --- | --- | --- |
 | DeepSeek V4 Flash 0731 | `deepseek` | `deepseek/deepseek-v4-flash` |
+| DeepSeek V4 Flash Vision Exp | — | `deepseek/deepseek-v4-flash-vision-exp` |
 | DeepSeek V4 Pro 0813 | `deepseek-pro` | `deepseek/deepseek-v4-pro` |
 
 ## ElevenLabs

--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -152,6 +152,20 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.00000132,
     },
   },
+  "deepseek/deepseek-v4-flash-vision-exp": {
+    "cost": {
+      "completionTextTokens": 0.00000066,
+      "promptCachedTokens": 0.000000007,
+      "promptImageTokens": 0.00000022,
+      "promptTextTokens": 0.00000022,
+    },
+    "price": {
+      "completionTextTokens": 0.00000066,
+      "promptCachedTokens": 0.000000007,
+      "promptImageTokens": 0.00000022,
+      "promptTextTokens": 0.00000022,
+    },
+  },
   "dreamshaper": {
     "cost": {
       "completionImageTokens": 0.0001,

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -180,6 +180,13 @@ const models: ModelDefinition[] = [
         transform: fireworksThinking,
     },
     {
+        name: "deepseek/deepseek-v4-flash-vision-exp",
+        config: portkeyConfig[
+            "accounts/fireworks/models/deepseek-v4-flash-vision-exp"
+        ],
+        transform: fireworksThinking,
+    },
+    {
         name: "gemma",
         config: portkeyConfig["google/gemma-4-26b-a4b-it"],
     },

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -285,6 +285,10 @@ export const portkeyConfig: PortkeyConfigMap = {
         createFireworksModelConfig({
             model: "accounts/fireworks/models/deepseek-v4-flash-0731",
         }),
+    "accounts/fireworks/models/deepseek-v4-flash-vision-exp": () =>
+        createFireworksModelConfig({
+            model: "accounts/fireworks/models/deepseek-v4-flash-vision-exp",
+        }),
     "accounts/fireworks/models/deepseek-v4-pro-0813": () =>
         createFireworksModelConfig({
             model: "accounts/fireworks/models/deepseek-v4-pro-0813",

--- a/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
+++ b/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
@@ -336,6 +336,21 @@ describe("resolveModelConfig", () => {
         expect(result.options.provider).toBeUndefined();
     });
 
+    it("routes DeepSeek Vision to the exact Fireworks vision checkpoint", () => {
+        const result = resolveModelConfig(messages, {
+            model: "deepseek/deepseek-v4-flash-vision-exp",
+        });
+
+        expect(result.options.model).toBe(
+            "accounts/fireworks/models/deepseek-v4-flash-vision-exp",
+        );
+        expect(result.options.modelConfig).toMatchObject({
+            provider: "openai",
+            "custom-host": "https://api.fireworks.ai/inference/v1",
+        });
+        expect(result.options.provider).toBeUndefined();
+    });
+
     it("routes DeepSeek Pro to the exact Fireworks 0813 checkpoint", () => {
         const result = resolveModelConfig(messages, { model: "deepseek-pro" });
 

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -721,6 +721,32 @@ export const TEXT_SERVICES = {
         contextLength: 1048576,
         isSpecialized: false,
     },
+    "deepseek/deepseek-v4-flash-vision-exp": {
+        aliases: [],
+        provider: "fireworks",
+        brand: "DeepSeek",
+        category: "text",
+        addedDate: new Date("2026-09-02").getTime(),
+        paidOnly: false,
+        priceMultiplier: 1,
+        // Fireworks standard serverless rates (2026-09-01).
+        cost: {
+            promptTextTokens: perMillion(0.22),
+            promptCachedTokens: perMillion(0.007),
+            promptImageTokens: perMillion(0.22),
+            completionTextTokens: perMillion(0.66),
+        },
+        title: "DeepSeek V4 Flash Vision Exp",
+        description:
+            "Low-cost multimodal reasoning for coding, agents and visual analysis",
+        inputModalities: ["text", "image"],
+        outputModalities: ["text"],
+        maxReferenceImages: 30,
+        tools: true,
+        reasoning: true,
+        contextLength: 1048576,
+        isSpecialized: false,
+    },
     "gemma": {
         aliases: [
             "gemma-4",


### PR DESCRIPTION
- Adds deepseek/deepseek-v4-flash-vision-exp as a new Fireworks text and image model.
- Uses the exact Fireworks vision checkpoint with no aliases or fallback.
- Sets paidOnly false and a 1x price multiplier at $0.22/M input, $0.007/M cached input, and $0.66/M output.
- Updates MODEL_SLUGS.md and effective-price coverage.
- Verifies the route with resolver, registry, permission, catalog, pricing, snapshot, typecheck, local catalog, and direct Fireworks vision probes.