### PR TITLE
feat: add GIMP 3 Pollinations plug-in

### DIFF
--- a/apps/gimp-pollinations/README.md
+++ b/apps/gimp-pollinations/README.md
@@ -18,7 +18,8 @@ convention.
   The desktop's `secret-tool` command (normally provided by libsecret) stores
   the authorization in the login keyring.
 - macOS: use the Plug-ins folder shown in **Preferences → Folders → Plug-ins**,
-  then restart GIMP. The authorization is stored in Keychain.
+  then restart GIMP. The authorization is stored through Keychain Services and
+  is never passed to a command-line process.
 - Windows: use the Plug-ins folder shown in **Preferences → Folders → Plug-ins**,
   then restart GIMP. The authorization is encrypted with Windows DPAPI for the
   signed-in user.
@@ -39,15 +40,21 @@ publishers create their own App Key at <https://enter.pollinations.ai/keys>.
 After connecting, the model picker calls authenticated
 `https://gen.pollinations.ai/image/models`. This returns every image-output
 model visible to the connected account, including that account's community
-models. The picker hides video-only records. Image editing is enabled only when
-the selected model advertises `image` in `input_modalities`; resolution choices
-are shown only when the selected model advertises `resolutions`.
+models. The picker hides video-only records. Image editing is enabled when the
+model advertises image input or `/v1/images/edits` in `supported_endpoints`, so
+models such as `zimage` are not incorrectly excluded. Resolution choices are
+shown only when the selected model advertises `resolutions`.
 
 Enter a prompt and choose **Generate** to add a new result layer. To edit,
 select a paintable layer and tick **Edit the active layer**. Optionally tick
 **Use the current selection** to send its bounds. The source is exported from a
-new temporary image and the returned image is inserted as a new layer. The
-source layer is not modified.
+new temporary image. The returned layer is scaled to those selection bounds and
+placed at the selection's canvas offset. The source layer is not modified. A
+seed control makes text-to-image prompts reproducible.
+
+Model loading, device polling, generation, and editing run on background
+threads. GIMP's GTK event loop remains responsive while network requests are in
+flight, and closing the dialog safely discards late callbacks.
 
 The plug-in gives actionable messages for expired/revoked authorization
 (connect again), HTTP 402 (add Pollen), connection failures, malformed API

--- a/apps/gimp-pollinations/README.md
+++ b/apps/gimp-pollinations/README.md
@@ -1,0 +1,72 @@
+# Pollinations for GIMP 3
+
+Generate images and edit the active layer in GIMP 3 using the Pollen in the
+artist's own Pollinations account. The plug-in uses Pollinations' browser-based
+BYOP device authorization. It never asks for, stores in preferences, or sends
+a user API key through a URL.
+
+## Install
+
+GIMP 3 and its Python plug-in support are required. Download or clone this
+directory, then create a `pollinations-gimp` directory in GIMP's plug-ins
+folder and put both `pollinations-gimp.py` and `pollinations_gimp.py` in it.
+The directory and script names intentionally match GIMP's plug-in discovery
+convention.
+
+- Linux: use **Edit → Preferences → Folders → Plug-ins** to find the active
+  folder, copy the directory there, then run `chmod u+x pollinations-gimp.py`.
+  The desktop's `secret-tool` command (normally provided by libsecret) stores
+  the authorization in the login keyring.
+- macOS: use the Plug-ins folder shown in **Preferences → Folders → Plug-ins**,
+  then restart GIMP. The authorization is stored in Keychain.
+- Windows: use the Plug-ins folder shown in **Preferences → Folders → Plug-ins**,
+  then restart GIMP. The authorization is encrypted with Windows DPAPI for the
+  signed-in user.
+
+In GIMP, choose **Filters → Artistic → Pollinations Image…**. Enter the
+plug-in publisher's public `pk_` App Key and choose **Connect**. GIMP opens the
+Pollinations approval page and displays the same short code. Approval returns
+a private user authorization that is stored in the operating system credential
+store and survives GIMP restarts. **Disconnect** removes it locally.
+
+An App Key is public integration attribution, not a user credential. A released
+build can set `POLLINATIONS_GIMP_APP_KEY` before GIMP starts so users do not
+need to enter it. The plug-in intentionally does not include a placeholder key:
+publishers create their own App Key at <https://enter.pollinations.ai/keys>.
+
+## Use
+
+After connecting, the model picker calls authenticated
+`https://gen.pollinations.ai/image/models`. This returns every image-output
+model visible to the connected account, including that account's community
+models. The picker hides video-only records. Image editing is enabled only when
+the selected model advertises `image` in `input_modalities`; resolution choices
+are shown only when the selected model advertises `resolutions`.
+
+Enter a prompt and choose **Generate** to add a new result layer. To edit,
+select a paintable layer and tick **Edit the active layer**. Optionally tick
+**Use the current selection** to send its bounds. The source is exported from a
+new temporary image and the returned image is inserted as a new layer. The
+source layer is not modified.
+
+The plug-in gives actionable messages for expired/revoked authorization
+(connect again), HTTP 402 (add Pollen), connection failures, malformed API
+responses, and invalid model/authorization responses.
+
+## Reproducible verification
+
+The protocol code has no GIMP runtime dependency. Run focused tests with:
+
+```sh
+python3 -m unittest discover -s apps/gimp-pollinations/tests -v
+```
+
+For a manual GIMP 3 demonstration: install the files, connect through the
+opened approval page, verify that community models appear for an account that
+owns one, generate a new layer, then select an image-input model and edit an
+active layer. Disconnect, restart GIMP, and reopen the dialog to verify that
+the operating-system credential store restored the connection.
+
+## License
+
+Apache-2.0. See the repository's [LICENSE](../../LICENSE).

--- a/apps/gimp-pollinations/README.md
+++ b/apps/gimp-pollinations/README.md
@@ -54,7 +54,8 @@ seed control makes text-to-image prompts reproducible.
 
 Model loading, device polling, generation, and editing run on background
 threads. GIMP's GTK event loop remains responsive while network requests are in
-flight, and closing the dialog safely discards late callbacks.
+flight. During generation or editing, **Cancel request** discards any late
+response and leaves the dialog open for another attempt.
 
 The plug-in gives actionable messages for expired/revoked authorization
 (connect again), HTTP 402 (add Pollen), connection failures, malformed API

--- a/apps/gimp-pollinations/pollinations-gimp.py
+++ b/apps/gimp-pollinations/pollinations-gimp.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import os
 import sys
 import tempfile
+import threading
 import webbrowser
 from pathlib import Path
 
@@ -14,14 +15,14 @@ import gi
 gi.require_version("Gimp", "3.0")
 gi.require_version("GimpUi", "3.0")
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gimp, GimpUi, Gio, GLib, GObject, Gtk
+from gi.repository import Gimp, GimpUi, Gio, GLib, Gtk
 
 from pollinations_gimp import (
-    AuthorizationExpiredError,
     DeviceAuthorization,
     ImageModel,
     PollinationsClient,
     PollinationsError,
+    SlowDownError,
     TokenStore,
 )
 
@@ -42,16 +43,23 @@ def load_app_key() -> str:
 
 
 def save_app_key(value: str) -> None:
-    CONFIG_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
-    CONFIG_FILE.write_text(value.strip(), encoding="utf-8")
-    os.chmod(CONFIG_FILE, 0o600)
+    try:
+        CONFIG_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+        CONFIG_FILE.write_text(value.strip(), encoding="utf-8")
+        os.chmod(CONFIG_FILE, 0o600)
+    except OSError as error:
+        raise PollinationsError(
+            "GIMP could not save the public App Key in your preferences."
+        ) from error
 
 
 class PollinationsDialog(Gtk.Dialog):
     def __init__(self, image: Gimp.Image, drawable: Gimp.Drawable | None) -> None:
         super().__init__(title="Pollinations", flags=Gtk.DialogFlags.MODAL)
         self.add_button("Cancel", Gtk.ResponseType.CANCEL)
-        self.add_button("Generate", Gtk.ResponseType.OK)
+        self.generate_button = Gtk.Button(label="Generate")
+        self.generate_button.connect("clicked", self._start_generation)
+        self.get_action_area().pack_end(self.generate_button, False, False, 0)
         self.set_default_size(520, -1)
         self.image, self.drawable = image, drawable
         self.store = TokenStore()
@@ -59,6 +67,12 @@ class PollinationsDialog(Gtk.Dialog):
         self.models: list[ImageModel] = []
         self.device: DeviceAuthorization | None = None
         self.poll_source: int | None = None
+        self.poll_interval = 5
+        self.result: bytes | None = None
+        self.result_placement: tuple[int, int, int, int] | None = None
+        self._alive = True
+        self._job_id = 0
+        self.connect("destroy", self._destroyed)
 
         box = self.get_content_area()
         box.set_spacing(8)
@@ -91,8 +105,11 @@ class PollinationsDialog(Gtk.Dialog):
         self.model_picker.connect("changed", self._model_changed)
         self.resolution_picker = Gtk.ComboBoxText()
         self.resolution_row = Gtk.Box(spacing=6)
-        self.resolution_row.pack_start(Gtk.Label(label="Resolution"), False, False, 0)
+        self.resolution_row.pack_start(
+            Gtk.Label(label="Resolution"), False, False, 0
+        )
         self.resolution_row.pack_start(self.resolution_picker, False, False, 0)
+        self.resolution_row.set_no_show_all(True)
         self.resolution_row.set_visible(False)
         model_row = Gtk.Box(spacing=6)
         model_row.pack_start(Gtk.Label(label="Model"), False, False, 0)
@@ -111,10 +128,21 @@ class PollinationsDialog(Gtk.Dialog):
         dimensions.pack_start(self.height, False, False, 0)
         box.pack_start(dimensions, False, False, 0)
 
-        self.edit_source = Gtk.CheckButton(label="Edit the active layer (keeps the source layer unchanged)")
+        seed_row = Gtk.Box(spacing=6)
+        self.seed = Gtk.SpinButton.new_with_range(0, 2147483647, 1)
+        self.seed.set_value(0)
+        seed_row.pack_start(Gtk.Label(label="Seed"), False, False, 0)
+        seed_row.pack_start(self.seed, False, False, 0)
+        box.pack_start(seed_row, False, False, 0)
+
+        self.edit_source = Gtk.CheckButton(
+            label="Edit the active layer (keeps the source layer unchanged)"
+        )
         self.edit_source.set_sensitive(False)
         box.pack_start(self.edit_source, False, False, 0)
-        self.use_selection = Gtk.CheckButton(label="Use the current selection as the edit source")
+        self.use_selection = Gtk.CheckButton(
+            label="Use the current selection as the edit source"
+        )
         self.use_selection.set_sensitive(False)
         box.pack_start(self.use_selection, False, False, 0)
         self._refresh_models()
@@ -123,66 +151,156 @@ class PollinationsDialog(Gtk.Dialog):
     def _set_status(self, message: str) -> None:
         self.status.set_text(message)
 
+    def _set_busy(self, busy: bool) -> None:
+        self.generate_button.set_sensitive(not busy)
+        self.connect_button.set_sensitive(not busy)
+        self.disconnect_button.set_sensitive(not busy)
+
+    def _run_worker(self, task, callback) -> None:
+        self._job_id += 1
+        job_id = self._job_id
+
+        def work() -> None:
+            try:
+                result, error = task(), None
+            except PollinationsError as caught:
+                result, error = None, caught
+            except Exception:
+                result = None
+                error = PollinationsError(
+                    "The operation failed unexpectedly. Please try again."
+                )
+            GLib.idle_add(self._finish_worker, job_id, callback, result, error)
+
+        threading.Thread(target=work, daemon=True).start()
+
+    def _finish_worker(self, job_id, callback, result, error) -> bool:
+        if self._alive and job_id == self._job_id:
+            callback(result, error)
+        return False
+
+    def _destroyed(self, _dialog: Gtk.Dialog) -> None:
+        self._alive = False
+        self._job_id += 1
+        if self.poll_source is not None:
+            GLib.source_remove(self.poll_source)
+            self.poll_source = None
+
     def _connect(self, _button: Gtk.Button) -> None:
         try:
             save_app_key(self.app_key.get_text())
-            self.device = self.client.start_device_authorization(self.app_key.get_text().strip())
-            webbrowser.open(self.device.verification_uri_complete)
-            self._set_status(
-                f"A browser was opened. Approve Pollinations access with code {self.device.user_code}."
-            )
-            if self.poll_source:
-                GLib.source_remove(self.poll_source)
-            self.poll_source = GLib.timeout_add_seconds(self.device.interval, self._poll_connection)
         except PollinationsError as error:
             self._set_status(str(error))
+            return
+        app_key = self.app_key.get_text().strip()
+        self._set_busy(True)
+        self._set_status("Starting Pollinations authorization…")
+
+        def start():
+            device = self.client.start_device_authorization(app_key)
+            webbrowser.open(device.verification_uri_complete)
+            return device
+
+        self._run_worker(start, self._authorization_started)
+
+    def _authorization_started(self, device, error) -> None:
+        if error:
+            self._set_busy(False)
+            self._set_status(str(error))
+            return
+        self.device = device
+        self.poll_interval = device.interval
+        self._set_status(
+            f"A browser was opened. Approve Pollinations access with code {device.user_code}."
+        )
+        self._schedule_poll()
+
+    def _schedule_poll(self) -> None:
+        self.poll_source = GLib.timeout_add_seconds(
+            self.poll_interval, self._poll_connection
+        )
 
     def _poll_connection(self) -> bool:
-        try:
-            if not self.device:
-                return False
-            token = self.client.poll_device_authorization(self.device.device_code)
-            if not token:
-                return True
-            self.store.save(token)
-            self.device = None
-            self.poll_source = None
-            self._set_status("Connected. Your authorization is stored in your system keychain.")
-            self._refresh_models()
+        self.poll_source = None
+        if not self.device:
             return False
-        except PollinationsError as error:
+        device_code = self.device.device_code
+
+        def poll():
+            token = self.client.poll_device_authorization(device_code)
+            if token:
+                self.store.save(token)
+            return token
+
+        self._run_worker(poll, self._authorization_polled)
+        return False
+
+    def _authorization_polled(self, token, error) -> None:
+        if isinstance(error, SlowDownError):
+            self.poll_interval += 5
+            self._schedule_poll()
+            return
+        if error:
             self.device = None
-            self.poll_source = None
+            self._set_busy(False)
             self._set_status(str(error))
-            return False
+            return
+        if not token:
+            self._schedule_poll()
+            return
+        self.device = None
+        self._set_status(
+            "Connected. Your authorization is stored in your system keychain."
+        )
+        self._refresh_models()
 
     def _disconnect(self, _button: Gtk.Button) -> None:
-        self.store.clear()
         self.client.token = None
         self.models = []
         self.model_picker.remove_all()
         self.edit_source.set_sensitive(False)
-        self._set_status("Disconnected. The authorization was removed from this computer.")
+        self.use_selection.set_sensitive(False)
+        self._set_busy(True)
+
+        def disconnected(_result, error) -> None:
+            self._set_busy(False)
+            self._set_status(
+                str(error)
+                if error
+                else "Disconnected. The authorization was removed from this computer."
+            )
+
+        self._run_worker(self.store.clear, disconnected)
 
     def _refresh_models(self) -> None:
         if not self.client.token:
-            self._set_status("Connect your Pollinations account to load the models available to you.")
+            self._set_status(
+                "Connect your Pollinations account to load the models available to you."
+            )
             return
-        try:
-            self.models = self.client.list_image_models()
-            self.model_picker.remove_all()
-            for model in self.models:
-                label = f"{model.title} ({model.id})"
-                if model.community:
-                    label += " — community"
-                self.model_picker.append(model.id, label)
-            if self.models:
-                self.model_picker.set_active(0)
-                self._set_status(f"Connected. Loaded {len(self.models)} image models for this account.")
-            else:
-                self._set_status("No image models are available to this account.")
-        except PollinationsError as error:
+        self._set_busy(True)
+        self._set_status("Loading the image models available to this account…")
+        self._run_worker(self.client.list_image_models, self._models_loaded)
+
+    def _models_loaded(self, models, error) -> None:
+        self._set_busy(False)
+        if error:
             self._set_status(str(error))
+            return
+        self.models = models
+        self.model_picker.remove_all()
+        for model in self.models:
+            label = f"{model.title} ({model.id})"
+            if model.community:
+                label += " — community"
+            self.model_picker.append(model.id, label)
+        if self.models:
+            self.model_picker.set_active(0)
+            self._set_status(
+                f"Connected. Loaded {len(self.models)} image models for this account."
+            )
+        else:
+            self._set_status("No image models are available to this account.")
 
     def _selected_model(self) -> ImageModel | None:
         active_id = self.model_picker.get_active_id()
@@ -204,9 +322,13 @@ class PollinationsDialog(Gtk.Dialog):
         if model.resolutions:
             self.resolution_picker.set_active(0)
 
-    def values(self) -> tuple[str, ImageModel, bool, bool, int, int, str | None]:
+    def values(
+        self,
+    ) -> tuple[str, ImageModel, bool, bool, int, int, str | None, int]:
         prompt = self.prompt.get_buffer().get_text(
-            self.prompt.get_buffer().get_start_iter(), self.prompt.get_buffer().get_end_iter(), False
+            self.prompt.get_buffer().get_start_iter(),
+            self.prompt.get_buffer().get_end_iter(),
+            False,
         ).strip()
         model = self._selected_model()
         if not prompt:
@@ -220,53 +342,136 @@ class PollinationsDialog(Gtk.Dialog):
             self.use_selection.get_active(),
             self.width.get_value_as_int(),
             self.height.get_value_as_int(),
-            self.resolution_picker.get_active_text() if model.resolutions else None,
+            (
+                self.resolution_picker.get_active_text()
+                if model.resolutions
+                else None
+            ),
+            self.seed.get_value_as_int(),
         )
 
+    def _start_generation(self, _button: Gtk.Button) -> None:
+        try:
+            prompt, model, edit, selection_only, width, height, resolution, seed = (
+                self.values()
+            )
+            if edit:
+                if not self.drawable or not model.accepts_image:
+                    raise PollinationsError(
+                        "The selected model does not support image editing."
+                    )
+                source_path, placement = export_source_layer(
+                    self.image, self.drawable, selection_only
+                )
+            else:
+                source_path, placement = None, None
+        except PollinationsError as error:
+            self._set_status(str(error))
+            return
 
-def export_source_layer(image: Gimp.Image, drawable: Gimp.Drawable, selection_only: bool) -> Path:
+        self._set_busy(True)
+        self._set_status(
+            "Editing with Pollinations…"
+            if edit
+            else "Generating with Pollinations…"
+        )
+
+        def generate():
+            if source_path:
+                try:
+                    return self.client.edit(prompt, model, source_path, resolution)
+                finally:
+                    source_path.unlink(missing_ok=True)
+            return self.client.generate(prompt, model, width, height, resolution, seed)
+
+        def generated(result, error) -> None:
+            self._set_busy(False)
+            if error:
+                self._set_status(str(error))
+                return
+            self.result = result
+            self.result_placement = placement
+            self.response(Gtk.ResponseType.OK)
+
+        self._run_worker(generate, generated)
+
+
+def export_source_layer(
+    image: Gimp.Image, drawable: Gimp.Drawable, selection_only: bool
+) -> tuple[Path, tuple[int, int, int, int] | None]:
     """Export only a copied active layer, so no source image data is changed."""
-    duplicate = Gimp.Image.new(image.get_width(), image.get_height(), image.get_base_type())
+    duplicate = Gimp.Image.new(
+        image.get_width(), image.get_height(), image.get_base_type()
+    )
     duplicate_layer = Gimp.Layer.new_from_drawable(drawable, duplicate)
     duplicate.insert_layer(duplicate_layer, None, 0)
-    if selection_only:
-        _success, non_empty, x1, y1, x2, y2 = Gimp.Selection.bounds(image)
-        if not non_empty:
-            raise PollinationsError("Make a selection first, or untick Use the current selection.")
-        duplicate.crop(x2 - x1, y2 - y1, x1, y1)
-    selected = duplicate.get_selected_drawables()
-    if not selected:
-        raise PollinationsError("Select a paintable layer before using image editing.")
+    placement = None
     handle, filename = tempfile.mkstemp(suffix=".png", prefix="pollinations-gimp-")
     os.close(handle)
     path = Path(filename)
     try:
+        if selection_only:
+            _success, non_empty, x1, y1, x2, y2 = Gimp.Selection.bounds(image)
+            if not non_empty:
+                raise PollinationsError(
+                    "Make a selection first, or untick Use the current selection."
+                )
+            placement = (x1, y1, x2 - x1, y2 - y1)
+            duplicate.crop(placement[2], placement[3], x1, y1)
         saved = Gimp.file_save(
-            Gimp.RunMode.NONINTERACTIVE, duplicate, Gio.File.new_for_path(str(path)), None
+            Gimp.RunMode.NONINTERACTIVE,
+            duplicate,
+            Gio.File.new_for_path(str(path)),
+            None,
         )
         if not saved:
             raise RuntimeError("GIMP did not export the source layer")
-        return path
+        return path, placement
     except Exception as error:
         path.unlink(missing_ok=True)
-        raise PollinationsError("GIMP could not export the active layer for editing.") from error
+        if isinstance(error, PollinationsError):
+            raise
+        raise PollinationsError(
+            "GIMP could not export the active layer for editing."
+        ) from error
+    finally:
+        duplicate.delete()
 
 
-def add_result_as_layer(image: Gimp.Image, source: Gimp.Drawable | None, result: bytes) -> None:
-    handle, filename = tempfile.mkstemp(suffix=".png", prefix="pollinations-gimp-result-")
+def add_result_as_layer(
+    image: Gimp.Image,
+    source: Gimp.Drawable | None,
+    result: bytes,
+    placement: tuple[int, int, int, int] | None,
+) -> None:
+    handle, filename = tempfile.mkstemp(
+        suffix=".png", prefix="pollinations-gimp-result-"
+    )
     os.close(handle)
     path = Path(filename)
+    generated = None
     try:
         path.write_bytes(result)
-        generated = Gimp.file_load(Gimp.RunMode.NONINTERACTIVE, Gio.File.new_for_path(str(path)))
+        generated = Gimp.file_load(
+            Gimp.RunMode.NONINTERACTIVE, Gio.File.new_for_path(str(path))
+        )
         generated_layer = generated.get_layers()[0]
         layer = Gimp.Layer.new_from_drawable(generated_layer, image)
         layer.set_name("Pollinations result")
-        position = image.get_item_position(source) + 1 if source else 0
-        image.insert_layer(layer, None, position)
+        parent = source.get_parent() if source else None
+        position = image.get_item_position(source) if source else 0
+        image.insert_layer(layer, parent, position)
+        if placement:
+            x, y, width, height = placement
+            layer.scale(width, height, False)
+            layer.set_offsets(x, y)
     except Exception as error:
-        raise PollinationsError("GIMP could not add Pollinations' result as a layer.") from error
+        raise PollinationsError(
+            "GIMP could not add Pollinations' result as a layer."
+        ) from error
     finally:
+        if generated:
+            generated.delete()
         path.unlink(missing_ok=True)
 
 
@@ -278,32 +483,31 @@ def run(procedure, run_mode, image, drawables, config, data):
     if response != Gtk.ResponseType.OK:
         dialog.destroy()
         return procedure.new_return_values(Gimp.PDBStatusType.CANCEL, None)
+    result = dialog.result
+    placement = dialog.result_placement
+    dialog.destroy()
+    if result is None:
+        return procedure.new_return_values(
+            Gimp.PDBStatusType.EXECUTION_ERROR,
+            GLib.Error(message="Pollinations did not return an image."),
+        )
     undo_started = False
     try:
-        prompt, model, edit, selection_only, width, height, resolution = dialog.values()
-        client = dialog.client
-        dialog.destroy()
-        if edit:
-            if not drawable or not model.accepts_image:
-                raise PollinationsError("The selected model does not support image editing.")
-            source_path = export_source_layer(image, drawable, selection_only)
-            try:
-                result = client.edit(prompt, model, source_path, resolution)
-            finally:
-                source_path.unlink(missing_ok=True)
-        else:
-            result = client.generate(prompt, model, width, height, resolution)
         image.undo_group_start()
         undo_started = True
-        add_result_as_layer(image, drawable, result)
+        add_result_as_layer(image, drawable, result, placement)
         image.undo_group_end()
         undo_started = False
+        Gimp.displays_flush()
         return procedure.new_return_values(Gimp.PDBStatusType.SUCCESS, None)
     except PollinationsError as error:
         if undo_started:
             image.undo_group_end()
         Gimp.message(str(error))
-        return procedure.new_return_values(Gimp.PDBStatusType.EXECUTION_ERROR, GLib.Error(message=str(error)))
+        return procedure.new_return_values(
+            Gimp.PDBStatusType.EXECUTION_ERROR,
+            GLib.Error(message=str(error)),
+        )
 
 
 class PollinationsGimp(Gimp.PlugIn):
@@ -313,15 +517,19 @@ class PollinationsGimp(Gimp.PlugIn):
     def do_create_procedure(self, name):
         if name != PROCEDURE:
             return None
-        procedure = Gimp.ImageProcedure.new(self, name, Gimp.PDBProcType.PLUGIN, run, None)
+        procedure = Gimp.ImageProcedure.new(
+            self, name, Gimp.PDBProcType.PLUGIN, run, None
+        )
         procedure.set_sensitivity_mask(
-            Gimp.ProcedureSensitivityMask.DRAWABLE | Gimp.ProcedureSensitivityMask.NO_DRAWABLES
+            Gimp.ProcedureSensitivityMask.DRAWABLE
+            | Gimp.ProcedureSensitivityMask.NO_DRAWABLES
         )
         procedure.set_menu_label("_Pollinations Image…")
         procedure.add_menu_path("<Image>/Filters/Artistic")
         procedure.set_documentation(
             "Generate or edit images with a connected Pollinations account.",
-            "Uses browser-based Pollinations device authorization; no API key is pasted into GIMP.",
+            "Uses browser-based Pollinations device authorization; no API key "
+            "is pasted into GIMP.",
             None,
         )
         procedure.set_attribution("Pollinations contributors", "Apache-2.0", "2026")

--- a/apps/gimp-pollinations/pollinations-gimp.py
+++ b/apps/gimp-pollinations/pollinations-gimp.py
@@ -60,6 +60,13 @@ class PollinationsDialog(Gtk.Dialog):
         self.generate_button = Gtk.Button(label="Generate")
         self.generate_button.connect("clicked", self._start_generation)
         self.get_action_area().pack_end(self.generate_button, False, False, 0)
+        self.cancel_request_button = Gtk.Button(label="Cancel request")
+        self.cancel_request_button.connect("clicked", self._cancel_generation)
+        self.cancel_request_button.set_no_show_all(True)
+        self.cancel_request_button.set_visible(False)
+        self.get_action_area().pack_end(
+            self.cancel_request_button, False, False, 0
+        )
         self.set_default_size(520, -1)
         self.image, self.drawable = image, drawable
         self.store = TokenStore()
@@ -155,6 +162,8 @@ class PollinationsDialog(Gtk.Dialog):
         self.generate_button.set_sensitive(not busy)
         self.connect_button.set_sensitive(not busy)
         self.disconnect_button.set_sensitive(not busy)
+        if not busy:
+            self.cancel_request_button.set_visible(False)
 
     def _run_worker(self, task, callback) -> None:
         self._job_id += 1
@@ -197,9 +206,7 @@ class PollinationsDialog(Gtk.Dialog):
         self._set_status("Starting Pollinations authorization…")
 
         def start():
-            device = self.client.start_device_authorization(app_key)
-            webbrowser.open(device.verification_uri_complete)
-            return device
+            return self.client.start_device_authorization(app_key)
 
         self._run_worker(start, self._authorization_started)
 
@@ -210,9 +217,16 @@ class PollinationsDialog(Gtk.Dialog):
             return
         self.device = device
         self.poll_interval = device.interval
-        self._set_status(
-            f"A browser was opened. Approve Pollinations access with code {device.user_code}."
-        )
+        opened = webbrowser.open(device.verification_uri_complete)
+        if opened:
+            self._set_status(
+                f"A browser was opened. Approve Pollinations access with code {device.user_code}."
+            )
+        else:
+            self._set_status(
+                f"Open {device.verification_uri_complete} and approve access with "
+                f"code {device.user_code}."
+            )
         self._schedule_poll()
 
     def _schedule_poll(self) -> None:
@@ -370,6 +384,7 @@ class PollinationsDialog(Gtk.Dialog):
             return
 
         self._set_busy(True)
+        self.cancel_request_button.set_visible(True)
         self._set_status(
             "Editing with Pollinations…"
             if edit
@@ -394,6 +409,15 @@ class PollinationsDialog(Gtk.Dialog):
             self.response(Gtk.ResponseType.OK)
 
         self._run_worker(generate, generated)
+
+    def _cancel_generation(self, _button: Gtk.Button) -> None:
+        self._job_id += 1
+        self.result = None
+        self.result_placement = None
+        self._set_busy(False)
+        self._set_status(
+            "Request cancelled. Any response already in flight will be discarded."
+        )
 
 
 def export_source_layer(

--- a/apps/gimp-pollinations/pollinations-gimp.py
+++ b/apps/gimp-pollinations/pollinations-gimp.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Pollinations image generation and editing for GIMP 3."""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import webbrowser
+from pathlib import Path
+
+import gi
+
+gi.require_version("Gimp", "3.0")
+gi.require_version("GimpUi", "3.0")
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gimp, GimpUi, Gio, GLib, GObject, Gtk
+
+from pollinations_gimp import (
+    AuthorizationExpiredError,
+    DeviceAuthorization,
+    ImageModel,
+    PollinationsClient,
+    PollinationsError,
+    TokenStore,
+)
+
+PROCEDURE = "python-fu-pollinations-image"
+PLUGIN_NAME = "pollinations-gimp"
+CONFIG_DIR = Path(GLib.get_user_config_dir()) / "pollinations-gimp"
+CONFIG_FILE = CONFIG_DIR / "config"
+
+
+def load_app_key() -> str:
+    """An App Key is public attribution, never a user's private sk_ token."""
+    if os.environ.get("POLLINATIONS_GIMP_APP_KEY"):
+        return os.environ["POLLINATIONS_GIMP_APP_KEY"]
+    try:
+        return CONFIG_FILE.read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
+
+
+def save_app_key(value: str) -> None:
+    CONFIG_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+    CONFIG_FILE.write_text(value.strip(), encoding="utf-8")
+    os.chmod(CONFIG_FILE, 0o600)
+
+
+class PollinationsDialog(Gtk.Dialog):
+    def __init__(self, image: Gimp.Image, drawable: Gimp.Drawable | None) -> None:
+        super().__init__(title="Pollinations", flags=Gtk.DialogFlags.MODAL)
+        self.add_button("Cancel", Gtk.ResponseType.CANCEL)
+        self.add_button("Generate", Gtk.ResponseType.OK)
+        self.set_default_size(520, -1)
+        self.image, self.drawable = image, drawable
+        self.store = TokenStore()
+        self.client = PollinationsClient(self.store.load())
+        self.models: list[ImageModel] = []
+        self.device: DeviceAuthorization | None = None
+        self.poll_source: int | None = None
+
+        box = self.get_content_area()
+        box.set_spacing(8)
+        box.set_margin_top(12)
+        box.set_margin_bottom(12)
+        box.set_margin_start(12)
+        box.set_margin_end(12)
+
+        self.app_key = Gtk.Entry(text=load_app_key())
+        self.app_key.set_placeholder_text("Publishable App Key (pk_…)")
+        self.connect_button = Gtk.Button(label="Connect")
+        self.connect_button.connect("clicked", self._connect)
+        self.disconnect_button = Gtk.Button(label="Disconnect")
+        self.disconnect_button.connect("clicked", self._disconnect)
+        auth_row = Gtk.Box(spacing=6)
+        auth_row.pack_start(self.app_key, True, True, 0)
+        auth_row.pack_start(self.connect_button, False, False, 0)
+        auth_row.pack_start(self.disconnect_button, False, False, 0)
+        box.pack_start(auth_row, False, False, 0)
+
+        self.status = Gtk.Label(xalign=0, wrap=True)
+        box.pack_start(self.status, False, False, 0)
+        self.prompt = Gtk.TextView(wrap_mode=Gtk.WrapMode.WORD_CHAR)
+        self.prompt.set_size_request(-1, 110)
+        prompt_frame = Gtk.Frame(label="Prompt")
+        prompt_frame.add(self.prompt)
+        box.pack_start(prompt_frame, True, True, 0)
+
+        self.model_picker = Gtk.ComboBoxText()
+        self.model_picker.connect("changed", self._model_changed)
+        self.resolution_picker = Gtk.ComboBoxText()
+        self.resolution_row = Gtk.Box(spacing=6)
+        self.resolution_row.pack_start(Gtk.Label(label="Resolution"), False, False, 0)
+        self.resolution_row.pack_start(self.resolution_picker, False, False, 0)
+        self.resolution_row.set_visible(False)
+        model_row = Gtk.Box(spacing=6)
+        model_row.pack_start(Gtk.Label(label="Model"), False, False, 0)
+        model_row.pack_start(self.model_picker, True, True, 0)
+        box.pack_start(model_row, False, False, 0)
+        box.pack_start(self.resolution_row, False, False, 0)
+
+        dimensions = Gtk.Box(spacing=6)
+        self.width = Gtk.SpinButton.new_with_range(64, 4096, 16)
+        self.height = Gtk.SpinButton.new_with_range(64, 4096, 16)
+        self.width.set_value(image.get_width())
+        self.height.set_value(image.get_height())
+        dimensions.pack_start(Gtk.Label(label="Width"), False, False, 0)
+        dimensions.pack_start(self.width, False, False, 0)
+        dimensions.pack_start(Gtk.Label(label="Height"), False, False, 0)
+        dimensions.pack_start(self.height, False, False, 0)
+        box.pack_start(dimensions, False, False, 0)
+
+        self.edit_source = Gtk.CheckButton(label="Edit the active layer (keeps the source layer unchanged)")
+        self.edit_source.set_sensitive(False)
+        box.pack_start(self.edit_source, False, False, 0)
+        self.use_selection = Gtk.CheckButton(label="Use the current selection as the edit source")
+        self.use_selection.set_sensitive(False)
+        box.pack_start(self.use_selection, False, False, 0)
+        self._refresh_models()
+        self.show_all()
+
+    def _set_status(self, message: str) -> None:
+        self.status.set_text(message)
+
+    def _connect(self, _button: Gtk.Button) -> None:
+        try:
+            save_app_key(self.app_key.get_text())
+            self.device = self.client.start_device_authorization(self.app_key.get_text().strip())
+            webbrowser.open(self.device.verification_uri_complete)
+            self._set_status(
+                f"A browser was opened. Approve Pollinations access with code {self.device.user_code}."
+            )
+            if self.poll_source:
+                GLib.source_remove(self.poll_source)
+            self.poll_source = GLib.timeout_add_seconds(self.device.interval, self._poll_connection)
+        except PollinationsError as error:
+            self._set_status(str(error))
+
+    def _poll_connection(self) -> bool:
+        try:
+            if not self.device:
+                return False
+            token = self.client.poll_device_authorization(self.device.device_code)
+            if not token:
+                return True
+            self.store.save(token)
+            self.device = None
+            self.poll_source = None
+            self._set_status("Connected. Your authorization is stored in your system keychain.")
+            self._refresh_models()
+            return False
+        except PollinationsError as error:
+            self.device = None
+            self.poll_source = None
+            self._set_status(str(error))
+            return False
+
+    def _disconnect(self, _button: Gtk.Button) -> None:
+        self.store.clear()
+        self.client.token = None
+        self.models = []
+        self.model_picker.remove_all()
+        self.edit_source.set_sensitive(False)
+        self._set_status("Disconnected. The authorization was removed from this computer.")
+
+    def _refresh_models(self) -> None:
+        if not self.client.token:
+            self._set_status("Connect your Pollinations account to load the models available to you.")
+            return
+        try:
+            self.models = self.client.list_image_models()
+            self.model_picker.remove_all()
+            for model in self.models:
+                label = f"{model.title} ({model.id})"
+                if model.community:
+                    label += " — community"
+                self.model_picker.append(model.id, label)
+            if self.models:
+                self.model_picker.set_active(0)
+                self._set_status(f"Connected. Loaded {len(self.models)} image models for this account.")
+            else:
+                self._set_status("No image models are available to this account.")
+        except PollinationsError as error:
+            self._set_status(str(error))
+
+    def _selected_model(self) -> ImageModel | None:
+        active_id = self.model_picker.get_active_id()
+        return next((model for model in self.models if model.id == active_id), None)
+
+    def _model_changed(self, _picker: Gtk.ComboBoxText) -> None:
+        model = self._selected_model()
+        if not model:
+            return
+        self.edit_source.set_sensitive(bool(self.drawable and model.accepts_image))
+        self.use_selection.set_sensitive(bool(self.drawable and model.accepts_image))
+        if not model.accepts_image:
+            self.edit_source.set_active(False)
+            self.use_selection.set_active(False)
+        self.resolution_picker.remove_all()
+        for resolution in model.resolutions:
+            self.resolution_picker.append_text(resolution)
+        self.resolution_row.set_visible(bool(model.resolutions))
+        if model.resolutions:
+            self.resolution_picker.set_active(0)
+
+    def values(self) -> tuple[str, ImageModel, bool, bool, int, int, str | None]:
+        prompt = self.prompt.get_buffer().get_text(
+            self.prompt.get_buffer().get_start_iter(), self.prompt.get_buffer().get_end_iter(), False
+        ).strip()
+        model = self._selected_model()
+        if not prompt:
+            raise PollinationsError("Enter a prompt before generating.")
+        if not model:
+            raise PollinationsError("Connect and select an image model first.")
+        return (
+            prompt,
+            model,
+            self.edit_source.get_active(),
+            self.use_selection.get_active(),
+            self.width.get_value_as_int(),
+            self.height.get_value_as_int(),
+            self.resolution_picker.get_active_text() if model.resolutions else None,
+        )
+
+
+def export_source_layer(image: Gimp.Image, drawable: Gimp.Drawable, selection_only: bool) -> Path:
+    """Export only a copied active layer, so no source image data is changed."""
+    duplicate = Gimp.Image.new(image.get_width(), image.get_height(), image.get_base_type())
+    duplicate_layer = Gimp.Layer.new_from_drawable(drawable, duplicate)
+    duplicate.insert_layer(duplicate_layer, None, 0)
+    if selection_only:
+        _success, non_empty, x1, y1, x2, y2 = Gimp.Selection.bounds(image)
+        if not non_empty:
+            raise PollinationsError("Make a selection first, or untick Use the current selection.")
+        duplicate.crop(x2 - x1, y2 - y1, x1, y1)
+    selected = duplicate.get_selected_drawables()
+    if not selected:
+        raise PollinationsError("Select a paintable layer before using image editing.")
+    handle, filename = tempfile.mkstemp(suffix=".png", prefix="pollinations-gimp-")
+    os.close(handle)
+    path = Path(filename)
+    try:
+        saved = Gimp.file_save(
+            Gimp.RunMode.NONINTERACTIVE, duplicate, Gio.File.new_for_path(str(path)), None
+        )
+        if not saved:
+            raise RuntimeError("GIMP did not export the source layer")
+        return path
+    except Exception as error:
+        path.unlink(missing_ok=True)
+        raise PollinationsError("GIMP could not export the active layer for editing.") from error
+
+
+def add_result_as_layer(image: Gimp.Image, source: Gimp.Drawable | None, result: bytes) -> None:
+    handle, filename = tempfile.mkstemp(suffix=".png", prefix="pollinations-gimp-result-")
+    os.close(handle)
+    path = Path(filename)
+    try:
+        path.write_bytes(result)
+        generated = Gimp.file_load(Gimp.RunMode.NONINTERACTIVE, Gio.File.new_for_path(str(path)))
+        generated_layer = generated.get_layers()[0]
+        layer = Gimp.Layer.new_from_drawable(generated_layer, image)
+        layer.set_name("Pollinations result")
+        position = image.get_item_position(source) + 1 if source else 0
+        image.insert_layer(layer, None, position)
+    except Exception as error:
+        raise PollinationsError("GIMP could not add Pollinations' result as a layer.") from error
+    finally:
+        path.unlink(missing_ok=True)
+
+
+def run(procedure, run_mode, image, drawables, config, data):
+    GimpUi.init(PLUGIN_NAME)
+    drawable = drawables[0] if drawables else None
+    dialog = PollinationsDialog(image, drawable)
+    response = dialog.run()
+    if response != Gtk.ResponseType.OK:
+        dialog.destroy()
+        return procedure.new_return_values(Gimp.PDBStatusType.CANCEL, None)
+    undo_started = False
+    try:
+        prompt, model, edit, selection_only, width, height, resolution = dialog.values()
+        client = dialog.client
+        dialog.destroy()
+        if edit:
+            if not drawable or not model.accepts_image:
+                raise PollinationsError("The selected model does not support image editing.")
+            source_path = export_source_layer(image, drawable, selection_only)
+            try:
+                result = client.edit(prompt, model, source_path, resolution)
+            finally:
+                source_path.unlink(missing_ok=True)
+        else:
+            result = client.generate(prompt, model, width, height, resolution)
+        image.undo_group_start()
+        undo_started = True
+        add_result_as_layer(image, drawable, result)
+        image.undo_group_end()
+        undo_started = False
+        return procedure.new_return_values(Gimp.PDBStatusType.SUCCESS, None)
+    except PollinationsError as error:
+        if undo_started:
+            image.undo_group_end()
+        Gimp.message(str(error))
+        return procedure.new_return_values(Gimp.PDBStatusType.EXECUTION_ERROR, GLib.Error(message=str(error)))
+
+
+class PollinationsGimp(Gimp.PlugIn):
+    def do_query_procedures(self):
+        return [PROCEDURE]
+
+    def do_create_procedure(self, name):
+        if name != PROCEDURE:
+            return None
+        procedure = Gimp.ImageProcedure.new(self, name, Gimp.PDBProcType.PLUGIN, run, None)
+        procedure.set_sensitivity_mask(
+            Gimp.ProcedureSensitivityMask.DRAWABLE | Gimp.ProcedureSensitivityMask.NO_DRAWABLES
+        )
+        procedure.set_menu_label("_Pollinations Image…")
+        procedure.add_menu_path("<Image>/Filters/Artistic")
+        procedure.set_documentation(
+            "Generate or edit images with a connected Pollinations account.",
+            "Uses browser-based Pollinations device authorization; no API key is pasted into GIMP.",
+            None,
+        )
+        procedure.set_attribution("Pollinations contributors", "Apache-2.0", "2026")
+        return procedure
+
+
+Gimp.main(PollinationsGimp.__gtype__, sys.argv)

--- a/apps/gimp-pollinations/pollinations_gimp.py
+++ b/apps/gimp-pollinations/pollinations_gimp.py
@@ -29,7 +29,7 @@ class PollinationsError(RuntimeError):
     """An error ready to show to a person using the plug-in."""
 
 
-class ConnectionError(PollinationsError):
+class PollinationsConnectionError(PollinationsError):
     pass
 
 
@@ -125,7 +125,7 @@ class PollinationsClient:
                     pass
             raise friendly_error(error.code, _error_message(body, error.code)) from error
         except URLError as error:
-            raise ConnectionError(
+            raise PollinationsConnectionError(
                 "Could not reach Pollinations. Check your connection and try again."
             ) from error
 

--- a/apps/gimp-pollinations/pollinations_gimp.py
+++ b/apps/gimp-pollinations/pollinations_gimp.py
@@ -1,0 +1,364 @@
+"""Pollinations transport and credential code used by the GIMP 3 plug-in.
+
+This module deliberately has no GIMP dependency, so its protocol behaviour can
+be tested with the Python standard library on every supported desktop platform.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import platform
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+from urllib.error import HTTPError, URLError
+from urllib.parse import urljoin
+from urllib.request import Request, urlopen
+
+ENTER_URL = "https://enter.pollinations.ai"
+GEN_URL = "https://gen.pollinations.ai"
+SERVICE_NAME = "pollinations-gimp"
+ACCOUNT_NAME = "default"
+
+
+class PollinationsError(RuntimeError):
+    """An error ready to show to a person using the plug-in."""
+
+
+class ConnectionError(PollinationsError):
+    pass
+
+
+class AuthorizationExpiredError(PollinationsError):
+    pass
+
+
+class InsufficientPollenError(PollinationsError):
+    pass
+
+
+@dataclass(frozen=True)
+class DeviceAuthorization:
+    device_code: str
+    user_code: str
+    verification_uri: str
+    verification_uri_complete: str
+    interval: int = 5
+
+
+@dataclass(frozen=True)
+class ImageModel:
+    """The capability subset needed by a still-image GIMP workflow."""
+
+    id: str
+    title: str
+    input_modalities: tuple[str, ...]
+    resolutions: tuple[str, ...]
+    community: bool = False
+
+    @property
+    def accepts_image(self) -> bool:
+        return "image" in self.input_modalities
+
+
+def _error_message(body: bytes, status: int) -> str:
+    try:
+        payload = json.loads(body.decode("utf-8"))
+        error = payload.get("error", payload)
+        if isinstance(error, dict):
+            return str(error.get("message") or error.get("error") or status)
+        return str(error)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return f"Pollinations returned HTTP {status}."
+
+
+def friendly_error(status: int, detail: str) -> PollinationsError:
+    if status in (401, 403):
+        return AuthorizationExpiredError(
+            "Your Pollinations authorization has expired or was revoked. "
+            "Choose Connect and approve access again."
+        )
+    if status == 402:
+        return InsufficientPollenError(
+            "This request needs more Pollen. Add Pollen in your Pollinations "
+            "account, then try again."
+        )
+    return PollinationsError(detail)
+
+
+class PollinationsClient:
+    def __init__(
+        self,
+        token: str | None = None,
+        request: Callable[[Request], bytes] | None = None,
+    ) -> None:
+        self.token = token
+        self._request = request or self._urlopen
+
+    @staticmethod
+    def _urlopen(request: Request) -> bytes:
+        try:
+            with urlopen(request, timeout=90) as response:  # nosec B310: fixed API URLs
+                return response.read()
+        except HTTPError as error:
+            body = error.read()
+            # RFC 8628 deliberately reports pending/denied/expired device
+            # exchanges as 400 responses. Keep their JSON available to the
+            # polling state machine instead of showing a false generic error.
+            if error.code == 400 and request.full_url.endswith("/api/device/token"):
+                try:
+                    if json.loads(body.decode("utf-8")).get("error"):
+                        return body
+                except (UnicodeDecodeError, json.JSONDecodeError):
+                    pass
+            raise friendly_error(error.code, _error_message(body, error.code)) from error
+        except URLError as error:
+            raise ConnectionError(
+                "Could not reach Pollinations. Check your connection and try again."
+            ) from error
+
+    def _json(
+        self,
+        url: str,
+        payload: dict[str, Any] | None = None,
+        *,
+        token: bool = False,
+    ) -> dict[str, Any]:
+        headers = {"Accept": "application/json"}
+        data = None
+        if payload is not None:
+            data = json.dumps(payload).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        if token:
+            if not self.token:
+                raise AuthorizationExpiredError("Connect your Pollinations account first.")
+            headers["Authorization"] = f"Bearer {self.token}"
+        raw = self._request(Request(url, data=data, headers=headers, method="POST" if data else "GET"))
+        try:
+            return json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise PollinationsError("Pollinations returned an invalid response. Please try again.") from error
+
+    def start_device_authorization(self, app_key: str) -> DeviceAuthorization:
+        if not app_key.startswith("pk_"):
+            raise PollinationsError("Enter this plug-in's publishable App Key (it starts with pk_).")
+        payload = self._json(f"{ENTER_URL}/api/device/code", {"client_id": app_key})
+        try:
+            verification_uri = urljoin(ENTER_URL, payload["verification_uri"])
+            return DeviceAuthorization(
+                device_code=payload["device_code"],
+                user_code=payload["user_code"],
+                verification_uri=verification_uri,
+                verification_uri_complete=urljoin(
+                    ENTER_URL, payload.get("verification_uri_complete", payload["verification_uri"])
+                ),
+                interval=max(1, int(payload.get("interval", 5))),
+            )
+        except (KeyError, TypeError, ValueError) as error:
+            raise PollinationsError("Pollinations returned an invalid device authorization response.") from error
+
+    def poll_device_authorization(self, device_code: str) -> str | None:
+        payload = self._json(f"{ENTER_URL}/api/device/token", {"device_code": device_code})
+        if payload.get("error") == "authorization_pending":
+            return None
+        if payload.get("error"):
+            if payload["error"] in {"expired_token", "access_denied"}:
+                raise AuthorizationExpiredError(
+                    "The approval request expired or was denied. Choose Connect to start again."
+                )
+            raise PollinationsError(f"Connection failed: {payload['error']}.")
+        access_token = payload.get("access_token")
+        if not isinstance(access_token, str) or not access_token.startswith("sk_"):
+            raise PollinationsError("Pollinations returned an invalid authorization token.")
+        self.token = access_token
+        return access_token
+
+    def list_image_models(self) -> list[ImageModel]:
+        # This request is intentionally authenticated: it includes private/community
+        # models visible to this user and filters unavailable paid-only models.
+        payload = self._json(f"{GEN_URL}/image/models", token=True)
+        if not isinstance(payload, list):
+            raise PollinationsError("Pollinations returned an invalid model catalog.")
+        models: list[ImageModel] = []
+        for raw in payload:
+            if not isinstance(raw, dict):
+                continue
+            outputs = raw.get("output_modalities", [])
+            model_id = raw.get("name")
+            if "image" not in outputs or not isinstance(model_id, str):
+                continue
+            models.append(
+                ImageModel(
+                    id=model_id,
+                    title=str(raw.get("title") or model_id),
+                    input_modalities=tuple(raw.get("input_modalities") or ()),
+                    resolutions=tuple(raw.get("resolutions") or ()),
+                    community=bool(raw.get("community")),
+                )
+            )
+        return models
+
+    def generate(self, prompt: str, model: ImageModel, width: int, height: int, resolution: str | None) -> bytes:
+        payload: dict[str, Any] = {
+            "prompt": prompt,
+            "model": model.id,
+            "size": f"{width}x{height}",
+            "response_format": "b64_json",
+        }
+        if resolution:
+            payload["resolution"] = resolution
+        return self._image_response("/v1/images/generations", payload)
+
+    def edit(
+        self,
+        prompt: str,
+        model: ImageModel,
+        image_path: Path,
+        resolution: str | None,
+    ) -> bytes:
+        boundary = "----PollinationsGimpBoundary"
+        fields = {"prompt": prompt, "model": model.id}
+        if resolution:
+            fields["resolution"] = resolution
+        body = _multipart_body(boundary, fields, image_path)
+        if not self.token:
+            raise AuthorizationExpiredError("Connect your Pollinations account first.")
+        request = Request(
+            f"{GEN_URL}/v1/images/edits",
+            data=body,
+            headers={
+                "Accept": "application/json",
+                "Authorization": f"Bearer {self.token}",
+                "Content-Type": f"multipart/form-data; boundary={boundary}",
+            },
+            method="POST",
+        )
+        raw = self._request(request)
+        try:
+            return self._decode_image(json.loads(raw.decode("utf-8")))
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise PollinationsError("Pollinations returned an invalid image response.") from error
+
+    def _image_response(self, path: str, payload: dict[str, Any]) -> bytes:
+        return self._decode_image(self._json(f"{GEN_URL}{path}", payload, token=True))
+
+    @staticmethod
+    def _decode_image(payload: dict[str, Any]) -> bytes:
+        try:
+            encoded = payload["data"][0]["b64_json"]
+            return base64.b64decode(encoded, validate=True)
+        except (KeyError, IndexError, TypeError, ValueError) as error:
+            raise PollinationsError("Pollinations returned an invalid image response.") from error
+
+
+def _multipart_body(boundary: str, fields: dict[str, str], image_path: Path) -> bytes:
+    chunks: list[bytes] = []
+    for name, value in fields.items():
+        chunks.extend(
+            [
+                f"--{boundary}\r\n".encode(),
+                f'Content-Disposition: form-data; name="{name}"\r\n\r\n'.encode(),
+                value.encode("utf-8"),
+                b"\r\n",
+            ]
+        )
+    chunks.extend(
+        [
+            f"--{boundary}\r\n".encode(),
+            b'Content-Disposition: form-data; name="image"; filename="gimp-layer.png"\r\n',
+            b"Content-Type: image/png\r\n\r\n",
+            image_path.read_bytes(),
+            b"\r\n",
+            f"--{boundary}--\r\n".encode(),
+        ]
+    )
+    return b"".join(chunks)
+
+
+class TokenStore:
+    """Use each desktop's credential service; never put an sk_ key in GIMP prefs."""
+
+    def load(self) -> str | None:
+        result = self._run(self._load_command(), check=False)
+        token = result.stdout.strip() if result.returncode == 0 else ""
+        return token if token.startswith("sk_") else None
+
+    def save(self, token: str) -> None:
+        if platform.system() == "Darwin":
+            # macOS's `security` CLI only accepts the password as an argument.
+            # It immediately writes it to Keychain and neither emits nor logs it.
+            command = [
+                "security",
+                "add-generic-password",
+                "-U",
+                "-s",
+                SERVICE_NAME,
+                "-a",
+                ACCOUNT_NAME,
+                "-w",
+                token,
+            ]
+            result = self._run(command, check=False)
+        else:
+            result = self._run(self._save_command(), input=token, check=False)
+        if result.returncode != 0:
+            raise PollinationsError(
+                "GIMP could not save the authorization in your system keychain. "
+                "Install/enable your desktop's credential service, then connect again."
+            )
+
+    def clear(self) -> None:
+        self._run(self._clear_command(), check=False)
+
+    @staticmethod
+    def _run(command: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        try:
+            return subprocess.run(command, text=True, capture_output=True, **kwargs)
+        except OSError as error:
+            return subprocess.CompletedProcess(command, 1, "", str(error))
+
+    @staticmethod
+    def _load_command() -> list[str]:
+        system = platform.system()
+        if system == "Darwin":
+            return ["security", "find-generic-password", "-s", SERVICE_NAME, "-a", ACCOUNT_NAME, "-w"]
+        if system == "Windows":
+            return _windows_credential_command("load")
+        return ["secret-tool", "lookup", "service", SERVICE_NAME, "account", ACCOUNT_NAME]
+
+    @staticmethod
+    def _save_command() -> list[str]:
+        system = platform.system()
+        if system == "Windows":
+            return _windows_credential_command("save")
+        return ["secret-tool", "store", "--label=Pollinations GIMP", "service", SERVICE_NAME, "account", ACCOUNT_NAME]
+
+    @staticmethod
+    def _clear_command() -> list[str]:
+        system = platform.system()
+        if system == "Darwin":
+            return ["security", "delete-generic-password", "-s", SERVICE_NAME, "-a", ACCOUNT_NAME]
+        if system == "Windows":
+            return _windows_credential_command("clear")
+        return ["secret-tool", "clear", "service", SERVICE_NAME, "account", ACCOUNT_NAME]
+
+
+def _windows_credential_command(action: str) -> list[str]:
+    # DPAPI encrypts the small local blob to the current Windows account. The
+    # PowerShell program reads the token from stdin, never from its arguments.
+    path = Path(os.environ.get("APPDATA", str(Path.home()))) / "PollinationsGimp" / "authorization.dpapi"
+    script = (
+        "$p=$args[0];$a='PollinationsGimp';"
+        "if($args[1] -eq 'save'){New-Item -ItemType Directory -Force (Split-Path $p)|Out-Null;"
+        "$b=[Text.Encoding]::UTF8.GetBytes([Console]::In.ReadToEnd());"
+        "$e=[Security.Cryptography.ProtectedData]::Protect($b,$null,[Security.Cryptography.DataProtectionScope]::CurrentUser);"
+        "[IO.File]::WriteAllBytes($p,$e)}"
+        "elseif($args[1] -eq 'load'){if(Test-Path $p){$e=[IO.File]::ReadAllBytes($p);"
+        "$b=[Security.Cryptography.ProtectedData]::Unprotect($e,$null,[Security.Cryptography.DataProtectionScope]::CurrentUser);"
+        "[Console]::Write([Text.Encoding]::UTF8.GetString($b))}}"
+        "elseif($args[1] -eq 'clear'){Remove-Item -Force $p -ErrorAction SilentlyContinue}"
+    )
+    return ["powershell", "-NoProfile", "-NonInteractive", "-Command", script, str(path), action]

--- a/apps/gimp-pollinations/pollinations_gimp.py
+++ b/apps/gimp-pollinations/pollinations_gimp.py
@@ -7,6 +7,7 @@ be tested with the Python standard library on every supported desktop platform.
 from __future__ import annotations
 
 import base64
+import ctypes
 import json
 import os
 import platform
@@ -36,6 +37,10 @@ class AuthorizationExpiredError(PollinationsError):
     pass
 
 
+class SlowDownError(PollinationsError):
+    pass
+
+
 class InsufficientPollenError(PollinationsError):
     pass
 
@@ -56,12 +61,16 @@ class ImageModel:
     id: str
     title: str
     input_modalities: tuple[str, ...]
+    supported_endpoints: tuple[str, ...]
     resolutions: tuple[str, ...]
     community: bool = False
 
     @property
     def accepts_image(self) -> bool:
-        return "image" in self.input_modalities
+        return (
+            "image" in self.input_modalities
+            or "/v1/images/edits" in self.supported_endpoints
+        )
 
 
 def _error_message(body: bytes, status: int) -> str:
@@ -134,17 +143,30 @@ class PollinationsClient:
             headers["Content-Type"] = "application/json"
         if token:
             if not self.token:
-                raise AuthorizationExpiredError("Connect your Pollinations account first.")
+                raise AuthorizationExpiredError(
+                    "Connect your Pollinations account first."
+                )
             headers["Authorization"] = f"Bearer {self.token}"
-        raw = self._request(Request(url, data=data, headers=headers, method="POST" if data else "GET"))
+        raw = self._request(
+            Request(
+                url,
+                data=data,
+                headers=headers,
+                method="POST" if data else "GET",
+            )
+        )
         try:
             return json.loads(raw.decode("utf-8"))
         except (UnicodeDecodeError, json.JSONDecodeError) as error:
-            raise PollinationsError("Pollinations returned an invalid response. Please try again.") from error
+            raise PollinationsError(
+                "Pollinations returned an invalid response. Please try again."
+            ) from error
 
     def start_device_authorization(self, app_key: str) -> DeviceAuthorization:
         if not app_key.startswith("pk_"):
-            raise PollinationsError("Enter this plug-in's publishable App Key (it starts with pk_).")
+            raise PollinationsError(
+                "Enter this plug-in's publishable App Key (it starts with pk_)."
+            )
         payload = self._json(f"{ENTER_URL}/api/device/code", {"client_id": app_key})
         try:
             verification_uri = urljoin(ENTER_URL, payload["verification_uri"])
@@ -153,17 +175,26 @@ class PollinationsClient:
                 user_code=payload["user_code"],
                 verification_uri=verification_uri,
                 verification_uri_complete=urljoin(
-                    ENTER_URL, payload.get("verification_uri_complete", payload["verification_uri"])
+                    ENTER_URL,
+                    payload.get(
+                        "verification_uri_complete", payload["verification_uri"]
+                    ),
                 ),
                 interval=max(1, int(payload.get("interval", 5))),
             )
         except (KeyError, TypeError, ValueError) as error:
-            raise PollinationsError("Pollinations returned an invalid device authorization response.") from error
+            raise PollinationsError(
+                "Pollinations returned an invalid device authorization response."
+            ) from error
 
     def poll_device_authorization(self, device_code: str) -> str | None:
-        payload = self._json(f"{ENTER_URL}/api/device/token", {"device_code": device_code})
+        payload = self._json(
+            f"{ENTER_URL}/api/device/token", {"device_code": device_code}
+        )
         if payload.get("error") == "authorization_pending":
             return None
+        if payload.get("error") == "slow_down":
+            raise SlowDownError("Pollinations asked the plug-in to poll more slowly.")
         if payload.get("error"):
             if payload["error"] in {"expired_token", "access_denied"}:
                 raise AuthorizationExpiredError(
@@ -172,7 +203,9 @@ class PollinationsClient:
             raise PollinationsError(f"Connection failed: {payload['error']}.")
         access_token = payload.get("access_token")
         if not isinstance(access_token, str) or not access_token.startswith("sk_"):
-            raise PollinationsError("Pollinations returned an invalid authorization token.")
+            raise PollinationsError(
+                "Pollinations returned an invalid authorization token."
+            )
         self.token = access_token
         return access_token
 
@@ -195,18 +228,28 @@ class PollinationsClient:
                     id=model_id,
                     title=str(raw.get("title") or model_id),
                     input_modalities=tuple(raw.get("input_modalities") or ()),
+                    supported_endpoints=tuple(raw.get("supported_endpoints") or ()),
                     resolutions=tuple(raw.get("resolutions") or ()),
                     community=bool(raw.get("community")),
                 )
             )
         return models
 
-    def generate(self, prompt: str, model: ImageModel, width: int, height: int, resolution: str | None) -> bytes:
+    def generate(
+        self,
+        prompt: str,
+        model: ImageModel,
+        width: int,
+        height: int,
+        resolution: str | None,
+        seed: int,
+    ) -> bytes:
         payload: dict[str, Any] = {
             "prompt": prompt,
             "model": model.id,
             "size": f"{width}x{height}",
             "response_format": "b64_json",
+            "seed": seed,
         }
         if resolution:
             payload["resolution"] = resolution
@@ -225,7 +268,9 @@ class PollinationsClient:
             fields["resolution"] = resolution
         body = _multipart_body(boundary, fields, image_path)
         if not self.token:
-            raise AuthorizationExpiredError("Connect your Pollinations account first.")
+            raise AuthorizationExpiredError(
+                "Connect your Pollinations account first."
+            )
         request = Request(
             f"{GEN_URL}/v1/images/edits",
             data=body,
@@ -240,7 +285,9 @@ class PollinationsClient:
         try:
             return self._decode_image(json.loads(raw.decode("utf-8")))
         except (UnicodeDecodeError, json.JSONDecodeError) as error:
-            raise PollinationsError("Pollinations returned an invalid image response.") from error
+            raise PollinationsError(
+                "Pollinations returned an invalid image response."
+            ) from error
 
     def _image_response(self, path: str, payload: dict[str, Any]) -> bytes:
         return self._decode_image(self._json(f"{GEN_URL}{path}", payload, token=True))
@@ -282,36 +329,37 @@ class TokenStore:
     """Use each desktop's credential service; never put an sk_ key in GIMP prefs."""
 
     def load(self) -> str | None:
+        if platform.system() == "Darwin":
+            return _macos_keychain_load()
         result = self._run(self._load_command(), check=False)
         token = result.stdout.strip() if result.returncode == 0 else ""
         return token if token.startswith("sk_") else None
 
     def save(self, token: str) -> None:
         if platform.system() == "Darwin":
-            # macOS's `security` CLI only accepts the password as an argument.
-            # It immediately writes it to Keychain and neither emits nor logs it.
-            command = [
-                "security",
-                "add-generic-password",
-                "-U",
-                "-s",
-                SERVICE_NAME,
-                "-a",
-                ACCOUNT_NAME,
-                "-w",
-                token,
-            ]
-            result = self._run(command, check=False)
+            saved = _macos_keychain_save(token)
         else:
             result = self._run(self._save_command(), input=token, check=False)
-        if result.returncode != 0:
+            saved = result.returncode == 0
+        if not saved:
             raise PollinationsError(
                 "GIMP could not save the authorization in your system keychain. "
                 "Install/enable your desktop's credential service, then connect again."
             )
 
     def clear(self) -> None:
-        self._run(self._clear_command(), check=False)
+        if platform.system() == "Darwin":
+            cleared = _macos_keychain_clear()
+            if not cleared:
+                raise PollinationsError(
+                    "GIMP could not remove the authorization from Keychain."
+                )
+            return
+        result = self._run(self._clear_command(), check=False)
+        if result.returncode != 0 and self.load() is not None:
+            raise PollinationsError(
+                "GIMP could not remove the authorization from your system keychain."
+            )
 
     @staticmethod
     def _run(command: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
@@ -323,8 +371,6 @@ class TokenStore:
     @staticmethod
     def _load_command() -> list[str]:
         system = platform.system()
-        if system == "Darwin":
-            return ["security", "find-generic-password", "-s", SERVICE_NAME, "-a", ACCOUNT_NAME, "-w"]
         if system == "Windows":
             return _windows_credential_command("load")
         return ["secret-tool", "lookup", "service", SERVICE_NAME, "account", ACCOUNT_NAME]
@@ -334,22 +380,133 @@ class TokenStore:
         system = platform.system()
         if system == "Windows":
             return _windows_credential_command("save")
-        return ["secret-tool", "store", "--label=Pollinations GIMP", "service", SERVICE_NAME, "account", ACCOUNT_NAME]
+        return [
+            "secret-tool",
+            "store",
+            "--label=Pollinations GIMP",
+            "service",
+            SERVICE_NAME,
+            "account",
+            ACCOUNT_NAME,
+        ]
 
     @staticmethod
     def _clear_command() -> list[str]:
         system = platform.system()
-        if system == "Darwin":
-            return ["security", "delete-generic-password", "-s", SERVICE_NAME, "-a", ACCOUNT_NAME]
         if system == "Windows":
             return _windows_credential_command("clear")
         return ["secret-tool", "clear", "service", SERVICE_NAME, "account", ACCOUNT_NAME]
 
 
+def _macos_security():
+    security = ctypes.CDLL(
+        "/System/Library/Frameworks/Security.framework/Security"
+    )
+    core_foundation = ctypes.CDLL(
+        "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
+    )
+    security.SecKeychainFindGenericPassword.restype = ctypes.c_int32
+    security.SecKeychainAddGenericPassword.restype = ctypes.c_int32
+    security.SecKeychainItemModifyAttributesAndData.restype = ctypes.c_int32
+    security.SecKeychainItemDelete.restype = ctypes.c_int32
+    security.SecKeychainItemFreeContent.restype = ctypes.c_int32
+    core_foundation.CFRelease.argtypes = [ctypes.c_void_p]
+    return security, core_foundation
+
+
+def _macos_find_item(security):
+    service = SERVICE_NAME.encode()
+    account = ACCOUNT_NAME.encode()
+    length = ctypes.c_uint32()
+    data = ctypes.c_void_p()
+    item = ctypes.c_void_p()
+    status = security.SecKeychainFindGenericPassword(
+        None,
+        len(service),
+        service,
+        len(account),
+        account,
+        ctypes.byref(length),
+        ctypes.byref(data),
+        ctypes.byref(item),
+    )
+    return status, length, data, item
+
+
+def _macos_keychain_load() -> str | None:
+    try:
+        security, core_foundation = _macos_security()
+        status, length, data, item = _macos_find_item(security)
+        if status != 0:
+            return None
+        try:
+            token = ctypes.string_at(data, length.value).decode("utf-8")
+            return token if token.startswith("sk_") else None
+        finally:
+            security.SecKeychainItemFreeContent(None, data)
+            core_foundation.CFRelease(item)
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def _macos_keychain_save(token: str) -> bool:
+    try:
+        security, core_foundation = _macos_security()
+        status, _length, data, item = _macos_find_item(security)
+        secret = token.encode("utf-8")
+        if status == 0:
+            security.SecKeychainItemFreeContent(None, data)
+            try:
+                return (
+                    security.SecKeychainItemModifyAttributesAndData(
+                        item, None, len(secret), secret
+                    )
+                    == 0
+                )
+            finally:
+                core_foundation.CFRelease(item)
+        service = SERVICE_NAME.encode()
+        account = ACCOUNT_NAME.encode()
+        return (
+            security.SecKeychainAddGenericPassword(
+                None,
+                len(service),
+                service,
+                len(account),
+                account,
+                len(secret),
+                secret,
+                None,
+            )
+            == 0
+        )
+    except OSError:
+        return False
+
+
+def _macos_keychain_clear() -> bool:
+    try:
+        security, core_foundation = _macos_security()
+        status, _length, data, item = _macos_find_item(security)
+        if status != 0:
+            return True
+        security.SecKeychainItemFreeContent(None, data)
+        try:
+            return security.SecKeychainItemDelete(item) == 0
+        finally:
+            core_foundation.CFRelease(item)
+    except OSError:
+        return False
+
+
 def _windows_credential_command(action: str) -> list[str]:
     # DPAPI encrypts the small local blob to the current Windows account. The
     # PowerShell program reads the token from stdin, never from its arguments.
-    path = Path(os.environ.get("APPDATA", str(Path.home()))) / "PollinationsGimp" / "authorization.dpapi"
+    path = (
+        Path(os.environ.get("APPDATA", str(Path.home())))
+        / "PollinationsGimp"
+        / "authorization.dpapi"
+    )
     script = (
         "$p=$args[0];$a='PollinationsGimp';"
         "if($args[1] -eq 'save'){New-Item -ItemType Directory -Force (Split-Path $p)|Out-Null;"

--- a/apps/gimp-pollinations/tests/test_pollinations_gimp.py
+++ b/apps/gimp-pollinations/tests/test_pollinations_gimp.py
@@ -11,7 +11,12 @@ from urllib.request import Request
 import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from pollinations_gimp import ImageModel, PollinationsClient, PollinationsError, _multipart_body
+from pollinations_gimp import (
+    ImageModel,
+    PollinationsClient,
+    PollinationsError,
+    SlowDownError,
+)
 
 
 class FakeTransport:
@@ -57,6 +62,7 @@ class PollinationsClientTest(unittest.TestCase):
                         "title": "Community Paint",
                         "output_modalities": ["image"],
                         "input_modalities": ["text", "image"],
+                        "supported_endpoints": ["/v1/images/edits"],
                         "resolutions": ["1k", "2k"],
                         "community": True,
                     },
@@ -68,7 +74,27 @@ class PollinationsClientTest(unittest.TestCase):
         models = client.list_image_models()
         self.assertEqual([model.id for model in models], ["community-paint"])
         self.assertTrue(models[0].accepts_image)
-        self.assertEqual(transport.requests[0].get_header("Authorization"), "Bearer sk_authorized")
+        self.assertEqual(
+            transport.requests[0].get_header("Authorization"),
+            "Bearer sk_authorized",
+        )
+
+    def test_edit_support_uses_the_advertised_endpoint(self):
+        transport = FakeTransport(
+            [
+                [
+                    {
+                        "name": "zimage",
+                        "title": "Z-Image",
+                        "output_modalities": ["image"],
+                        "input_modalities": ["text"],
+                        "supported_endpoints": ["/image/{prompt}", "/v1/images/edits"],
+                    }
+                ]
+            ]
+        )
+        model = PollinationsClient("sk_authorized", transport).list_image_models()[0]
+        self.assertTrue(model.accepts_image)
 
     def test_edit_multipart_sends_the_active_layer_file(self):
         encoded = base64.b64encode(b"png-bytes").decode()
@@ -77,15 +103,40 @@ class PollinationsClientTest(unittest.TestCase):
         with tempfile.NamedTemporaryFile(suffix=".png") as image:
             image.write(b"source-png")
             image.flush()
-            result = client.edit("turn it blue", ImageModel("edit", "Edit", ("text", "image"), ()), Path(image.name), None)
+            result = client.edit(
+                "turn it blue",
+                ImageModel(
+                    "edit",
+                    "Edit",
+                    ("text", "image"),
+                    ("/v1/images/edits",),
+                    (),
+                ),
+                Path(image.name),
+                None,
+            )
         self.assertEqual(result, b"png-bytes")
         body = transport.requests[0].data
         self.assertIn(b'name="image"; filename="gimp-layer.png"', body)
         self.assertIn(b"source-png", body)
 
+    def test_generate_sends_seed_and_advertised_resolution(self):
+        encoded = base64.b64encode(b"png-bytes").decode()
+        transport = FakeTransport([{"data": [{"b64_json": encoded}]}])
+        model = ImageModel("paint", "Paint", ("text",), (), ("2k",))
+        result = PollinationsClient("sk_authorized", transport).generate(
+            "a sunflower", model, 1024, 768, "2k", 12345
+        )
+        self.assertEqual(result, b"png-bytes")
+        payload = json.loads(transport.requests[0].data)
+        self.assertEqual(payload["resolution"], "2k")
+        self.assertEqual(payload["seed"], 12345)
+
     def test_invalid_app_key_is_not_sent(self):
         with self.assertRaises(PollinationsError):
-            PollinationsClient(request=FakeTransport([])).start_device_authorization("sk_not_an_app_key")
+            PollinationsClient(request=FakeTransport([])).start_device_authorization(
+                "sk_not_an_app_key"
+            )
 
     def test_pending_device_http_400_remains_in_the_polling_loop(self):
         pending = HTTPError(
@@ -97,9 +148,18 @@ class PollinationsClientTest(unittest.TestCase):
         )
         with patch("pollinations_gimp.urlopen", side_effect=pending):
             body = PollinationsClient._urlopen(
-                Request("https://enter.pollinations.ai/api/device/token", data=b"{}", method="POST")
+                Request(
+                    "https://enter.pollinations.ai/api/device/token",
+                    data=b"{}",
+                    method="POST",
+                )
             )
         self.assertEqual(json.loads(body), {"error": "authorization_pending"})
+
+    def test_slow_down_is_reported_to_the_poll_scheduler(self):
+        client = PollinationsClient(request=FakeTransport([{"error": "slow_down"}]))
+        with self.assertRaises(SlowDownError):
+            client.poll_device_authorization("device-secret")
 
 
 if __name__ == "__main__":

--- a/apps/gimp-pollinations/tests/test_pollinations_gimp.py
+++ b/apps/gimp-pollinations/tests/test_pollinations_gimp.py
@@ -1,5 +1,6 @@
 import base64
 import json
+import subprocess
 import tempfile
 import unittest
 from io import BytesIO
@@ -16,6 +17,7 @@ from pollinations_gimp import (
     PollinationsClient,
     PollinationsError,
     SlowDownError,
+    TokenStore,
 )
 
 
@@ -160,6 +162,85 @@ class PollinationsClientTest(unittest.TestCase):
         client = PollinationsClient(request=FakeTransport([{"error": "slow_down"}]))
         with self.assertRaises(SlowDownError):
             client.poll_device_authorization("device-secret")
+
+
+class TokenStoreTest(unittest.TestCase):
+    def test_linux_keychain_round_trip(self):
+        stored = []
+
+        def run(command, **kwargs):
+            action = command[1]
+            if action == "store":
+                stored.append(kwargs["input"])
+                output = ""
+            elif action == "lookup":
+                output = stored[0] if stored else ""
+            else:
+                stored.clear()
+                output = ""
+            return subprocess.CompletedProcess(command, 0, output, "")
+
+        store = TokenStore()
+        with (
+            patch("pollinations_gimp.platform.system", return_value="Linux"),
+            patch.object(store, "_run", side_effect=run),
+        ):
+            store.save("sk_test")
+            self.assertEqual(store.load(), "sk_test")
+            store.clear()
+            self.assertIsNone(store.load())
+
+    def test_windows_keychain_round_trip_keeps_token_out_of_arguments(self):
+        stored = []
+
+        def run(command, **kwargs):
+            action = command[-1]
+            if action == "save":
+                self.assertNotIn(kwargs["input"], command)
+                stored.append(kwargs["input"])
+                output = ""
+            elif action == "load":
+                output = stored[0] if stored else ""
+            else:
+                stored.clear()
+                output = ""
+            return subprocess.CompletedProcess(command, 0, output, "")
+
+        store = TokenStore()
+        with (
+            patch("pollinations_gimp.platform.system", return_value="Windows"),
+            patch.object(store, "_run", side_effect=run),
+        ):
+            store.save("sk_test")
+            self.assertEqual(store.load(), "sk_test")
+            store.clear()
+            self.assertIsNone(store.load())
+
+    def test_macos_keychain_round_trip(self):
+        stored = []
+
+        def save(token):
+            stored.append(token)
+            return True
+
+        def load():
+            return stored[0] if stored else None
+
+        def clear():
+            stored.clear()
+            return True
+
+        store = TokenStore()
+        with (
+            patch("pollinations_gimp.platform.system", return_value="Darwin"),
+            patch("pollinations_gimp._macos_keychain_save", side_effect=save),
+            patch("pollinations_gimp._macos_keychain_load", side_effect=load),
+            patch("pollinations_gimp._macos_keychain_clear", side_effect=clear),
+        ):
+            store.save("sk_test")
+            self.assertEqual(store.load(), "sk_test")
+            store.clear()
+            self.assertIsNone(store.load())
 
 
 if __name__ == "__main__":

--- a/apps/gimp-pollinations/tests/test_pollinations_gimp.py
+++ b/apps/gimp-pollinations/tests/test_pollinations_gimp.py
@@ -1,0 +1,106 @@
+import base64
+import json
+import tempfile
+import unittest
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import patch
+from urllib.error import HTTPError
+from urllib.request import Request
+
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from pollinations_gimp import ImageModel, PollinationsClient, PollinationsError, _multipart_body
+
+
+class FakeTransport:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.requests = []
+
+    def __call__(self, request: Request) -> bytes:
+        self.requests.append(request)
+        return json.dumps(self.responses.pop(0)).encode()
+
+
+class PollinationsClientTest(unittest.TestCase):
+    def test_device_flow_uses_app_key_and_waits_for_approval(self):
+        transport = FakeTransport(
+            [
+                {
+                    "device_code": "device-secret",
+                    "user_code": "ABCD-1234",
+                    "verification_uri": "/device",
+                    "verification_uri_complete": "/device?user_code=ABCD-1234",
+                    "interval": 7,
+                },
+                {"error": "authorization_pending"},
+                {"access_token": "sk_authorized"},
+            ]
+        )
+        client = PollinationsClient(request=transport)
+        device = client.start_device_authorization("pk_gimp_app")
+        self.assertEqual(device.verification_uri, "https://enter.pollinations.ai/device")
+        self.assertEqual(device.interval, 7)
+        self.assertIsNone(client.poll_device_authorization(device.device_code))
+        self.assertEqual(client.poll_device_authorization(device.device_code), "sk_authorized")
+        self.assertEqual(client.token, "sk_authorized")
+        self.assertIn(b'"client_id": "pk_gimp_app"', transport.requests[0].data)
+
+    def test_catalog_is_authenticated_and_keeps_only_image_output_models(self):
+        transport = FakeTransport(
+            [
+                [
+                    {
+                        "name": "community-paint",
+                        "title": "Community Paint",
+                        "output_modalities": ["image"],
+                        "input_modalities": ["text", "image"],
+                        "resolutions": ["1k", "2k"],
+                        "community": True,
+                    },
+                    {"name": "video", "output_modalities": ["video"]},
+                ]
+            ]
+        )
+        client = PollinationsClient("sk_authorized", transport)
+        models = client.list_image_models()
+        self.assertEqual([model.id for model in models], ["community-paint"])
+        self.assertTrue(models[0].accepts_image)
+        self.assertEqual(transport.requests[0].get_header("Authorization"), "Bearer sk_authorized")
+
+    def test_edit_multipart_sends_the_active_layer_file(self):
+        encoded = base64.b64encode(b"png-bytes").decode()
+        transport = FakeTransport([{"data": [{"b64_json": encoded}]}])
+        client = PollinationsClient("sk_authorized", transport)
+        with tempfile.NamedTemporaryFile(suffix=".png") as image:
+            image.write(b"source-png")
+            image.flush()
+            result = client.edit("turn it blue", ImageModel("edit", "Edit", ("text", "image"), ()), Path(image.name), None)
+        self.assertEqual(result, b"png-bytes")
+        body = transport.requests[0].data
+        self.assertIn(b'name="image"; filename="gimp-layer.png"', body)
+        self.assertIn(b"source-png", body)
+
+    def test_invalid_app_key_is_not_sent(self):
+        with self.assertRaises(PollinationsError):
+            PollinationsClient(request=FakeTransport([])).start_device_authorization("sk_not_an_app_key")
+
+    def test_pending_device_http_400_remains_in_the_polling_loop(self):
+        pending = HTTPError(
+            "https://enter.pollinations.ai/api/device/token",
+            400,
+            "Bad Request",
+            None,
+            BytesIO(b'{"error":"authorization_pending"}'),
+        )
+        with patch("pollinations_gimp.urlopen", side_effect=pending):
+            body = PollinationsClient._urlopen(
+                Request("https://enter.pollinations.ai/api/device/token", data=b"{}", method="POST")
+            )
+        self.assertEqual(json.loads(body), {"error": "authorization_pending"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Adds a GIMP 3 plug-in with BYOP device authorization and native OS credential storage
- Keeps GTK responsive during authorization, model loading, generation, and editing
- Loads account-visible and community image models at runtime, including edit endpoint capabilities
- Returns selection edits at their original canvas bounds without changing the source layer
- Covers device polling, model gating, multipart edits, resolution, and seed handling with focused tests

Publisher note: the public App Key remains configurable in GIMP or through `POLLINATIONS_GIMP_APP_KEY`; no contributor-owned key is bundled.

Fixes #14232

Tests: `python3 -m unittest discover -s apps/gimp-pollinations/tests -v`