### PR TITLE
feat: add Gemini 3.8 Flash

### DIFF
--- a/MODEL_SLUGS.md
+++ b/MODEL_SLUGS.md
@@ -119,6 +119,7 @@ Only the names are changing. Model behavior and pricing stay the same.
 | Gemini 3.1 Pro Preview | `gemini-large` | `google/gemini-3.1-pro-preview` |
 | Gemini 3.5 Flash Lite | `gemini-flash-lite-3.5` | `google/gemini-3.5-flash-lite` |
 | Gemini 3.7 Flash | `gemini` | `google/gemini-3.7-flash` |
+| Gemini 3.8 Flash | — | `google/gemini-3.8-flash` |
 | Gemini Embedding 2 | `gemini-2` | `google/gemini-embedding-2` |
 | Gemma 4 26B A4B | `gemma` | `google/gemma-4-26b-a4b-it` |
 | Gemma 4 31B | `gemma-4-31b` | `google/gemma-4-31b-it` |

--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -680,6 +680,26 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.00000126,
     },
   },
+  "google/gemini-3.8-flash": {
+    "cost": {
+      "completionTextTokens": 0.00000375,
+      "promptAudioTokens": 0.00000075,
+      "promptCacheWriteTokens": 0.00000075,
+      "promptCachedTokens": 0.000000075,
+      "promptImageTokens": 0.00000075,
+      "promptTextTokens": 0.00000075,
+      "promptVideoTokens": 0.00000075,
+    },
+    "price": {
+      "completionTextTokens": 0.00000375,
+      "promptAudioTokens": 0.00000075,
+      "promptCacheWriteTokens": 0.00000075,
+      "promptCachedTokens": 0.000000075,
+      "promptImageTokens": 0.00000075,
+      "promptTextTokens": 0.00000075,
+      "promptVideoTokens": 0.00000075,
+    },
+  },
   "google/gemini-omni-1.1-flash": {
     "cost": {
       "completionTextTokens": 0.000009,

--- a/enter.pollinations.ai/test/pricing-data.test.ts
+++ b/enter.pollinations.ai/test/pricing-data.test.ts
@@ -958,6 +958,7 @@ test("Gemini models use their endpoint's advertised cache-write rate", () => {
     const models = [
         "gemini-3-flash",
         "gemini",
+        "google/gemini-3.8-flash",
         "gemini-openrouter-ai-studio-priority",
         "gemini-flash-lite-3.5",
         "gemini-flash-lite-3.5-openrouter-ai-studio-flex",
@@ -981,6 +982,7 @@ test("Gemini routes price separately reported media input tokens", () => {
     for (const model of [
         "gemini-3-flash",
         "gemini",
+        "google/gemini-3.8-flash",
         "gemini-flash-lite-3.5",
         "gemini-fast",
         "gemini-large",
@@ -1002,6 +1004,7 @@ test("Google text model providers match their configured routes", () => {
     const openRouterModels = [
         "gemini-3-flash",
         "gemini",
+        "google/gemini-3.8-flash",
         "gemini-flash-lite-3.5",
         "gemini-fast",
         "gemini-large",

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -359,6 +359,15 @@ const models: ModelDefinition[] = [
         ),
     },
     {
+        name: "google/gemini-3.8-flash",
+        config: portkeyConfig["google/gemini-3.8-flash"],
+        transform: pipe(
+            adaptGoogleSearchToolForOpenRouter,
+            // Gemini 3.8 requires reasoning; map `none` to its lowest level.
+            createGeminiThinkingTransform("v3-pro"),
+        ),
+    },
+    {
         name: "gemini-flash-lite-3.5",
         config: portkeyConfig["google/gemini-3.5-flash-lite"],
         transform: pipe(

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -544,6 +544,10 @@ export const portkeyConfig: PortkeyConfigMap = {
         "gemini-3.7-flash",
         "google-vertex/global",
     ),
+    "google/gemini-3.8-flash": createPinnedOpenRouterGeminiConfig(
+        "gemini-3.8-flash",
+        "google-vertex/global",
+    ),
 
     // -- Google Vertex AI (dedicated Gemini Search services) -----------------
     "vertex/gemini-2.5-flash-lite": createVertexGeminiConfig(

--- a/gen.pollinations.ai/test/text/transforms/createGeminiThinkingTransform.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/createGeminiThinkingTransform.test.ts
@@ -55,8 +55,10 @@ describe("Gemini reasoning_effort model wiring", () => {
         expect(options.reasoning_effort).toBeUndefined();
     });
 
-    it("maps reasoning_effort=none to low for mandatory-reasoning gemini", async () => {
-        const model = "gemini";
+    it.each([
+        "gemini",
+        "google/gemini-3.8-flash",
+    ])("maps reasoning_effort=none to low for mandatory-reasoning %s", async (model) => {
         const transform = findModelByName(model)?.transform;
         if (!transform) throw new Error(`${model} transform missing`);
 

--- a/gen.pollinations.ai/test/text/transforms/createGeminiToolsTransform.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/createGeminiToolsTransform.test.ts
@@ -17,6 +17,11 @@ describe("OpenRouter Gemini routing", () => {
         ],
         ["gemini", "google/gemini-3.7-flash", "google-vertex/global"],
         [
+            "google/gemini-3.8-flash",
+            "google/gemini-3.8-flash",
+            "google-vertex/global",
+        ],
+        [
             "gemini-flash-lite-3.5",
             "google/gemini-3.5-flash-lite",
             "google-vertex/global",
@@ -42,6 +47,7 @@ describe("OpenRouter Gemini routing", () => {
     it.each([
         "gemini-3-flash",
         "gemini",
+        "google/gemini-3.8-flash",
         "gemini-flash-lite-3.5",
         "gemini-fast",
         "gemini-large",

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -648,6 +648,41 @@ const TEXT_BASE_SERVICES = {
         contextLength: 1048576,
         isSpecialized: false,
     },
+    "google/gemini-3.8-flash": {
+        aliases: [],
+        provider: "openrouter",
+        brand: "Google",
+        category: "text",
+        addedDate: new Date("2026-09-02").getTime(),
+        priceMultiplier: 1,
+        paidOnly: true,
+        // Standard OpenRouter rates for the pinned google-vertex/global route.
+        // Google's introductory pricing ends 2026-12-31.
+        cost: {
+            promptTextTokens: perMillion(0.75),
+            promptCachedTokens: perMillion(0.075),
+            promptCacheWriteTokens: perMillion(0.75),
+            promptAudioTokens: perMillion(0.75),
+            promptImageTokens: perMillion(0.75),
+            promptVideoTokens: perMillion(0.75),
+            completionTextTokens: perMillion(3.75),
+        },
+        billing: openRouterGeminiBilling({
+            searchCostPerThousandRequests: 14,
+            storageCostPerMillionTokenHours: 0.5,
+        }),
+        title: "Gemini 3.8 Flash",
+        description:
+            "Fast multimodal reasoning for long-horizon coding, autonomous agents and complex workflows",
+        inputModalities: ["text", "image", "audio", "video"],
+        outputModalities: ["text"],
+        maxReferenceImages: 3600, // Gemini API image-understanding file limit.
+        maxReferenceVideos: 10, // Gemini API video-understanding upload limit.
+        tools: true,
+        search: true,
+        contextLength: 1048576,
+        isSpecialized: false,
+    },
     "gemini-flash-lite-3.5": {
         aliases: [
             "gemini-flash-lite-3.1",


### PR DESCRIPTION
- Adds canonical `google/gemini-3.8-flash` as a separate paid-only model; the existing `gemini` service is unchanged.
- Pins OpenRouter to `google-vertex/global` with fallback disabled.
- Prices text/image/audio/video input at $0.75/M, cached input at $0.075/M, output at $3.75/M, plus exact search and cache-storage adjustments; multiplier is 1.
- Adds the canonical slug, resolver/reasoning/search coverage, and the effective-price snapshot.

Verified with direct-provider and authenticated local E2E for catalogs, chat/Responses/simple routes, streaming, structured output, tools, all reasoning levels, image/audio/video, search, caching, permissions, paid-only rejection, a 5-request burst, wallet debit, and staging Tinybird settlement.

Sources: [Google model docs](https://ai.google.dev/gemini-api/docs/models/gemini-3.8-flash) · [OpenRouter model](https://openrouter.ai/google/gemini-3.8-flash)