### PR TITLE
feat: render agent tool calls with assistant-ui

### DIFF
--- a/pollinations.ai/package-lock.json
+++ b/pollinations.ai/package-lock.json
@@ -8,6 +8,7 @@
             "name": "pollinations.ai",
             "version": "1.0.0",
             "dependencies": {
+                "@assistant-ui/react": "^0.15.17",
                 "@pollinations/sdk": "file:../packages/sdk",
                 "@pollinations/ui": "file:../packages/ui",
                 "@tanstack/react-router": "^1.139.3",
@@ -92,6 +93,125 @@
             },
             "peerDependenciesMeta": {
                 "@pollinations/sdk": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@assistant-ui/core": {
+            "version": "0.3.16",
+            "resolved": "https://registry.npmjs.org/@assistant-ui/core/-/core-0.3.16.tgz",
+            "integrity": "sha512-fZ9ud+z7hEjegu6NrHyMEcQKCdij2KRcqpLsyOYzHE9LhnBv59Q29jU287EkD0NZE0SG4YTo5/klzz7C/lKA+Q==",
+            "license": "MIT",
+            "dependencies": {
+                "assistant-stream": "^0.3.40",
+                "nanoid": "^6.0.1"
+            },
+            "peerDependencies": {
+                "@assistant-ui/store": "^0.3.0",
+                "@assistant-ui/tap": "^0.9.0",
+                "@types/react": "*",
+                "assistant-cloud": "^0.1.42",
+                "react": "^18 || ^19",
+                "zustand": "^5.0.11"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "assistant-cloud": {
+                    "optional": true
+                },
+                "react": {
+                    "optional": true
+                },
+                "zustand": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@assistant-ui/core/node_modules/nanoid": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-6.0.1.tgz",
+            "integrity": "sha512-3wVS3i51pE2pi1k5FFL/95BGfVS0kSsvDVuGXHOtxox/TywUmtgq+3qiTOTbs9J7KfHaXPiN171k/A6dBnaXFw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "bin": {
+                "nanoid": "bin/nanoid.js"
+            },
+            "engines": {
+                "node": "^22 || ^24 || >=26"
+            }
+        },
+        "node_modules/@assistant-ui/react": {
+            "version": "0.15.17",
+            "resolved": "https://registry.npmjs.org/@assistant-ui/react/-/react-0.15.17.tgz",
+            "integrity": "sha512-lCjukORuR2olq+XZYj8fF1MCYttqk90299CUrvruoKDr0cAPQzyIAxpTwOkJDhte4U+GyDHaov/KNb7NQe1EJg==",
+            "license": "MIT",
+            "dependencies": {
+                "@assistant-ui/core": "^0.3.16",
+                "@assistant-ui/store": "^0.3.11",
+                "@assistant-ui/tap": "^0.9.15",
+                "assistant-cloud": "^0.1.42",
+                "assistant-stream": "^0.3.40",
+                "radix-ui": "^1.6.7",
+                "react-textarea-autosize": "^8.5.9",
+                "safe-content-frame": "^0.0.28",
+                "zod": "^4.4.3",
+                "zustand": "^5.0.15"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^18 || ^19",
+                "react-dom": "^18 || ^19"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@assistant-ui/store": {
+            "version": "0.3.11",
+            "resolved": "https://registry.npmjs.org/@assistant-ui/store/-/store-0.3.11.tgz",
+            "integrity": "sha512-P9xHWIUIcpcPYJTunRWw4dAOZLONMx0OZ+aWnHUt7zwjH9UDQ1VCGK0JBorD4ZqhHgX/MUKYB4YRMwgF6yjXnA==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@assistant-ui/tap": "^0.9.12",
+                "@types/react": "*",
+                "react": "^18 || ^19"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@assistant-ui/tap": {
+            "version": "0.9.15",
+            "resolved": "https://registry.npmjs.org/@assistant-ui/tap/-/tap-0.9.15.tgz",
+            "integrity": "sha512-3rTHh1xUedyrgP0pAYKs0LsOmnJfV9HoQN1D2pLXkIjyJvgyuoAW4vPiJ627obbJnlj0QwvIlw9IKoLdO+ecbA==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^18 || ^19"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "react": {
                     "optional": true
                 }
             }
@@ -314,6 +434,15 @@
                 "@babel/core": "^7.0.0-0"
             }
         },
+        "node_modules/@babel/runtime": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+            "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@babel/template": {
             "version": "7.27.2",
             "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
@@ -487,15 +616,6 @@
             "engines": {
                 "node": ">=16"
             }
-        },
-        "node_modules/@cloudflare/workers-types": {
-            "version": "4.20260313.1",
-            "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260313.1.tgz",
-            "integrity": "sha512-jMEeX3RKfOSVqqXRKr/ulgglcTloeMzSH3FdzIfqJHtvc12/ELKd5Ldsg8ZHahKX/4eRxYdw3kbzb8jLXbq/jQ==",
-            "dev": true,
-            "license": "MIT OR Apache-2.0",
-            "optional": true,
-            "peer": true
         },
         "node_modules/@cspotcode/source-map-support": {
             "version": "0.8.1",
@@ -1166,6 +1286,44 @@
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
+        "node_modules/@floating-ui/core": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+            "integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@floating-ui/utils": "^0.2.12"
+            }
+        },
+        "node_modules/@floating-ui/dom": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+            "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
+            "license": "MIT",
+            "dependencies": {
+                "@floating-ui/core": "^1.8.0",
+                "@floating-ui/utils": "^0.2.12"
+            }
+        },
+        "node_modules/@floating-ui/react-dom": {
+            "version": "2.1.9",
+            "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+            "integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+            "license": "MIT",
+            "dependencies": {
+                "@floating-ui/dom": "^1.8.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0",
+                "react-dom": ">=16.8.0"
+            }
+        },
+        "node_modules/@floating-ui/utils": {
+            "version": "0.2.12",
+            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+            "integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
+            "license": "MIT"
+        },
         "node_modules/@humanfs/core": {
             "version": "0.19.1",
             "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1790,6 +1948,1502 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@radix-ui/number": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.3.tgz",
+            "integrity": "sha512-Road2bidD0uu/1BGDOWNdPI06g0lIRy6IF9GZcIrDK2KGItfor8IQwQa+yM2ERgHM1MmHxaxpTzk0/Jp42lNfA==",
+            "license": "MIT"
+        },
+        "node_modules/@radix-ui/primitive": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+            "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+            "license": "MIT"
+        },
+        "node_modules/@radix-ui/react-accessible-icon": {
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-accessible-icon/-/react-accessible-icon-1.1.15.tgz",
+            "integrity": "sha512-WTQwcAvQf5sOcuUyi90lKPbhwcvQ+j55cjrSmeaN+L2vKU3DooOvlKw2MDeiJ5IkV5N905KW0/fGojKOBhD11A==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-visually-hidden": "1.2.11"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-accordion": {
+            "version": "1.2.20",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.20.tgz",
+            "integrity": "sha512-jDhG9FvAEnlhnjrsINbNXcUa4G+L1KqSkJSunkbKEzFRcAb52jvM0PjPxPRvhe1HNc5F5yc0yzzWeeqlH4yBIg==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.7",
+                "@radix-ui/react-collapsible": "1.1.20",
+                "@radix-ui/react-collection": "1.1.15",
+                "@radix-ui/react-compose-refs": "1.1.5",
+                "@radix-ui/react-context": "1.2.2",
+                "@radix-ui/react-direction": "1.1.4",
+                "@radix-ui/react-id": "1.1.4",
+                "@radix-ui/react-primitive": "2.1.10",
+                "@radix-ui/react-use-controllable-state": "1.2.6"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-alert-dialog": {
+            "version": "1.1.23",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.23.tgz",
+            "integrity": "sha512-VAYOiQRqj3GPpYJE0I9J+X8Ip05cyVlNdKOFeiGS2Ou1HHGfpl0BxOyZm6nmVDyU+W+NF3/XLzmjHmVGydhwgA==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.7",
+                "@radix-ui/react-compose-refs": "1.1.5",
+                "@radix-ui/react-context": "1.2.2",
+                "@radix-ui/react-dialog": "1.1.23",
+                "@radix-ui/react-primitive": "2.1.10"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-arrow": {
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.15.tgz",
+            "integrity": "sha512-v4zggRcjadnI+ClKDuijlQEW4tw3NoaeHc/PwpKnLoLLKNUG4InLegkstooLcRIUWCs+8L22dGURCVuFfOKfnA==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-primitive": "2.1.10"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-aspect-ratio": {
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.15.tgz",
+            "integrity": "sha512-fy+dyVR+90nelK8rqIznFlxzx7uPcGbhxH8Nfr2bHb4UfSe+e3hklOC0luK0hDwVwnRX7xTRySpsrQVeW+/oNQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-primitive": "2.1.10"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-avatar": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.2.6.tgz",
+            "integrity": "sha512-4ULOTJ/mqy2hT9GlWa/MFHxHSvH3nJzHnZM1waNsc5Bonv7i70aNenghXmD97S6OJ81ekXONGGt4nT1r0PfEdA==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.7",
+                "@radix-ui/react-context": "1.2.2",
+                "@radix-ui/react-primitive": "2.1.10",
+                "@radix-ui/react-use-callback-ref": "1.1.4",
+                "@radix-ui/react-use-is-hydrated": "0.1.3",
+                "@radix-ui/react-use-layout-effect": "1.1.4"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-checkbox": {
+            "version": "1.3.11",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.11.tgz",
+            "integrity": "sha512-Gnptr9pDDQxD3hgq2dtPbtrp/c2qH1mBwIzw3X/ivrMb2e1t0jMTi606fVEqFPaQR1ggXIVQWKj3P2WW9v7zGQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.7",
+                "@radix-ui/react-compose-refs": "1.1.5",
+                "@radix-ui/react-context": "1.2.2",
+                "@radix-ui/react-presence": "1.1.10",
+                "@radix-ui/react-primitive": "2.1.10",
+                "@radix-ui/react-use-controllable-state": "1.2.6",
+                "@radix-ui/react-use-size": "1.1.4"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-collapsible": {
+            "version": "1.1.20",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.20.tgz",
+            "integrity": "sha512-mcGesGplBnzN2sbvJETzpCNfSMyPnb29q1GRLU+Ib7bJrpIG2ywmRoh2V5VbA2uNvKikKUlVbAPks7JDjz4A8Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.7",
+                "@radix-ui/react-compose-refs": "1.1.5",
+                "@radix-ui/react-context": "1.2.2",
+                "@radix-ui/react-id": "1.1.4",
+                "@radix-ui/react-presence": "1.1.10",
+                "@radix-ui/react-primitive": "2.1.10",
+                "@radix-ui/react-use-controllable-state": "1.2.6",
+                "@radix-ui/react-use-layout-effect": "1.1.4"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-collection": {
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.15.tgz",
+            "integrity": "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-compose-refs": "1.1.5",
+                "@radix-ui/react-context": "1.2.2",
+                "@radix-ui/react-primitive": "2.1.10",
+                "@radix-ui/react-slot": "1.3.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-compose-refs": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+            "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-context": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+            "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-context-menu": {
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.3.7.tgz",
+            "integrity": "sha512-CtXP35dxaB5T3zXSd+E3uHe/QpXcpYnZmxp6OaIbfthtfW4wyb77M23BG+bwIJDtsMwEP/YssdsmNyZu7jhWew==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.7",
+                "@radix-ui/react-context": "1.2.2",
+                "@radix-ui/react-menu": "2.1.24",
+                "@radix-ui/react-primitive": "2.1.10",
+                "@radix-ui/react-use-controllable-state": "1.2.6"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-dialog": {
+            "version": "1.1.23",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.23.tgz",
+            "integrity": "sha512-Ksw4WeROkO4rC9k/onilX/Ao2Cr1ku1unMNH+XSCcP4jSXYu7HDsg9n4ojMjVb22XpYjAQ9qfrFlVbru1vXDUA==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.7",
+                "@radix-ui/react-compose-refs": "1.1.5",
+                "@radix-ui/react-context": "1.2.2",
+                "@radix-ui/react-dismissable-layer": "1.1.19",
+                "@radix-ui/react-focus-guards": "1.1.6",
+                "@radix-ui/react-focus-scope": "1.1.16",
+                "@radix-ui/react-id": "1.1.4",
+                "@radix-ui/react-portal": "1.1.17",
+                "@radix-ui/react-presence": "1.1.10",
+                "@radix-ui/react-primitive": "2.1.10",
+                "@radix-ui/react-slot": "1.3.3",
+                "@radix-ui/react-use-controllable-state": "1.2.6",
+                "@radix-ui/react-use-layout-effect": "1.1.4",
+                "aria-hidden": "^1.2.4",
+                "react-remove-scroll": "^2.7.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-direction": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.4.tgz",
+            "integrity": "sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-dismissable-layer": {
+            "version": "1.1.19",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.19.tgz",
+            "integrity": "sha512-8g4pfOL9HoKKLWGiypT+dphVqjFfmcXO5GBnhsG6zI+lxAx/8feQpr+1LSN8Re3hiZ+XkLNS4O9ztK11/LzQ6w==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.7",
+                "@radix-ui/react-compose-refs": "1.1.5",
+                "@radix-ui/react-primitive": "2.1.10",
+                "@radix-ui/react-use-callback-ref": "1.1.4",
+                "@radix-ui/react-use-effect-event": "0.0.5"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-dropdown-menu": {
+            "version": "2.1.24",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.24.tgz",
+            "integrity": "sha512-geq8l2rJkxvkXsT9RMgtUE3P8pITFpTsvYpbySi1IH4fZEABD/Gp85myayFgxk0ktljGMJnCbeFkyTusvSvv7g==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.7",
+                "@radix-ui/react-compose-refs": "1.1.5",
+                "@radix-ui/react-context": "1.2.2",
+                "@radix-ui/react-id": "1.1.4",
+                "@radix-ui/react-menu": "2.1.24",
+                "@radix-ui/react-primitive": "2.1.10",
+                "@radix-ui/react-use-controllable-state": "1.2.6"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-focus-guards": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.6.tgz",
+            "integrity": "sha512-RNOJjfZMTyBM6xYmV3IVGXkPjIhcBAuv48POevAXwrGJhkWZ9p1rFoIS1JFooPuT193AZmRsCPhpoVJxx6OPoQ==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-focus-scope": {
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.16.tgz",
+            "integrity": "sha512-wmRZ2WWLvmt6KHy2rNPOdPUjwq5xOHY02+m+udwJTn0aNIox/rkskAvJTyTLGhPK6KgrUjlJUJpgmx/+wFiFIQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-compose-refs": "1.1.5",
+                "@radix-ui/react-primitive": "2.1.10",
+                "@radix-ui/react-use-callback-ref": "1.1.4"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-form": {
+            "version": "0.1.16",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-form/-/react-form-0.1.16.tgz",
+            "integrity": "sha512-Q4TLEn2A7TAypxwmd6R9EwrlXDvkfYSDMrq9/887AXAGh+G1rH+kYJKSTv+Si9Y0JPKTwKYv6PviAJosysNimA==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.7",
+                "@radix-ui/react-compose-refs": "1.1.5",
+                "@radix-ui/react-context": "1.2.2",
+                "@radix-ui/react-id": "1.1.4",
+                "@radix-ui/react-label": "2.1.15",
+                "@radix-ui/react-primitive": "2.1.10"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-hover-card": {
+            "version": "1.1.23",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.23.tgz",
+            "integrity": "sha512-H8qONfZd3ltrU3+jHCIgITbWo6e1iTKvP9DHdrvYbX48ooRM5FjEDTn16AMwdfuOGkWdZEhpl3PLL/Wk/AnHDQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.7",
+                "@radix-ui/react-compose-refs": "1.1.5",
+                "@radix-ui/react-context": "1.2.2",
+                "@radix-ui/react-dismissable-layer": "1.1.19",
+                "@radix-ui/react-popper": "1.3.7",
+                "@radix-ui/react-portal": "1.1.17",
+                "@radix-ui/react-presence": "1.1.10",
+                "@radix-ui/react-primitive": "2.1.10",
+                "@radix-ui/react-use-controllable-state": "1.2.6"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-id": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.4.tgz",
+            "integrity": "sha512-TMQp2llA+RYn7JcjnrMnz7wN4pcVttPZnRZo52PLQsoLVKzNlVwUeHmfePgTgRluXFvlD3GD5g5MOVVTJCO0qA==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-use-layout-effect": "1.1.4"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-label": {
+            "version": "2.1.15",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.15.tgz",
+            "integrity": "sha512-o/rdYEwZTTo5tjknnPeyQFU45kUC4i/XyeDPP+HGyi6XqpOP6Zf5Ya5vh/Yfe9Id5JiuWnnAx2XqIeD3UYZt0g==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-primitive": "2.1.10"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-menu": {
+            "version": "2.1.24",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.24.tgz",
+            "integrity": "sha512-uW7RVuU6Lp/ZtfeY4b3kL32zccgEWvPv1+cf17ubYzHa9cL8AHokmk36cG/XEiH/smbQvumnieXX9j/e9RqJWA==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.7",
+                "@radix-ui/react-collection": "1.1.15",
+                "@radix-ui/react-compose-refs": "1.1.5",
+                "@radix-ui/react-context": "1.2.2",
+                "@radix-ui/react-direction": "1.1.4",
+                "@radix-ui/react-dismissable-layer": "1.1.19",
+                "@radix-ui/react-focus-guards": "1.1.6",
+                "@radix-ui/react-focus-scope": "1.1.16",
+                "@radix-ui/react-id": "1.1.4",
+                "@radix-ui/react-popper": "1.3.7",
+                "@radix-ui/react-portal": "1.1.17",
+                "@radix-ui/react-presence": "1.1.10",
+                "@radix-ui/react-primitive": "2.1.10",
+                "@radix-ui/react-roving-focus": "1.1.19",
+                "@radix-ui/react-slot": "1.3.3",
+                "@radix-ui/react-use-callback-ref": "1.1.4",
+                "aria-hidden": "^1.2.4",
+                "react-remove-scroll": "^2.7.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-menubar": {
+            "version": "1.1.24",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.24.tgz",
+            "integrity": "sha512-eeVs0vf7cuqXaM0qLQCPcufImiJNVBXdJDLu7ZGYl2732UH23Qat/foNGrr6vYV3/DdTsBqASoggUFgH14OcZA==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.7",
+                "@radix-ui/react-collection": "1.1.15",
+                "@radix-ui/react-compose-refs": "1.1.5",
+                "@radix-ui/react-context": "1.2.2",
+                "@radix-ui/react-direction": "1.1.4",
+                "@radix-ui/react-id": "1.1.4",
+                "@radix-ui/react-menu": "2.1.24",
+                "@radix-ui/react-primitive": "2.1.10",
+                "@radix-ui/react-roving-focus": "1.1.19",
+                "@radix-ui/react-use-controllable-state": "1.2.6"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-navigation-menu": {
+            "version": "1.2.22",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.22.tgz",
+            "integrity": "sha512-ou7iLEJ+yrhQndkkA4U21XIdS/CS45F4iXIkTZcb6/Ne9EMsOuDudVmCwmDnfFZZ+y1FZqXRNSIgBy+YMvZVZg==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.7",
+                "@radix-ui/react-collection": "1.1.15",
+                "@radix-ui/react-compose-refs": "1.1.5",
+                "@radix-ui/react-context": "1.2.2",
+                "@radix-ui/react-direction": "1.1.4",
+                "@radix-ui/react-dismissable-layer": "1.1.19",
+                "@radix-ui/react-id": "1.1.4",
+                "@radix-ui/react-presence": "1.1.10",
+                "@radix-ui/react-primitive": "2.1.10",
+                "@radix-ui/react-use-callback-ref": "1.1.4",
+                "@radix-ui/react-use-controllable-state": "1.2.6",
+                "@radix-ui/react-use-layout-effect": "1.1.4",
+                "@radix-ui/react-use-previous": "1.1.4",
+                "@radix-ui/react-visually-hidden": "1.2.11"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-one-time-password-field": {
+            "version": "0.1.16",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-one-time-password-field/-/react-one-time-password-field-0.1.16.tgz",
+            "integrity": "sha512-Tj9P6ntAJEw52oq/F0AGknXR4XncxEt7XU47O3xJQOiWfLzEy3d9gtgKfvjSzGxzHkfL+VzvxGu2KTFsloJqXw==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/number": "1.1.3",
+                "@radix-ui/primitive": "1.1.7",
+                "@radix-ui/react-collection": "1.1.15",
+                "@radix-ui/react-compose-refs": "1.1.5",
+                "@radix-ui/react-context": "1.2.2",
+                "@radix-ui/react-direction": "1.1.4",
+                "@radix-ui/react-primitive": "2.1.10",
+                "@radix-ui/react-roving-focus": "1.1.19",
+                "@radix-ui/react-use-controllable-state": "1.2.6",
+                "@radix-ui/react-use-effect-event": "0.0.5",
+                "@radix-ui/react-use-is-hydrated": "0.1.3",
+                "@radix-ui/react-use-layout-effect": "1.1.4"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-password-toggle-field": {
+            "version": "0.1.11",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-password-toggle-field/-/react-password-toggle-field-0.1.11.tgz",
+            "integrity": "sha512-4gvFnmDXu3dgj21CqsufzIameRvlRd4SBqaWhcrlrNhRo0Y5i/49AmRJYe1fdAM3G2VNBbmin4b0D6cdQocwgw==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.7",
+                "@radix-ui/react-compose-refs": "1.1.5",
+                "@radix-ui/react-context": "1.2.2",
+                "@radix-ui/react-id": "1.1.4",
+                "@radix-ui/react-primitive": "2.1.10",
+                "@radix-ui/react-use-controllable-state": "1.2.6",
+                "@radix-ui/react-use-effect-event": "0.0.5",
+                "@radix-ui/react-use-is-hydrated": "0.1.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-popover": {
+            "version": "1.1.23",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.23.tgz",
+            "integrity": "sha512-mw58MrBlyHWFisTOYignD0vf/3gdcgAR+9of1s9G/38CbFiUwH1nCDkc0AUM9IrXFgN5Ue8n45j9WCgyM1sbiQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.7",
+                "@radix-ui/react-compose-refs": "1.1.5",
+                "@radix-ui/react-context": "1.2.2",
+                "@radix-ui/react-dismissable-layer": "1.1.19",
+                "@radix-ui/react-focus-guards": "1.1.6",
+                "@radix-ui/react-focus-scope": "1.1.16",
+                "@radix-ui/react-id": "1.1.4",
+                "@radix-ui/react-popper": "1.3.7",
+                "@radix-ui/react-portal": "1.1.17",
+                "@radix-ui/react-presence": "1.1.10",
+                "@radix-ui/react-primitive": "2.1.10",
+                "@radix-ui/react-slot": "1.3.3",
+                "@radix-ui/react-use-controllable-state": "1.2.6",
+                "aria-hidden": "^1.2.4",
+                "react-remove-scroll": "^2.7.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-popper": {
+            "version": "1.3.7",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.7.tgz",
+            "integrity": "sha512-UsJrrd7w4wuKKTdvd/DNERVlwSlUcyXzjhyDwBk+3aPOsCjOY6ZSbxuw8E6lZTjjfP8Cpd0J8VVkrYUWyGYXyg==",
+            "license": "MIT",
+            "dependencies": {
+                "@floating-ui/react-dom": "^2.0.0",
+                "@radix-ui/react-arrow": "1.1.15",
+                "@radix-ui/react-compose-refs": "1.1.5",
+                "@radix-ui/react-context": "1.2.2",
+                "@radix-ui/react-primitive": "2.1.10",
+                "@radix-ui/react-use-callback-ref": "1.1.4",
+                "@radix-ui/react-use-layout-effect": "1.1.4",
+                "@radix-ui/react-use-rect": "1.1.4",
+                "@radix-ui/react-use-size": "1.1.4",
+                "@radix-ui/rect": "1.1.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-portal": {
+            "version": "1.1.17",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.17.tgz",
+            "integrity": "sha512-vKQLcWypUnwZVvfV7UkGahH2g6ySe8M8R+zYBwPrv5byZ9QAW6cQVvNKo7GgmD+p8aYb6D9JBuvy8/WhOno2wQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-primitive": "2.1.10",
+                "@radix-ui/react-use-layout-effect": "1.1.4"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-presence": {
+            "version": "1.1.10",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.10.tgz",
+            "integrity": "sha512-3wyzCQ6+ubRA+D4uv9m95JYLXxmOHp05qjrkjeA7uKHHtjpPggQzc6DAb0URl7j67oR0K2foO4ip27TiX037Bw==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-use-layout-effect": "1.1.4"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-primitive": {
+            "version": "2.1.10",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+            "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-slot": "1.3.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-progress": {
+            "version": "1.1.16",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.16.tgz",
+            "integrity": "sha512-5XnomAsoZZCY+KNTxbIghpGqPruZvKFNlvcAljVAOdDRDsH4/OZQxhtwo5wdtoDM5R6MhJBb2sPnDuRFep3lzg==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-context": "1.2.2",
+                "@radix-ui/react-primitive": "2.1.10"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-radio-group": {
+            "version": "1.4.7",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.4.7.tgz",
+            "integrity": "sha512-cgYFEkntCxppHZgtSZ+7vh0wbZQ+IC7PPMw8DSnRG27B6kDd32/Zw0OJt7dGDigCoprMuWHjg2PvUn3PYvPFoQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.7",
+                "@radix-ui/react-compose-refs": "1.1.5",
+                "@radix-ui/react-context": "1.2.2",
+                "@radix-ui/react-direction": "1.1.4",
+                "@radix-ui/react-presence": "1.1.10",
+                "@radix-ui/react-primitive": "2.1.10",
+                "@radix-ui/react-roving-focus": "1.1.19",
+                "@radix-ui/react-use-controllable-state": "1.2.6",
+                "@radix-ui/react-use-size": "1.1.4"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-roving-focus": {
+            "version": "1.1.19",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.19.tgz",
+            "integrity": "sha512-V9jI6hDjT7l3jsCQD9bLNvDLM3tH/gdbOTp7Tefp3hbbgCGQoK7tUvrWiRlcoBHIZ809ElXwNQwVo0B98LuTXQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.7",
+                "@radix-ui/react-collection": "1.1.15",
+                "@radix-ui/react-compose-refs": "1.1.5",
+                "@radix-ui/react-context": "1.2.2",
+                "@radix-ui/react-direction": "1.1.4",
+                "@radix-ui/react-id": "1.1.4",
+                "@radix-ui/react-primitive": "2.1.10",
+                "@radix-ui/react-use-callback-ref": "1.1.4",
+                "@radix-ui/react-use-controllable-state": "1.2.6",
+                "@radix-ui/react-use-is-hydrated": "0.1.3",
+                "@radix-ui/react-use-layout-effect": "1.1.4"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-scroll-area": {
+            "version": "1.2.18",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.18.tgz",
+            "integrity": "sha512-Zn5Cd171wxsO3Dfg8HaW6RifTb9CYTKQJHs/G4+LN1GfmJpaQMZQyQxMprVPHpaz7QY4l9BxK2JwQuzHsXC8nA==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/number": "1.1.3",
+                "@radix-ui/primitive": "1.1.7",
+                "@radix-ui/react-compose-refs": "1.1.5",
+                "@radix-ui/react-context": "1.2.2",
+                "@radix-ui/react-direction": "1.1.4",
+                "@radix-ui/react-presence": "1.1.10",
+                "@radix-ui/react-primitive": "2.1.10",
+                "@radix-ui/react-use-callback-ref": "1.1.4",
+                "@radix-ui/react-use-layout-effect": "1.1.4"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-select": {
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.3.7.tgz",
+            "integrity": "sha512-WFGImkmbzcfxeIwq/+4HvRN0pizBwbwQUED4I13ezQsDdfl38ZntN6TmR8XaSzPBqoCToe8rF75j6NPNDSzhbg==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/number": "1.1.3",
+                "@radix-ui/primitive": "1.1.7",
+                "@radix-ui/react-collection": "1.1.15",
+                "@radix-ui/react-compose-refs": "1.1.5",
+                "@radix-ui/react-context": "1.2.2",
+                "@radix-ui/react-direction": "1.1.4",
+                "@radix-ui/react-dismissable-layer": "1.1.19",
+                "@radix-ui/react-focus-guards": "1.1.6",
+                "@radix-ui/react-focus-scope": "1.1.16",
+                "@radix-ui/react-id": "1.1.4",
+                "@radix-ui/react-popper": "1.3.7",
+                "@radix-ui/react-portal": "1.1.17",
+                "@radix-ui/react-presence": "1.1.10",
+                "@radix-ui/react-primitive": "2.1.10",
+                "@radix-ui/react-slot": "1.3.3",
+                "@radix-ui/react-use-callback-ref": "1.1.4",
+                "@radix-ui/react-use-controllable-state": "1.2.6",
+                "@radix-ui/react-use-layout-effect": "1.1.4",
+                "@radix-ui/react-use-previous": "1.1.4",
+                "@radix-ui/react-visually-hidden": "1.2.11",
+                "aria-hidden": "^1.2.4",
+                "react-remove-scroll": "^2.7.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-separator": {
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.15.tgz",
+            "integrity": "sha512-jOLO4lssEzWpoDu7G+Ze4VjwMRUBt291pnZD0gmalREZipnTX3wadQo7Fy48GCTfe14/YRN6rw/rOJqrE85Wxw==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-primitive": "2.1.10"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-slider": {
+            "version": "1.4.7",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.4.7.tgz",
+            "integrity": "sha512-mTSLf1GC/C0moWjTbvCM6Qn/gBjvlFt1azuWF2v7MN5C3Zq2U2J2lN3ZEYkpujuOU5Ro7A28wkviSxaKnG0BYg==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/number": "1.1.3",
+                "@radix-ui/primitive": "1.1.7",
+                "@radix-ui/react-collection": "1.1.15",
+                "@radix-ui/react-compose-refs": "1.1.5",
+                "@radix-ui/react-context": "1.2.2",
+                "@radix-ui/react-direction": "1.1.4",
+                "@radix-ui/react-primitive": "2.1.10",
+                "@radix-ui/react-use-controllable-state": "1.2.6",
+                "@radix-ui/react-use-layout-effect": "1.1.4",
+                "@radix-ui/react-use-previous": "1.1.4",
+                "@radix-ui/react-use-size": "1.1.4"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-slot": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+            "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-compose-refs": "1.1.5"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-switch": {
+            "version": "1.3.7",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.3.7.tgz",
+            "integrity": "sha512-48tB/4dn2UVLBCYhTu9AuR63IHl73l/qLbLgxd86noTUor4/K4LFDAcYjK+isP5313qxaFpjPVogE7+Y0/V3Kw==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.7",
+                "@radix-ui/react-compose-refs": "1.1.5",
+                "@radix-ui/react-context": "1.2.2",
+                "@radix-ui/react-primitive": "2.1.10",
+                "@radix-ui/react-use-controllable-state": "1.2.6",
+                "@radix-ui/react-use-size": "1.1.4"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-tabs": {
+            "version": "1.1.21",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.21.tgz",
+            "integrity": "sha512-UKxJlZid7FVtsk/WTxj4i4uSEgj2Au+KBbS7SQyTlzMhhn+86Cz3tISZdTa87bfEfcuvZezf2ZsxD4xuEKtkog==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.7",
+                "@radix-ui/react-context": "1.2.2",
+                "@radix-ui/react-direction": "1.1.4",
+                "@radix-ui/react-id": "1.1.4",
+                "@radix-ui/react-presence": "1.1.10",
+                "@radix-ui/react-primitive": "2.1.10",
+                "@radix-ui/react-roving-focus": "1.1.19",
+                "@radix-ui/react-use-controllable-state": "1.2.6"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-toast": {
+            "version": "1.2.23",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.23.tgz",
+            "integrity": "sha512-ofhyAsYaocRGOs/n0XWdUOSVzEAG6BfrMVM8z0c0kLEWY38w/0WuMFPTJP/HVaZPYkMvHZoKIIhNcjbTCBILPg==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.7",
+                "@radix-ui/react-collection": "1.1.15",
+                "@radix-ui/react-compose-refs": "1.1.5",
+                "@radix-ui/react-context": "1.2.2",
+                "@radix-ui/react-dismissable-layer": "1.1.19",
+                "@radix-ui/react-portal": "1.1.17",
+                "@radix-ui/react-presence": "1.1.10",
+                "@radix-ui/react-primitive": "2.1.10",
+                "@radix-ui/react-use-callback-ref": "1.1.4",
+                "@radix-ui/react-use-controllable-state": "1.2.6",
+                "@radix-ui/react-use-layout-effect": "1.1.4",
+                "@radix-ui/react-visually-hidden": "1.2.11"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-toggle": {
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.18.tgz",
+            "integrity": "sha512-7lonPlKfSacd20GlOBx2ltuVKz9oqWYZz+oMQyOltw6t1y2nyftj2ZmwwUHYn49kqfDWcp8dNZm5NgV+5Z+mug==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.7",
+                "@radix-ui/react-primitive": "2.1.10",
+                "@radix-ui/react-use-controllable-state": "1.2.6"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-toggle-group": {
+            "version": "1.1.19",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.19.tgz",
+            "integrity": "sha512-OtnwuSVjd1Ofi+AdnvhsjQdyuhCDwYs1w9RyB5BN/OavXOVQo42SYqQjwUnbPnaiPFBpQ9aX70dWeee+v2oBLA==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.7",
+                "@radix-ui/react-context": "1.2.2",
+                "@radix-ui/react-direction": "1.1.4",
+                "@radix-ui/react-primitive": "2.1.10",
+                "@radix-ui/react-roving-focus": "1.1.19",
+                "@radix-ui/react-toggle": "1.1.18",
+                "@radix-ui/react-use-controllable-state": "1.2.6"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-toolbar": {
+            "version": "1.1.19",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-toolbar/-/react-toolbar-1.1.19.tgz",
+            "integrity": "sha512-Ph0IvtYw4VB12ZnZg+YtrGs8yJQsnizwo/zu0R4Y/nWugtJzA7Pg1eWeuDR9+LSqn+xjamss+UOSOJJJ4gx8jw==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.7",
+                "@radix-ui/react-context": "1.2.2",
+                "@radix-ui/react-direction": "1.1.4",
+                "@radix-ui/react-primitive": "2.1.10",
+                "@radix-ui/react-roving-focus": "1.1.19",
+                "@radix-ui/react-separator": "1.1.15",
+                "@radix-ui/react-toggle-group": "1.1.19"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-tooltip": {
+            "version": "1.2.16",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.16.tgz",
+            "integrity": "sha512-6EamKFRRnlpdadndbZ6LMwycfwkwPte1B42hs6QA0gYhjaOKqW4PZ4pjaW9UrlDX5eVt/OjncE7BFTPL5nmZhg==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.7",
+                "@radix-ui/react-compose-refs": "1.1.5",
+                "@radix-ui/react-context": "1.2.2",
+                "@radix-ui/react-dismissable-layer": "1.1.19",
+                "@radix-ui/react-id": "1.1.4",
+                "@radix-ui/react-popper": "1.3.7",
+                "@radix-ui/react-portal": "1.1.17",
+                "@radix-ui/react-presence": "1.1.10",
+                "@radix-ui/react-primitive": "2.1.10",
+                "@radix-ui/react-slot": "1.3.3",
+                "@radix-ui/react-use-controllable-state": "1.2.6",
+                "@radix-ui/react-use-layout-effect": "1.1.4",
+                "@radix-ui/react-visually-hidden": "1.2.11"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-callback-ref": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.4.tgz",
+            "integrity": "sha512-R6OUY2e2fA6Yn6s+VSx5KBV6Nx8LQEhu+cz7LCej18rQ1HLyg9PSC9jP/ZNx0o6FAIK9c0F1kHylzSxKsdlkrQ==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-controllable-state": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+            "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.7",
+                "@radix-ui/react-use-effect-event": "0.0.5",
+                "@radix-ui/react-use-layout-effect": "1.1.4"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-effect-event": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+            "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-use-layout-effect": "1.1.4"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-escape-keydown": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.5.tgz",
+            "integrity": "sha512-ge3ipobwSXTj4JyVtswQ7qZj0ZHdtbGuOno/LrgAAeSxtsJ6Vs4Gz5IkPH2bmqpjcLUFoqGhA/mueuIf63UXlA==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-use-callback-ref": "1.1.4"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-is-hydrated": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.3.tgz",
+            "integrity": "sha512-umO/aJ+82CpOnhDZUTbILCQf7kU/g0iv+oGs/Q8jw7IkhWBzaEP4sA268PhFAJTFetbwp3ICc6ktpI4TqtxcIw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-layout-effect": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+            "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-previous": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.4.tgz",
+            "integrity": "sha512-XoSLhbRbqxFtgJoi2fNHA3C6pDlY34x508vUpUGoFZfvePfHXHbE1lC4FYFMnJWgiCRroSTw6fOsXQoVS9RwZg==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-rect": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.4.tgz",
+            "integrity": "sha512-cSOCh6JlkmfjLyNcLiu2nB4v+nm+dkZ+Q5KHWk/soo4U7ZLiEQFKHK9/YmtBHjfCEaU43IBKQOc4/uJmCaiCTQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/rect": "1.1.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-size": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.4.tgz",
+            "integrity": "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-use-layout-effect": "1.1.4"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-visually-hidden": {
+            "version": "1.2.11",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.11.tgz",
+            "integrity": "sha512-NFS86RYYZb4/exihaESBGOpMJFz8MGLAfu3mOBSGByVnVPC9JPASfYubxd/8KbkQK0sYAv8lVQDEQukDX/qXvQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-primitive": "2.1.10"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/rect": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.3.tgz",
+            "integrity": "sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==",
+            "license": "MIT"
+        },
         "node_modules/@rolldown/pluginutils": {
             "version": "1.0.0-beta.47",
             "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.47.tgz",
@@ -2101,6 +3755,12 @@
             "integrity": "sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA==",
             "dev": true,
             "license": "CC0-1.0"
+        },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "license": "MIT"
         },
         "node_modules/@tailwindcss/node": {
             "version": "4.3.3",
@@ -2701,7 +4361,7 @@
             "version": "19.2.18",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
             "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "csstype": "^3.2.2"
@@ -2711,7 +4371,7 @@
             "version": "19.2.3",
             "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
             "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-            "dev": true,
+            "devOptional": true,
             "peerDependencies": {
                 "@types/react": "^19.2.0"
             }
@@ -2794,6 +4454,18 @@
             "dev": true,
             "license": "Python-2.0",
             "peer": true
+        },
+        "node_modules/aria-hidden": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+            "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/aria-query": {
             "version": "5.3.2",
@@ -2897,6 +4569,56 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/assistant-cloud": {
+            "version": "0.1.42",
+            "resolved": "https://registry.npmjs.org/assistant-cloud/-/assistant-cloud-0.1.42.tgz",
+            "integrity": "sha512-w76ACM0705SNmWgz3Zl0SwX95rukju30PUPNzeEFEXhLi/NRQyWshYF8izdaHeoy9h4dgSuJtnS5v1Qh6IMClA==",
+            "license": "MIT",
+            "dependencies": {
+                "assistant-stream": "^0.3.40"
+            }
+        },
+        "node_modules/assistant-stream": {
+            "version": "0.3.40",
+            "resolved": "https://registry.npmjs.org/assistant-stream/-/assistant-stream-0.3.40.tgz",
+            "integrity": "sha512-gAQZC80N6jfTH5eIbCmAM94DKpEgmnLnIZmk3UtmrpogePGuCFX73u5brASvDYnekZK/71Ed9mwvCzFWIyzdZg==",
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.1.0",
+                "nanoid": "^6.0.1",
+                "secure-json-parse": "^4.1.0"
+            },
+            "peerDependencies": {
+                "ioredis": "^5.10.1 || ^6.0.0",
+                "redis": "^5.12.1"
+            },
+            "peerDependenciesMeta": {
+                "ioredis": {
+                    "optional": true
+                },
+                "redis": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/assistant-stream/node_modules/nanoid": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-6.0.1.tgz",
+            "integrity": "sha512-3wVS3i51pE2pi1k5FFL/95BGfVS0kSsvDVuGXHOtxox/TywUmtgq+3qiTOTbs9J7KfHaXPiN171k/A6dBnaXFw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "license": "MIT",
+            "bin": {
+                "nanoid": "bin/nanoid.js"
+            },
+            "engines": {
+                "node": "^22 || ^24 || >=26"
             }
         },
         "node_modules/ast-types-flow": {
@@ -3226,7 +4948,7 @@
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.2.tgz",
             "integrity": "sha512-D80T+tiqkd/8B0xNlbstWDG4x6aqVfO52+OlSUNIdkTvmNw0uQpJLeos2J/2XvpyidAFuTPmpad+tUxLndwj6g==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/damerau-levenshtein": {
             "version": "1.0.8",
@@ -3352,6 +5074,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/detect-node-es": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+            "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+            "license": "MIT"
         },
         "node_modules/diff": {
             "version": "8.0.4",
@@ -4057,6 +5785,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-nonce": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+            "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/get-proto": {
@@ -5460,6 +7197,83 @@
                 "node": ">=6"
             }
         },
+        "node_modules/radix-ui": {
+            "version": "1.6.7",
+            "resolved": "https://registry.npmjs.org/radix-ui/-/radix-ui-1.6.7.tgz",
+            "integrity": "sha512-QBdhh1arIEUvPC0dQ5+nwWAxt7+N+oP/9jPwjJkGFoSk/sqxg32gJtSXGtFh8frAIcS6oC9cx2Q+7KYCQLOAeA==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.7",
+                "@radix-ui/react-accessible-icon": "1.1.15",
+                "@radix-ui/react-accordion": "1.2.20",
+                "@radix-ui/react-alert-dialog": "1.1.23",
+                "@radix-ui/react-arrow": "1.1.15",
+                "@radix-ui/react-aspect-ratio": "1.1.15",
+                "@radix-ui/react-avatar": "1.2.6",
+                "@radix-ui/react-checkbox": "1.3.11",
+                "@radix-ui/react-collapsible": "1.1.20",
+                "@radix-ui/react-collection": "1.1.15",
+                "@radix-ui/react-compose-refs": "1.1.5",
+                "@radix-ui/react-context": "1.2.2",
+                "@radix-ui/react-context-menu": "2.3.7",
+                "@radix-ui/react-dialog": "1.1.23",
+                "@radix-ui/react-direction": "1.1.4",
+                "@radix-ui/react-dismissable-layer": "1.1.19",
+                "@radix-ui/react-dropdown-menu": "2.1.24",
+                "@radix-ui/react-focus-guards": "1.1.6",
+                "@radix-ui/react-focus-scope": "1.1.16",
+                "@radix-ui/react-form": "0.1.16",
+                "@radix-ui/react-hover-card": "1.1.23",
+                "@radix-ui/react-label": "2.1.15",
+                "@radix-ui/react-menu": "2.1.24",
+                "@radix-ui/react-menubar": "1.1.24",
+                "@radix-ui/react-navigation-menu": "1.2.22",
+                "@radix-ui/react-one-time-password-field": "0.1.16",
+                "@radix-ui/react-password-toggle-field": "0.1.11",
+                "@radix-ui/react-popover": "1.1.23",
+                "@radix-ui/react-popper": "1.3.7",
+                "@radix-ui/react-portal": "1.1.17",
+                "@radix-ui/react-presence": "1.1.10",
+                "@radix-ui/react-primitive": "2.1.10",
+                "@radix-ui/react-progress": "1.1.16",
+                "@radix-ui/react-radio-group": "1.4.7",
+                "@radix-ui/react-roving-focus": "1.1.19",
+                "@radix-ui/react-scroll-area": "1.2.18",
+                "@radix-ui/react-select": "2.3.7",
+                "@radix-ui/react-separator": "1.1.15",
+                "@radix-ui/react-slider": "1.4.7",
+                "@radix-ui/react-slot": "1.3.3",
+                "@radix-ui/react-switch": "1.3.7",
+                "@radix-ui/react-tabs": "1.1.21",
+                "@radix-ui/react-toast": "1.2.23",
+                "@radix-ui/react-toggle": "1.1.18",
+                "@radix-ui/react-toggle-group": "1.1.19",
+                "@radix-ui/react-toolbar": "1.1.19",
+                "@radix-ui/react-tooltip": "1.2.16",
+                "@radix-ui/react-use-callback-ref": "1.1.4",
+                "@radix-ui/react-use-controllable-state": "1.2.6",
+                "@radix-ui/react-use-effect-event": "0.0.5",
+                "@radix-ui/react-use-escape-keydown": "1.1.5",
+                "@radix-ui/react-use-is-hydrated": "0.1.3",
+                "@radix-ui/react-use-layout-effect": "1.1.4",
+                "@radix-ui/react-use-size": "1.1.4",
+                "@radix-ui/react-visually-hidden": "1.2.11"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/react": {
             "version": "19.2.8",
             "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
@@ -5488,6 +7302,92 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/react-remove-scroll": {
+            "version": "2.7.2",
+            "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+            "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+            "license": "MIT",
+            "dependencies": {
+                "react-remove-scroll-bar": "^2.3.7",
+                "react-style-singleton": "^2.2.3",
+                "tslib": "^2.1.0",
+                "use-callback-ref": "^1.3.3",
+                "use-sidecar": "^1.1.3"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/react-remove-scroll-bar": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+            "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+            "license": "MIT",
+            "dependencies": {
+                "react-style-singleton": "^2.2.2",
+                "tslib": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/react-style-singleton": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+            "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+            "license": "MIT",
+            "dependencies": {
+                "get-nonce": "^1.0.0",
+                "tslib": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/react-textarea-autosize": {
+            "version": "8.5.9",
+            "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.9.tgz",
+            "integrity": "sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.20.13",
+                "use-composed-ref": "^1.3.0",
+                "use-latest": "^1.2.1"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/readdirp": {
@@ -5617,6 +7517,12 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/safe-content-frame": {
+            "version": "0.0.28",
+            "resolved": "https://registry.npmjs.org/safe-content-frame/-/safe-content-frame-0.0.28.tgz",
+            "integrity": "sha512-P8QAY8NZOEGRNMR8ybzKKELuz3DA46NOjhZXybGcaNejLMrMBSqvrUdqNHoR1kfL0iFtWYoD7wgIzp3qRysgtQ==",
+            "license": "MIT"
+        },
         "node_modules/safe-push-apply": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -5655,6 +7561,22 @@
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
             "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
             "license": "MIT"
+        },
+        "node_modules/secure-json-parse": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+            "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "BSD-3-Clause"
         },
         "node_modules/semver": {
             "version": "6.3.1",
@@ -6065,9 +7987,7 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "dev": true,
-            "license": "0BSD",
-            "optional": true
+            "license": "0BSD"
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -6306,6 +8226,94 @@
             "peer": true,
             "dependencies": {
                 "punycode": "^2.1.0"
+            }
+        },
+        "node_modules/use-callback-ref": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+            "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/use-composed-ref": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.4.0.tgz",
+            "integrity": "sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/use-isomorphic-layout-effect": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
+            "integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/use-latest": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.3.0.tgz",
+            "integrity": "sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==",
+            "license": "MIT",
+            "dependencies": {
+                "use-isomorphic-layout-effect": "^1.1.1"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/use-sidecar": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+            "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+            "license": "MIT",
+            "dependencies": {
+                "detect-node-es": "^1.1.0",
+                "tslib": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
             }
         },
         "node_modules/use-sync-external-store": {
@@ -7140,10 +9148,38 @@
             "version": "4.5.4",
             "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
             "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
-            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/zustand": {
+            "version": "5.0.15",
+            "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.15.tgz",
+            "integrity": "sha512-MpSEjRiBkA9crSYeOUH32rJC7SVqAbm0Fqcqge/bUi2PPoLcBWKOsG+C8mevmpr8TwXHBVkChbbJiyvkE+i/3A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.20.0"
+            },
+            "peerDependencies": {
+                "@types/react": ">=18.0.0",
+                "immer": ">=9.0.6",
+                "react": ">=18.0.0",
+                "use-sync-external-store": ">=1.2.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "immer": {
+                    "optional": true
+                },
+                "react": {
+                    "optional": true
+                },
+                "use-sync-external-store": {
+                    "optional": true
+                }
             }
         }
     }

--- a/pollinations.ai/package.json
+++ b/pollinations.ai/package.json
@@ -19,6 +19,7 @@
         "deploy:production": "npm run build:production && wrangler deploy --config dist/pollinations_ai/wrangler.json"
     },
     "dependencies": {
+        "@assistant-ui/react": "^0.15.17",
         "@pollinations/sdk": "file:../packages/sdk",
         "@pollinations/ui": "file:../packages/ui",
         "@tanstack/react-router": "^1.139.3",

--- a/pollinations.ai/src/ui/play/Chat.tsx
+++ b/pollinations.ai/src/ui/play/Chat.tsx
@@ -1,4 +1,13 @@
 import {
+    AssistantRuntimeProvider,
+    MessagePrimitive,
+    type TextMessagePartProps,
+    type ThreadMessageLike,
+    ThreadPrimitive,
+    type ToolCallMessagePartProps,
+    useExternalStoreRuntime,
+} from "@assistant-ui/react";
+import {
     type AudioFormat,
     type ChatRoutingCapability,
     type MessageContentPart,
@@ -51,6 +60,7 @@ import {
 } from "react";
 import {
     type AgentChoice,
+    type AgentMessagePart,
     AUTO_ROUTING,
     agentActivity,
     agentChoices,
@@ -65,6 +75,7 @@ import {
     conversationForRequest,
     extractStreamedMedia,
     fileKind,
+    parseAgentMessage,
     type RenderedMedia,
     type RoutingChoice,
     type RoutingSelection,
@@ -238,6 +249,58 @@ function textContent(message: ConversationMessage): string {
         .filter((part) => part.type === "text")
         .map((part) => part.text)
         .join("\n");
+}
+
+function renderedAssistantMessage(message: ConversationMessage) {
+    const rawText = textContent(message);
+    const extracted = extractStreamedMedia(rawText);
+    const media = message.media?.length ? message.media : extracted.media;
+    const content =
+        message.status === "streaming"
+            ? []
+            : parseAgentMessage(rawText).reduce<AgentMessagePart[]>(
+                  (parts, part) => {
+                      if (part.type === "tool-call") {
+                          parts.push(part);
+                          return parts;
+                      }
+                      const markdown = extractStreamedMedia(part.text).markdown;
+                      if (markdown) parts.push({ ...part, text: markdown });
+                      return parts;
+                  },
+                  [],
+              );
+    return { content, media };
+}
+
+function toAssistantUiMessage(message: ConversationMessage): ThreadMessageLike {
+    if (message.role === "user") {
+        return {
+            id: message.id,
+            role: "user",
+            content: textContent(message),
+        };
+    }
+
+    const status =
+        message.status === "streaming"
+            ? ({ type: "running" } as const)
+            : message.status === "cancelled"
+              ? ({ type: "incomplete", reason: "cancelled" } as const)
+              : message.status === "error"
+                ? ({
+                      type: "incomplete",
+                      reason: "error",
+                      error: message.error || "Response interrupted",
+                  } as const)
+                : ({ type: "complete", reason: "stop" } as const);
+
+    return {
+        id: message.id,
+        role: "assistant",
+        content: renderedAssistantMessage(message).content,
+        status,
+    };
 }
 
 function AttachmentView({ attachment }: { attachment: PreparedAttachment }) {
@@ -578,6 +641,87 @@ function VideoPlayer({
     );
 }
 
+function UserTextPart({ text }: TextMessagePartProps) {
+    return <p className="whitespace-pre-wrap break-words">{text}</p>;
+}
+
+function AssistantTextPart({ text }: TextMessagePartProps) {
+    return <Markdown>{text}</Markdown>;
+}
+
+function ToolValue({ value }: { value: unknown }) {
+    const formatted =
+        typeof value === "string"
+            ? value
+            : (() => {
+                  try {
+                      return JSON.stringify(value, null, 2) ?? String(value);
+                  } catch {
+                      return String(value);
+                  }
+              })();
+    const segments = formatted.split(/(https?:\/\/[^\s"\\]+)/g);
+    let offset = 0;
+    const linkedSegments = segments.map((segment) => {
+        const key = `${offset}:${segment}`;
+        offset += segment.length;
+        return /^https?:\/\//.test(segment) ? (
+            <a
+                key={key}
+                href={segment}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline"
+            >
+                {segment}
+            </a>
+        ) : (
+            segment
+        );
+    });
+
+    return (
+        <pre className="max-h-72 overflow-auto whitespace-pre-wrap break-words rounded-lg bg-theme-bg-pale p-3 text-xs">
+            {linkedSegments}
+        </pre>
+    );
+}
+
+function AgentToolCall({
+    toolName,
+    args,
+    result,
+    isError,
+}: ToolCallMessagePartProps) {
+    return (
+        <details className="group overflow-hidden rounded-lg border border-theme-border/40 bg-theme-bg-pale">
+            <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2 text-sm font-semibold [&::-webkit-details-marker]:hidden">
+                <ChevronIcon className="size-4 transition-transform group-open:rotate-180" />
+                <span>{isError ? "Tool failed" : "Tool executed"}</span>
+                <code className="min-w-0 truncate text-xs font-normal">
+                    {toolName}
+                </code>
+            </summary>
+            <div className="flex flex-col gap-3 border-theme-border/40 border-t px-3 py-3">
+                <div className="flex flex-col gap-1">
+                    <Text size="xs" tone="muted" weight="bold">
+                        Input
+                    </Text>
+                    <ToolValue value={args} />
+                </div>
+                {result !== undefined && (
+                    <div className="flex flex-col gap-1">
+                        <Text size="xs" tone="muted" weight="bold">
+                            {isError ? "Error" : "Output"}
+                        </Text>
+                        <ToolValue value={result} />
+                    </div>
+                )}
+            </div>
+        </details>
+    );
+}
+
 function MessageCard({
     message,
     assistantName,
@@ -590,25 +734,23 @@ function MessageCard({
     onRetry: () => void;
 }) {
     const rawText = textContent(message);
-    const rendered =
-        message.role === "assistant"
-            ? message.media?.length
-                ? { markdown: "", media: message.media }
-                : extractStreamedMedia(rawText)
-            : { markdown: rawText, media: [] };
     const isUser = message.role === "user";
+    const rendered = isUser
+        ? {
+              content: rawText ? [{ type: "text", text: rawText }] : [],
+              media: [],
+          }
+        : renderedAssistantMessage(message);
     const activity = agentActivity(message);
-    const displayedMarkdown =
-        message.status === "streaming" && !isUser ? "" : rendered.markdown;
     const showArticle =
         isUser ||
-        Boolean(displayedMarkdown) ||
+        rendered.content.length > 0 ||
         message.attachments.length > 0 ||
         message.status !== "complete" ||
         canRetry;
 
     return (
-        <div
+        <MessagePrimitive.Root
             className={cn(
                 "play-chat-message flex min-w-0 flex-col gap-3",
                 isUser ? "ml-auto items-end" : "mr-auto items-start",
@@ -637,15 +779,12 @@ function MessageCard({
                     ) : (
                         <RobotIcon className="h-4 w-4 text-theme-text-strong" />
                     )}
-                    {isUser
-                        ? displayedMarkdown && (
-                              <p className="whitespace-pre-wrap break-words">
-                                  {displayedMarkdown}
-                              </p>
-                          )
-                        : displayedMarkdown && (
-                              <Markdown>{displayedMarkdown}</Markdown>
-                          )}
+                    <MessagePrimitive.Parts
+                        components={{
+                            Text: isUser ? UserTextPart : AssistantTextPart,
+                            tools: { Fallback: AgentToolCall },
+                        }}
+                    />
                     {message.attachments.length > 0 && (
                         <div className="grid gap-3 sm:grid-cols-2">
                             {message.attachments.map((attachment) => (
@@ -694,7 +833,7 @@ function MessageCard({
                     ))}
                 </div>
             )}
-        </div>
+        </MessagePrimitive.Root>
     );
 }
 
@@ -916,6 +1055,25 @@ export function Chat() {
         () => (selectedAgent ? welcomeMessage(selectedAgent) : null),
         [selectedAgent],
     );
+    const runtimeMessages = useMemo(
+        () => (selectedWelcome ? [selectedWelcome, ...messages] : messages),
+        [messages, selectedWelcome],
+    );
+    const assistantRuntime = useExternalStoreRuntime<ConversationMessage>({
+        messages: runtimeMessages,
+        convertMessage: toAssistantUiMessage,
+        isRunning: sending,
+        // Pollinations keeps ownership of uploads and routing while
+        // assistant-ui owns thread/message/tool presentation.
+        onNew: async (message) => {
+            const text = message.content
+                .filter((part) => part.type === "text")
+                .map((part) => part.text)
+                .join("\n");
+            await send(text);
+        },
+        onCancel: async () => abortRef.current?.abort(),
+    });
     const acceptedAttachmentKinds = attachmentKinds(selectedAgent);
     const attachmentAccept = [...acceptedAttachmentKinds]
         .map((kind) => ATTACHMENT_ACCEPT[kind])
@@ -1097,7 +1255,7 @@ export function Chat() {
         }
     }
 
-    async function send() {
+    async function send(messageText = draft) {
         if (sending || !isHydrated) return;
         if (!isLoggedIn || !client) {
             login();
@@ -1107,7 +1265,7 @@ export function Chat() {
             setError("Select an agent first.");
             return;
         }
-        if (!draft.trim() && files.length === 0) return;
+        if (!messageText.trim() && files.length === 0) return;
         const controller = new AbortController();
         abortRef.current = controller;
         setSending(true);
@@ -1122,7 +1280,7 @@ export function Chat() {
                 id: crypto.randomUUID(),
                 role: "user",
                 content: buildUserContent(
-                    draft,
+                    messageText,
                     attachments.map((attachment) => attachment.contentPart),
                 ),
                 status: "complete",
@@ -1294,45 +1452,54 @@ export function Chat() {
                         onSelectAgent={selectAgent}
                     />
                 </div>
-                <ScrollArea
-                    ref={transcriptRef}
-                    className="play-chat-transcript min-h-0 flex-1 py-3"
-                    aria-label="Conversation"
-                    aria-live="polite"
-                    aria-busy={sending}
-                    onScroll={(event) => {
-                        const target = event.currentTarget;
-                        followOutputRef.current =
-                            target.scrollHeight -
-                                target.scrollTop -
-                                target.clientHeight <
-                            96;
-                    }}
-                >
-                    <div className="flex flex-col gap-5">
-                        {selectedWelcome && (
-                            <MessageCard
-                                message={selectedWelcome}
-                                assistantName={assistantName}
-                                canRetry={false}
-                                onRetry={() => undefined}
-                            />
-                        )}
-                        {messages.map((message) => (
-                            <MessageCard
-                                key={message.id}
-                                message={message}
-                                assistantName={assistantName}
-                                canRetry={
-                                    canRetryLast(message.id) &&
-                                    (message.status === "error" ||
-                                        message.status === "cancelled")
-                                }
-                                onRetry={() => void retry(message.id)}
-                            />
-                        ))}
-                    </div>
-                </ScrollArea>
+                <AssistantRuntimeProvider runtime={assistantRuntime}>
+                    <ThreadPrimitive.Root className="contents">
+                        <ScrollArea
+                            ref={transcriptRef}
+                            className="play-chat-transcript min-h-0 flex-1 py-3"
+                            aria-label="Conversation"
+                            aria-live="polite"
+                            aria-busy={sending}
+                            onScroll={(event) => {
+                                const target = event.currentTarget;
+                                followOutputRef.current =
+                                    target.scrollHeight -
+                                        target.scrollTop -
+                                        target.clientHeight <
+                                    96;
+                            }}
+                        >
+                            <div className="flex flex-col gap-5">
+                                <ThreadPrimitive.Messages>
+                                    {({ message: runtimeMessage }) => {
+                                        const message = runtimeMessages.find(
+                                            (candidate) =>
+                                                candidate.id ===
+                                                runtimeMessage.id,
+                                        );
+                                        if (!message) return null;
+                                        return (
+                                            <MessageCard
+                                                message={message}
+                                                assistantName={assistantName}
+                                                canRetry={
+                                                    canRetryLast(message.id) &&
+                                                    (message.status ===
+                                                        "error" ||
+                                                        message.status ===
+                                                            "cancelled")
+                                                }
+                                                onRetry={() =>
+                                                    void retry(message.id)
+                                                }
+                                            />
+                                        );
+                                    }}
+                                </ThreadPrimitive.Messages>
+                            </div>
+                        </ScrollArea>
+                    </ThreadPrimitive.Root>
+                </AssistantRuntimeProvider>
                 <form
                     onSubmit={submit}
                     className="relative flex shrink-0 flex-col gap-3 pt-3"

--- a/pollinations.ai/src/ui/play/Chat.tsx
+++ b/pollinations.ai/src/ui/play/Chat.tsx
@@ -660,12 +660,12 @@ function ToolValue({ value }: { value: unknown }) {
                       return String(value);
                   }
               })();
-    const segments = formatted.split(/(https?:\/\/[^\s"\\]+)/g);
+    const segments = formatted.split(/(https:\/\/[^\s"\\]+)/g);
     let offset = 0;
     const linkedSegments = segments.map((segment) => {
         const key = `${offset}:${segment}`;
         offset += segment.length;
-        return /^https?:\/\//.test(segment) ? (
+        return segment.startsWith("https://") ? (
             <a
                 key={key}
                 href={segment}

--- a/pollinations.ai/src/ui/play/chat-models.test.ts
+++ b/pollinations.ai/src/ui/play/chat-models.test.ts
@@ -13,6 +13,7 @@ import {
     conversationForRequest,
     extractStreamedMedia,
     fileKind,
+    parseAgentMessage,
     routingChoices,
     supportsRoutingField,
 } from "./chat-models";
@@ -231,6 +232,60 @@ describe("chat conversation history", () => {
             { role: "assistant", content: "hi" },
             { role: "user", content: "continue" },
             { role: "assistant", content: "partial" },
+        ]);
+    });
+});
+
+describe("agent tool-call rendering", () => {
+    it("converts completed tool details into a structured message part", () => {
+        const content =
+            'I found it.\n\n<details type="tool_calls" done="true" id="call-1" ' +
+            'name="SEARCH_WEB" arguments="{&quot;query&quot;:&quot;pollinations&quot;}">\n' +
+            "<summary>Tool Executed</summary>\n" +
+            "{&quot;results&quot;:[{&quot;title&quot;:&quot;Pollinations &amp; friends&quot;}]}\n" +
+            "</details>\n\nDone.";
+
+        expect(parseAgentMessage(content)).toEqual([
+            { type: "text", text: "I found it.\n\n" },
+            {
+                type: "tool-call",
+                toolCallId: "call-1",
+                toolName: "SEARCH_WEB",
+                args: { query: "pollinations" },
+                argsText: '{"query":"pollinations"}',
+                result: {
+                    results: [{ title: "Pollinations & friends" }],
+                },
+                isError: false,
+            },
+            { type: "text", text: "\n\nDone." },
+        ]);
+    });
+
+    it("marks failed tools and keeps their readable error", () => {
+        const content =
+            '<details type="tool_calls" done="true" id="call-2" ' +
+            'name="SEND_EMAIL" arguments="{}">\n' +
+            "<summary>Tool Failed</summary>\nMailbox unavailable\n</details>";
+
+        expect(parseAgentMessage(content)).toEqual([
+            {
+                type: "tool-call",
+                toolCallId: "call-2",
+                toolName: "SEND_EMAIL",
+                args: {},
+                argsText: "{}",
+                result: "Mailbox unavailable",
+                isError: true,
+            },
+        ]);
+    });
+
+    it("leaves malformed or unrelated details as text", () => {
+        const content =
+            "<details><summary>More</summary>Not a tool call</details>";
+        expect(parseAgentMessage(content)).toEqual([
+            { type: "text", text: content },
         ]);
     });
 });

--- a/pollinations.ai/src/ui/play/chat-models.ts
+++ b/pollinations.ai/src/ui/play/chat-models.ts
@@ -56,9 +56,112 @@ export interface AgentToolActivity {
     status: "running" | "failed";
 }
 
+type JsonValue =
+    | string
+    | number
+    | boolean
+    | null
+    | JsonValue[]
+    | { [key: string]: JsonValue };
+
+export type AgentMessagePart =
+    | { type: "text"; text: string }
+    | {
+          type: "tool-call";
+          toolCallId: string;
+          toolName: string;
+          args: { [key: string]: JsonValue };
+          argsText: string;
+          result: unknown;
+          isError: boolean;
+      };
+
 export interface AgentResourceCandidate extends RenderedMedia {
     callId: string;
     mediaType?: string;
+}
+
+const TOOL_DETAILS_PATTERN =
+    /<details\b([^>]*)>\s*<summary>([\s\S]*?)<\/summary>\s*([\s\S]*?)<\/details>/gi;
+const DETAILS_ATTRIBUTE_PATTERN = /([\w:-]+)\s*=\s*"([^"]*)"/g;
+
+function decodeAgentHtml(value: string): string {
+    return value.replace(
+        /&(amp|lt|gt|quot|#39);/g,
+        (entity) =>
+            ({
+                "&amp;": "&",
+                "&lt;": "<",
+                "&gt;": ">",
+                "&quot;": '"',
+                "&#39;": "'",
+            })[entity] ?? entity,
+    );
+}
+
+function detailsAttributes(source: string): Record<string, string> {
+    const attributes: Record<string, string> = {};
+    for (const match of source.matchAll(DETAILS_ATTRIBUTE_PATTERN)) {
+        attributes[match[1]] = decodeAgentHtml(match[2]);
+    }
+    return attributes;
+}
+
+function jsonObject(source: string): { [key: string]: JsonValue } {
+    try {
+        const parsed = JSON.parse(source) as JsonValue;
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed))
+            return parsed;
+        return { value: parsed };
+    } catch {
+        return {};
+    }
+}
+
+function toolResult(source: string): unknown {
+    const decoded = decodeAgentHtml(source.trim());
+    try {
+        return JSON.parse(decoded) as unknown;
+    } catch {
+        return decoded;
+    }
+}
+
+/** Convert managed-agent tool markup into assistant-ui compatible parts. */
+export function parseAgentMessage(content: string): AgentMessagePart[] {
+    const parts: AgentMessagePart[] = [];
+    let cursor = 0;
+
+    for (const match of content.matchAll(TOOL_DETAILS_PATTERN)) {
+        const index = match.index;
+        if (index > cursor)
+            parts.push({ type: "text", text: content.slice(cursor, index) });
+
+        const attributes = detailsAttributes(match[1]);
+        if (
+            attributes.type !== "tool_calls" ||
+            !attributes.id ||
+            !attributes.name
+        ) {
+            parts.push({ type: "text", text: match[0] });
+        } else {
+            const argsText = attributes.arguments || "{}";
+            parts.push({
+                type: "tool-call",
+                toolCallId: attributes.id,
+                toolName: attributes.name,
+                args: jsonObject(argsText),
+                argsText,
+                result: toolResult(match[3]),
+                isError: decodeAgentHtml(match[2]) === "Tool Failed",
+            });
+        }
+        cursor = index + match[0].length;
+    }
+
+    if (cursor < content.length)
+        parts.push({ type: "text", text: content.slice(cursor) });
+    return parts.length > 0 ? parts : [{ type: "text", text: content }];
 }
 
 export type ChatMessageStatus =


### PR DESCRIPTION
- Adds assistant-ui’s external-store runtime and thread/message primitives while preserving the Pollinations SDK transport, agent selector, uploads, routing, and cancellation.
- Converts the managed-agent `<details type="tool_calls">` wire format into typed tool-call message parts without rendering raw HTML or re-executing server-side tools.
- Renders collapsible tool input, output, and error details, including clickable HTTPS links in tool data.
- Keeps `react-markdown` for prose; `marked-react` would still display these custom HTML blocks as text, while Vercel `useChat` would require a UI Message Stream transport migration.
- Tests: 38 chat-model tests; `npm run build` in `pollinations.ai`.