### PR TITLE
chore: add encrypted secrets for apps/openwebui

### DIFF
--- a/apps/openwebui/secrets/secrets.vars.json
+++ b/apps/openwebui/secrets/secrets.vars.json
@@ -1,0 +1,26 @@
+{
+	"production": {
+		"WEBUI_SECRET_KEY": "ENC[AES256_GCM,data:Rjs588shtAK9CZLTDnfxasUd/xteLf/H0/3GyD8zuviunlL5r/Fgi6CNhYQJy44mC6PO39ukxftk8fzS1ehCDQ==,iv:F9y7ILK3sCMEUolCkr1lzx+z94yr+XqGeIiuE9bLoKw=,tag:APS0Yhl3uSaJv73e/XVnXQ==,type:str]",
+		"DATABASE_URL": "ENC[AES256_GCM,data:vicW/6raz6js3N86Vb9BL7CreZmXDaNrKnLjvh9jYIBH4DvnnUKgmy92ztbY47IdvNnaiV8P9A+HXoMYKZw2DQiX7sOuxoREFll9dldF2Pm5TJIPARFV8TGHMzW/p0ZyPKWC5NcHd+RLoB98jmY8AA7hzxE=,iv:V3YmQmrnPGs4eDaUt5Kc3a5AU+UeNXfIO25PLKGWuEs=,tag:82KOW+yvI+zg2PYnAkheGw==,type:str]"
+	},
+	"staging": {
+		"WEBUI_SECRET_KEY": "ENC[AES256_GCM,data:yeS+oX8Rn0ufjn7NxEfVg75JNo4+rYg6O9Vwm0RRfyhhYvU6cJHASsfxivW5Y4pzZTY3MKlKb/jSwJosm0V7CA==,iv:Tf51DINhm8F//fnB5Fb1gp+QLr72Qs7sFN9kqz5GTcs=,tag:n1O0qJbnQmwRhZ0QszXahw==,type:str]",
+		"DATABASE_URL": "ENC[AES256_GCM,data:I2Wr4g3jhwzIGFME1AJ7yfH1abbxL99PAUZMDtWfk7q4RWTezjJwkZbWTcnLPe4HOkqxdSjtwYOmkFbX1hfIVx/9Nf7ls5xcD0KBZdRLBlGGtmovVPC0qcsCa/o5QSG7C/a2vDAX3jEhZC9gdmCtb4rpYrJ+JLDBeenbMQ==,iv:KnqlrP5MmhWHwTN9YiZLXmvsPhpwjANdK5t62fuOHs8=,tag:jZewJb74TCLdGqWhrxCTrg==,type:str]"
+	},
+	"sops": {
+		"age": [
+			{
+				"recipient": "age1k85e3hjd2tv3wtjv7npjtmp9pwr5cfda22hyz9ajg06uqel3cc5s6c34rd",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3cmRwY0p6S1BaY1B2MHVw\nNDR3bUNGWW5TVXA2M3BtVzVpRFkwZWJ3OHpjCjRxb005ZXJLVjFHUXBZaGxkanpk\nVS9iYS93S3h5bUl5R3k4N21TTFhXaUkKLS0tIElCOW84T28vYVN5UldtS3JZWkcr\nOUN5L1M2OVhQcGo3dEhLcFUyZWdwazQK9l/DTG6SZuOh68g/pnfAsgrMmgx82QLZ\nXjPneYC8r2Op4KBMKwUpywI7dQB5bi/CNWrq8XUACmd1bhmxf0AY/Q==\n-----END AGE ENCRYPTED FILE-----\n"
+			},
+			{
+				"recipient": "age1ry4pg28f38yrnd5nhdl2zrkh8f7vgfu0p6hdu8lwpvpa7vz8ag6qqxy4d6",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2ekQ0R2hHbTd6QlR2L2lG\nbE1mbDJyT2VZOGhLODNld2toTENpYlZRUXowCnJWZ1FOSHRGY0JYdlF5RERPRy8r\ncExFNStzSnl1SVl1cHUzTW4vSmVXWDgKLS0tIDZzMHZ4eWYwNnBpK1dJRk9OQkk0\nRDVRZ3dWYWhmSExoTGdNYXpGQzBjL3MK/NNRRF5W4BhEKipKla/Qfa0x81ZIR8DE\nmzm9tIY3VSxFNRjSCYiO6FNrB4K/mqXGzqwPcBltk5Jl/wMs90cHGg==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2026-09-03T01:37:03Z",
+		"mac": "ENC[AES256_GCM,data:4UhhicfH6FfNMichKMBZ/HQbKz42xAnr/AfANm3sbK5Lw+gKWXkjP9X825FB+iFBCbPDcIfPxsTwB5Y9EkOlSDuTUU92T3z1BMFk8lZtCMpz0BgXT8CL8KQmlsbsiKsy0AWT4Z1j/q5u3U1qt7hvljpSg7ORD1y49beMeKGkTg0=,iv:d7jF7cjlCVMYk4pFUy/9R8E+h4mS5C2cg+FJay6t2Ns=,tag:aq946OvkOkLNTvEw4BZl4A==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.11.0"
+	}
+}


### PR DESCRIPTION
- Adds sops-encrypted `apps/openwebui/secrets/secrets.vars.json` (`WEBUI_SECRET_KEY`, `DATABASE_URL` for production and staging)
- Consumed by `push-secrets` in #14372; secrets-only PR per the secret mutation policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mNrP6DkRQmm3YStNjfFv3