### PR TITLE
fix: retry embedded upstream rate limits

### DIFF
--- a/gen.pollinations.ai/src/text/genericOpenAIClient.ts
+++ b/gen.pollinations.ai/src/text/genericOpenAIClient.ts
@@ -86,6 +86,31 @@ function extractErrorMessage(details: unknown): string | null {
     return typeof message === "string" && message.trim() ? message : null;
 }
 
+/**
+ * Some OpenAI-compatible gateways return an upstream rate limit inside an
+ * otherwise successful completion. Normalize only an explicit 429; other
+ * finish errors are not necessarily retryable.
+ */
+function responseBodyError(
+    completion: ChatCompletion,
+): ChatCompletion["error"] {
+    if (completion.error) return completion.error;
+
+    for (const choice of completion.choices ?? []) {
+        if (choice.finish_reason !== "error") continue;
+        const details = choice.error;
+        if (!details || typeof details !== "object") continue;
+        const embedded = details as { code?: unknown; status?: unknown };
+        if (embedded.code !== 429 && embedded.status !== 429) continue;
+
+        return {
+            message: extractErrorMessage(details) ?? undefined,
+            status: 429,
+            details,
+        };
+    }
+}
+
 function createApiError(
     response: Response,
     details: unknown,
@@ -258,11 +283,12 @@ export async function genericOpenAIClient(
         } catch (thrown: unknown) {
             throw withUpstreamContext(thrown, requestUrl);
         }
-        if (data.error) {
+        const responseError = responseBodyError(data);
+        if (responseError) {
             const errorDetails =
-                typeof data.error === "string"
-                    ? { message: data.error }
-                    : data.error;
+                typeof responseError === "string"
+                    ? { message: responseError }
+                    : responseError;
             const error = new Error(
                 errorDetails.message || "Text generation failed",
             ) as ServiceError;

--- a/gen.pollinations.ai/test/text/genericOpenAIClient.test.ts
+++ b/gen.pollinations.ai/test/text/genericOpenAIClient.test.ts
@@ -459,6 +459,63 @@ describe("genericOpenAIClient", () => {
         ).rejects.toMatchObject({ status: 502, upstreamStatus: 429 });
     });
 
+    it("maps an embedded completion 429 to a retryable upstream error", async () => {
+        const details = {
+            code: 429,
+            message: "Provider rate limited",
+            metadata: { error_type: "rate_limit_exceeded" },
+        };
+        vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+            Response.json({
+                choices: [
+                    {
+                        finish_reason: "error",
+                        error: details,
+                    },
+                ],
+            }),
+        );
+
+        await expect(
+            genericOpenAIClient(
+                [{ role: "user", content: "hello" }],
+                { model: "provider-model" },
+                { endpoint: "https://portkey.test/chat" },
+            ),
+        ).rejects.toMatchObject({
+            status: 502,
+            upstreamStatus: 429,
+            details,
+        });
+    });
+
+    it("leaves non-rate-limit completion errors unchanged", async () => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+            Response.json({
+                choices: [
+                    {
+                        finish_reason: "error",
+                        error: {
+                            code: 400,
+                            message: "Malformed function call",
+                        },
+                    },
+                ],
+            }),
+        );
+
+        const completion = await genericOpenAIClient(
+            [{ role: "user", content: "hello" }],
+            { model: "provider-model" },
+            { endpoint: "https://portkey.test/chat" },
+        );
+
+        expect(completion.choices?.[0]).toMatchObject({
+            finish_reason: "error",
+            error: { code: 400 },
+        });
+    });
+
     it.each([
         '{"error":{"message":"Failed to load image: cannot identify image file","code":400}}',
         '{"error":{"message":"Invalid or unsupported audio file.","code":400}}',


### PR DESCRIPTION
- Normalizes explicit embedded 429 completion errors into the existing upstream error shape
- Preserves the original provider error details for observability
- Leaves other finish errors and streaming behavior unchanged
- Adds focused regression coverage