### PR TITLE
fix: deploy Composio MCP secret

### DIFF
--- a/apps/composio-mcp/deploy.json
+++ b/apps/composio-mcp/deploy.json
@@ -1,6 +1,7 @@
 {
   "target": "worker",
   "credentials": "myceli",
+  "sops": "default",
   "install": "npm ci",
   "build": "npm test",
   "deploy": "npm run deploy",

--- a/apps/composio-mcp/package.json
+++ b/apps/composio-mcp/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "test": "node --test worker.test.js",
     "check": "wrangler deploy --dry-run",
-    "deploy": "wrangler deploy",
-    "deploy:staging": "wrangler deploy --env staging"
+    "deploy": "sops exec-file --no-fifo secrets.vars.json 'wrangler deploy --secrets-file {}'",
+    "deploy:staging": "sops exec-file --no-fifo secrets.vars.json 'wrangler deploy --env staging --secrets-file {}'"
   },
   "devDependencies": {
     "wrangler": "^4.125.0"

--- a/apps/composio-mcp/secrets.vars.json
+++ b/apps/composio-mcp/secrets.vars.json
@@ -1,0 +1,19 @@
+{
+	"COMPOSIO_API_KEY": "ENC[AES256_GCM,data:9WEMVNJJbVHKmlcZoM4B/t12loCcE74=,iv:jWDqR6akdLQomy/SqO2eJ5STTKSR1B/7qO6I2nytLJQ=,tag:XoFoCAqrVJMxf6n5drRgfQ==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"recipient": "age1k85e3hjd2tv3wtjv7npjtmp9pwr5cfda22hyz9ajg06uqel3cc5s6c34rd",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArNEJzUjB1M2p6NTVzRWRo\nZ3pPaTJoTiszQlZacmtXKzJncUVGNFV4RWk4Cm9UMjNFR2p1M0dNNG5iSG9TTEgv\nY1QzNUVNL2FnN1hrWjJ3UFVwajlPQm8KLS0tIDE5OXR6eGtqZXBxV2w0QVlZZHhs\nRFMxMkxPYWhkaWdhNkp2RGwwOTJXbUEKO8GqEgpne2mSqdvxxCSQfY60VP3TzZVU\n5J4I5wvLNOKOSUYczUPe+9Zj8W2bHfPW9CG7H4vQId8Rk2zWoMT28g==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1ry4pg28f38yrnd5nhdl2zrkh8f7vgfu0p6hdu8lwpvpa7vz8ag6qqxy4d6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVNHliMGE3NlRFNDI1N2Ur\nMHhLZlM3d0NBMTFCL3NtVE9PczNibjBTZWlzCnE1dXZleStmT3RjcWJmRUxWcndw\nYktTNDJqZEV2cCtncUNMbTNIRVdCTDgKLS0tIHl5c3NGMlNSUUdHOWRtSG1HT3lp\ndHRDQkdnMTNLQ20wTTd5Sm12Ly9PamcK2i+ZXKffEMxt/jCtlee65tcSSVUuGqwb\n0Ry7RVKhKpT3C1T0TC0YGWCXXHO1ygIDOx0Sog21bXhCxG+GR00jxg==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2026-09-02T15:42:34Z",
+		"mac": "ENC[AES256_GCM,data:zg1TczV+Lzi693iztDmf6JS+DR6V/maUDkZt7PL+IkXNnmrQchAqPIk7fHpm56qoqwwaaBW4NI2Ib8mi5fp6Nvli7PR2smm7JGS6XPGQZLWNBVLHdnscmw7+dLmG25YzktebLUsBsb8x8jXILUXUWTaCbhmetg5F7B6GSiPGap4=,iv:yrEeLYto/gSmugisQDO5o9JGROW3mjwot/LWbzMobmo=,tag:vUqynKk9kD6A4tnCjfjdPA==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.11.0"
+	}
+}


### PR DESCRIPTION
- Adds the encrypted Composio API key for Worker deployments.
- Uses the existing SOPS secret-file pattern used by hosted MCP workers.
- Fixes production agents loading zero Composio tools.

Checks: Composio credential HTTP 200; worker tests pass; Wrangler production dry run detects the hidden binding.