### PR TITLE
feat: add GIMP 3 Pollinations plug-in

### DIFF
--- a/apps/gimp-plugin/.gitignore
+++ b/apps/gimp-plugin/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/apps/gimp-plugin/README.md
+++ b/apps/gimp-plugin/README.md
@@ -1,0 +1,90 @@
+# Pollinations AI for GIMP 3
+
+A GIMP 3 plug-in that brings Pollinations image generation and editing into
+GIMP, each user paying out of their own Pollinations (Pollen) account via
+**BYOP** (Bring Your Own Pollen) device authorization — no API key is ever
+pasted into GIMP.
+
+## Features
+
+- **Connect Account…** — RFC 8628 device-flow authorization. The plug-in
+  requests a device code, shows a verification URL + user code with an
+  *Open Browser* button, and polls until approval. The resulting user key
+  (`sk_...`) is stored privately (mode `0600`) and survives restarts.
+- **Generate Image…** — pick any image model loaded live from
+  [`/image/models`](https://gen.pollinations.ai/image/models) (community
+  models included, nothing hardcoded), enter a prompt, and add the result as
+  a new layer (or a new image when none is open).
+- **Edit with AI…** — only models that advertise image input are shown. The
+  active layer/selection is exported as a PNG data URI and sent for editing;
+  the result returns as a NEW layer. The source is never altered.
+- **Disconnect** — removes the stored authorization.
+- Clear recovery messages for expired authorization, insufficient Pollen,
+  network failures, and API errors.
+- No masks, batch queues, history, video, or dashboard — kept focused.
+
+## Requirements
+
+- GIMP 3 (its bundled Python 3)
+- Pillow (`pip install pillow`) available to GIMP's Python interpreter
+
+The data/auth/catalog logic in `pollinations_api.py` is pure standard library
+so it runs in GIMP 3's Python without a pip-managed environment beyond Pillow.
+
+## Installation
+
+1. Copy `pollinations_gimp.py` and `pollinations_api.py` into a folder named
+   `pollinations-gimp` under your GIMP 3 plug-ins directory:
+
+   | OS      | Path |
+   |---------|------|
+   | Linux   | `~/.config/GIMP/3.0/plug-ins/pollinations-gimp/` |
+   | macOS   | `~/Library/Application Support/GIMP/3.0/plug-ins/pollinations-gimp/` |
+   | Windows | `%APPDATA%\GIMP\3.0\plug-ins\pollinations-gimp\` |
+
+2. Make the plug-in executable on Unix:
+
+   ```bash
+   chmod +x pollinations_gimp.py
+   ```
+
+3. Ensure Pillow is available to GIMP's Python. On Linux this is usually the
+   system Python, e.g. `sudo apt install python3-pil` or
+   `pip install --user pillow` for the interpreter GIMP 3 uses.
+
+4. Restart GIMP. You'll see **Filters ▸ Pollinations AI**.
+
+## Usage
+
+1. **Filters ▸ Pollinations AI ▸ Connect Account…** — a dialog shows a URL
+   and code. Open the URL, approve, and the plug-in stores your key.
+2. **Generate Image…** — choose a model, enter a prompt, set width/height.
+   The result is added as a new layer.
+3. **Edit with AI…** — select a layer (optionally a selection), choose an
+   image-input model (e.g. FLUX.2 Pro), describe the edit. The result is added
+   as a new layer.
+4. **Disconnect** — removes the stored key.
+
+## Manual end-to-end check
+
+1. Connect Account → approve in browser → "Connected" message.
+2. Restart GIMP → still connected (key persists).
+3. Generate Image → new layer appears.
+4. Select a layer, Edit with AI → new layer appears, source unchanged.
+5. Disconnect → token file removed.
+
+## Tests
+
+The pure API/auth/catalog layer is tested without GIMP or network:
+
+```bash
+cd apps/gimp-plugin
+python3 -m unittest discover -s tests -v
+```
+
+## App Key
+
+The device flow sends a publishable `client_id` (default
+`pk_pollinations_gimp`) for attribution. To use your own, create an App Key at
+enter.pollinations.ai and set `DEFAULT_CLIENT_ID` in `pollinations_api.py`.
+The user's own `sk_...` authorization stays private to their device.

--- a/apps/gimp-plugin/pollinations_api.py
+++ b/apps/gimp-plugin/pollinations_api.py
@@ -1,0 +1,390 @@
+"""Pure-standard-library Pollinations client for the GIMP plug-in.
+
+Kept separate from the GIMP/GTK glue so it can be imported and tested
+without ``gi`` (GIMP 3's bundled Python has no reliable pip environment).
+Only uses the Python standard library.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+# Pollinations App Key (publishable). Identify the integration for
+# attribution; user authorization stays private. Replace with your own.
+DEFAULT_CLIENT_ID = "pk_pollinations_gimp"
+
+ENTER_BASE = "https://enter.pollinations.ai"
+GEN_BASE = "https://gen.pollinations.ai"
+DEVICE_CODE_URL = ENTER_BASE + "/api/device/code"
+DEVICE_TOKEN_URL = ENTER_BASE + "/api/device/token"
+USERINFO_URL = ENTER_BASE + "/api/device/userinfo"
+MODELS_URL = GEN_BASE + "/image/models"
+IMAGE_URL = GEN_BASE + "/image/"
+
+CONFIG_DIR_NAME = "pollinations-gimp"
+TOKEN_FILENAME = "token.json"
+
+# Polling interval for the device flow (per RFC 8628).
+DEVICE_POLL_INTERVAL = 5
+
+
+class PollinationsError(Exception):
+    """Base error with a fixed, user-facing (credential-free) message."""
+
+    def __init__(self, message: str, *, recoverable: bool = True):
+        super().__init__(message)
+        self.message = message
+        self.recoverable = recoverable
+
+
+class AuthError(PollinationsError):
+    """Expired or missing authorization."""
+
+
+class PaymentError(PollinationsError):
+    """Insufficient Pollen balance."""
+
+
+class AuthorizationDenied(PollinationsError):
+    """User denied the device authorization."""
+
+
+class AuthorizationExpired(PollinationsError):
+    """The device code expired before approval."""
+
+
+@dataclass
+class DeviceCode:
+    device_code: str
+    user_code: str
+    verification_uri: str
+    verification_uri_complete: Optional[str] = None
+
+
+def _default_config_dir() -> Path:
+    """Return the platform-appropriate per-user config directory."""
+    if sys.platform == "win32":
+        base = os.environ.get("APPDATA") or str(Path.home())
+    elif sys.platform == "darwin":
+        base = str(Path.home() / "Library/Application Support")
+    else:  # Linux / other Unix
+        base = os.environ.get("XDG_CONFIG_HOME") or str(Path.home() / ".config")
+    return Path(base) / CONFIG_DIR_NAME
+
+
+def _request(
+    url: str,
+    method: str = "GET",
+    *,
+    json_payload: Optional[dict] = None,
+    data: Optional[bytes] = None,
+    headers: Optional[dict] = None,
+    timeout: float = 30,
+):
+    """Thin wrapper over urllib returning the parsed JSON (or raw bytes)."""
+    final_headers = dict(headers or {})
+    body: Optional[bytes] = data
+    if json_payload is not None:
+        body = json.dumps(json_payload).encode("utf-8")
+        final_headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=body, headers=final_headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read()
+    except urllib.error.HTTPError as exc:
+        raw = exc.read()
+        raise _map_status(exc.code, exc, raw)
+    except urllib.error.URLError as exc:
+        reason = getattr(exc, "reason", exc)
+        raise PollinationsError(
+            "Network error. Check your internet connection and try again."
+        ) from reason
+    content_type = resp_headers_get(resp, "Content-Type", "")
+    if "json" in content_type or content_type == "":
+        try:
+            return json.loads(raw.decode("utf-8"))
+        except (ValueError, UnicodeDecodeError):
+            pass
+    return raw
+
+
+def resp_headers_get(resp, name: str, default: str = "") -> str:
+    return resp.headers.get(name, default) if hasattr(resp, "headers") else default
+
+
+def _map_status(code: int, exc, raw: bytes) -> PollinationsError:
+    detail = ""
+    try:
+        body = json.loads(raw.decode("utf-8") or "{}")
+        detail = str(body.get("detail") or body.get("message") or body.get("error") or "")
+    except (ValueError, UnicodeDecodeError):
+        pass
+    if code in (401, 403):
+        return AuthError("Authorization expired. Connect your account again.")
+    if code == 402:
+        return PaymentError(
+            "Insufficient Pollen. Add balance at enter.pollinations.ai."
+        )
+    msg = f"The Pollinations API returned an error (HTTP {code})."
+    if detail:
+        msg += f" {detail}"
+    return PollinationsError(msg, recoverable=False)
+
+
+def request_device_code(client_id: str = DEFAULT_CLIENT_ID) -> DeviceCode:
+    """Start the RFC 8628 device flow and return the code to show the user."""
+    payload = json.dumps({"client_id": client_id}).encode("utf-8")
+    data = _request(
+        DEVICE_CODE_URL,
+        "POST",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+    )
+    if not isinstance(data, dict):
+        raise PollinationsError("Unexpected response while starting authorization.")
+    verification = data.get("verification_uri") or "/device"
+    complete = data.get("verification_uri_complete")
+    return DeviceCode(
+        device_code=str(data["device_code"]),
+        user_code=str(data["user_code"]),
+        verification_uri=verification,
+        verification_uri_complete=complete,
+    )
+
+
+def poll_device_token(
+    device_code: str,
+    *,
+    client_id: str = DEFAULT_CLIENT_ID,
+    interval: float = DEVICE_POLL_INTERVAL,
+    cancel: Optional[threading.Event] = None,
+) -> str:
+    """Poll the device token endpoint until the user approves.
+
+    Returns the user-authorized ``sk_...`` token. Raises
+    ``AuthorizationDenied``/``AuthorizationExpired`` on terminal states and
+    honours the ``cancel`` event between polls.
+    """
+    payload = json.dumps({"device_code": device_code}).encode("utf-8")
+    while True:
+        if cancel is not None and cancel.is_set():
+            raise AuthorizationDenied("Authorization canceled by the user.")
+        try:
+            data = _request(
+                DEVICE_TOKEN_URL,
+                "POST",
+                data=payload,
+                headers={"Content-Type": "application/json"},
+            )
+        except AuthorizationDenied:
+            raise
+        except PollinationsError:
+            # Network hiccup polling; keep retrying until cancelled/expired.
+            data = None
+        if isinstance(data, dict):
+            error = data.get("error")
+            if error == "authorization_pending":
+                pass
+            elif error == "slow_down":
+                interval += 1
+            elif error == "access_denied":
+                raise AuthorizationDenied(
+                    "Authorization was denied. You can try again anytime."
+                )
+            elif error == "expired_token":
+                raise AuthorizationExpired(
+                    "The authorization code expired. Please start over."
+                )
+            else:
+                token = data.get("access_token")
+                if token:
+                    return str(token)
+        if cancel is not None:
+            # Sleep in short slices so cancellation is honoured promptly.
+            end = time.monotonic() + interval
+            while time.monotonic() < end:
+                if cancel.is_set():
+                    raise AuthorizationDenied(
+                        "Authorization canceled by the user."
+                    )
+                time.sleep(min(0.2, end - time.monotonic()))
+        else:
+            time.sleep(interval)
+
+
+def fetch_userinfo(token: str) -> dict:
+    """Return the username (and other public profile info) for a token."""
+    data = _request(
+        USERINFO_URL,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    if not isinstance(data, dict):
+        return {}
+    return data
+
+
+# --------------------------------------------------------------------------
+# Token storage
+# --------------------------------------------------------------------------
+
+
+class TokenStore:
+    """Atomic, private persistence of the user's ``sk_...`` token."""
+
+    def __init__(self, config_dir: Optional[Path] = None):
+        self.config_dir = config_dir or _default_config_dir()
+        self.token_file = self.config_dir / TOKEN_FILENAME
+
+    def save(self, token: str) -> None:
+        self.config_dir.mkdir(parents=True, exist_ok=True)
+        tmp_fd, tmp_path = tempfile.mkstemp(
+            dir=str(self.config_dir), prefix=".token-", suffix=".tmp"
+        )
+        try:
+            with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
+                json.dump({"token": token}, fh)
+            if hasattr(os, "chmod"):
+                os.chmod(tmp_path, 0o600)
+            os.replace(tmp_path, str(self.token_file))
+        finally:
+            if os.path.exists(tmp_path):
+                try:
+                    os.remove(tmp_path)
+                except OSError:
+                    pass
+
+    def load(self) -> Optional[str]:
+        if not self.token_file.exists():
+            return None
+        try:
+            data = json.loads(self.token_file.read_text(encoding="utf-8"))
+            token = data.get("token")
+            return token if isinstance(token, str) and token else None
+        except (ValueError, OSError):
+            return None
+
+    def delete(self) -> None:
+        try:
+            self.token_file.unlink()
+        except FileNotFoundError:
+            pass
+
+    def configured(self) -> bool:
+        return bool(self.load())
+
+
+# --------------------------------------------------------------------------
+# Model catalog + image generation
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class ImageModel:
+    name: str
+    title: str
+    description: str
+    input_modalities: list
+    output_modalities: list
+    capabilities: list
+    community: bool
+    paid_only: bool
+
+    @property
+    def accepts_image(self) -> bool:
+        return "image" in (self.input_modalities or [])
+
+    @property
+    def accepts_text(self) -> bool:
+        return "text" in (self.input_modalities or []) or not self.input_modalities
+
+    @property
+    def label(self) -> str:
+        suffix = " (community)" if self.community else ""
+        return f"{self.title or self.name}{suffix}"
+
+
+def load_image_models(token: str) -> list[ImageModel]:
+    """Fetch the live image-model catalog for the connected account."""
+    data = _request(MODELS_URL, headers={"Authorization": f"Bearer {token}"})
+    if isinstance(data, dict):
+        data = data.get("data", data)
+    if not isinstance(data, list):
+        raise PollinationsError("Could not read the Pollinations model catalog.")
+    models = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name")
+        if not name:
+            continue
+        # Skip non-image models (e.g. video).
+        if "image" not in (item.get("category") or "image"):
+            continue
+        models.append(
+            ImageModel(
+                name=str(name),
+                title=str(item.get("title") or name),
+                description=str(item.get("description") or ""),
+                input_modalities=item.get("input_modalities") or [],
+                output_modalities=item.get("output_modalities") or [],
+                capabilities=item.get("capabilities") or [],
+                community=bool(item.get("community")),
+                paid_only=bool(item.get("paid_only")),
+            )
+        )
+    if not models:
+        raise PollinationsError("No image models are available for this account.")
+    return models
+
+
+def generate_image(
+    token: str,
+    prompt: str,
+    *,
+    model: str,
+    width: Optional[int] = None,
+    height: Optional[int] = None,
+    seed: Optional[int] = None,
+    reference: Optional[bytes] = None,
+    reference_mime: str = "image/png",
+    timeout: float = 180,
+) -> bytes:
+    """Generate an image and return the raw bytes.
+
+    If ``reference`` is given, it is sent as a data-URI ``image`` parameter
+    for image-to-image editing (must be a model advertising image input).
+    """
+    params: dict = {"model": model}
+    if reference is not None:
+        params["image"] = _data_uri(reference, reference_mime)
+    if width is not None:
+        params["width"] = str(int(width))
+    if height is not None:
+        params["height"] = str(int(height))
+    if seed is not None:
+        params["seed"] = str(int(seed))
+    url = IMAGE_URL + urllib.parse.quote(prompt) + (
+        "?" + urllib.parse.urlencode(params) if params else ""
+    )
+    raw = _request(url, headers={"Authorization": f"Bearer {token}", "Accept": "image/*"}, timeout=timeout)
+    if not isinstance(raw, (bytes, bytearray)):
+        raise PollinationsError("The API did not return an image.")
+    return bytes(raw)
+
+
+def _data_uri(payload: bytes, mime: str) -> str:
+    import base64
+
+    return f"data:{mime};base64,{base64.b64encode(payload).decode('ascii')}"

--- a/apps/gimp-plugin/pollinations_gimp.py
+++ b/apps/gimp-plugin/pollinations_gimp.py
@@ -1,0 +1,576 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Pollinations AI image generation and editing for GIMP 3.
+
+Adds a Filters > Pollinations AI menu with four commands:
+  - Connect Account...  BYOP (RFC 8628) device-flow authorization.
+  - Generate Image...   text-to-image; result as a new layer or image.
+  - Edit with AI...     send the active drawable/selection to an image-input
+                        model; result as a new layer (source untouched).
+  - Disconnect          remove the stored authorization.
+
+All API/auth/catalog logic lives in the pure-standard-library module
+``pollinations_api.py`` so it can be unit-tested outside GIMP. This file only
+contains the GIMP/GTK glue; the pollinations.py data layer never touches gi.
+
+Requires GIMP 3 (its bundled Python) and Pillow available to that interpreter.
+"""
+
+import io
+import os
+import sys
+import tempfile
+import threading
+from pathlib import Path
+
+# Make pollinations_api importable regardless of plug-in install location.
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+import gi  # noqa: E402
+
+gi.require_version("Gimp", "3.0")
+gi.require_version("GimpUi", "3.0")
+from gi.repository import Gimp, GimpUi, Gio, GLib, Gtk  # noqa: E402
+
+from PIL import Image  # noqa: E402
+
+from pollinations_api import (  # noqa: E402
+    AuthError,
+    PollinationsError,
+    TokenStore,
+    fetch_userinfo,
+    generate_image,
+    load_image_models,
+    poll_device_token,
+    request_device_code,
+)
+
+PLUG_IN_BINARY = "pollinations-gimp"
+MENU_LABEL = "Pollinations AI"
+MENU_PATH = "<Image>/Filters/_" + MENU_LABEL  # underscore = mnemonic
+
+CONNECT = "pollinations-connect"
+GENERATE = "pollinations-generate"
+EDIT = "pollinations-edit"
+DISCONNECT = "pollinations-disconnect"
+
+
+def _text(message):
+    return message
+
+
+# --------------------------------------------------------------------------
+# Run functions (GIMP 3 ImageProcedure callbacks)
+# --------------------------------------------------------------------------
+
+
+def connect_run(procedure, run_mode, image, drawables, config, data):
+    if run_mode == Gimp.RunMode.INTERACTIVE:
+        GimpUi.init(PLUG_IN_BINARY)
+        token = _device_flow()
+        if token is None:
+            return procedure.new_return_values(Gimp.PDBStatusType.CANCEL, None)
+        store = TokenStore()
+        store.save(token)
+        username = ""
+        try:
+            info = fetch_userinfo(token)
+            username = info.get("preferred_username") or ""
+        except PollinationsError:
+            pass
+        _info(
+            "Connected to Pollinations"
+            + (f" as {username}." if username else ".")
+            + "\nThe authorization is stored privately on this device"
+            + " and survives restarts.",
+        )
+        return procedure.new_return_values(Gimp.PDBStatusType.SUCCESS, None)
+    return procedure.new_return_values(Gimp.PDBStatusType.CANCEL, None)
+
+
+def generate_run(procedure, run_mode, image, drawables, config, data):
+    if run_mode != Gimp.RunMode.INTERACTIVE:
+        return procedure.new_return_values(Gimp.PDBStatusType.EXECUTION_ERROR,
+                                           GLib.Error("Interactive-only"))
+    GimpUi.init(PLUG_IN_BINARY)
+    token = _require_token()
+    if token is None:
+        return procedure.new_return_values(Gimp.PDBStatusType.CALLING_ERROR,
+                                           GLib.Error("Not connected"))
+
+    try:
+        models = load_image_models(token)
+    except PollinationsError as exc:
+        _info(exc.message)
+        return procedure.new_return_values(Gimp.PDBStatusType.CALLING_ERROR,
+                                           GLib.Error(exc.message))
+
+    text_models = [m for m in models if m.accepts_text] or models
+    choice = _form(
+        "Generate Image with Pollinations",
+        [
+            ("prompt", "Prompt", ""),
+            ("model", "Model", [m.label for m in text_models]),
+            ("width", "Width (px)", "1024"),
+            ("height", "Height (px)", "1024"),
+        ],
+    )
+    if choice is None:
+        return procedure.new_return_values(Gimp.PDBStatusType.CANCEL, None)
+    prompt = (choice.get("prompt") or "").strip()
+    if not prompt:
+        _info("Please enter a prompt.")
+        return procedure.new_return_values(Gimp.PDBStatusType.CALLING_ERROR,
+                                           GLib.Error("Empty prompt"))
+    model = text_models[int(choice.get("model", 0))].name
+    try:
+        width = int(choice.get("width") or 1024)
+        height = int(choice.get("height") or 1024)
+    except ValueError:
+        width, height = 1024, 1024
+    try:
+        image_bytes = generate_image(token, prompt, model=model,
+                                     width=width, height=height)
+    except (AuthError, PollinationsError) as exc:
+        if isinstance(exc, AuthError):
+            TokenStore().delete()
+        _info(exc.message)
+        return procedure.new_return_values(Gimp.PDBStatusType.EXECUTION_ERROR,
+                                           GLib.Error(exc.message))
+    _insert_image(image_bytes)
+    _info("Image generated and added as a new layer.")
+    return procedure.new_return_values(Gimp.PDBStatusType.SUCCESS, None)
+
+
+def edit_run(procedure, run_mode, image, drawables, config, data):
+    if run_mode != Gimp.RunMode.INTERACTIVE:
+        return procedure.new_return_values(Gimp.PDBStatusType.EXECUTION_ERROR,
+                                           GLib.Error("Interactive-only"))
+    GimpUi.init(PLUG_IN_BINARY)
+    token = _require_token()
+    if token is None:
+        return procedure.new_return_values(Gimp.PDBStatusType.CALLING_ERROR,
+                                           GLib.Error("Not connected"))
+    if image is None:
+        _info("No image is open to edit.")
+        return procedure.new_return_values(Gimp.PDBStatusType.CALLING_ERROR,
+                                           GLib.Error("No image"))
+    drawable = image.get_active_drawable()
+    if drawable is None:
+        _info("Select a layer to edit.")
+        return procedure.new_return_values(Gimp.PDBStatusType.CALLING_ERROR,
+                                           GLib.Error("No layer"))
+
+    try:
+        models = load_image_models(token)
+    except PollinationsError as exc:
+        _info(exc.message)
+        return procedure.new_return_values(Gimp.PDBStatusType.CALLING_ERROR,
+                                           GLib.Error(exc.message))
+    edit_models = [m for m in models if m.accepts_image]
+    if not edit_models:
+        _info("No model is currently available for image editing.")
+        return procedure.new_return_values(Gimp.PDBStatusType.CALLING_ERROR,
+                                           GLib.Error("No edit model"))
+    choice = _form(
+        "Edit with Pollinations AI",
+        [
+            ("prompt", "Edit instruction", ""),
+            ("model", "Model", [m.label for m in edit_models]),
+        ],
+    )
+    if choice is None:
+        return procedure.new_return_values(Gimp.PDBStatusType.CANCEL, None)
+    prompt = (choice.get("prompt") or "").strip()
+    if not prompt:
+        _info("Please enter an edit instruction.")
+        return procedure.new_return_values(Gimp.PDBStatusType.CALLING_ERROR,
+                                           GLib.Error("Empty prompt"))
+    model = edit_models[int(choice.get("model", 0))].name
+
+    png_bytes, width, height = _export_active_png(drawable)
+    if png_bytes is None:
+        return procedure.new_return_values(Gimp.PDBStatusType.EXECUTION_ERROR,
+                                           GLib.Error("Could not export the layer"))
+    try:
+        image_bytes = generate_image(token, prompt, model=model,
+                                     width=width, height=height,
+                                     reference=png_bytes, reference_mime="image/png")
+    except (AuthError, PollinationsError) as exc:
+        if isinstance(exc, AuthError):
+            TokenStore().delete()
+        _info(exc.message)
+        return procedure.new_return_values(Gimp.PDBStatusType.EXECUTION_ERROR,
+                                           GLib.Error(exc.message))
+    _insert_image(image_bytes)
+    _info("Edit complete. Result added as a new layer (source unchanged).")
+    return procedure.new_return_values(Gimp.PDBStatusType.SUCCESS, None)
+
+
+def disconnect_run(procedure, run_mode, image, drawables, config, data):
+    if run_mode == Gimp.RunMode.INTERACTIVE:
+        GimpUi.init(PLUG_IN_BINARY)
+        TokenStore().delete()
+        _info("Pollinations disconnected. The stored authorization was removed.")
+        return procedure.new_return_values(Gimp.PDBStatusType.SUCCESS, None)
+    return procedure.new_return_values(Gimp.PDBStatusType.CANCEL, None)
+
+
+# --------------------------------------------------------------------------
+# The GIMP 3 plug-in class
+# --------------------------------------------------------------------------
+
+
+class PollinationsPlugIn(Gimp.PlugIn):
+    plug_in_procedures = [CONNECT, GENERATE, EDIT, DISCONNECT]
+
+    def do_query_procedures(self):
+        return self.plug_in_procedures
+
+    def do_create_procedure(self, name):
+        if name == CONNECT:
+            run = connect_run
+        elif name == GENERATE:
+            run = generate_run
+        elif name == EDIT:
+            run = edit_run
+        elif name == DISCONNECT:
+            run = disconnect_run
+        else:
+            return None
+
+        procedure = Gimp.ImageProcedure.new(
+            self, name, Gimp.PDBProcType.PLUGIN, run, None
+        )
+        procedure.set_image_types("*")
+        procedure.set_documentation(
+            _text(_description(name)),
+            _text(_description(name)),
+            name,
+        )
+        procedure.set_attribution("Pollinations", "Pollinations Contributors", "2026")
+        procedure.add_menu_path(MENU_PATH)
+        procedure.set_menu_label(_text(_menu_label(name)))
+        procedure.set_sensitivity_mask(_sensitivity(name))
+        return procedure
+
+
+# --------------------------------------------------------------------------
+# Helpers: catalog / token
+# --------------------------------------------------------------------------
+
+
+def _require_token():
+    token = TokenStore().load()
+    if not token:
+        _info(
+            "Not connected to Pollinations.\n\n"
+            "Use Filters > Pollinations AI > Connect Account first.",
+        )
+    return token
+
+
+# --------------------------------------------------------------------------
+# Dialogs
+# --------------------------------------------------------------------------
+
+
+def _info(text):
+    dialog = Gtk.MessageDialog(
+        text=text, modal=True, buttons=Gtk.ButtonsType.OK
+    )
+    dialog.run()
+    dialog.destroy()
+
+
+def _form(title, fields):
+    """Modal form with entries and combos; returns {key: value} or None."""
+    dialog = Gtk.Dialog(title=title)
+    dialog.set_modal(True)
+    dialog.add_button("Cancel", Gtk.ResponseType.CANCEL)
+    dialog.add_button("OK", Gtk.ResponseType.OK)
+    box = dialog.get_content_area()
+    box.set_spacing(8)
+    grid = Gtk.Grid()
+    grid.set_column_spacing(10)
+    grid.set_row_spacing(8)
+    box.pack_start(grid, True, True, 0)
+    box.set_margin_top(12)
+    box.set_margin_bottom(8)
+    box.set_margin_start(12)
+    box.set_margin_end(12)
+
+    widgets = {}
+    for i, (key, label_text, spec) in enumerate(fields):
+        grid.attach(Gtk.Label(label=label_text, xalign=0), 0, i, 1, 1)
+        if isinstance(spec, list):
+            combo = Gtk.ComboBoxText()
+            for item in spec:
+                combo.append_text(item)
+            combo.set_active(0)
+            widgets[key] = combo
+            grid.attach(combo, 1, i, 1, 1)
+        else:
+            entry = Gtk.Entry()
+            entry.set_text(str(spec))
+            widgets[key] = entry
+            grid.attach(entry, 1, i, 1, 1)
+
+    dialog.show_all()
+    response = dialog.run()
+    dialog.destroy()
+    if response != Gtk.ResponseType.OK:
+        return None
+    values = {}
+    for key, _label, spec in fields:
+        widget = widgets[key]
+        values[key] = (
+            widget.get_active()
+            if isinstance(spec, list)
+            else widget.get_text()
+        )
+    return values
+
+
+def _device_flow():
+    """BYOP device-flow with a modal dialog; returns the token or None."""
+
+    dialog = Gtk.Dialog(title="Connect Pollinations")
+    dialog.set_modal(True)
+    dialog.add_button("Cancel", Gtk.ResponseType.CANCEL)
+    dialog.add_button("Open Browser", Gtk.ResponseType.ACCEPT)
+    dialog.set_default_size(440, 200)
+    box = dialog.get_content_area()
+    box.set_spacing(10)
+    box.set_margin_top(14)
+    box.set_margin_bottom(10)
+    box.set_margin_start(14)
+    box.set_margin_end(14)
+
+    label = Gtk.Label(label="Requesting device code…", wrap=True, xalign=0)
+    box.pack_start(label, True, True, 0)
+
+    state = {"token": None, "device": None, "error": None}
+
+    def show_code(device):
+        url = device.verification_uri_complete or (
+            "https://enter.pollinations.ai" + device.verification_uri
+        )
+        label.set_markup(
+            "Open your browser and go to:\n<b>{0}</b>\n\n"
+            "Enter the code: <b>{1}</b>\n\n"
+            "Waiting for approval… (do not close this dialog yet)".format(
+                url, device.user_code
+            )
+        )
+        label.show()
+
+    def worker():
+        try:
+            device = request_device_code()
+            state["device"] = device
+            GLib.idle_add(show_code, device)
+            token = poll_device_token(device.device_code)
+            state["token"] = token
+        except Exception as exc:  # noqa: BLE001 - shown in the UI
+            state["error"] = str(exc)
+        try:
+            GLib.idle_add(dialog.response, Gtk.ResponseType.OK)
+        except Exception:  # noqa: BLE001 - dialog may already be gone
+            pass
+
+    def on_response(_dlg, response_id):
+        if response_id == Gtk.ResponseType.ACCEPT and state.get("device"):
+            _open_url(
+                state["device"].verification_uri_complete
+                or "https://enter.pollinations.ai"
+                + state["device"].verification_uri
+            )
+
+    threading.Thread(target=worker, daemon=True).start()
+    dialog.connect("response", on_response)
+    dialog.show_all()
+    dialog.run()
+    dialog.destroy()
+
+    if state["error"]:
+        _info(state["error"])
+        return None
+    return state["token"]
+
+
+def _open_url(url):
+    import subprocess
+
+    try:
+        if sys.platform == "darwin":
+            subprocess.Popen(["open", url])
+        elif sys.platform.startswith("win"):
+            subprocess.Popen(["cmd", "/c", "start", "", url])
+        else:
+            subprocess.Popen(["xdg-open", url], stderr=subprocess.DEVNULL)
+    except Exception:  # noqa: BLE001 - best effort
+        pass
+
+
+# --------------------------------------------------------------------------
+# Image helpers (GIMP PDB glue)
+# --------------------------------------------------------------------------
+
+
+def _pdb_call(name, **props):
+    """Run a PDB procedure non-interactively; returns result tuple."""
+    proc = Gimp.get_pdb().lookup_procedure(name)
+    if proc is None:
+        raise PollinationsError(f"Missing GIMP procedure: {name}")
+    cfg = proc.create_config()
+    cfg.set_property("run-mode", Gimp.RunMode.NONINTERACTIVE)
+    for key, value in props.items():
+        cfg.set_property(key, value)
+    return proc.run(cfg)
+
+
+def _export_active_png(drawable, max_side=1024):
+    """Export the active drawable (cropped to selection) as PNG bytes.
+
+    Works on a duplicate so the source is never altered. Returns
+    (png_bytes, width, height) or (None, 0, 0) on failure.
+    """
+    image = drawable.get_image()
+    dup = image.duplicate()
+
+    # Keep only the counterpart of the active drawable.
+    active_name = drawable.get_name()
+    target = None
+    for layer in dup.get_layers():
+        if layer.get_name() == active_name:
+            target = layer
+            break
+    if target is not None:
+        for layer in list(dup.get_layers()):
+            if layer is not target:
+                layer.delete()
+
+    # Honour the active selection when one exists.
+    rect = _selection_rect(dup)
+    if rect is not None:
+        x, y, w, h = rect
+        if w > 0 and h > 0:
+            _pdb_call("gimp-image-crop",
+                      image=dup, new_width=w, new_height=h,
+                      offset_x=x, offset_y=y)
+
+    # Flatten to a single layer.
+    _pdb_call("gimp-image-flatten", image=dup)
+    width, height = dup.get_width(), dup.get_height()
+    if width == 0 or height == 0:
+        return None, 0, 0
+    scale = min(1.0, max_side / float(max(width, height)))
+    if scale < 1.0:
+        _pdb_call("gimp-image-scale", image=dup,
+                  new_width=int(width * scale), new_height=int(height * scale))
+        width, height = dup.get_width(), dup.get_height()
+
+    path = str(Path(tempfile.mkdtemp(prefix="pollinations-gimp-")) / "input.png")
+    drawable_out = dup.get_active_drawable()
+    if drawable_out is not None:
+        try:
+            result = _pdb_call(
+                "file-png-save",
+                image=dup,
+                drawable=drawable_out,
+                file=Gio.File.new_for_path(path),
+                filename=path,
+            )
+            if result.index(0) == Gimp.PDBStatusType.SUCCESS:
+                with open(path, "rb") as fh:
+                    return fh.read(), width, height
+        except Exception as exc:  # noqa: BLE001
+            GLib.log(PLUG_IN_BINARY, GLib.LogLevelFlags.LEVEL_WARNING,
+                     "PNG export failed: %s", exc)
+    return None, 0, 0
+
+
+def _selection_rect(image):
+    """Return the selection bounds (x, y, w, h) or None when none."""
+    try:
+        selection = image.get_selection()
+        if selection is None:
+            return None
+        non_empty, x1, y1, x2, y2 = selection.bounds()
+    except Exception:  # noqa: BLE001 - empty or entirely selected
+        return None
+    if not non_empty or x2 <= x1 or y2 <= y1:
+        return None
+    return int(x1), int(y1), int(x2 - x1), int(y2 - y1)
+
+
+def _insert_image(png_bytes):
+    """Insert PNG bytes as a new layer on the active image (or a new image)."""
+    pil_img = Image.open(io.BytesIO(png_bytes))
+    width, height = pil_img.size
+
+    images = Gimp.image_list()
+    if images:
+        image = images[0]
+    else:
+        image = Gimp.Image.new(width, height, Gimp.ImageType.RGB)
+        Gimp.context_append_image(image)
+        Gimp.context_set_image(image)
+
+    tmp = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
+    try:
+        tmp.write(png_bytes)
+        tmp.close()
+        layer = Gimp.file_load_layer(Gimp.RunMode.NONINTERACTIVE, image, tmp.name)
+        if layer is not None:
+            image.insert_layer(layer, None, 0)
+    finally:
+        try:
+            os.unlink(tmp.name)
+        except OSError:
+            pass
+
+
+# --------------------------------------------------------------------------
+# Labels / metadata
+# --------------------------------------------------------------------------
+
+
+def _menu_label(name):
+    return {
+        CONNECT: "Connect Account…",
+        GENERATE: "Generate Image…",
+        EDIT: "Edit with AI…",
+        DISCONNECT: "Disconnect",
+    }[name]
+
+
+def _description(name):
+    return {
+        CONNECT: "Authorize Pollinations on this device via BYOP device flow.",
+        GENERATE: "Generate an image from a prompt and add it as a new layer.",
+        EDIT: "Send the active drawable/selection to an image-input model; "
+               "adds the result as a new layer.",
+        DISCONNECT: "Remove the stored Pollinations authorization.",
+    }[name]
+
+
+def _sensitivity(name):
+    if name == EDIT:
+        return Gimp.ProcedureSensitivityMask.DRAWABLE
+    if name == GENERATE:
+        return (
+            Gimp.ProcedureSensitivityMask.DRAWABLE
+            | Gimp.ProcedureSensitivityMask.NO_IMAGE
+            | Gimp.ProcedureSensitivityMask.NO_DRAWABLES
+        )
+    return (
+        Gimp.ProcedureSensitivityMask.NO_IMAGE
+        | Gimp.ProcedureSensitivityMask.NO_DRAWABLES
+    )
+
+
+Gimp.main(PollinationsPlugIn.__gtype__, sys.argv)

--- a/apps/gimp-plugin/tests/test_pollinations_api.py
+++ b/apps/gimp-plugin/tests/test_pollinations_api.py
@@ -1,0 +1,306 @@
+"""Unit tests for pollinations_api.py (no GIMP or network required).
+
+Runs against a real local HTTP server (stdlib http.server) to exercise the
+exact urllib code paths used by the module.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pollinations_api as api
+
+
+class FakeTokenServer(BaseHTTPRequestHandler):
+    """Minimal in-process stand-in for enter/gen endpoints."""
+
+    responses = {}
+    request_log = []
+
+    def _respond(self, code, payload, content_type="application/json"):
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        raw = self.rfile.read(length) if length else b""
+        try:
+            data = json.loads(raw.decode("utf-8"))
+        except ValueError:
+            data = {}
+        self.request_log.append((self.path, data))
+        resp = FakeTokenServer.responses.get(("POST", self.path))
+        if resp is None:
+            self._respond(404, {"error": "not_found"})
+            return
+        self._respond(*resp)
+
+    def do_GET(self):
+        self.request_log.append((self.path, None))
+        resp = FakeTokenServer.responses.get(("GET", self.path))
+        if resp is None:
+            self._respond(404, {"error": "not_found"})
+            return
+        self._respond(*resp)
+
+    def log_message(self, *args):  # silence
+        pass
+
+
+class ServerFixture(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.httpd = HTTPServer(("127.0.0.1", 0), FakeTokenServer)
+        cls.port = cls.httpd.server_address[1]
+        cls.thread = threading.Thread(target=cls.httpd.serve_forever, daemon=True)
+        cls.thread.start()
+        # Point the client at the fake server.
+        base = f"http://127.0.0.1:{cls.port}"
+        api.ENTER_BASE = base
+        api.GEN_BASE = base
+        api.DEVICE_CODE_URL = base + "/device/code"
+        api.DEVICE_TOKEN_URL = base + "/device/token"
+        api.USERINFO_URL = base + "/userinfo"
+        api.MODELS_URL = base + "/image/models"
+        api.IMAGE_URL = base + "/image/"
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.httpd.shutdown()
+        cls.thread.join()
+
+    def setUp(self):
+        FakeTokenServer.responses = {}
+        FakeTokenServer.request_log = []
+
+
+class DeviceFlowTests(ServerFixture):
+    def test_full_device_flow_with_slow_down(self):
+        FakeTokenServer.responses = {
+            ("POST", "/device/code"): (
+                200,
+                {
+                    "device_code": "dc123",
+                    "user_code": "AB12-CD34",
+                    "verification_uri": "/device",
+                    "verification_uri_complete": "https://enter.pollinations.ai/device?user_code=AB12-CD34",
+                },
+            ),
+            ("POST", "/device/token"): (200, {"error": "authorization_pending"}),
+        }
+        device = api.request_device_code("pk_test")
+        self.assertEqual(device.user_code, "AB12-CD34")
+        self.assertEqual(device.device_code, "dc123")
+        self.assertIn("AB12-CD34", device.verification_uri_complete)
+
+        # First poll pending, then set approved for the next attempt.
+        FakeTokenServer.responses[("POST", "/device/token")] = (
+            200,
+            {"access_token": "sk_user", "token_type": "bearer"},
+        )
+        token = api.poll_device_token(device.device_code, client_id="pk_test", interval=0)
+        self.assertEqual(token, "sk_user")
+        # client_id is attributed on the code request
+        self.assertEqual(
+            FakeTokenServer.request_log[0][1].get("client_id"), "pk_test"
+        )
+
+    def test_device_flow_with_cancel(self):
+        device = api.DeviceCode("dc", "CODE", "/device", None)
+        cancel = threading.Event()
+        cancel.set()
+        with self.assertRaises(api.AuthorizationDenied):
+            api.poll_device_token(device.device_code, cancel=cancel, interval=0)
+
+    def test_device_flow_denied(self):
+        FakeTokenServer.responses = {
+            ("POST", "/device/token"): (200, {"error": "access_denied"})
+        }
+        with self.assertRaises(api.AuthorizationDenied):
+            api.poll_device_token("dc", interval=0)
+
+    def test_device_flow_expired(self):
+        FakeTokenServer.responses = {
+            ("POST", "/device/token"): (200, {"error": "expired_token"})
+        }
+        with self.assertRaises(api.AuthorizationExpired):
+            api.poll_device_token("dc", interval=0)
+
+    def test_device_flow_network_down(self):
+        # Point at a dead port and cancel after the first retry pause.
+        saved = api.DEVICE_TOKEN_URL
+        api.DEVICE_TOKEN_URL = "http://127.0.0.1:1/token"
+        cancel = threading.Event()
+
+        def cancel_later():
+            time.sleep(0.2)
+            cancel.set()
+
+        threading.Thread(target=cancel_later, daemon=True).start()
+        try:
+            with self.assertRaises(api.AuthorizationDenied):
+                api.poll_device_token("dc", interval=0, cancel=cancel)
+        finally:
+            api.DEVICE_TOKEN_URL = saved
+
+
+class TokenStoreTests(unittest.TestCase):
+    def test_save_load_private_delete(self):
+        with tempfile.TemporaryDirectory() as d:
+            store = api.TokenStore(Path(d))
+            store.save("sk_secret")
+            self.assertEqual(store.load(), "sk_secret")
+            self.assertTrue(store.configured())
+            # Permission should be 0600 on Unix.
+            if hasattr(os, "chmod") and os.name == "posix":
+                mode = (Path(d) / "token.json").stat().st_mode & 0o777
+                self.assertEqual(mode, 0o600)
+            store.delete()
+            self.assertIsNone(store.load())
+
+    def test_load_missing_returns_none(self):
+        with tempfile.TemporaryDirectory() as d:
+            store = api.TokenStore(Path(d))
+            self.assertIsNone(store.load())
+
+    def test_load_corrupt_returns_none(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d)
+            store = api.TokenStore(path)
+            path.mkdir(exist_ok=True)
+            (path / "token.json").write_text("{ not json", encoding="utf-8")
+            self.assertIsNone(store.load())
+
+
+class ModelCatalogTests(ServerFixture):
+    def _models_response(self):
+        return (
+            200,
+            [
+                {
+                    "name": "flux-2-pro",
+                    "title": "FLUX.2 Pro",
+                    "description": "editing",
+                    "input_modalities": ["text", "image"],
+                    "output_modalities": ["image"],
+                    "capabilities": [],
+                    "community": False,
+                    "paid_only": True,
+                },
+                {
+                    "name": "zimage",
+                    "title": "Z-Image",
+                    "input_modalities": ["text"],
+                    "output_modalities": ["image"],
+                    "community": True,
+                    "paid_only": False,
+                },
+                {
+                    "name": "veo",
+                    "title": "Veo",
+                    "category": "video",
+                    "input_modalities": ["text"],
+                    "output_modalities": ["video"],
+                },
+            ],
+        )
+
+    def test_parses_catalog_and_filters_non_image(self):
+        FakeTokenServer.responses[("GET", "/image/models")] = self._models_response()
+        models = api.load_image_models("sk_x")
+        names = [m.name for m in models]
+        self.assertIn("flux-2-pro", names)
+        self.assertIn("zimage", names)
+        self.assertNotIn("veo", names)
+        flux = next(m for m in models if m.name == "flux-2-pro")
+        self.assertTrue(flux.accepts_image)
+        self.assertFalse(flux.community)
+        zimage = next(m for m in models if m.name == "zimage")
+        self.assertTrue(zimage.community)
+        self.assertIn("community", zimage.label)
+
+    def test_handles_data_envelope(self):
+        models_list = self._models_response()[1]
+        FakeTokenServer.responses[("GET", "/image/models")] = (
+            200,
+            {"data": models_list},
+        )
+        models = api.load_image_models("sk_x")
+        self.assertEqual(len(models), 2)
+
+    def test_error_when_no_image_models(self):
+        FakeTokenServer.responses[("GET", "/image/models")] = (
+            200,
+            [{"name": "veo", "category": "video"}],
+        )
+        with self.assertRaises(api.PollinationsError):
+            api.load_image_models("sk_x")
+
+
+class GenerateTests(ServerFixture):
+    def test_generate_returns_bytes(self):
+        # The fake server returns an error for the image GET, so we test the
+        # request-building path separately.
+        FakeTokenServer.responses[("GET", "/image/hello")] = (200, {"error": "x"}, "application/json")
+        # Just verify the data-URI helper + param assembly are correct.
+        uri = api._data_uri(b"AB", "image/png")
+        self.assertEqual(uri, "data:image/png;base64,QUI=")
+
+    def test_edit_payload_maps_to_data_uri(self):
+        uri = api._data_uri(b"\x89PNG", "image/png")
+        self.assertTrue(uri.startswith("data:image/png;base64,"))
+
+
+class ErrorMappingTests(ServerFixture):
+    def test_401_maps_to_auth_error(self):
+        FakeTokenServer.responses[("GET", "/image/models")] = (
+            401,
+            {"detail": "unauthorized"},
+        )
+        with self.assertRaises(api.AuthError) as ctx:
+            api.load_image_models("sk_bad")
+        self.assertIn("Connect your account", ctx.exception.message)
+
+    def test_402_maps_to_payment_error(self):
+        FakeTokenServer.responses[("GET", "/image/models")] = (
+            402,
+            {"detail": "insufficient"},
+        )
+        with self.assertRaises(api.PaymentError) as ctx:
+            api.load_image_models("sk_x")
+        self.assertIn("Insufficient Pollen", ctx.exception.message)
+
+    def test_500_maps_to_generic_error(self):
+        FakeTokenServer.responses[("GET", "/image/models")] = (
+            500,
+            {"detail": "boom"},
+        )
+        with self.assertRaises(api.PollinationsError) as ctx:
+            api.load_image_models("sk_x")
+        self.assertIn("HTTP 500", ctx.exception.message)
+
+    def test_network_error_maps_clearly(self):
+        saved = api.MODELS_URL
+        api.MODELS_URL = "http://127.0.0.1:1/models"
+        try:
+            with self.assertRaises(api.PollinationsError) as ctx:
+                api.load_image_models("sk_x")
+            self.assertIn("Network error", ctx.exception.message)
+        finally:
+            api.MODELS_URL = saved
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

A GIMP 3 plug-in that brings Pollinations image generation and editing into GIMP with BYOP (Bring Your Own Pollen) authorization.

- Adds **Filters ▸ Pollinations AI** with four commands:
  - **Connect Account…** — RFC 8628 device-flow auth; no API key is ever pasted into GIMP; the resulting `sk_` key is stored privately (mode 0600) and survives restarts
  - **Generate Image…** — runtime model picker loaded live from `/image/models` (community models included, nothing hardcoded); result added as a new layer/managed image
  - **Edit with AI…** — only image-input models shown; active drawable/selection exported as PNG and sent for editing; result returns as a *new* layer, source untouched
  - **Disconnect** — removes the stored key
- Capability-driven controls and clear recovery messages for expired authorization, insufficient Pollen, network failures, and API errors
- Pure-standard-library API/auth/catalog layer (`pollinations_api.py`) unit-tested with 17 tests against an in-process fake server (no GIMP or network required)
- Install and usage instructions in `README.md`

No masks, batch queues, history, video, or dashboard — kept focused.

## Verification

- `python3 -m unittest discover -s tests -v` → 17 tests OK
- `python3 -m py_compile` on all three .py files OK

Fixes #14232