### PR TITLE
fix: set minimum model RPM to 60

### DIFF
--- a/gen.pollinations.ai/test/community-model-rate-limit.test.ts
+++ b/gen.pollinations.ai/test/community-model-rate-limit.test.ts
@@ -1,7 +1,11 @@
 import { env } from "cloudflare:test";
 import { IMAGE_SERVICES } from "@shared/registry/image.ts";
 import { modelInfoFromDefinition } from "@shared/registry/model-info.ts";
-import type { ModelDefinition } from "@shared/registry/registry.ts";
+import {
+    getModels,
+    getRegistryModelDefinition,
+    type ModelDefinition,
+} from "@shared/registry/registry.ts";
 import { describe, expect, it } from "vitest";
 import type { CommunityModelRateLimiter } from "../src/durable-objects/CommunityModelRateLimiter.ts";
 
@@ -11,6 +15,13 @@ describe("model rate limiting", () => {
         expect(IMAGE_SERVICES.zimage.perUserRpm).toBe(60);
         expect(IMAGE_SERVICES.klein.perUserRpm).toBe(60);
         expect(IMAGE_SERVICES.dreamshaper.perUserRpm).toBe(300);
+    });
+
+    it("keeps configured catalog model limits at 60 RPM or higher", () => {
+        for (const model of getModels()) {
+            const limit = getRegistryModelDefinition(model).perUserRpm;
+            if (limit != null) expect(limit).toBeGreaterThanOrEqual(60);
+        }
     });
 
     it("publishes a catalog model's configured per-user RPM", () => {

--- a/shared/registry/audio.ts
+++ b/shared/registry/audio.ts
@@ -660,7 +660,7 @@ export const AUDIO_SERVICES = {
         addedDate: new Date("2026-04-22").getTime(),
         paidOnly: true,
         priceMultiplier: 1,
-        perUserRpm: 30,
+        perUserRpm: 60,
         cost: {
             // DashScope Qwen3-TTS-Flash: $0.10 per 10K characters
             completionAudioTokens: 0.01 / 1000,

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -222,7 +222,7 @@ const IMAGE_BASE_SERVICES = {
         category: "image",
         addedDate: new Date("2026-02-27").getTime(),
         priceMultiplier: 1,
-        perUserRpm: 20,
+        perUserRpm: 60,
         paidOnly: true,
         cost: {
             completionImageTokens: 0.035, // per image

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -494,7 +494,7 @@ export const TEXT_SERVICES = {
         addedDate: new Date("2026-05-15").getTime(),
         paidOnly: true,
         priceMultiplier: 1,
-        perUserRpm: 10,
+        perUserRpm: 60,
         cost: {
             // OpenRouter Mistral endpoint, verified 2026-08-22.
             promptTextTokens: perMillion(0.15),
@@ -732,7 +732,7 @@ export const TEXT_SERVICES = {
         category: "text",
         addedDate: new Date("2025-10-10").getTime(),
         priceMultiplier: 1,
-        perUserRpm: 30,
+        perUserRpm: 60,
         cost: {
             promptTextTokens: perMillion(0.22),
             promptCachedTokens: perMillion(0.007),
@@ -1558,7 +1558,7 @@ export const TEXT_SERVICES = {
         addedDate: new Date("2026-08-19").getTime(),
         paidOnly: false,
         priceMultiplier: 1,
-        perUserRpm: 20,
+        perUserRpm: 60,
         cost: {
             // Fireworks, verified 2026-08-19: $0.05/$0.01/$0.20 per million.
             promptTextTokens: perMillion(0.05),
@@ -1878,7 +1878,7 @@ export const TEXT_SERVICES = {
         addedDate: new Date("2026-05-04").getTime(),
         paidOnly: true,
         priceMultiplier: 1,
-        perUserRpm: 5,
+        perUserRpm: 60,
         cost: {
             // OpenRouter DeepInfra FP8 endpoint, verified 2026-08-22.
             promptTextTokens: perMillion(0.1),
@@ -1928,7 +1928,7 @@ export const TEXT_SERVICES = {
         category: "text",
         addedDate: new Date("2026-06-02").getTime(),
         priceMultiplier: 1,
-        perUserRpm: 10,
+        perUserRpm: 60,
         cost: {
             // Fireworks accounts/fireworks/models/minimax-m3 rates (2026-06-14):
             // prompt $0.30/M, completion $1.20/M, cache read $0.06/M.
@@ -1955,7 +1955,7 @@ export const TEXT_SERVICES = {
         addedDate: new Date("2026-08-14").getTime(),
         paidOnly: false,
         priceMultiplier: 1,
-        perUserRpm: 10,
+        perUserRpm: 60,
         cost: {
             promptTextTokens: perMillion(0.35),
             promptCachedTokens: perMillion(0.04),


### PR DESCRIPTION
- Raises every configured canonical model RPM below 60 to 60.
- Preserves uncapped models, existing 60 RPM caps, and DreamShaper at 300 RPM.
- Adds a registry-wide regression assertion for the 60 RPM floor.
- Leaves community-owner limits unchanged.

Addresses #14326