### PR TITLE
feat: add speech modality for community TTS endpoints

### DIFF
--- a/BRING_YOUR_OWN_MODEL.md
+++ b/BRING_YOUR_OWN_MODEL.md
@@ -1,0 +1,152 @@
+# Publish a Model
+
+Publishing a model lets you connect an endpoint to Pollinations and call it through `gen.pollinations.ai` under an `owner/model` id. Pollinations handles authentication, Pollen billing, model discovery, and routing; the model continues to run on infrastructure you control.
+
+Model publishing and [connecting user wallets](./BRING_YOUR_OWN_POLLEN.md) solve different problems. Model publishing supplies a model to the Pollinations catalog. The wallet flow lets users authorize an app to spend their own Pollen. An app can use either or both.
+
+## Supported Models
+
+| Model family | Required upstream endpoint | Pollinations endpoint |
+|---|---|---|
+| Text | `POST /v1/chat/completions` | `POST /v1/chat/completions` |
+| Image | `POST /v1/images/generations` | `GET /image/{prompt}` or `POST /v1/images/generations` |
+| Image editing | `POST /v1/images/edits` in addition to image generation | `POST /v1/images/edits` |
+| Video | Exact endpoint URL entered at registration | `GET /video/{prompt}`, `GET /image/{prompt}`, or `POST /v1/images/generations` |
+| Speech to text | `POST /v1/audio/transcriptions` | `POST /v1/audio/transcriptions` |
+| Text to speech | `POST /v1/audio/speech` | `POST /v1/audio/speech` |
+| Embeddings | `POST /v1/embeddings` | `POST /v1/embeddings` |
+
+Image providers must return `b64_json`. During testing, Pollinations checks whether an image provider supports edits and whether it reports OpenAI image-token usage.
+
+Video generation is synchronous. Pollinations calls the exact URL entered at registration with a required numeric `duration`:
+
+```json
+{
+  "prompt": "A green sprout moving in the breeze",
+  "duration": 4,
+  "image": ["https://example.com/start.jpg", "https://example.com/end.jpg"],
+  "reference_images": ["https://example.com/style.jpg"],
+  "reference_videos": ["https://example.com/motion.mp4"],
+  "reference_audios": ["https://example.com/audio.mp3"]
+}
+```
+
+Only supplied fields are included. In `image`, the first URL is the start frame and the second is the end frame. The `reference_*` arrays are general guidance rather than frame controls. Publishers select the accepted image, video, and audio input types when registering the model; unsupported combinations should return an error.
+
+Return one completed MP4 within 300 seconds as `b64_json` or a public `url`:
+
+```json
+{
+  "data": [
+    {
+      "url": "https://video-provider.example/output/clip.mp4"
+    }
+  ]
+}
+```
+
+Pollinations sends no upstream model id and bills the accepted request duration. Inline and downloaded responses are limited to 20 MB. Do not return an async job id; polling must finish inside the publisher endpoint before it responds.
+
+Realtime and 3D endpoints cannot currently be registered through this workflow.
+
+## Private and Public Models
+
+Any signed-in user can register and call a private model. Private models are owner-only, do not appear in the public catalog, and are free at the Pollinations layer.
+
+Publishing a model requires account-level community publisher access while community model publishing is in alpha. Submit a [publisher access request](https://github.com/pollinations/pollinations/issues/new?template=community-model-allowlist.yml); the request enables public publishing for the account but does not register a model for you.
+
+Public models appear in the model catalog and can be called by other Pollinations users. Owners set public pricing:
+
+- Text models use the token categories reported by the upstream endpoint.
+- Image models use per-token pricing when the registration test finds valid OpenAI image usage; otherwise they use a fixed price per generated image.
+- Video models are priced from the requested duration in seconds.
+- Transcription models are priced from reported audio duration.
+- Speech models are priced by character count of the synthesized text.
+- Embedding models use the prompt-token count reported by the upstream endpoint.
+- A zero price makes the public model free.
+
+Owners receive 75% of the Pollen spent on their models. Paid and Quest Pollen earnings remain in their respective wallet buckets. Cash payouts are not currently available.
+
+## Register in the Dashboard
+
+1. Open [My Models](https://enter.pollinations.ai/my-models).
+2. Choose **Add model**.
+3. Select text, image, transcription, or embedding and enter the upstream base URL, model id, and bearer token. For video, enter the exact generation URL and bearer token.
+4. Fetch the upstream model list or run the endpoint test before saving.
+5. Save the model as private, then call its `owner/model` id through the normal Pollinations endpoint.
+6. If your account has publisher access, change visibility to public and set prices when it is ready for other users.
+
+### Model names
+
+Choose a short, stable slug for the model ID (`owner/slug`) and a clear title for the catalog. Keep details that may change, such as price, hosting provider, routing, or context size, out of the slug. Use the description to identify the upstream model or explain what a router or rebranded model does. For example, use `owner/llama-3.1-8b` with the title `Llama 3.1 8B` and the description `Direct proxy to Meta Llama 3.1 8B via Groq`, or `owner/fast-router` with the title `Fast Chat Router` and the description `Routes between Llama and Mistral based on latency`.
+
+The upstream credential is used by Pollinations to proxy requests to your endpoint. Do not place it in a model name, description, public URL, or example.
+
+## Register with the CLI
+
+The CLI manages text, image, video, transcription, speech, and embedding model registrations. Sign in, test the endpoint, then create the model:
+
+```bash
+npx @pollinations/cli auth login
+
+npx @pollinations/cli my-models test \
+  --modality image \
+  --base-url https://api.example.com/v1 \
+  --bearer-token "$UPSTREAM_API_KEY" \
+  --model image-v1
+
+npx @pollinations/cli my-models create \
+  --name my-image \
+  --title "My Image" \
+  --modality image \
+  --image-pricing request \
+  --completion-image-price 0.01 \
+  --input-modalities text,image \
+  --base-url https://api.example.com/v1 \
+  --bearer-token "$UPSTREAM_API_KEY" \
+  --upstream-model image-v1
+```
+
+Use `polli my-models list`, `update`, and `delete` for the rest of the lifecycle. API keys used for model management require the `account:keys` permission.
+
+Embedding models use `--modality embedding`. For example, `--prompt-text-price 0.000001` charges 1 Pollen per 1M input tokens.
+
+## Publishing Controls
+
+Public models support these owner controls in the dashboard or Account API:
+
+- `paidOnly` restricts calls to Paid Pollen.
+- `perUserRpm` limits each Pollinations user; `null` removes the limit.
+- Text models can declare `advertised.contextLength` and the `tool_calling` or `reasoning` capabilities.
+- The provider profile at `POST /account/my-models/provider` sets the public provider name and service URL shared by your models.
+- Owners can hide or relist their models without deleting them.
+
+Token prices cannot exceed 50 Pollen per 1M tokens. Fixed image prices cannot exceed 0.25 Pollen per image, video prices cannot exceed 0.5 Pollen per generated second, and transcription prices cannot exceed 0.012 Pollen per minute. See the [Community Models API reference](https://gen.pollinations.ai/docs#tag/community-models) for the exact fields.
+
+## Call Your Model
+
+Use the generated `owner/model` id anywhere the corresponding Pollinations endpoint accepts a model:
+
+```bash
+curl https://gen.pollinations.ai/v1/chat/completions \
+  -H "Authorization: Bearer $POLLINATIONS_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "owner/my-model",
+    "messages": [{"role": "user", "content": "Hello"}]
+  }'
+```
+
+Authenticated model-list requests include your own private models. Public discovery endpoints accept `community=true` to return only community models.
+
+## Fallbacks and Health
+
+Public and private community models can nominate up to three compatible community fallbacks. Fallbacks are tried in order and must use the same model family. They must not cost more than the primary model; image fallbacks must also match its pricing mode and support image input when the primary model does. A fallback cannot require Paid Pollen unless the primary model does too.
+
+Pollinations monitors public text and image models using live traffic and active probes. Sustained failures can hide a model from listings while exact-ID calls continue to work. Owners can relist a fixed model, and the monitor can automatically relist models it hid after recovery is verified. View public model health at [model-monitor.pollinations.ai](https://model-monitor.pollinations.ai).
+
+## Trust Boundary
+
+Community models run on the owner's infrastructure, not Pollinations infrastructure. Prompts, input media, and other request content are sent to that upstream provider. Do not send credentials or sensitive information to a community model unless you trust its owner and data handling.
+
+For complete `/account/my-models` request and response schemas, use the [Community Models API reference](https://gen.pollinations.ai/docs#tag/community-models).

--- a/enter.pollinations.ai/src/routes/community-endpoints.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints.ts
@@ -1,232 +1,77 @@
+import { validateCommunityEndpointUrl } from "@shared/community-endpoint-urls.ts";
 import {
-    COMMUNITY_ENDPOINT_DESCRIPTION_MAX_LENGTH,
-    COMMUNITY_ENDPOINT_IMAGE_PRICING_MODES,
-    COMMUNITY_ENDPOINT_MODALITIES,
-    COMMUNITY_ENDPOINT_PRICE_FIELDS,
-    COMMUNITY_ENDPOINT_TITLE_MAX_LENGTH,
-    COMMUNITY_ENDPOINT_VISIBILITIES,
-    type CommunityEndpointPriceKey,
+    COMMUNITY_ENDPOINT_CHANGE_DELAY_MS,
     type CommunityEndpointVisibility,
-    communityEndpointPriceFieldsForModality,
-    communityEndpointPrices,
-    communityEndpointPricesForModality,
-    communityEndpointTitle,
     communityModelId,
+    type EndpointAgentListingPayload,
+    effectiveCommunityEndpointVisibility,
     isCommunityEndpointOwnerAllowed,
-    MAX_COMMUNITY_PRICE_PER_IMAGE,
-    MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS,
-    MAX_COMMUNITY_PRICE_PER_TOKEN,
-    MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS,
-    MIN_COMMUNITY_PRICE_PER_TOKEN,
-    normalizeCommunityEndpointBaseUrl,
     normalizeCommunityEndpointBearerToken,
-    normalizeCommunityEndpointImagePricing,
-    normalizeCommunityEndpointModality,
+    normalizeCommunityProviderUrl,
+    type ProxyListingPayload,
+    parseListingPayload,
+    pendingCommunityEndpointChangeIsReady,
+    resolveEffectiveProxyListing,
 } from "@shared/community-endpoints.ts";
 import * as schema from "@shared/db/better-auth.ts";
 import { validator } from "@shared/middleware/validator.ts";
 import { encryptSecret } from "@shared/secret-encryption.ts";
-import { and, eq } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import type { Context } from "hono";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { describeRoute, resolver } from "hono-openapi";
-import { z } from "zod";
 import type { Env } from "../env.ts";
 import { auth } from "../middleware/auth.ts";
 import {
+    type CommunityEndpointTestResult,
     listCommunityEndpointModels,
+    testCommunityEmbeddingEndpoint,
     testCommunityEndpoint,
     testCommunityImageEndpoint,
+    testCommunitySpeechEndpoint,
+    testCommunityTranscriptionEndpoint,
+    testCommunityVideoEndpoint,
 } from "../services/community-endpoint-openai.ts";
-import { hasDirectAccountPermission } from "./account-permissions.ts";
+import { requireAccountPermission } from "./account-permissions.ts";
+import {
+    type FallbackPrimary,
+    fallbackTargetRejection,
+    resolveFallbacks,
+} from "./community-endpoints/fallbacks.ts";
+import { toCommunityEndpointResponse } from "./community-endpoints/presenter.ts";
+import {
+    changesProxyPayload,
+    deriveCreateProxyPolicy,
+    deriveUpdatedProxyPolicy,
+    hasProxyPricingInput,
+    proxyPricingChanged,
+    withoutProxyPricingChanges,
+} from "./community-endpoints/proxy-policy.ts";
+import {
+    assertValidUpdate,
+    CommunityEndpointDeleteResponseSchema,
+    CommunityEndpointListResponseSchema,
+    CommunityEndpointModelsResponseSchema,
+    CommunityEndpointResponseSchema,
+    CommunityEndpointTestResponseSchema,
+    CommunityProviderProfileInputSchema,
+    CommunityProviderProfileResponseSchema,
+    CreateEndpointAgentSchema,
+    CreateEndpointSchema,
+    EndpointAgentResponseSchema,
+    FallbackCandidatesResponseSchema,
+    ModelListSchema,
+    TestEndpointSchema,
+    UpdateEndpointSchema,
+} from "./community-endpoints/schemas.ts";
 
-const ModalitySchema = z
-    .enum(COMMUNITY_ENDPOINT_MODALITIES)
-    .describe(
-        'Upstream API family. "text" uses `/v1/chat/completions`; "image" uses `/v1/images/generations` and optionally `/v1/images/edits` when the endpoint test succeeds.',
-    );
-const ImagePricingSchema = z
-    .enum(COMMUNITY_ENDPOINT_IMAGE_PRICING_MODES)
-    .describe(
-        'Image models only. "request": the generated-image price is charged once per generation. "tokens": provider-returned OpenAI image token usage is charged against per-token prices. Detected by the endpoint test.',
-    );
-const PriceSchema = z
-    .number()
-    .finite()
-    .min(0)
-    .refine((price) => price === 0 || price >= MIN_COMMUNITY_PRICE_PER_TOKEN, {
-        message: `Price must be 0 (free) or at least ${MIN_COMMUNITY_PRICE_PER_TOKEN} per token (${MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS} per 1M tokens)`,
-    })
-    .describe(
-        'Pollen price. Token rates are per token internally (the dashboard displays per 1M); `completionImagePrice` is per generated image when `imagePricing` is "request".',
-    );
-const UpdatePriceFieldsSchema = Object.fromEntries(
-    COMMUNITY_ENDPOINT_PRICE_FIELDS.map((field) => [
-        field.key,
-        PriceSchema.optional(),
-    ]),
-) as unknown as Record<
-    CommunityEndpointPriceKey,
-    z.ZodOptional<z.ZodType<number>>
->;
-
-function enforceCommunityEndpointPriceLimits(
-    source: Partial<Record<CommunityEndpointPriceKey, number>>,
-    modality: (typeof COMMUNITY_ENDPOINT_MODALITIES)[number],
-    imagePricing: (typeof COMMUNITY_ENDPOINT_IMAGE_PRICING_MODES)[number],
-): void {
-    for (const field of communityEndpointPriceFieldsForModality(
-        modality,
-        imagePricing,
-    )) {
-        const price = source[field.key];
-        const maxPrice =
-            field.priceUnit === "image"
-                ? MAX_COMMUNITY_PRICE_PER_IMAGE
-                : MAX_COMMUNITY_PRICE_PER_TOKEN;
-        if (price === undefined || price <= maxPrice) continue;
-
-        const limit =
-            field.priceUnit === "image"
-                ? `${MAX_COMMUNITY_PRICE_PER_IMAGE} Pollen per image`
-                : `${MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS} Pollen per 1M tokens`;
-        throw new HTTPException(400, {
-            message: `${field.label} price must not exceed ${limit}`,
-        });
-    }
-}
-
-const VisibilitySchema = z
-    .enum(COMMUNITY_ENDPOINT_VISIBILITIES)
-    .describe(
-        '"private": owner-only, shown only to the owner, with no owner-set price. "public": anyone and listed in the catalog; it may be free or priced. Publishing requires an allowlisted account.',
-    );
-const EndpointFieldsSchema = {
-    // No "/": the public model id is `<owner>/<name>`, so a slash in the name
-    // would inject a second separator and let one model spoof another's id.
-    name: z
-        .string()
-        .trim()
-        .min(1)
-        .max(120)
-        .regex(/^[^/]+$/, "Model name cannot contain '/'"),
-    title: z
-        .string()
-        .trim()
-        .min(1)
-        .max(COMMUNITY_ENDPOINT_TITLE_MAX_LENGTH)
-        .describe("Display name shown in the model catalog."),
-    description: z
-        .string()
-        .trim()
-        .max(COMMUNITY_ENDPOINT_DESCRIPTION_MAX_LENGTH)
-        .optional(),
-    baseUrl: z
-        .string()
-        .url()
-        .describe(
-            "OpenAI-compatible `/v1` base URL or full chat, image generation, or image edit URL.",
-        ),
-    upstreamModel: z.string().trim().min(1).max(253).optional(),
-    bearerToken: z.string().min(1),
-} as const;
-
-const CreateEndpointSchema = z.object({
-    ...EndpointFieldsSchema,
-    modality: ModalitySchema.optional().default("text"),
-    imagePricing: ImagePricingSchema.optional().default("request"),
-    supportsImageEdits: z.boolean().optional().default(false),
-    visibility: VisibilitySchema.optional().default("private"),
-    ...UpdatePriceFieldsSchema,
-});
-const UpdateEndpointSchema = z.object({
-    name: EndpointFieldsSchema.name.optional(),
-    title: EndpointFieldsSchema.title.optional(),
-    description: EndpointFieldsSchema.description,
-    baseUrl: EndpointFieldsSchema.baseUrl.optional(),
-    upstreamModel: EndpointFieldsSchema.upstreamModel,
-    bearerToken: EndpointFieldsSchema.bearerToken.optional(),
-    visibility: VisibilitySchema.optional(),
-    imagePricing: ImagePricingSchema.optional(),
-    supportsImageEdits: z.boolean().optional(),
-    active: z.boolean().optional(),
-    ...UpdatePriceFieldsSchema,
-});
-const ModelListSchema = z.object({
-    baseUrl: z.string().url(),
-    bearerToken: z.string().min(1),
-});
-const TestEndpointSchema = z.object({
-    baseUrl: z.string().url(),
-    bearerToken: z.string().min(1),
-    model: z.string().trim().min(1).max(253),
-    modality: ModalitySchema.optional().default("text"),
-});
-const ResponsePriceFieldsSchema = Object.fromEntries(
-    COMMUNITY_ENDPOINT_PRICE_FIELDS.map((field) => [field.key, z.number()]),
-) as unknown as Record<CommunityEndpointPriceKey, z.ZodType<number>>;
-const CommunityEndpointResponseSchema = z.object({
-    id: z.string(),
-    modelId: z.string(),
-    name: z.string(),
-    title: z.string(),
-    description: z.string().nullable(),
-    modality: ModalitySchema,
-    imagePricing: ImagePricingSchema,
-    supportsImageEdits: z.boolean(),
-    baseUrl: z.string(),
-    upstreamModel: z.string(),
-    visibility: VisibilitySchema,
-    ...ResponsePriceFieldsSchema,
-    disabled: z.boolean(),
-    disabledReason: z.string().nullable(),
-    disabledAt: z.string().nullable(),
-    createdAt: z.string(),
-    updatedAt: z.string(),
-});
-const CommunityEndpointListResponseSchema = z.object({
-    data: z.array(CommunityEndpointResponseSchema),
-});
-const CommunityEndpointModelsResponseSchema = z.object({
-    data: z.array(z.string()),
-});
-const CommunityEndpointTestResponseSchema = z
-    .object({
-        ok: z.boolean(),
-        message: z.string(),
-        usage: z
-            .record(z.string(), z.unknown())
-            .describe(
-                "Raw provider usage, or `{ images: 1 }` when an image provider returns no token usage.",
-            ),
-        billableUsage: z
-            .record(z.string(), z.number())
-            .describe(
-                "Normalized billable usage fields used to reveal applicable prices.",
-            ),
-        imagePricing: ImagePricingSchema.optional().describe(
-            "Image tests only: pricing mode detected from the provider response.",
-        ),
-        supportsImageEdits: z
-            .boolean()
-            .optional()
-            .describe(
-                "Image tests only: true when the derived `/images/edits` endpoint returned a valid image.",
-            ),
-    })
-    .passthrough();
-const CommunityEndpointDeleteResponseSchema = z.object({
-    id: z.string(),
-});
 const ENDPOINT_PROBE_THROTTLE_SECONDS = 30;
 type Db = ReturnType<typeof drizzle<typeof schema>>;
-type CommunityEndpointRow = typeof schema.communityEndpoint.$inferSelect;
-
-function normalizeInputBaseUrl(value: string): string {
+function validateInputEndpointUrl(value: string): string {
     try {
-        return normalizeCommunityEndpointBaseUrl(value);
+        return validateCommunityEndpointUrl(value);
     } catch (error) {
         throw new HTTPException(400, {
             message:
@@ -248,8 +93,19 @@ function normalizeInputBearerToken(value: string): string {
     }
 }
 
-// Anyone may register private endpoints for their own use. Publishing and raw
-// upstream probes require an allowlisted account.
+function normalizeInputProviderUrl(value: string): string {
+    try {
+        return normalizeCommunityProviderUrl(value);
+    } catch (error) {
+        throw new HTTPException(400, {
+            message:
+                error instanceof Error ? error.message : "Invalid provider URL",
+        });
+    }
+}
+
+// Anyone may register private endpoints for their own use and probe their own
+// upstream. Publishing requires an allowlisted account.
 async function requireCommunityEndpointPublishAccess(
     db: Db,
     userId: string,
@@ -262,7 +118,7 @@ async function requireCommunityEndpointPublishAccess(
     if (!isCommunityEndpointOwnerAllowed(user)) {
         throw new HTTPException(403, {
             message:
-                "Community model publishing tools require approval. Models can stay private for your own use.",
+                "Community model publishing requires approval. Models can stay private for your own use.",
         });
     }
 }
@@ -280,33 +136,6 @@ async function requireOwnerGithubUsername(
         message:
             "A GitHub username is required to register community endpoints",
     });
-}
-
-function toResponse(row: CommunityEndpointRow, ownerGithubUsername: string) {
-    const modality = normalizeCommunityEndpointModality(row.modality);
-    return {
-        id: row.id,
-        modelId: communityModelId(ownerGithubUsername, row.name),
-        name: row.name,
-        title: communityEndpointTitle({
-            modelId: communityModelId(ownerGithubUsername, row.name),
-            title: row.title,
-            description: row.description,
-        }),
-        description: row.description,
-        modality,
-        imagePricing: normalizeCommunityEndpointImagePricing(row.imagePricing),
-        supportsImageEdits: row.supportsImageEdits,
-        baseUrl: row.baseUrl,
-        upstreamModel: row.upstreamModel,
-        visibility: row.visibility,
-        ...communityEndpointPrices(row),
-        disabled: row.disabledAt !== null,
-        disabledReason: row.disabledReason,
-        disabledAt: row.disabledAt,
-        createdAt: row.createdAt,
-        updatedAt: row.updatedAt,
-    };
 }
 
 async function requireOwnedEndpoint(db: Db, id: string, ownerUserId: string) {
@@ -351,18 +180,6 @@ function throwEndpointTestError(error: unknown): never {
 }
 
 type EndpointProbeKind = "models" | "test";
-
-function requireCommunityEndpointManagePermission(apiKey?: {
-    permissions?: Record<string, string[]>;
-    metadata?: Record<string, unknown>;
-}): void {
-    if (!apiKey) return;
-    if (!hasDirectAccountPermission(apiKey, "keys")) {
-        throw new HTTPException(403, {
-            message: "API key does not have 'account:keys' permission",
-        });
-    }
-}
 
 // Publishing is allowlist-gated. Pricing is independent: public endpoints may
 // be free or owner-priced.
@@ -409,7 +226,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
     .get(
         "/",
         describeRoute({
-            tags: ["👤 Account"],
+            tags: ["🧩 Community Models"],
             summary: "List My Models",
             description:
                 "List private and public community models owned by the authenticated account. API keys require `account:keys`.",
@@ -431,27 +248,258 @@ export const communityEndpointsRoutes = new Hono<Env>()
         async (c) => {
             const user = c.var.auth.requireUser();
             const db = drizzle(c.env.DB, { schema });
-            requireCommunityEndpointManagePermission(c.var.auth.apiKey);
+            requireAccountPermission(c.var.auth.apiKey, "keys");
             const ownerGithubUsername = await requireOwnerGithubUsername(
                 db,
                 user.id,
             );
-            const rows = await db.query.communityEndpoint.findMany({
-                where: eq(schema.communityEndpoint.ownerUserId, user.id),
-                orderBy: (endpoint, { desc }) => [desc(endpoint.createdAt)],
+            const rows = await db
+                .select()
+                .from(schema.communityEndpoint)
+                .where(eq(schema.communityEndpoint.ownerUserId, user.id))
+                .orderBy(desc(schema.communityEndpoint.createdAt));
+            const owner = await db.query.user.findFirst({
+                columns: {
+                    communityProviderName: true,
+                    communityProviderUrl: true,
+                },
+                where: eq(schema.user.id, user.id),
             });
-            return c.json({
-                data: rows.map((row) => toResponse(row, ownerGithubUsername)),
+            return c.json(
+                CommunityEndpointListResponseSchema.parse({
+                    data: rows.map((endpoint) =>
+                        toCommunityEndpointResponse(
+                            endpoint,
+                            ownerGithubUsername,
+                            c.env.AGENT_RUNTIME_BASE_URL,
+                        ),
+                    ),
+                    provider: {
+                        name: owner?.communityProviderName ?? null,
+                        url: owner?.communityProviderUrl ?? null,
+                    },
+                }),
+            );
+        },
+    )
+    .post(
+        "/provider",
+        describeRoute({
+            tags: ["🧩 Community Models"],
+            summary: "Update Community Provider Profile",
+            description:
+                "Set the public provider name and HTTPS service link shared by all community models owned by the authenticated account. Send both fields empty to clear the profile. Publishing approval and `account:keys` are required.",
+            responses: {
+                200: {
+                    description: "Updated community provider profile",
+                    content: {
+                        "application/json": {
+                            schema: resolver(
+                                CommunityProviderProfileResponseSchema,
+                            ),
+                        },
+                    },
+                },
+                400: { description: "Invalid provider profile" },
+                401: { description: "Unauthorized" },
+                403: { description: "Permission denied" },
+            },
+        }),
+        validator("json", CommunityProviderProfileInputSchema),
+        async (c) => {
+            const user = c.var.auth.requireUser();
+            const input = c.req.valid("json");
+            const db = drizzle(c.env.DB, { schema });
+            requireAccountPermission(c.var.auth.apiKey, "keys");
+            await requireCommunityEndpointPublishAccess(db, user.id);
+
+            const name = input.name.trim();
+            const url = input.url.trim();
+            if (Boolean(name) !== Boolean(url)) {
+                throw new HTTPException(400, {
+                    message: "Provider name and URL must be set together",
+                });
+            }
+
+            const [profile] = await db
+                .update(schema.user)
+                .set({
+                    communityProviderName: name || null,
+                    communityProviderUrl: url
+                        ? normalizeInputProviderUrl(url)
+                        : null,
+                    updatedAt: new Date(),
+                })
+                .where(eq(schema.user.id, user.id))
+                .returning({
+                    name: schema.user.communityProviderName,
+                    url: schema.user.communityProviderUrl,
+                });
+            return c.json(profile);
+        },
+    )
+    .get(
+        "/:id/fallback-candidates",
+        describeRoute({
+            tags: ["🧩 Community Models"],
+            summary: "List Fallback Candidates",
+            description:
+                "Community models this model may declare as fallbacks: listed, public or owned by you, same modality, and priced at or below it on every price field. Computed with the same rule the update endpoint validates against, so every id listed here is accepted. Eligibility is re-checked when a request is routed, so a target repriced above this model afterwards stops serving without changing the stored list.",
+            responses: {
+                200: {
+                    description: "Eligible fallback model ids",
+                    content: {
+                        "application/json": {
+                            schema: resolver(FallbackCandidatesResponseSchema),
+                        },
+                    },
+                },
+                401: { description: "Unauthorized" },
+                403: { description: "Permission denied" },
+                404: { description: "Model not found" },
+            },
+        }),
+        async (c) => {
+            const user = c.var.auth.requireUser();
+            const db = drizzle(c.env.DB, { schema });
+            requireAccountPermission(c.var.auth.apiKey, "keys");
+            const ownerGithubUsername = await requireOwnerGithubUsername(
+                db,
+                user.id,
+            );
+            const endpoint = await db.query.communityEndpoint.findFirst({
+                where: and(
+                    eq(schema.communityEndpoint.id, c.req.param("id")),
+                    eq(schema.communityEndpoint.ownerUserId, user.id),
+                ),
             });
+            if (!endpoint) {
+                throw new HTTPException(404, { message: "Model not found" });
+            }
+            if (endpoint.type !== "proxy") return c.json({ data: [] });
+            const currentPayload = parseListingPayload(
+                "proxy",
+                endpoint.payload,
+            );
+            if (!currentPayload) {
+                throw new Error(`Invalid proxy payload for ${endpoint.id}`);
+            }
+            const endpointPayload = resolveEffectiveProxyListing({
+                visibility: endpoint.visibility,
+                payload: currentPayload,
+                pendingVisibility: endpoint.pendingVisibility,
+                pendingPayload: parseListingPayload(
+                    "proxy",
+                    endpoint.pendingPayload,
+                ),
+                pendingAt: endpoint.pendingAt,
+            }).payload;
+            const primary: FallbackPrimary = {
+                modelId: communityModelId(ownerGithubUsername, endpoint.name),
+                ownerUserId: user.id,
+                modality: endpointPayload.modality,
+                imagePricing: endpointPayload.imagePricing,
+                paidOnly: endpointPayload.paidOnly,
+                prices: endpointPayload.prices,
+                inputModalities: endpointPayload.inputModalities,
+            };
+            const candidates = await db
+                .select({
+                    endpoint: schema.communityEndpoint,
+                    ownerGithubUsername: schema.user.githubUsername,
+                })
+                .from(schema.communityEndpoint)
+                .innerJoin(
+                    schema.user,
+                    eq(schema.communityEndpoint.ownerUserId, schema.user.id),
+                );
+            const data = candidates
+                .flatMap(({ endpoint: row, ownerGithubUsername: owner }) => {
+                    if (!owner) return [];
+                    const modelId = communityModelId(owner, row.name);
+                    return fallbackTargetRejection(primary, modelId, row)
+                        ? []
+                        : [modelId];
+                })
+                .sort();
+            return c.json({ data });
+        },
+    )
+    .post(
+        "/endpoint-agents",
+        describeRoute({
+            tags: ["🤖 Community Agents"],
+            summary: "Create Endpoint Agent",
+            description:
+                "Register an agent running on an external OpenAI-compatible endpoint. Pollinations sends a short-lived agent run token instead of a stored bearer credential. Private is the default; public agents require an allowlisted account and become public after 12 hours. API keys require `account:keys`.",
+            responses: {
+                200: {
+                    description: "Created endpoint agent",
+                    content: {
+                        "application/json": {
+                            schema: resolver(EndpointAgentResponseSchema),
+                        },
+                    },
+                },
+                400: { description: "Invalid endpoint agent configuration" },
+                401: { description: "Unauthorized" },
+                403: { description: "Permission denied" },
+            },
+        }),
+        validator("json", CreateEndpointAgentSchema),
+        async (c) => {
+            const user = c.var.auth.requireUser();
+            const input = c.req.valid("json");
+            const db = drizzle(c.env.DB, { schema });
+            requireAccountPermission(c.var.auth.apiKey, "keys");
+            const ownerGithubUsername = await requireOwnerGithubUsername(
+                db,
+                user.id,
+            );
+            await ensureModelNameAvailable(db, user.id, input.name);
+            await enforcePublishingAccess(db, user.id, input.visibility);
+            const queuesPublication = input.visibility === "public";
+            const payload: EndpointAgentListingPayload = {
+                perUserRpm: input.perUserRpm,
+            };
+            const [row] = await db
+                .insert(schema.communityEndpoint)
+                .values({
+                    id: crypto.randomUUID(),
+                    ownerUserId: user.id,
+                    name: input.name,
+                    title: input.title,
+                    description: input.description || null,
+                    visibility: queuesPublication
+                        ? "private"
+                        : input.visibility,
+                    pendingVisibility: queuesPublication ? "public" : null,
+                    pendingAt: queuesPublication ? new Date() : null,
+                    type: "endpoint_agent",
+                    baseUrl: validateInputEndpointUrl(input.baseUrl),
+                    upstreamModel: input.upstreamModel ?? input.name,
+                    requiredSafetyFeatures: input.requiredSafetyFeatures,
+                    payload: JSON.stringify(payload),
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                })
+                .returning();
+            return c.json(
+                toCommunityEndpointResponse(
+                    row,
+                    ownerGithubUsername,
+                    c.env.AGENT_RUNTIME_BASE_URL,
+                ),
+            );
         },
     )
     .post(
         "/",
         describeRoute({
-            tags: ["👤 Account"],
+            tags: ["🧩 Community Models"],
             summary: "Create My Model",
             description:
-                "Register a private or public community text or image model. Private is the default. Public models require an allowlisted account and may be free or priced. API keys require `account:keys`. The upstream bearer token is encrypted and never returned.",
+                "Register a private or public community text, image, video, transcription, or embedding model. Private is the default. Public models require an allowlisted account and become public after 12 hours. API keys require `account:keys`. The upstream bearer token is encrypted and never returned.",
             responses: {
                 200: {
                     description: "Created community model",
@@ -471,63 +519,80 @@ export const communityEndpointsRoutes = new Hono<Env>()
             const user = c.var.auth.requireUser();
             const input = c.req.valid("json");
             const db = drizzle(c.env.DB, { schema });
-            requireCommunityEndpointManagePermission(c.var.auth.apiKey);
+            requireAccountPermission(c.var.auth.apiKey, "keys");
             const ownerGithubUsername = await requireOwnerGithubUsername(
                 db,
                 user.id,
             );
             await ensureModelNameAvailable(db, user.id, input.name);
-            const imagePricing =
-                input.modality === "image" ? input.imagePricing : "request";
-            const prices =
-                input.visibility === "public"
-                    ? communityEndpointPricesForModality(
-                          input,
-                          input.modality,
-                          imagePricing,
-                      )
-                    : communityEndpointPrices({});
-            enforceCommunityEndpointPriceLimits(
-                prices,
-                input.modality,
-                imagePricing,
+            const targetPolicy = deriveCreateProxyPolicy(input);
+            const queuesPublication = input.visibility === "public";
+            const policy = queuesPublication
+                ? deriveCreateProxyPolicy({ ...input, visibility: "private" })
+                : targetPolicy;
+            const modelId = communityModelId(ownerGithubUsername, input.name);
+            const bearerTokenCiphertext = await encryptSecret(
+                normalizeInputBearerToken(input.bearerToken),
+                c.env.BETTER_AUTH_SECRET,
             );
+            const fallbacks = input.fallbacks
+                ? await resolveFallbacks(db, input.fallbacks, {
+                      modelId,
+                      ownerUserId: user.id,
+                      ...targetPolicy,
+                  })
+                : [];
+            const payload: ProxyListingPayload = {
+                bearerTokenCiphertext,
+                ...policy,
+                fallbacks,
+            };
             await enforcePublishingAccess(db, user.id, input.visibility);
-            const id = crypto.randomUUID();
             const [row] = await db
                 .insert(schema.communityEndpoint)
                 .values({
-                    id,
+                    id: crypto.randomUUID(),
                     ownerUserId: user.id,
                     name: input.name,
                     title: input.title,
                     description: input.description || null,
-                    modality: input.modality,
-                    imagePricing,
-                    supportsImageEdits:
-                        input.modality === "image" && input.supportsImageEdits,
-                    baseUrl: normalizeInputBaseUrl(input.baseUrl),
+                    visibility: queuesPublication
+                        ? "private"
+                        : input.visibility,
+                    type: "proxy",
+                    baseUrl: validateInputEndpointUrl(input.baseUrl),
                     upstreamModel: input.upstreamModel ?? input.name,
-                    bearerTokenCiphertext: await encryptSecret(
-                        normalizeInputBearerToken(input.bearerToken),
-                        c.env.BETTER_AUTH_SECRET,
-                    ),
-                    visibility: input.visibility,
-                    ...prices,
+                    requiredSafetyFeatures: input.requiredSafetyFeatures,
+                    payload: JSON.stringify(payload),
+                    pendingPayload: queuesPublication
+                        ? JSON.stringify({
+                              bearerTokenCiphertext,
+                              ...targetPolicy,
+                              fallbacks,
+                          } satisfies ProxyListingPayload)
+                        : null,
+                    pendingVisibility: queuesPublication ? "public" : null,
+                    pendingAt: queuesPublication ? new Date() : null,
                     createdAt: new Date(),
                     updatedAt: new Date(),
                 })
                 .returning();
-            return c.json(toResponse(row, ownerGithubUsername));
+            return c.json(
+                toCommunityEndpointResponse(
+                    row,
+                    ownerGithubUsername,
+                    c.env.AGENT_RUNTIME_BASE_URL,
+                ),
+            );
         },
     )
     .post(
         "/models",
         describeRoute({
-            tags: ["👤 Account"],
+            tags: ["🧩 Community Models"],
             summary: "List Upstream Models",
             description:
-                "Fetch OpenAI-compatible upstream model IDs before publishing a My Models endpoint. Requires community model publishing approval; API keys also require `account:keys`.",
+                "Fetch OpenAI-compatible upstream model IDs from a provider before registering a My Models endpoint. Limited to one probe every 30 seconds per account. API keys require `account:keys`.",
             responses: {
                 200: {
                     description: "Upstream model IDs",
@@ -549,9 +614,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
         async (c) => {
             const user = c.var.auth.requireUser();
             const input = c.req.valid("json");
-            const db = drizzle(c.env.DB, { schema });
-            requireCommunityEndpointManagePermission(c.var.auth.apiKey);
-            await requireCommunityEndpointPublishAccess(db, user.id);
+            requireAccountPermission(c.var.auth.apiKey, "keys");
             const throttled = await enforceEndpointProbeThrottle(
                 c,
                 user.id,
@@ -569,10 +632,10 @@ export const communityEndpointsRoutes = new Hono<Env>()
     .post(
         "/test",
         describeRoute({
-            tags: ["👤 Account"],
+            tags: ["🧩 Community Models"],
             summary: "Test My Model Endpoint",
             description:
-                "Test an OpenAI-compatible upstream model before publishing it. Image tests detect token pricing and probe the derived `/images/edits` endpoint. Requires community model publishing approval; API keys also require `account:keys`.",
+                "Test an upstream model before registering it. Image tests detect the image pricing mode and probe the derived `/images/edits` endpoint; video tests call the exact configured URL and validate completed MP4 data. Limited to one probe every 30 seconds per account. API keys require `account:keys`.",
             responses: {
                 200: {
                     description: "Endpoint test result",
@@ -594,9 +657,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
         async (c) => {
             const user = c.var.auth.requireUser();
             const input = c.req.valid("json");
-            const db = drizzle(c.env.DB, { schema });
-            requireCommunityEndpointManagePermission(c.var.auth.apiKey);
-            await requireCommunityEndpointPublishAccess(db, user.id);
+            requireAccountPermission(c.var.auth.apiKey, "keys");
             const throttled = await enforceEndpointProbeThrottle(
                 c,
                 user.id,
@@ -604,18 +665,54 @@ export const communityEndpointsRoutes = new Hono<Env>()
             );
             if (throttled) return throttled;
             try {
-                const result =
-                    input.modality === "image"
-                        ? await testCommunityImageEndpoint(input)
-                        : await testCommunityEndpoint(input);
+                const endpointInput = {
+                    ...input,
+                    baseUrl: validateInputEndpointUrl(input.baseUrl),
+                };
+                let result: CommunityEndpointTestResult;
+                if (input.modality === "video") {
+                    result = await testCommunityVideoEndpoint(endpointInput);
+                } else {
+                    if (!input.model) {
+                        throw new HTTPException(400, {
+                            message:
+                                "model is required unless modality is video",
+                        });
+                    }
+                    const modelInput = { ...endpointInput, model: input.model };
+                    result =
+                        input.modality === "image"
+                            ? await testCommunityImageEndpoint(modelInput)
+                            : input.modality === "transcription"
+                              ? await testCommunityTranscriptionEndpoint(
+                                    modelInput,
+                                )
+                              : input.modality === "embedding"
+                                ? await testCommunityEmbeddingEndpoint(
+                                      modelInput,
+                                  )
+                                : input.modality === "speech"
+                                  ? await testCommunitySpeechEndpoint(
+                                        modelInput,
+                                    )
+                                  : await testCommunityEndpoint(modelInput);
+                }
                 return c.json({
                     ok: true,
                     message:
                         input.modality === "image"
-                            ? result.supportsImageEdits
+                            ? result.inputModalities?.includes("image")
                                 ? "Generation and editing endpoints responded with image data"
                                 : "Generation endpoint responded; editing is not supported"
-                            : "Endpoint responded with usage",
+                            : input.modality === "video"
+                              ? "Endpoint responded with playable video"
+                              : input.modality === "transcription"
+                                ? "Endpoint responded with transcription text"
+                                : input.modality === "embedding"
+                                  ? "Endpoint responded with embedding data"
+                                  : input.modality === "speech"
+                                    ? "Endpoint responded with audio"
+                                    : "Endpoint responded with usage",
                     ...result,
                 });
             } catch (error) {
@@ -626,10 +723,10 @@ export const communityEndpointsRoutes = new Hono<Env>()
     .post(
         "/:id/update",
         describeRoute({
-            tags: ["👤 Account"],
+            tags: ["🧩 Community Models"],
             summary: "Update My Model",
             description:
-                "Update a community model owned by the authenticated account. Changing visibility to public publishes it and requires an allowlisted account; public models may be free or priced. API keys require `account:keys`.",
+                "Update a community model owned by the authenticated account. Changing visibility to public requires an allowlisted account and takes effect after 12 hours; public models may be free or priced. API keys require `account:keys`.",
             responses: {
                 200: {
                     description: "Updated community model",
@@ -651,15 +748,16 @@ export const communityEndpointsRoutes = new Hono<Env>()
             const input = c.req.valid("json");
             const { id } = c.req.param();
             const db = drizzle(c.env.DB, { schema });
-            requireCommunityEndpointManagePermission(c.var.auth.apiKey);
+            requireAccountPermission(c.var.auth.apiKey, "keys");
             const ownerGithubUsername = await requireOwnerGithubUsername(
                 db,
                 user.id,
             );
             const endpoint = await requireOwnedEndpoint(db, id, user.id);
-            const modality = normalizeCommunityEndpointModality(
-                endpoint.modality,
-            );
+            // The row already owns its immutable type. Validate the external
+            // body against that exact strict Zod schema instead of asking
+            // every client to echo a redundant discriminator.
+            assertValidUpdate(endpoint.type, input);
             await ensureModelNameAvailable(
                 db,
                 user.id,
@@ -672,80 +770,174 @@ export const communityEndpointsRoutes = new Hono<Env>()
             > = {
                 updatedAt: new Date(),
             };
+            const pendingReady = pendingCommunityEndpointChangeIsReady(
+                endpoint.pendingAt,
+            );
+            const currentVisibility = effectiveCommunityEndpointVisibility(
+                endpoint.visibility,
+                endpoint.pendingVisibility,
+                endpoint.pendingAt,
+            );
+            let pendingPayload = pendingReady ? null : endpoint.pendingPayload;
+            let pendingVisibility = pendingReady
+                ? null
+                : endpoint.pendingVisibility;
+            let pendingAt = pendingReady ? null : endpoint.pendingAt;
             if (input.name !== undefined) update.name = input.name;
             if (input.title !== undefined) update.title = input.title;
             if (input.description !== undefined) {
                 update.description = input.description || null;
             }
-            if (input.baseUrl !== undefined) {
-                update.baseUrl = normalizeInputBaseUrl(input.baseUrl);
+            if (input.requiredSafetyFeatures !== undefined) {
+                update.requiredSafetyFeatures = input.requiredSafetyFeatures;
             }
-            if (input.upstreamModel !== undefined) {
-                update.upstreamModel = input.upstreamModel;
+            if (input.hidden !== undefined) {
+                if (
+                    !input.hidden &&
+                    (input.visibility ?? currentVisibility) === "public" &&
+                    endpoint.hiddenAt &&
+                    Date.now() <
+                        endpoint.hiddenAt.getTime() +
+                            COMMUNITY_ENDPOINT_CHANGE_DELAY_MS
+                ) {
+                    throw new HTTPException(400, {
+                        message:
+                            "Community models can be relisted 12 hours after they were hidden",
+                    });
+                }
+                update.hiddenAt = input.hidden ? new Date() : null;
+                update.hiddenReason = input.hidden ? "Hidden by owner" : null;
+                update.hiddenBy = input.hidden ? "owner" : null;
             }
-            if (input.bearerToken !== undefined) {
-                update.bearerTokenCiphertext = await encryptSecret(
-                    normalizeInputBearerToken(input.bearerToken),
-                    c.env.BETTER_AUTH_SECRET,
-                );
-            }
-            if (input.visibility !== undefined) {
-                update.visibility = input.visibility;
-            }
-            if (input.supportsImageEdits !== undefined) {
-                update.supportsImageEdits =
-                    modality === "image" && input.supportsImageEdits;
-            }
-            if (input.active !== undefined) {
-                update.disabledAt = input.active ? null : new Date();
-                update.disabledReason = input.active
-                    ? null
-                    : "Deactivated by owner";
-                update.disabledBy = input.active ? null : "owner";
-            }
-            const storedImagePricing = normalizeCommunityEndpointImagePricing(
-                endpoint.imagePricing,
+            await enforcePublishingAccess(
+                db,
+                user.id,
+                input.visibility ?? currentVisibility,
             );
-            const effectiveImagePricing =
-                modality === "image" && input.imagePricing !== undefined
-                    ? input.imagePricing
-                    : storedImagePricing;
-            update.imagePricing = effectiveImagePricing;
-            for (const field of communityEndpointPriceFieldsForModality(
-                modality,
-                effectiveImagePricing,
-            )) {
-                if (input[field.key] !== undefined) {
-                    update[field.key] = input[field.key];
-                } else if (effectiveImagePricing !== storedImagePricing) {
-                    // Switching modes changes the unit of the shared price
-                    // columns (per image ↔ per token); stored values must not
-                    // be reinterpreted, so unsent prices reset to free.
-                    update[field.key] = 0;
+            let nextVisibility = currentVisibility;
+            if (input.visibility === "private") {
+                nextVisibility = "private";
+                pendingPayload = null;
+                pendingVisibility = null;
+                pendingAt = null;
+            } else if (
+                input.visibility === "public" &&
+                currentVisibility === "private"
+            ) {
+                pendingVisibility = "public";
+                pendingAt ??= new Date();
+            }
+            update.visibility = nextVisibility;
+            if (endpoint.type === "prompt_agent") {
+                // Prompt configuration is edited through /account/agents.
+                // This route only updates shared listing state such as hidden.
+            } else if (endpoint.type === "endpoint_agent") {
+                if (!parseListingPayload("endpoint_agent", endpoint.payload)) {
+                    throw new Error(
+                        `Invalid endpoint_agent payload for ${endpoint.id}`,
+                    );
+                }
+                if (input.baseUrl !== undefined) {
+                    update.baseUrl = validateInputEndpointUrl(input.baseUrl);
+                }
+                if (input.upstreamModel !== undefined) {
+                    update.upstreamModel = input.upstreamModel;
+                }
+                if (input.perUserRpm !== undefined) {
+                    update.payload = JSON.stringify({
+                        perUserRpm: input.perUserRpm,
+                    });
+                }
+            } else {
+                const current = parseListingPayload("proxy", endpoint.payload);
+                if (!current) {
+                    throw new Error(`Invalid proxy payload for ${endpoint.id}`);
+                }
+                const stored = resolveEffectiveProxyListing({
+                    visibility: endpoint.visibility,
+                    payload: current,
+                    pendingVisibility: endpoint.pendingVisibility,
+                    pendingPayload: parseListingPayload(
+                        "proxy",
+                        endpoint.pendingPayload,
+                    ),
+                    pendingAt: endpoint.pendingAt,
+                }).payload;
+                const queued = parseListingPayload("proxy", pendingPayload);
+                const targetBase = queued ?? stored;
+                const targetVisibility = pendingVisibility ?? nextVisibility;
+                const targetPolicy = deriveUpdatedProxyPolicy(
+                    targetBase,
+                    input,
+                    targetVisibility,
+                );
+                const delayPricing =
+                    targetVisibility === "public" &&
+                    (currentVisibility === "public" ||
+                        pendingVisibility === "public") &&
+                    hasProxyPricingInput(input);
+                const pricingChanged = proxyPricingChanged(
+                    targetBase,
+                    targetPolicy,
+                );
+                const immediateInput = delayPricing
+                    ? withoutProxyPricingChanges(input)
+                    : input;
+                const policy = deriveUpdatedProxyPolicy(
+                    stored,
+                    immediateInput,
+                    nextVisibility,
+                );
+                const fallbacks =
+                    input.fallbacks === undefined
+                        ? stored.fallbacks
+                        : await resolveFallbacks(db, input.fallbacks, {
+                              modelId: communityModelId(
+                                  ownerGithubUsername,
+                                  input.name ?? endpoint.name,
+                              ),
+                              ownerUserId: user.id,
+                              ...targetPolicy,
+                          });
+                const bearerTokenCiphertext =
+                    input.bearerToken === undefined
+                        ? stored.bearerTokenCiphertext
+                        : await encryptSecret(
+                              normalizeInputBearerToken(input.bearerToken),
+                              c.env.BETTER_AUTH_SECRET,
+                          );
+                if (input.baseUrl !== undefined) {
+                    update.baseUrl = validateInputEndpointUrl(input.baseUrl);
+                }
+                if (input.upstreamModel !== undefined) {
+                    update.upstreamModel = input.upstreamModel;
+                }
+                if (pendingReady || changesProxyPayload(input)) {
+                    const payload: ProxyListingPayload = {
+                        bearerTokenCiphertext,
+                        ...policy,
+                        fallbacks,
+                    };
+                    update.payload = JSON.stringify(payload);
+                }
+                const queuesPublication =
+                    input.visibility === "public" &&
+                    currentVisibility === "private";
+                if ((delayPricing && pricingChanged) || queuesPublication) {
+                    const targetPayload: ProxyListingPayload = {
+                        bearerTokenCiphertext,
+                        ...targetPolicy,
+                        fallbacks,
+                    };
+                    pendingPayload = JSON.stringify(targetPayload);
+                    if (pricingChanged) {
+                        pendingAt = new Date();
+                    }
                 }
             }
-            const effectiveVisibility = input.visibility ?? endpoint.visibility;
-            // A private model is owner-only, so owner-declared public pricing
-            // does not apply; making a published model private clears prices.
-            const effectivePrices =
-                effectiveVisibility === "private"
-                    ? communityEndpointPrices({})
-                    : communityEndpointPricesForModality(
-                          { ...endpoint, ...update },
-                          modality,
-                          effectiveImagePricing,
-                      );
-            enforceCommunityEndpointPriceLimits(
-                effectivePrices,
-                modality,
-                effectiveImagePricing,
-            );
-            await enforcePublishingAccess(db, user.id, effectiveVisibility);
-            // Persist visibility together with the complete effective price
-            // set on every update, so concurrent partial updates cannot
-            // interleave into a public row with cleared prices.
-            update.visibility = effectiveVisibility;
-            Object.assign(update, effectivePrices);
+            update.pendingPayload = pendingPayload;
+            update.pendingVisibility = pendingVisibility;
+            update.pendingAt = pendingAt;
             const [row] = await db
                 .update(schema.communityEndpoint)
                 .set(update)
@@ -756,13 +948,19 @@ export const communityEndpointsRoutes = new Hono<Env>()
                     ),
                 )
                 .returning();
-            return c.json(toResponse(row, ownerGithubUsername));
+            return c.json(
+                toCommunityEndpointResponse(
+                    row,
+                    ownerGithubUsername,
+                    c.env.AGENT_RUNTIME_BASE_URL,
+                ),
+            );
         },
     )
     .delete(
         "/:id",
         describeRoute({
-            tags: ["👤 Account"],
+            tags: ["🧩 Community Models"],
             summary: "Delete My Model",
             description:
                 "Delete a community model owned by the authenticated account. API keys require `account:keys`.",
@@ -786,7 +984,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
             const user = c.var.auth.requireUser();
             const { id } = c.req.param();
             const db = drizzle(c.env.DB, { schema });
-            requireCommunityEndpointManagePermission(c.var.auth.apiKey);
+            requireAccountPermission(c.var.auth.apiKey, "keys");
             await requireOwnedEndpoint(db, id, user.id);
             await db
                 .delete(schema.communityEndpoint)

--- a/enter.pollinations.ai/src/routes/community-endpoints/schemas.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints/schemas.ts
@@ -1,0 +1,355 @@
+import {
+    COMMUNITY_ENDPOINT_DESCRIPTION_MAX_LENGTH,
+    COMMUNITY_ENDPOINT_IMAGE_PRICING_MODES,
+    COMMUNITY_ENDPOINT_MODALITIES,
+    COMMUNITY_ENDPOINT_PRICE_FIELDS,
+    COMMUNITY_ENDPOINT_TITLE_MAX_LENGTH,
+    COMMUNITY_ENDPOINT_VISIBILITIES,
+    COMMUNITY_PROVIDER_NAME_MAX_LENGTH,
+    COMMUNITY_PROVIDER_URL_MAX_LENGTH,
+    CommunityEndpointAdvertisedSchema,
+    type CommunityEndpointPriceKey,
+    MAX_FALLBACK_TARGETS,
+    MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS,
+    MIN_COMMUNITY_PRICE_PER_TOKEN,
+} from "@shared/community-endpoints.ts";
+import { ValidationError } from "@shared/http/validation-error.ts";
+import { MODEL_INPUT_MODALITIES } from "@shared/registry/registry.ts";
+import { SAFETY_FEATURES } from "@shared/schemas/safety.ts";
+import { z } from "zod";
+
+const ModalitySchema = z
+    .enum(COMMUNITY_ENDPOINT_MODALITIES)
+    .describe(
+        'Upstream API family. "text" uses `/v1/chat/completions`; "image" uses `/v1/images/generations` and optionally `/v1/images/edits`; "video" calls the exact configured URL; "transcription" uses `/v1/audio/transcriptions`; "speech" uses `/v1/audio/speech`.',
+    );
+const ImagePricingSchema = z
+    .enum(COMMUNITY_ENDPOINT_IMAGE_PRICING_MODES)
+    .describe(
+        'Image models only. "request": the generated-image price is charged once per generation. "tokens": provider-returned OpenAI image token usage is charged against per-token prices. Detected by the endpoint test.',
+    );
+const InputModalitySchema = z.enum(MODEL_INPUT_MODALITIES);
+const InputModalitiesSchema = z
+    .array(InputModalitySchema)
+    .min(1)
+    .describe(
+        "Input types accepted by the model. Select every supported modality so the model catalog can advertise them accurately.",
+    );
+export const RequiredSafetyFeaturesSchema = z
+    .array(z.enum(SAFETY_FEATURES))
+    .max(SAFETY_FEATURES.length)
+    .describe(
+        "Input safety checks callers cannot disable. Use sexual and violence to block harmful prompts before they reach the provider.",
+    );
+const AdvertisedSchema = z
+    .object(CommunityEndpointAdvertisedSchema.shape)
+    .strict()
+    .describe("Owner-declared catalog metadata for text models.");
+const PriceSchema = z
+    .number()
+    .finite()
+    .min(0)
+    .refine((price) => price === 0 || price >= MIN_COMMUNITY_PRICE_PER_TOKEN, {
+        message: `Price must be 0 (free) or at least ${MIN_COMMUNITY_PRICE_PER_TOKEN} per token (${MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS} per 1M tokens)`,
+    })
+    .describe(
+        'Pollen price. Token rates are per token internally (the dashboard displays per 1M); `completionImagePrice` is per generated image when `imagePricing` is "request"; `completionVideoPrice` is per generated second.',
+    );
+const UpdatePriceFieldsSchema = Object.fromEntries(
+    COMMUNITY_ENDPOINT_PRICE_FIELDS.map((field) => [
+        field.key,
+        PriceSchema.optional(),
+    ]),
+) as unknown as Record<
+    CommunityEndpointPriceKey,
+    z.ZodOptional<z.ZodType<number>>
+>;
+const FallbacksSchema = z
+    .array(z.string().trim().min(1))
+    .max(MAX_FALLBACK_TARGETS)
+    .describe(
+        'Community model ids ("<owner>/<name>") tried in order when this model\'s upstream fails, or an empty array to clear them. Each must be another listed community model of the same modality, public or owned by you, and priced at or below this model on every price field.',
+    );
+const VisibilitySchema = z
+    .enum(COMMUNITY_ENDPOINT_VISIBILITIES)
+    .describe(
+        '"private": owner-only, shown only to the owner, with no owner-set price. "public": anyone and listed in the catalog; it may be free or priced. Publishing requires an allowlisted account.',
+    );
+const PaidOnlySchema = z
+    .boolean()
+    .describe(
+        "Restrict callers to spending Paid Pollen on this model. Use it when the upstream bills per use, so Quest Pollen cannot cover the price and leave you paying the inference cost.",
+    );
+const PerUserRpmSchema = z
+    .number()
+    .finite()
+    .positive()
+    .nullable()
+    .describe(
+        "Maximum requests per minute for each Pollinations user. Decimals are supported; 0.5 means one request every two minutes. Null means no Pollinations-side limit.",
+    );
+const EndpointFieldsSchema = {
+    name: z
+        .string()
+        .trim()
+        .min(1)
+        .max(120)
+        .regex(
+            /^[A-Za-z0-9._:-]+$/,
+            "Model name may only contain letters, numbers, periods, underscores, colons, and hyphens",
+        ),
+    title: z
+        .string()
+        .trim()
+        .min(1)
+        .max(COMMUNITY_ENDPOINT_TITLE_MAX_LENGTH)
+        .describe("Display name shown in the model catalog."),
+    description: z
+        .string()
+        .trim()
+        .max(COMMUNITY_ENDPOINT_DESCRIPTION_MAX_LENGTH)
+        .optional(),
+    baseUrl: z
+        .string()
+        .url()
+        .describe(
+            "OpenAI-compatible `/v1` base URL or full chat, image, transcription, or speech URL. For video, the exact generation URL.",
+        ),
+    upstreamModel: z.string().trim().min(1).max(253).optional(),
+    bearerToken: z.string().min(1),
+} as const;
+
+const ProxyCreateSchema = z
+    .object({
+        name: EndpointFieldsSchema.name,
+        title: EndpointFieldsSchema.title,
+        description: EndpointFieldsSchema.description,
+        visibility: VisibilitySchema.optional().default("private"),
+        baseUrl: EndpointFieldsSchema.baseUrl,
+        bearerToken: EndpointFieldsSchema.bearerToken,
+        upstreamModel: EndpointFieldsSchema.upstreamModel,
+        modality: ModalitySchema.optional().default("text"),
+        imagePricing: ImagePricingSchema.optional().default("request"),
+        inputModalities: InputModalitiesSchema.optional(),
+        requiredSafetyFeatures: RequiredSafetyFeaturesSchema.optional().default(
+            [],
+        ),
+        advertised: AdvertisedSchema.optional(),
+        perUserRpm: PerUserRpmSchema.optional(),
+        paidOnly: PaidOnlySchema.optional().default(false),
+        fallbacks: FallbacksSchema.optional(),
+        ...UpdatePriceFieldsSchema,
+    })
+    .strict();
+export const CreateEndpointSchema = ProxyCreateSchema;
+export type ProxyCreateInput = z.infer<typeof ProxyCreateSchema>;
+
+export const CreateEndpointAgentSchema = z
+    .object({
+        name: EndpointFieldsSchema.name,
+        title: EndpointFieldsSchema.title,
+        description: EndpointFieldsSchema.description,
+        visibility: VisibilitySchema.optional().default("private"),
+        baseUrl: EndpointFieldsSchema.baseUrl,
+        upstreamModel: EndpointFieldsSchema.upstreamModel,
+        requiredSafetyFeatures: RequiredSafetyFeaturesSchema.optional().default(
+            [],
+        ),
+        perUserRpm: PerUserRpmSchema.optional().default(null),
+    })
+    .strict();
+
+const CommonUpdateFieldsSchema = {
+    name: EndpointFieldsSchema.name.optional(),
+    title: EndpointFieldsSchema.title.optional(),
+    description: EndpointFieldsSchema.description,
+    visibility: VisibilitySchema.optional(),
+    requiredSafetyFeatures: RequiredSafetyFeaturesSchema.optional(),
+    hidden: z.boolean().optional(),
+} as const;
+const ProxyUpdateSchema = z
+    .object({
+        ...CommonUpdateFieldsSchema,
+        baseUrl: EndpointFieldsSchema.baseUrl.optional(),
+        upstreamModel: EndpointFieldsSchema.upstreamModel,
+        bearerToken: EndpointFieldsSchema.bearerToken.optional(),
+        perUserRpm: PerUserRpmSchema.optional(),
+        paidOnly: PaidOnlySchema.optional(),
+        imagePricing: ImagePricingSchema.optional(),
+        inputModalities: InputModalitiesSchema.optional(),
+        advertised: AdvertisedSchema.optional(),
+        fallbacks: FallbacksSchema.optional(),
+        ...UpdatePriceFieldsSchema,
+    })
+    .strict();
+export type ProxyUpdateInput = z.infer<typeof ProxyUpdateSchema>;
+const PromptAgentUpdateSchema = z.object(CommonUpdateFieldsSchema).strict();
+const EndpointAgentUpdateSchema = z
+    .object({
+        ...CommonUpdateFieldsSchema,
+        baseUrl: EndpointFieldsSchema.baseUrl.optional(),
+        upstreamModel: EndpointFieldsSchema.upstreamModel,
+        perUserRpm: PerUserRpmSchema.optional(),
+    })
+    .strict();
+
+export const UpdateEndpointSchema = ProxyUpdateSchema;
+
+const UPDATE_SCHEMA_BY_TYPE = {
+    proxy: ProxyUpdateSchema,
+    prompt_agent: PromptAgentUpdateSchema,
+    endpoint_agent: EndpointAgentUpdateSchema,
+} as const;
+
+export function assertValidUpdate(
+    type: keyof typeof UPDATE_SCHEMA_BY_TYPE,
+    input: unknown,
+): void {
+    const result = UPDATE_SCHEMA_BY_TYPE[type].safeParse(input);
+    if (!result.success) throw new ValidationError(result.error, "json");
+}
+
+export const FallbackCandidatesResponseSchema = z.object({
+    data: z.array(z.string()),
+});
+export const ModelListSchema = z
+    .object({
+        baseUrl: z.string().url(),
+        bearerToken: z.string().min(1),
+    })
+    .strict();
+export const TestEndpointSchema = z
+    .object({
+        baseUrl: z.string().url(),
+        bearerToken: z.string().min(1),
+        model: z.string().trim().min(1).max(253).optional(),
+        modality: ModalitySchema.optional().default("text"),
+    })
+    .strict()
+    .superRefine((input, ctx) => {
+        if (input.modality !== "video" && !input.model) {
+            ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: ["model"],
+                message: "model is required unless modality is video",
+            });
+        }
+    });
+const ResponsePriceFieldsSchema = Object.fromEntries(
+    COMMUNITY_ENDPOINT_PRICE_FIELDS.map((field) => [field.key, z.number()]),
+) as unknown as Record<CommunityEndpointPriceKey, z.ZodType<number>>;
+const PendingCommunityEndpointChangeSchema = z
+    .object({
+        effectiveAt: z.string().datetime(),
+        visibility: z.literal("public").optional(),
+        paidOnly: z.boolean().optional(),
+        imagePricing: ImagePricingSchema.optional(),
+        ...Object.fromEntries(
+            COMMUNITY_ENDPOINT_PRICE_FIELDS.map((field) => [
+                field.key,
+                z.number().optional(),
+            ]),
+        ),
+    })
+    .strict()
+    .nullable();
+const CommunityEndpointResponseFieldsSchema = {
+    id: z.string(),
+    modelId: z.string(),
+    name: z.string(),
+    title: z.string(),
+    description: z.string().nullable(),
+    baseUrl: z.string().url(),
+    upstreamModel: z.string().min(1),
+    visibility: VisibilitySchema,
+    requiredSafetyFeatures: RequiredSafetyFeaturesSchema,
+    pending: PendingCommunityEndpointChangeSchema,
+    hidden: z.boolean(),
+    hiddenReason: z.string().nullable(),
+    hiddenAt: z.string().nullable(),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+} as const;
+const ProxyEndpointResponseSchema = z
+    .object({
+        ...CommunityEndpointResponseFieldsSchema,
+        type: z.literal("proxy"),
+        modality: ModalitySchema,
+        imagePricing: ImagePricingSchema,
+        inputModalities: z.array(InputModalitySchema),
+        advertised: AdvertisedSchema,
+        perUserRpm: PerUserRpmSchema,
+        paidOnly: z.boolean(),
+        fallbacks: z.array(z.string()),
+        ...ResponsePriceFieldsSchema,
+    })
+    .strict();
+const PromptAgentEndpointResponseSchema = z
+    .object({
+        ...CommunityEndpointResponseFieldsSchema,
+        type: z.literal("prompt_agent"),
+    })
+    .strict();
+export const EndpointAgentResponseSchema = z
+    .object({
+        ...CommunityEndpointResponseFieldsSchema,
+        type: z.literal("endpoint_agent"),
+        perUserRpm: PerUserRpmSchema,
+    })
+    .strict();
+export const CommunityEndpointResponseSchema = z.discriminatedUnion("type", [
+    ProxyEndpointResponseSchema,
+    PromptAgentEndpointResponseSchema,
+    EndpointAgentResponseSchema,
+]);
+export type CommunityEndpointResponse = z.infer<
+    typeof CommunityEndpointResponseSchema
+>;
+export const CommunityEndpointListResponseSchema = z.object({
+    data: z.array(CommunityEndpointResponseSchema),
+    provider: z.object({
+        name: z.string().nullable(),
+        url: z.string().url().nullable(),
+    }),
+});
+export const CommunityProviderProfileInputSchema = z
+    .object({
+        name: z.string().trim().max(COMMUNITY_PROVIDER_NAME_MAX_LENGTH),
+        url: z.string().trim().max(COMMUNITY_PROVIDER_URL_MAX_LENGTH),
+    })
+    .strict();
+export const CommunityProviderProfileResponseSchema = z.object({
+    name: z.string().nullable(),
+    url: z.string().url().nullable(),
+});
+export const CommunityEndpointModelsResponseSchema = z.object({
+    data: z.array(z.string()),
+});
+export const CommunityEndpointTestResponseSchema = z
+    .object({
+        ok: z.boolean(),
+        message: z.string(),
+        usage: z
+            .record(z.string(), z.unknown())
+            .describe(
+                "Raw provider usage, or `{ images: 1 }` when an image provider returns no token usage.",
+            ),
+        billableUsage: z
+            .record(z.string(), z.number())
+            .describe(
+                "Normalized billable usage fields used to reveal applicable prices.",
+            ),
+        imagePricing: ImagePricingSchema.optional().describe(
+            "Image tests only: pricing mode detected from the provider response.",
+        ),
+        inputModalities: z
+            .array(InputModalitySchema)
+            .optional()
+            .describe(
+                "Image tests only: input types detected from generation and edit probes.",
+            ),
+    })
+    .passthrough();
+export const CommunityEndpointDeleteResponseSchema = z.object({
+    id: z.string(),
+});

--- a/enter.pollinations.ai/src/services/community-endpoint-openai.ts
+++ b/enter.pollinations.ai/src/services/community-endpoint-openai.ts
@@ -1,26 +1,43 @@
 import {
-    type CommunityEndpointImagePricing,
+    communityAudioSpeechUrl,
+    communityAudioTranscriptionsUrl,
     communityChatCompletionsUrl,
+    communityEmbeddingsUrl,
     communityImageEditsUrl,
     communityImageGenerationsUrl,
     communityOpenAIBaseUrl,
-    normalizeCommunityAssetUrl,
+} from "@shared/community-endpoint-urls.ts";
+import {
+    COMMUNITY_ENDPOINT_TIMEOUT_MS,
+    type CommunityEndpointImagePricing,
+    communityEndpointErrorDetail,
+    communityTranscriptionSeconds,
     normalizeCommunityEndpointBearerToken,
 } from "@shared/community-endpoints.ts";
-import { detectImageMimeType } from "@shared/image-mime.ts";
-import type { Usage } from "@shared/registry/registry.ts";
 import {
+    decodeCommunityBase64,
+    firstCommunityImageBytes,
+    firstCommunityVideoBytes,
+    MAX_COMMUNITY_MEDIA_RESPONSE_BYTES,
+} from "@shared/community-media.ts";
+import { detectImageMimeType } from "@shared/image-mime.ts";
+import type { ModelInputModality, Usage } from "@shared/registry/registry.ts";
+import {
+    getOpenAIEmbeddingUsage,
     getOpenAIImageUsage,
     openaiImageUsageToUsage,
     openaiUsageToUsage,
 } from "@shared/registry/usage-headers.ts";
+import { readResponseBytes, readResponseText } from "@shared/response-bytes.ts";
+import { detectVideoMimeType } from "@shared/video-mime.ts";
+import { SAMPLE_AUDIO_BASE64 } from "./sample-audio.ts";
 
 type EndpointAuth = {
     baseUrl: string;
     bearerToken: string;
 };
 
-type EndpointTestInput = EndpointAuth & { model: string };
+type ModelEndpointTestInput = EndpointAuth & { model: string };
 
 export type CommunityEndpointUsage = Record<string, unknown>;
 
@@ -29,12 +46,9 @@ export type CommunityEndpointTestResult = {
     billableUsage: Usage;
     /** Image tests only: billing mode detected from the probe response. */
     imagePricing?: CommunityEndpointImagePricing;
-    /** Image tests only: whether a valid /images/edits response was observed. */
-    supportsImageEdits?: boolean;
+    /** Image tests only: input types detected by the generation/edit probes. */
+    inputModalities?: ModelInputModality[];
 };
-
-const REQUEST_TIMEOUT_MS = 90_000;
-const MAX_IMAGE_BYTES = 20 * 1024 * 1024;
 
 function authorizationHeaders(bearerToken: string): HeadersInit {
     return {
@@ -43,7 +57,9 @@ function authorizationHeaders(bearerToken: string): HeadersInit {
 }
 
 function communityModelsUrl(baseUrl: string): string {
-    return `${communityOpenAIBaseUrl(baseUrl)}/models`;
+    const url = new URL(communityOpenAIBaseUrl(baseUrl));
+    url.pathname = `${url.pathname.replace(/\/+$/, "")}/models`;
+    return url.toString();
 }
 
 async function fetchJson(url: string, init: RequestInit): Promise<unknown> {
@@ -55,21 +71,35 @@ async function fetchJson(url: string, init: RequestInit): Promise<unknown> {
         response = await fetch(url, {
             ...init,
             redirect: "manual",
-            signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+            signal: AbortSignal.timeout(COMMUNITY_ENDPOINT_TIMEOUT_MS),
         });
     } catch {
         throw new Error("Endpoint request timed out or could not connect");
     }
 
-    const body = await response.json().catch(() => null);
+    const body = parseJson(
+        await readResponseText(
+            response,
+            MAX_COMMUNITY_MEDIA_RESPONSE_BYTES,
+            () => new Error("Endpoint response is too large"),
+        ),
+    );
     if (!response.ok) {
         throw new Error(endpointErrorMessage(response.status, body));
     }
     return body;
 }
 
+function parseJson(text: string): unknown {
+    try {
+        return JSON.parse(text);
+    } catch {
+        return null;
+    }
+}
+
 function endpointErrorMessage(status: number, body: unknown): string {
-    const message = endpointBodyMessage(body);
+    const message = communityEndpointErrorDetail(body);
     const prefix =
         status === 401
             ? "Endpoint responded 401 after we sent Authorization"
@@ -77,24 +107,6 @@ function endpointErrorMessage(status: number, body: unknown): string {
               ? `Endpoint responded ${status} with a redirect, which is not supported`
               : `Endpoint responded ${status}`;
     return message ? `${prefix}: ${message}` : prefix;
-}
-
-function endpointBodyMessage(body: unknown): string | null {
-    if (!body || typeof body !== "object") return null;
-    if (
-        "error" in body &&
-        body.error &&
-        typeof body.error === "object" &&
-        "message" in body.error &&
-        typeof body.error.message === "string"
-    ) {
-        return body.error.message;
-    }
-    if ("error" in body && typeof body.error === "string") return body.error;
-    if ("message" in body && typeof body.message === "string") {
-        return body.message;
-    }
-    return null;
 }
 
 export async function listCommunityEndpointModels({
@@ -130,7 +142,7 @@ export async function testCommunityEndpoint({
     baseUrl,
     bearerToken,
     model,
-}: EndpointTestInput): Promise<CommunityEndpointTestResult> {
+}: ModelEndpointTestInput): Promise<CommunityEndpointTestResult> {
     const body = await fetchJson(communityChatCompletionsUrl(baseUrl), {
         method: "POST",
         headers: {
@@ -178,7 +190,7 @@ export async function testCommunityImageEndpoint({
     baseUrl,
     bearerToken,
     model,
-}: EndpointTestInput): Promise<CommunityEndpointTestResult> {
+}: ModelEndpointTestInput): Promise<CommunityEndpointTestResult> {
     const body = await fetchJson(communityImageGenerationsUrl(baseUrl), {
         method: "POST",
         headers: {
@@ -194,16 +206,19 @@ export async function testCommunityImageEndpoint({
         }),
     });
 
-    const imageBytes = await firstImageBytes(body, baseUrl);
+    const imageBytes = await firstCommunityImageBytes(body, baseUrl);
     const imageMimeType = imageBytes && detectImageMimeType(imageBytes);
     if (!imageBytes || !imageMimeType) {
         throw new Error("Endpoint did not return a supported image");
     }
-    const supportsImageEdits = await testCommunityImageEdits(
+    const supportsImageInput = await testCommunityImageEdits(
         { baseUrl, bearerToken, model },
         imageBytes,
         imageMimeType,
     );
+    const inputModalities: ModelInputModality[] = supportsImageInput
+        ? ["text", "image"]
+        : ["text"];
 
     // Endpoints that return valid OpenAI image token usage are billed
     // per token ("tokens"); everything else falls back to a fixed price
@@ -214,19 +229,228 @@ export async function testCommunityImageEndpoint({
             usage: { ...openaiUsage },
             billableUsage: openaiImageUsageToUsage(openaiUsage),
             imagePricing: "tokens",
-            supportsImageEdits,
+            inputModalities,
         };
     }
     return {
         usage: { images: 1 },
         billableUsage: { completionImageTokens: 1 },
         imagePricing: "request",
-        supportsImageEdits,
+        inputModalities,
+    };
+}
+
+// Video registration uses the same synchronous contract as request-time
+// generation: the exact configured URL must return completed playable media.
+export async function testCommunityVideoEndpoint({
+    baseUrl,
+    bearerToken,
+}: EndpointAuth): Promise<CommunityEndpointTestResult> {
+    const body = await fetchJson(baseUrl, {
+        method: "POST",
+        headers: {
+            ...authorizationHeaders(bearerToken),
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+            prompt: "A green sprout gently moving in the breeze.",
+            duration: 5,
+        }),
+    });
+    const video = await firstCommunityVideoBytes(body, baseUrl);
+    if (!video || !detectVideoMimeType(video)) {
+        throw new Error("Endpoint did not return a supported video");
+    }
+    return {
+        usage: { duration: 5 },
+        billableUsage: { completionVideoSeconds: 5 },
+    };
+}
+
+// Transcription endpoints are billed against prompt audio seconds, mirroring
+// the first-party whisper/scribe models. The probe uploads a real audio file
+// and validates the OpenAI transcription response shape.
+export async function testCommunityTranscriptionEndpoint({
+    baseUrl,
+    bearerToken,
+    model,
+}: ModelEndpointTestInput): Promise<CommunityEndpointTestResult> {
+    const sampleBytes = decodeCommunityBase64(SAMPLE_AUDIO_BASE64);
+    if (!sampleBytes) {
+        throw new Error("Failed to decode sample audio");
+    }
+    const formData = new FormData();
+    formData.append("model", model);
+    // Same format the request path pins, so what the probe proves is what
+    // callers actually get. See callCommunityTranscriptionEndpoint.
+    formData.append("response_format", "verbose_json");
+    formData.append(
+        "file",
+        new Blob([new Uint8Array(sampleBytes)], { type: "audio/wav" }),
+        "sample.wav",
+    );
+
+    let body: unknown;
+    try {
+        body = await fetchJson(communityAudioTranscriptionsUrl(baseUrl), {
+            method: "POST",
+            headers: authorizationHeaders(bearerToken),
+            body: formData,
+        });
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        // A plain-json-only endpoint rejects verbose_json outright. Name the
+        // requirement rather than leaving the owner staring at a bare 400.
+        throw new Error(
+            message.includes("responded 400")
+                ? `${message}. Pollinations requests response_format=verbose_json because that is where the audio duration transcription is billed on is reported; models that only support plain json cannot be registered yet.`
+                : message,
+        );
+    }
+
+    // The sample is real speech, so a working endpoint returns something. We
+    // never check what — the wording varies by model and language.
+    if (
+        !body ||
+        typeof body !== "object" ||
+        !("text" in body) ||
+        typeof body.text !== "string" ||
+        body.text.trim().length === 0
+    ) {
+        throw new Error("Endpoint did not return OpenAI transcription text");
+    }
+
+    // The duration is what the endpoint is billed on, so one that cannot report
+    // it must not register — otherwise every request through it would be
+    // unbillable and the owner would earn nothing.
+    const promptAudioSeconds = communityTranscriptionSeconds(body);
+    if (promptAudioSeconds === null) {
+        throw new Error(
+            "Endpoint did not report the audio duration (expected verbose_json's top-level duration, or usage.seconds), which is required to bill transcription",
+        );
+    }
+
+    return {
+        // The pricing UI marks the prompt-audio row against a usage key named
+        // in that field's rawUsagePaths, and the duration is the only thing
+        // billed here — so report it directly rather than echoing an upstream
+        // usage object that may not carry it.
+        usage: { duration: promptAudioSeconds },
+        billableUsage: { promptAudioSeconds },
+    };
+}
+
+export async function testCommunityEmbeddingEndpoint({
+    baseUrl,
+    bearerToken,
+    model,
+}: ModelEndpointTestInput): Promise<CommunityEndpointTestResult> {
+    const body = await fetchJson(communityEmbeddingsUrl(baseUrl), {
+        method: "POST",
+        headers: {
+            ...authorizationHeaders(bearerToken),
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+            model,
+            input: "A simple green sprout.",
+            encoding_format: "float",
+        }),
+    });
+
+    if (
+        !body ||
+        typeof body !== "object" ||
+        !("data" in body) ||
+        !Array.isArray(body.data) ||
+        body.data.length !== 1 ||
+        !body.data[0] ||
+        typeof body.data[0] !== "object" ||
+        !("embedding" in body.data[0]) ||
+        !Array.isArray(body.data[0].embedding) ||
+        body.data[0].embedding.length === 0 ||
+        !body.data[0].embedding.every(
+            (value: unknown) =>
+                typeof value === "number" && Number.isFinite(value),
+        )
+    ) {
+        throw new Error("Endpoint did not return OpenAI embedding data");
+    }
+
+    const usage = getOpenAIEmbeddingUsage(body);
+    if (!usage || usage.prompt_tokens <= 0) {
+        throw new Error("Endpoint did not return billable OpenAI token usage");
+    }
+
+    return {
+        usage,
+        billableUsage: { promptTextTokens: usage.prompt_tokens },
+    };
+}
+
+export async function testCommunitySpeechEndpoint({
+    baseUrl,
+    bearerToken,
+    model,
+}: ModelEndpointTestInput): Promise<CommunityEndpointTestResult> {
+    const input = "Hello.";
+    const url = communityAudioSpeechUrl(baseUrl);
+    let response: Response;
+    try {
+        response = await fetch(url, {
+            method: "POST",
+            headers: {
+                ...authorizationHeaders(bearerToken),
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                model,
+                input,
+                voice: "alloy",
+                response_format: "mp3",
+            }),
+            redirect: "manual",
+            signal: AbortSignal.timeout(COMMUNITY_ENDPOINT_TIMEOUT_MS),
+        });
+    } catch {
+        throw new Error("Endpoint request timed out or could not connect");
+    }
+    const contentType = response.headers.get("content-type") ?? "";
+    if (!response.ok) {
+        const body = parseJson(
+            await readResponseText(
+                response,
+                MAX_COMMUNITY_MEDIA_RESPONSE_BYTES,
+                () => new Error("Endpoint response is too large"),
+            ),
+        );
+        throw new Error(endpointErrorMessage(response.status, body));
+    }
+    if (
+        !contentType.startsWith("audio/") &&
+        contentType !== "application/octet-stream"
+    ) {
+        throw new Error(
+            `Endpoint did not return audio (Content-Type: ${contentType || "(none)"})`,
+        );
+    }
+    const bytes = await readResponseBytes(
+        response,
+        MAX_COMMUNITY_MEDIA_RESPONSE_BYTES,
+        () => new Error("Endpoint response is too large"),
+    );
+    if (bytes.length === 0) {
+        throw new Error("Endpoint returned empty audio");
+    }
+    const characters = input.length;
+    return {
+        usage: { characters },
+        billableUsage: { completionAudioTokens: characters },
     };
 }
 
 async function testCommunityImageEdits(
-    { baseUrl, bearerToken, model }: EndpointTestInput,
+    { baseUrl, bearerToken, model }: ModelEndpointTestInput,
     imageBytes: Uint8Array,
     imageMimeType: string,
 ): Promise<boolean> {
@@ -248,88 +472,9 @@ async function testCommunityImageEdits(
             headers: authorizationHeaders(bearerToken),
             body: formData,
         });
-        const editedImage = await firstImageBytes(body, baseUrl);
+        const editedImage = await firstCommunityImageBytes(body, baseUrl);
         return Boolean(editedImage && detectImageMimeType(editedImage));
     } catch {
         return false;
-    }
-}
-
-async function firstImageBytes(
-    body: unknown,
-    endpointBaseUrl: string,
-): Promise<Uint8Array | null> {
-    if (
-        !body ||
-        typeof body !== "object" ||
-        !("data" in body) ||
-        !Array.isArray(body.data)
-    ) {
-        return null;
-    }
-    for (const image of body.data) {
-        if (!image || typeof image !== "object") continue;
-        if (
-            "b64_json" in image &&
-            typeof image.b64_json === "string" &&
-            image.b64_json.length > 0
-        ) {
-            return decodeBase64(image.b64_json);
-        }
-        if (
-            "url" in image &&
-            typeof image.url === "string" &&
-            image.url.length > 0
-        ) {
-            return fetchImageBytes(image.url, endpointBaseUrl);
-        }
-    }
-    return null;
-}
-
-async function fetchImageBytes(
-    value: string,
-    endpointBaseUrl: string,
-): Promise<Uint8Array> {
-    let url: string;
-    try {
-        url = normalizeCommunityAssetUrl(value, endpointBaseUrl);
-    } catch {
-        throw new Error("Endpoint returned an unsafe image URL");
-    }
-    let response: Response;
-    try {
-        response = await fetch(url, {
-            redirect: "manual",
-            signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-        });
-    } catch {
-        throw new Error("Endpoint image URL timed out or could not connect");
-    }
-    if (!response.ok) {
-        throw new Error(`Endpoint image URL responded ${response.status}`);
-    }
-    const contentLength = Number(response.headers.get("content-length"));
-    if (Number.isFinite(contentLength) && contentLength > MAX_IMAGE_BYTES) {
-        throw new Error("Endpoint image is larger than 20 MB");
-    }
-    const bytes = new Uint8Array(await response.arrayBuffer());
-    if (bytes.byteLength > MAX_IMAGE_BYTES) {
-        throw new Error("Endpoint image is larger than 20 MB");
-    }
-    return bytes;
-}
-
-function decodeBase64(value: string): Uint8Array | null {
-    try {
-        const encoded = value
-            .replace(/^data:[^,]+,/, "")
-            .replace(/\s/g, "")
-            .replace(/-/g, "+")
-            .replace(/_/g, "/");
-        const decoded = atob(encoded);
-        return Uint8Array.from(decoded, (character) => character.charCodeAt(0));
-    } catch {
-        return null;
     }
 }

--- a/enter.pollinations.ai/test/community-endpoint-openai.test.ts
+++ b/enter.pollinations.ai/test/community-endpoint-openai.test.ts
@@ -1,12 +1,35 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { TestEndpointSchema } from "../src/routes/community-endpoints/schemas.ts";
 import {
     listCommunityEndpointModels,
+    testCommunityEmbeddingEndpoint,
     testCommunityEndpoint,
     testCommunityImageEndpoint,
+    testCommunitySpeechEndpoint,
+    testCommunityTranscriptionEndpoint,
+    testCommunityVideoEndpoint,
 } from "../src/services/community-endpoint-openai.ts";
 
 afterEach(() => {
     vi.unstubAllGlobals();
+});
+
+describe("community endpoint test input", () => {
+    const endpoint = {
+        baseUrl: "https://api.example.com/generate-video",
+        bearerToken: "sk_saved_token",
+    };
+
+    it("does not require an upstream model for video", () => {
+        expect(
+            TestEndpointSchema.safeParse({ ...endpoint, modality: "video" })
+                .success,
+        ).toBe(true);
+    });
+
+    it("requires an upstream model for OpenAI-compatible modalities", () => {
+        expect(TestEndpointSchema.safeParse(endpoint).success).toBe(false);
+    });
 });
 
 describe("community endpoint OpenAI service", () => {
@@ -31,6 +54,42 @@ describe("community endpoint OpenAI service", () => {
         ).resolves.toEqual(["gpt-4.1", "gpt-4.1-mini"]);
 
         expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("preserves endpoint query strings when building the models URL", async () => {
+        const fetchMock = vi.fn(async (input) => {
+            expect(String(input)).toBe(
+                "https://api.example.com/v1/models?api-version=2026-08-01",
+            );
+            return Response.json({ data: [{ id: "gpt-4.1" }] });
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        await expect(
+            listCommunityEndpointModels({
+                baseUrl: "https://api.example.com/v1/?api-version=2026-08-01",
+                bearerToken: "sk_saved_token",
+            }),
+        ).resolves.toEqual(["gpt-4.1"]);
+    });
+
+    it("bounds model-list responses before parsing provider JSON", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(
+                async () =>
+                    new Response("{}", {
+                        headers: { "content-length": "999999999" },
+                    }),
+            ),
+        );
+
+        await expect(
+            listCommunityEndpointModels({
+                baseUrl: "https://api.example.com/v1",
+                bearerToken: "sk_saved_token",
+            }),
+        ).rejects.toThrow("Endpoint response is too large");
     });
 
     it("sends the bearer token when testing an endpoint", async () => {
@@ -161,7 +220,7 @@ describe("community endpoint OpenAI service", () => {
                 completionImageTokens: 1056,
             },
             imagePricing: "tokens",
-            supportsImageEdits: true,
+            inputModalities: ["text", "image"],
         });
 
         expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -194,7 +253,7 @@ describe("community endpoint OpenAI service", () => {
             usage: { images: 1 },
             billableUsage: { completionImageTokens: 1 },
             imagePricing: "request",
-            supportsImageEdits: false,
+            inputModalities: ["text"],
         });
     });
 
@@ -225,7 +284,7 @@ describe("community endpoint OpenAI service", () => {
             usage: { images: 1 },
             billableUsage: { completionImageTokens: 1 },
             imagePricing: "request",
-            supportsImageEdits: true,
+            inputModalities: ["text", "image"],
         });
     });
 
@@ -299,5 +358,320 @@ describe("community endpoint OpenAI service", () => {
         ).rejects.toThrow(
             "Endpoint responded 401 after we sent Authorization: Authentication required",
         );
+    });
+
+    it("probes the exact synchronous video endpoint", async () => {
+        const fetchMock = vi.fn(async (input, init) => {
+            const request = new Request(input, init);
+            expect(request.url).toBe(
+                "https://api.example.com/generate-video?version=1",
+            );
+            expect(request.headers.get("authorization")).toBe(
+                "Bearer sk_saved_token",
+            );
+            await expect(request.json()).resolves.toEqual({
+                prompt: "A green sprout gently moving in the breeze.",
+                duration: 5,
+            });
+            return Response.json({
+                data: [
+                    {
+                        b64_json: "AAAAFGZ0eXBpc29tAAAAAGlzb20AAAAJbWRhdAA=",
+                    },
+                ],
+            });
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        await expect(
+            testCommunityVideoEndpoint({
+                baseUrl: "https://api.example.com/generate-video?version=1",
+                bearerToken: "sk_saved_token",
+            }),
+        ).resolves.toEqual({
+            usage: { duration: 5 },
+            billableUsage: { completionVideoSeconds: 5 },
+        });
+    });
+
+    it("probes transcription endpoints with a sample audio file and OpenAI duration usage", async () => {
+        const fetchMock = vi.fn(async (input, init) => {
+            const request = new Request(input, init);
+            expect(request.url).toBe(
+                "https://api.example.com/v1/audio/transcriptions",
+            );
+            expect(request.headers.get("authorization")).toBe(
+                "Bearer sk_saved_token",
+            );
+            const formData = await request.formData();
+            expect(formData.get("model")).toBe("whisper-1");
+            expect(formData.get("response_format")).toBe("verbose_json");
+            const file = formData.get("file");
+            expect(file).toBeInstanceOf(File);
+            expect((file as File).type).toBe("audio/wav");
+            // A structurally valid WAV carrying actual speech: 44-byte
+            // RIFF/WAVE header + ~0.9s of PCM at 8 kHz mono 16-bit. The
+            // non-silence assertion is the point — probing with silence would
+            // reject endpoints that legitimately report no duration for it.
+            const wav = new Uint8Array(await (file as File).arrayBuffer());
+            expect(wav.length).toBe(14518);
+            expect(new TextDecoder().decode(wav.subarray(0, 4))).toBe("RIFF");
+            expect(new TextDecoder().decode(wav.subarray(8, 12))).toBe("WAVE");
+            expect(wav.subarray(44).some((byte) => byte !== 0)).toBe(true);
+            return Response.json({
+                text: "Hello",
+                usage: { duration: 0.5 },
+            });
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        await expect(
+            testCommunityTranscriptionEndpoint({
+                baseUrl: "https://api.example.com/v1",
+                bearerToken: "Bearer sk_saved_token",
+                model: "whisper-1",
+            }),
+        ).resolves.toEqual({
+            usage: { duration: 0.5 },
+            billableUsage: { promptAudioSeconds: 0.5 },
+        });
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("accepts whisper-style usage.seconds from transcription upstreams", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () =>
+                Response.json({
+                    text: "Hello",
+                    usage: { seconds: 3 },
+                }),
+            ),
+        );
+
+        await expect(
+            testCommunityTranscriptionEndpoint({
+                baseUrl: "https://api.example.com/v1",
+                bearerToken: "sk_saved_token",
+                model: "whisper-1",
+            }),
+        ).resolves.toEqual({
+            usage: { duration: 3 },
+            billableUsage: { promptAudioSeconds: 3 },
+        });
+    });
+
+    it("accepts a top-level duration, which is where whisper verbose_json puts it", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => Response.json({ text: "Hello", duration: 4.5 })),
+        );
+
+        await expect(
+            testCommunityTranscriptionEndpoint({
+                baseUrl: "https://api.example.com/v1",
+                bearerToken: "sk_saved_token",
+                model: "whisper-1",
+            }),
+        ).resolves.toMatchObject({
+            billableUsage: { promptAudioSeconds: 4.5 },
+        });
+    });
+
+    it("refuses to register a transcription endpoint that omits duration", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => Response.json({ text: "Hello" })),
+        );
+
+        await expect(
+            testCommunityTranscriptionEndpoint({
+                baseUrl: "https://api.example.com/v1",
+                bearerToken: "sk_saved_token",
+                model: "whisper-1",
+            }),
+        ).rejects.toThrow("did not report the audio duration");
+    });
+
+    it("rejects an empty transcript, since the sample is real speech", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => Response.json({ text: "   ", duration: 0.9 })),
+        );
+
+        await expect(
+            testCommunityTranscriptionEndpoint({
+                baseUrl: "https://api.example.com/v1",
+                bearerToken: "sk_saved_token",
+                model: "whisper-1",
+            }),
+        ).rejects.toThrow("did not return OpenAI transcription text");
+    });
+
+    it("explains the verbose_json requirement when the endpoint rejects it", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () =>
+                Response.json(
+                    { error: { message: "unsupported response_format" } },
+                    { status: 400 },
+                ),
+            ),
+        );
+
+        await expect(
+            testCommunityTranscriptionEndpoint({
+                baseUrl: "https://api.example.com/v1",
+                bearerToken: "sk_saved_token",
+                model: "gpt-4o-transcribe",
+            }),
+        ).rejects.toThrow("response_format=verbose_json");
+    });
+
+    it("rejects transcription responses without text", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => Response.json({})),
+        );
+
+        await expect(
+            testCommunityTranscriptionEndpoint({
+                baseUrl: "https://api.example.com/v1",
+                bearerToken: "sk_saved_token",
+                model: "whisper-1",
+            }),
+        ).rejects.toThrow("Endpoint did not return OpenAI transcription text");
+    });
+
+    it("probes embedding endpoints and returns billable prompt tokens", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () =>
+                Response.json({
+                    data: [
+                        {
+                            embedding: Array.from({ length: 4 }, () =>
+                                Math.random(),
+                            ),
+                        },
+                    ],
+                    usage: { prompt_tokens: 12, total_tokens: 12 },
+                }),
+            ),
+        );
+
+        await expect(
+            testCommunityEmbeddingEndpoint({
+                baseUrl: "https://api.example.com/v1",
+                bearerToken: "Bearer sk_saved_token",
+                model: "text-embedding-3-small",
+            }),
+        ).resolves.toEqual({
+            usage: { prompt_tokens: 12, total_tokens: 12 },
+            billableUsage: { promptTextTokens: 12 },
+        });
+    });
+
+    it("rejects embedding upstreams that omit billable token usage", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () =>
+                Response.json({
+                    data: [
+                        {
+                            embedding: Array.from({ length: 4 }, () =>
+                                Math.random(),
+                            ),
+                        },
+                    ],
+                }),
+            ),
+        );
+
+        await expect(
+            testCommunityEmbeddingEndpoint({
+                baseUrl: "https://api.example.com/v1",
+                bearerToken: "Bearer sk_saved_token",
+                model: "text-embedding-3-small",
+            }),
+        ).rejects.toThrow(
+            "Endpoint did not return billable OpenAI token usage",
+        );
+    });
+
+    it("probes speech endpoints with a short input and accepts binary audio", async () => {
+        const fetchMock = vi.fn(async (input, init) => {
+            const request = new Request(input, init);
+            expect(request.url).toBe("https://api.example.com/v1/audio/speech");
+            expect(request.headers.get("authorization")).toBe(
+                "Bearer sk_saved_token",
+            );
+            const body = await request.json();
+            expect(body).toMatchObject({
+                model: "tts-1",
+                input: "Hello.",
+                voice: "alloy",
+                response_format: "mp3",
+            });
+            return new Response(new Uint8Array([255, 251, 144, 0]), {
+                headers: { "Content-Type": "audio/mpeg" },
+            });
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        await expect(
+            testCommunitySpeechEndpoint({
+                baseUrl: "https://api.example.com/v1",
+                bearerToken: "sk_saved_token",
+                model: "tts-1",
+            }),
+        ).resolves.toEqual({
+            usage: { characters: 6 },
+            billableUsage: { completionAudioTokens: 6 },
+        });
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects speech responses with non-audio content type", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () =>
+                Response.json(
+                    { error: { message: "Bad model" } },
+                    {
+                        status: 200,
+                        headers: { "Content-Type": "application/json" },
+                    },
+                ),
+            ),
+        );
+
+        await expect(
+            testCommunitySpeechEndpoint({
+                baseUrl: "https://api.example.com/v1",
+                bearerToken: "sk_saved_token",
+                model: "tts-1",
+            }),
+        ).rejects.toThrow("did not return audio");
+    });
+
+    it("rejects empty audio from speech endpoints", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(
+                async () =>
+                    new Response(new Uint8Array(0), {
+                        headers: { "Content-Type": "audio/mpeg" },
+                    }),
+            ),
+        );
+
+        await expect(
+            testCommunitySpeechEndpoint({
+                baseUrl: "https://api.example.com/v1",
+                bearerToken: "sk_saved_token",
+                model: "tts-1",
+            }),
+        ).rejects.toThrow("empty audio");
     });
 });

--- a/gen.pollinations.ai/src/audio/communityEndpoint.ts
+++ b/gen.pollinations.ai/src/audio/communityEndpoint.ts
@@ -1,0 +1,273 @@
+import {
+    communityAudioSpeechUrl,
+    communityAudioTranscriptionsUrl,
+} from "@shared/community-endpoint-urls.ts";
+import {
+    COMMUNITY_ENDPOINT_TIMEOUT_MS,
+    type CommunityEndpointRuntime,
+    communityTranscriptionSeconds,
+    normalizeCommunityEndpointBearerToken,
+} from "@shared/community-endpoints.ts";
+import { ensureUpstreamOk, UpstreamError } from "@shared/error.ts";
+import {
+    buildUsageHeaders,
+    createAudioSecondsUsage,
+    createAudioTokenUsage,
+} from "@shared/registry/usage-headers.ts";
+import { decryptSecret } from "@shared/secret-encryption.ts";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import {
+    assertTranscriptionResponseFormat,
+    buildTranscriptionResponse,
+    type NormalizedSegment,
+    type NormalizedWord,
+    UNDIARIZED_TRANSCRIPTION_RESPONSE_FORMATS,
+} from "../routes/transcription-response.ts";
+
+export type CommunityTranscriptionOptions = {
+    file: File;
+    language?: string;
+    prompt?: string;
+    responseFormat?: string;
+    temperature?: number;
+};
+
+export async function callCommunityTranscriptionEndpoint(
+    endpoint: CommunityEndpointRuntime,
+    options: CommunityTranscriptionOptions,
+    secret: string,
+): Promise<Response> {
+    // Managed agents are text-only, so a transcription endpoint is always external.
+    if (endpoint.type !== "proxy") {
+        throw new Error(
+            `Community transcription endpoint '${endpoint.modelId}' is a managed agent`,
+        );
+    }
+    const responseFormat = options.responseFormat ?? "json";
+    // No diarized_json: we never ask the endpoint to diarize and plain json
+    // carries no speaker data, so that branch would answer with segments: [].
+    assertTranscriptionResponseFormat(
+        responseFormat,
+        endpoint.modelId,
+        UNDIARIZED_TRANSCRIPTION_RESPONSE_FORMATS,
+    );
+
+    const bearerToken = await decryptSecret(
+        endpoint.bearerTokenCiphertext,
+        secret,
+    );
+    const upstreamUrl = communityAudioTranscriptionsUrl(endpoint.baseUrl);
+
+    const upstreamFormData = new FormData();
+    const filename =
+        options.file.name && options.file.name !== "blob"
+            ? options.file.name
+            : "audio.mp3";
+    upstreamFormData.append("file", options.file, filename);
+    upstreamFormData.append("model", endpoint.upstreamModel);
+    if (options.language) upstreamFormData.append("language", options.language);
+    if (options.prompt) upstreamFormData.append("prompt", options.prompt);
+    // Pin the upstream format instead of forwarding the caller's, the way
+    // whisper/grok/scribe do, and pin the same one our own whisper backend
+    // asks for. Community endpoints are self-hosted whisper servers, which
+    // report the audio duration only in verbose_json — plain json gives back a
+    // bare { text } with nothing to meter, and text/srt/vtt carry no usage at
+    // all. This is the exact shape the registration probe proved this endpoint
+    // meters. The caller's format is served from the parsed result below.
+    upstreamFormData.append("response_format", "verbose_json");
+    if (options.temperature !== undefined) {
+        upstreamFormData.append("temperature", String(options.temperature));
+    }
+
+    let response: Response;
+    try {
+        response = await fetch(upstreamUrl, {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${normalizeCommunityEndpointBearerToken(
+                    bearerToken,
+                )}`,
+            },
+            body: upstreamFormData,
+            redirect: "manual",
+            signal: AbortSignal.timeout(COMMUNITY_ENDPOINT_TIMEOUT_MS),
+        });
+    } catch (error) {
+        throw new UpstreamError(502 as ContentfulStatusCode, {
+            message:
+                "Community transcription endpoint timed out or could not connect",
+            cause: error,
+            requestUrl: new URL(upstreamUrl),
+        });
+    }
+    // Endpoints that only speak plain json (gpt-4o-transcribe and friends)
+    // reject verbose_json outright. Say so instead of surfacing a bare
+    // upstream 400, so the owner knows what their endpoint has to support.
+    if (response.status === 400) {
+        throw new UpstreamError(502 as ContentfulStatusCode, {
+            message: `Community transcription endpoint '${endpoint.modelId}' rejected response_format=verbose_json. Pollinations requests verbose_json because it reports the audio duration that transcription is billed on; models that only support plain json cannot be used yet.`,
+            requestUrl: new URL(upstreamUrl),
+        });
+    }
+    response = await ensureUpstreamOk(response, upstreamUrl);
+
+    const transcript = parseCommunityTranscription(await response.text());
+    return buildTranscriptionResponse({
+        normalized: {
+            text: transcript.text,
+            language: transcript.language,
+            duration: transcript.duration,
+            words: transcript.words,
+            segments: transcript.segments,
+            // We never ask the endpoint to diarize, so there are no speakers
+            // to report; diarized_json is rejected above rather than answered
+            // with an empty list.
+            diarizedSegments: [],
+        },
+        responseFormat,
+        usageHeaders: buildUsageHeaders(
+            endpoint.modelId,
+            createAudioSecondsUsage(transcript.duration),
+        ),
+    });
+}
+
+// The duration is the meter, so an endpoint that does not report one is a
+// provider regression rather than a free request — the stance whisper, grok
+// and scribe all take, and the one the image path takes on missing token
+// usage. The registration probe rejects endpoints that cannot report a
+// duration, so reaching this means an endpoint that could has stopped.
+function parseCommunityTranscription(bodyText: string): {
+    text: string;
+    language?: string;
+    duration: number;
+    words: NormalizedWord[];
+    segments: NormalizedSegment[];
+} {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(bodyText);
+    } catch {
+        parsed = null;
+    }
+    const duration = communityTranscriptionSeconds(parsed);
+    if (duration === null) {
+        throw new UpstreamError(502 as ContentfulStatusCode, {
+            message:
+                "Community transcription endpoint did not report the audio duration (expected verbose_json's top-level duration, or usage.seconds) that transcription is billed on",
+        });
+    }
+    const record = parsed as Record<string, unknown>;
+    if (typeof record.text !== "string") {
+        throw new UpstreamError(502 as ContentfulStatusCode, {
+            message:
+                "Community transcription endpoint did not return transcription text",
+        });
+    }
+    return {
+        text: record.text,
+        language:
+            typeof record.language === "string" ? record.language : undefined,
+        duration,
+        words: toTimedWords(record.words),
+        segments: toTimedSegments(record.segments),
+    };
+}
+
+// verbose_json carries the endpoint's own timings alongside the duration we
+// bill on. Take them: a self-hosted whisper server measured these, we did not,
+// and dropping them makes the caller's verbose_json poorer than the upstream's.
+// Entries that are not fully timed are skipped rather than defaulted, so a
+// partial upstream degrades to fewer segments instead of wrong ones.
+function toTimedSegments(value: unknown): NormalizedSegment[] {
+    if (!Array.isArray(value)) return [];
+    return value.flatMap((entry) => {
+        if (!entry || typeof entry !== "object") return [];
+        const { start, end, text } = entry as Record<string, unknown>;
+        if (
+            typeof start !== "number" ||
+            typeof end !== "number" ||
+            typeof text !== "string"
+        ) {
+            return [];
+        }
+        return [{ start, end, text }];
+    });
+}
+
+function toTimedWords(value: unknown): NormalizedWord[] {
+    if (!Array.isArray(value)) return [];
+    return value.flatMap((entry) => {
+        if (!entry || typeof entry !== "object") return [];
+        const { start, end, word } = entry as Record<string, unknown>;
+        if (
+            typeof start !== "number" ||
+            typeof end !== "number" ||
+            typeof word !== "string"
+        ) {
+            return [];
+        }
+        return [{ word, start, end }];
+    });
+}
+
+export type CommunitySpeechOptions = {
+    input: string;
+    voice?: string;
+    responseFormat?: string;
+};
+
+export async function callCommunitySpeechEndpoint(
+    endpoint: CommunityEndpointRuntime,
+    options: CommunitySpeechOptions,
+    secret: string,
+): Promise<Response> {
+    if (endpoint.type !== "proxy") {
+        throw new Error(
+            `Community speech endpoint '${endpoint.modelId}' is a managed agent`,
+        );
+    }
+    const bearerToken = await decryptSecret(
+        endpoint.bearerTokenCiphertext,
+        secret,
+    );
+    const upstreamUrl = communityAudioSpeechUrl(endpoint.baseUrl);
+
+    let response: Response;
+    try {
+        response = await fetch(upstreamUrl, {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${normalizeCommunityEndpointBearerToken(bearerToken)}`,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                model: endpoint.upstreamModel,
+                input: options.input,
+                voice: options.voice ?? "alloy",
+                response_format: options.responseFormat ?? "mp3",
+            }),
+            redirect: "manual",
+            signal: AbortSignal.timeout(COMMUNITY_ENDPOINT_TIMEOUT_MS),
+        });
+    } catch (error) {
+        throw new UpstreamError(502 as ContentfulStatusCode, {
+            message: "Community speech endpoint timed out or could not connect",
+            cause: error,
+            requestUrl: new URL(upstreamUrl),
+        });
+    }
+    response = await ensureUpstreamOk(response, upstreamUrl);
+
+    const contentType = response.headers.get("content-type") ?? "audio/mpeg";
+    const audioBuffer = await response.arrayBuffer();
+    return new Response(audioBuffer, {
+        headers: {
+            "Content-Type": contentType,
+            ...buildUsageHeaders(
+                endpoint.modelId,
+                createAudioTokenUsage(options.input.length),
+            ),
+        },
+    });
+}

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -4,16 +4,19 @@ import {
     AUDIO_VOICES,
     type AudioModelName,
     CSM_VOICES,
+    KOKORO_VOICES,
     resolveElevenLabsVoiceId,
+    XAI_TTS_VOICES,
 } from "@shared/registry/audio.ts";
-import type { ModelDefinition } from "@shared/registry/registry.ts";
 import {
     buildUsageHeaders,
     createAudioSecondsUsage,
     createAudioTokenUsage,
     createCompletionAudioSecondsUsage,
 } from "@shared/registry/usage-headers.ts";
-import { SafeSchema, type SafeValue } from "@shared/schemas/safety.ts";
+import { readResponseBytes } from "@shared/response-bytes.ts";
+import { SafeSchema } from "@shared/schemas/safety.ts";
+import { validateUserMediaUrl } from "@shared/user-media-url.ts";
 import { errorResponseDescriptions } from "@shared/utils/api-docs.ts";
 import { type Context, Hono } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
@@ -22,20 +25,40 @@ import { z } from "zod";
 import type { Env } from "@/env.ts";
 import { auth } from "@/middleware/auth.ts";
 import { balance } from "@/middleware/balance.ts";
+import { prepareGenerationRequest } from "@/middleware/generation-cache.ts";
+import { deduplicateGeneration } from "@/middleware/generation-deduplication.ts";
+import { audioCache } from "@/middleware/media-cache.ts";
 import { resolveModel } from "@/middleware/model.ts";
 import { frontendKeyRateLimit } from "@/middleware/rate-limit-durable.ts";
 import { edgeRateLimit } from "@/middleware/rate-limit-edge.ts";
-import {
-    applySafety,
-    applySafetyToTexts,
-    withSafetyHeaders,
-} from "@/middleware/safety.ts";
+import { applySafetyToInput, withSafetyHeaders } from "@/middleware/safety.ts";
+import { textCache } from "@/middleware/text-cache.ts";
 import { track } from "@/middleware/track.ts";
 import googleCloudAuth from "@/text/auth/googleCloudAuth.ts";
-import { arrayBufferToBase64 } from "@/util.ts";
-import { requireGenerationAccess } from "@/utils/generation-access.ts";
+import { arrayBufferToBase64, normalizeSeed } from "@/util.ts";
+import {
+    apiKeyBudgetReservation,
+    generationAccess,
+} from "@/utils/generation-access.ts";
+import {
+    callCommunitySpeechEndpoint,
+    callCommunityTranscriptionEndpoint,
+} from "../audio/communityEndpoint.ts";
+import {
+    type FallbackCandidate,
+    withModelFallbackResponse,
+} from "../fallback.ts";
+import { enforceModelRateLimit } from "../utils/model-rate-limit.ts";
 import { transcribeWithAssemblyAi } from "./assemblyai-transcription.ts";
-import { buildTranscriptionResponse } from "./transcription-response.ts";
+import type { SimpleAudioQuery } from "./generation-handlers.ts";
+import {
+    assertTranscriptionResponseFormat,
+    buildTranscriptionResponse,
+    type NormalizedDiarizedSegment,
+    type NormalizedSegment,
+    type NormalizedWord,
+    UNDIARIZED_TRANSCRIPTION_RESPONSE_FORMATS,
+} from "./transcription-response.ts";
 
 const CreateSpeechRequestSchema = z
     .object({
@@ -58,7 +81,7 @@ const CreateSpeechRequestSchema = z
             .default("mp3")
             .meta({
                 description:
-                    "The audio format for the output. CSM supports mp3, opus, flac, wav, and pcm; Qwen TTS currently returns WAV regardless of this setting; lyria-3-clip and eleven-sfx support mp3 only.",
+                    "The audio format for the output. Grok TTS supports mp3, wav, and pcm; Fish Audio supports mp3 and pcm; CSM and Kokoro support mp3, opus, flac, wav, and pcm; Qwen TTS currently returns WAV regardless of this setting; lyria-3-clip and eleven-sfx support mp3 only.",
                 example: "mp3",
             }),
         duration: z.number().min(0.5).max(300).optional().meta({
@@ -99,14 +122,15 @@ const CreateSpeechRequestSchema = z
                 "If true, stores the generated elevenmusic song and returns its song ID for later inpainting.",
             example: false,
         }),
-        extract_composition_plan: z.boolean().optional().meta({
+        reference_audio: z.url().optional().meta({
             description:
-                "If true with reference audio, uploads it and asks ElevenLabs to derive a music_v2 composition plan.",
-            example: false,
+                "Public HTTP(S) URL for reference-audio conditioning or audio-to-audio generation.",
+            example:
+                "https://media.pollinations.ai/3f9c1e2a-7b4d-4e2f-9a1c-8d6b5e4f3a2b",
         }),
         conditioning_ref: z.unknown().optional().meta({
             description:
-                "ElevenLabs music_v2 AudioRefChunk to apply to the generated chunk. Multipart reference_audio can create this automatically.",
+                "ElevenLabs music_v2 AudioRefChunk to apply to the generated chunk. reference_audio creates this automatically; advanced clients can reuse x-elevenlabs-reference-song-id here on later requests.",
         }),
         composition_plan: z.unknown().optional().meta({
             description:
@@ -117,7 +141,7 @@ const CreateSpeechRequestSchema = z
                 "Seed for deterministic output. Same seed + params = best-effort return of the same cached result. Omit for random.",
             example: 42,
         }),
-        instruct: z.string().optional().meta({
+        instructions: z.string().optional().meta({
             description:
                 "Emotion/style instruction (qwen-tts-instruct only). e.g. 'excited and cheerful'.",
             example: "speak softly and warmly",
@@ -126,51 +150,20 @@ const CreateSpeechRequestSchema = z
     .meta({ $id: "CreateSpeechRequest" });
 
 type CreateSpeechRequest = z.infer<typeof CreateSpeechRequestSchema>;
-const CreateDialogueRequestSchema = z
-    .object({
-        model: z.string().optional(),
-        inputs: z
-            .array(
-                z.object({
-                    text: z.string().min(1).max(2000),
-                    voice: z.string().min(1),
-                }),
-            )
-            .min(1)
-            .max(25),
-        response_format: z
-            .enum(["mp3", "opus", "aac", "wav", "pcm"])
-            .default("mp3"),
-        seed: z.number().int().min(0).max(4294967295).optional(),
-        safe: SafeSchema,
-    })
-    .refine(
-        ({ inputs }) =>
-            inputs.reduce((total, input) => total + input.text.length, 0) <=
-            2000,
-        {
-            path: ["inputs"],
-            message: "Dialogue input is limited to 2000 total text characters.",
-        },
-    )
-    .meta({ $id: "CreateDialogueRequest" });
 
 type AudioContext = Context<Env>;
-type SimpleAudioQuery = {
-    safe?: SafeValue;
-    duration?: number;
-    seconds?: number;
-    steps?: number;
-    negative_prompt?: string;
-    instrumental?: boolean;
-    seed?: number;
-    voice: string;
-    response_format: string;
-    instruct?: string;
-    loop?: boolean;
-    prompt_influence?: number;
-};
 
+async function withAudioFallback(
+    c: AudioContext,
+    attempt: (candidate: FallbackCandidate) => Promise<Response>,
+): Promise<Response> {
+    return withModelFallbackResponse(
+        c.var.model,
+        attempt,
+        c.var.track?.attempts,
+        (candidate) => enforceModelRateLimit(c, candidate),
+    );
+}
 type AudioRefChunk = {
     song_id: string;
     range: {
@@ -185,13 +178,96 @@ type GenerateMusicOptions = {
     forceInstrumental?: boolean;
     seed?: number;
     storeForInpainting?: boolean;
-    extractCompositionPlan?: boolean;
     conditioningRef?: unknown;
     compositionPlan?: unknown;
     referenceAudio?: File;
     apiKey: string;
     log: Logger;
 };
+
+const MAX_REFERENCE_AUDIO_SIZE = 20 * 1024 * 1024;
+const REFERENCE_AUDIO_FETCH_TIMEOUT_MS = 30_000;
+
+const AUDIO_EXTENSION_BY_TYPE: Record<string, string> = {
+    "audio/aac": "aac",
+    "audio/flac": "flac",
+    "audio/mp4": "m4a",
+    "audio/mpeg": "mp3",
+    "audio/ogg": "ogg",
+    "audio/wav": "wav",
+    "audio/x-wav": "wav",
+};
+
+async function fetchReferenceAudio(referenceAudioUrl: string): Promise<File> {
+    const validation = validateUserMediaUrl(referenceAudioUrl);
+    if (!validation.ok) {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message:
+                "reference_audio must be a public HTTP(S) URL without credentials",
+        });
+    }
+    const { url } = validation;
+
+    let response: Response;
+    try {
+        response = await fetch(url, {
+            headers: { "User-Agent": "Pollinations/1.0" },
+            signal: AbortSignal.timeout(REFERENCE_AUDIO_FETCH_TIMEOUT_MS),
+        });
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message: `Failed to fetch reference_audio from ${url.hostname}: ${message}`,
+            requestUrl: url,
+        });
+    }
+
+    if (!response.ok) {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message: `Failed to fetch reference_audio: ${url.hostname} returned ${response.status}`,
+            requestUrl: url,
+            upstreamStatus: response.status,
+        });
+    }
+
+    const contentType =
+        response.headers
+            .get("content-type")
+            ?.split(";", 1)[0]
+            .trim()
+            .toLowerCase() || "application/octet-stream";
+    if (
+        !contentType.startsWith("audio/") &&
+        contentType !== "application/octet-stream"
+    ) {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message: "reference_audio must point to an audio file",
+        });
+    }
+
+    const extension = AUDIO_EXTENSION_BY_TYPE[contentType] || "audio";
+    let bytes: Uint8Array<ArrayBuffer>;
+    try {
+        bytes = await readResponseBytes(
+            response,
+            MAX_REFERENCE_AUDIO_SIZE,
+            (total) =>
+                new UpstreamError(400 as ContentfulStatusCode, {
+                    message: `reference_audio is too large: ${total} bytes (max ${MAX_REFERENCE_AUDIO_SIZE})`,
+                    requestUrl: url,
+                }),
+        );
+    } catch (error) {
+        if (error instanceof UpstreamError) throw error;
+        const message = error instanceof Error ? error.message : String(error);
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message: `Failed to read reference_audio: ${message}`,
+            requestUrl: url,
+        });
+    }
+
+    return new File([bytes], `reference.${extension}`, { type: contentType });
+}
 
 function mapOutputFormat(format: string): string {
     const formatMap: Record<string, string> = {
@@ -244,11 +320,48 @@ export function fixWavHeader(buffer: ArrayBuffer): ArrayBuffer {
     return buffer; // no data chunk found
 }
 
+async function buildElevenLabsAudioResponse(
+    response: Response,
+    responseFormat: string,
+    headers: Record<string, string>,
+): Promise<Response> {
+    const contentType = response.headers.get("content-type") || "audio/mpeg";
+
+    // ElevenLabs streams WAV with placeholder RIFF sizes, so WAV must be
+    // buffered and repaired. Other formats keep streaming from upstream.
+    if (responseFormat === "wav") {
+        const audioBuffer = fixWavHeader(await response.arrayBuffer());
+        return new Response(audioBuffer, {
+            status: 200,
+            headers: {
+                "Content-Type": contentType,
+                "Content-Length": String(audioBuffer.byteLength),
+                ...headers,
+            },
+        });
+    }
+
+    return new Response(response.body, {
+        status: 200,
+        headers: {
+            "Content-Type": contentType,
+            ...headers,
+        },
+    });
+}
+
 const ELEVENLABS_TTS_MODEL_IDS = {
     elevenlabs: "eleven_v3",
     elevenflash: "eleven_flash_v2_5",
     "eleven-multilingual-v2": "eleven_multilingual_v2",
 } as const satisfies Partial<Record<AudioModelName, string>>;
+
+const ELEVENLABS_TTS_VOICE_SETTINGS = {
+    stability: 0.5,
+    similarity_boost: 0.75,
+    style: 0.0,
+    use_speaker_boost: true,
+} as const;
 
 type ElevenLabsTtsModelName = keyof typeof ELEVENLABS_TTS_MODEL_IDS;
 
@@ -296,19 +409,12 @@ export async function generateElevenLabsSpeech(opts: {
 
     const elevenLabsUrl = `https://api.elevenlabs.io/v1/text-to-speech/${encodeURIComponent(voiceId)}?output_format=${outputFormat}`;
 
-    const elevenLabsBody: Record<string, unknown> = {
+    const elevenLabsBody = {
         text,
         model_id: modelId,
-        voice_settings: {
-            stability: 0.5,
-            similarity_boost: 0.75,
-            style: 0.0,
-            use_speaker_boost: true,
-        },
+        voice_settings: ELEVENLABS_TTS_VOICE_SETTINGS,
+        ...(opts.seed === undefined ? {} : { seed: opts.seed }),
     };
-    if (opts.seed !== undefined) {
-        elevenLabsBody.seed = opts.seed;
-    }
 
     const rawResponse = await fetch(elevenLabsUrl, {
         method: "POST",
@@ -321,8 +427,6 @@ export async function generateElevenLabsSpeech(opts: {
     });
     const response = await ensureUpstreamOk(rawResponse, elevenLabsUrl);
 
-    const contentType = response.headers.get("content-type") || "audio/mpeg";
-
     const usageHeaders = {
         ...buildUsageHeaders(modelName, createAudioTokenUsage(text.length)),
         "x-tts-voice": voice,
@@ -330,28 +434,7 @@ export async function generateElevenLabsSpeech(opts: {
 
     log.info("TTS success: {chars} characters", { chars: text.length });
 
-    // WAV needs its RIFF header repaired (ElevenLabs ships a placeholder length),
-    // which requires buffering the body. Audio is small (input capped at 10000
-    // chars) so this is cheap; all other formats keep streaming.
-    if (responseFormat === "wav") {
-        const audioBuffer = fixWavHeader(await response.arrayBuffer());
-        return new Response(audioBuffer, {
-            status: 200,
-            headers: {
-                "Content-Type": contentType,
-                "Content-Length": String(audioBuffer.byteLength),
-                ...usageHeaders,
-            },
-        });
-    }
-
-    return new Response(response.body, {
-        status: 200,
-        headers: {
-            "Content-Type": contentType,
-            ...usageHeaders,
-        },
-    });
+    return buildElevenLabsAudioResponse(response, responseFormat, usageHeaders);
 }
 
 export async function generateElevenLabsSpeechWithTimestamps(opts: {
@@ -386,17 +469,12 @@ export async function generateElevenLabsSpeechWithTimestamps(opts: {
 
     const outputFormat = mapOutputFormat(responseFormat);
     const endpoint = `https://api.elevenlabs.io/v1/text-to-speech/${encodeURIComponent(voiceId)}/with-timestamps?output_format=${outputFormat}`;
-    const body: Record<string, unknown> = {
+    const body = {
         text,
         model_id: modelId,
-        voice_settings: {
-            stability: 0.5,
-            similarity_boost: 0.75,
-            style: 0.0,
-            use_speaker_boost: true,
-        },
+        voice_settings: ELEVENLABS_TTS_VOICE_SETTINGS,
+        ...(seed === undefined ? {} : { seed }),
     };
-    if (seed !== undefined) body.seed = seed;
 
     log.info(
         "Timestamped TTS request: voice={voice}, format={format}, chars={chars}",
@@ -449,12 +527,6 @@ export async function generateElevenLabsDialogue(opts: {
     log: Logger;
 }): Promise<Response> {
     const { inputs, responseFormat, seed, apiKey, log } = opts;
-    if (!apiKey) {
-        throw new UpstreamError(500 as ContentfulStatusCode, {
-            message: "Dialogue service is not configured (missing API key)",
-        });
-    }
-
     const characterCount = inputs.reduce(
         (total, input) => total + input.text.length,
         0,
@@ -462,6 +534,11 @@ export async function generateElevenLabsDialogue(opts: {
     if (characterCount > 2000) {
         throw new UpstreamError(400 as ContentfulStatusCode, {
             message: `Dialogue input too long: ${characterCount} characters. Maximum is 2000.`,
+        });
+    }
+    if (!apiKey) {
+        throw new UpstreamError(500 as ContentfulStatusCode, {
+            message: "Dialogue service is not configured (missing API key)",
         });
     }
 
@@ -516,24 +593,32 @@ export async function generateElevenLabsDialogue(opts: {
         "eleven-dialogue",
         createAudioTokenUsage(characterCount),
     );
-    const contentType = response.headers.get("content-type") || "audio/mpeg";
+    return buildElevenLabsAudioResponse(response, responseFormat, usageHeaders);
+}
 
-    if (responseFormat === "wav") {
-        const audioBuffer = fixWavHeader(await response.arrayBuffer());
-        return new Response(audioBuffer, {
-            headers: {
-                "Content-Type": contentType,
-                "Content-Length": String(audioBuffer.byteLength),
-                ...usageHeaders,
-            },
+function parseDialogueInput(input: string): { text: string; voice: string }[] {
+    const lines = input
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean);
+
+    if (lines.length === 0) {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message:
+                'Dialogue input must contain at least one "voice: text" line.',
         });
     }
 
-    return new Response(response.body, {
-        headers: {
-            "Content-Type": contentType,
-            ...usageHeaders,
-        },
+    return lines.map((line, index) => {
+        const separator = line.indexOf(":");
+        const voice = line.slice(0, separator).trim();
+        const text = line.slice(separator + 1).trim();
+        if (separator <= 0 || voice === "" || text === "") {
+            throw new UpstreamError(400 as ContentfulStatusCode, {
+                message: `Dialogue line ${index + 1} must use "voice: text" format.`,
+            });
+        }
+        return { text, voice };
     });
 }
 
@@ -631,29 +716,11 @@ export async function changeVoiceWithElevenLabs(opts: {
         ),
         "x-voice-changer-voice": voice,
     };
-    const contentType = response.headers.get("content-type") || "audio/mpeg";
-
     log.info("Voice Changer success: inputSeconds={seconds}", {
         seconds: inputSeconds,
     });
 
-    if (responseFormat === "wav") {
-        const audioBuffer = fixWavHeader(await response.arrayBuffer());
-        return new Response(audioBuffer, {
-            headers: {
-                "Content-Type": contentType,
-                "Content-Length": String(audioBuffer.byteLength),
-                ...usageHeaders,
-            },
-        });
-    }
-
-    return new Response(response.body, {
-        headers: {
-            "Content-Type": contentType,
-            ...usageHeaders,
-        },
-    });
+    return buildElevenLabsAudioResponse(response, responseFormat, usageHeaders);
 }
 
 export async function isolateVoiceWithElevenLabs(opts: {
@@ -724,6 +791,7 @@ export async function isolateVoiceWithElevenLabs(opts: {
 interface ElevenLabsTranscriptionResponse {
     text: string;
     language_code?: string;
+    audio_duration_secs?: number | null;
     words?: {
         text: string;
         start: number;
@@ -731,6 +799,254 @@ interface ElevenLabsTranscriptionResponse {
         speaker_id?: string | null;
         type?: string;
     }[];
+}
+
+interface AzureTranscriptionResponse {
+    text: string;
+    usage: {
+        type: "duration";
+        seconds: number;
+    };
+}
+
+const AZURE_GPT_TRANSCRIBE_ENDPOINT =
+    "https://myceli-prod-swedencentral.openai.azure.com/openai/deployments/test-gpt-transcribe/audio/transcriptions?api-version=2025-04-01-preview";
+
+export async function transcribeWithAzure(opts: {
+    file: File;
+    language?: string;
+    prompt?: string;
+    responseFormat?: string;
+    temperature?: number;
+    apiKey: string;
+}): Promise<Response> {
+    const {
+        file,
+        language,
+        prompt,
+        responseFormat = "json",
+        temperature,
+        apiKey,
+    } = opts;
+
+    if (!apiKey) {
+        throw new UpstreamError(500 as ContentfulStatusCode, {
+            message: "Azure transcription service is not configured",
+        });
+    }
+    assertTranscriptionResponseFormat(responseFormat, "gpt-transcribe", [
+        "json",
+    ]);
+
+    const formData = new FormData();
+    formData.append("model", "gpt-transcribe");
+    if (language) formData.append("language", language);
+    if (prompt) formData.append("prompt", prompt);
+    formData.append("response_format", responseFormat);
+    if (temperature !== undefined) {
+        formData.append("temperature", String(temperature));
+    }
+    formData.append("file", file, file.name || "audio");
+
+    const response = await ensureUpstreamOk(
+        await fetch(AZURE_GPT_TRANSCRIBE_ENDPOINT, {
+            method: "POST",
+            headers: { "api-key": apiKey },
+            body: formData,
+        }),
+        AZURE_GPT_TRANSCRIBE_ENDPOINT,
+    );
+    const transcript = (await response
+        .json()
+        .catch(() => null)) as AzureTranscriptionResponse | null;
+    if (
+        !transcript ||
+        typeof transcript.text !== "string" ||
+        transcript.usage?.type !== "duration" ||
+        typeof transcript.usage.seconds !== "number" ||
+        !Number.isFinite(transcript.usage.seconds) ||
+        transcript.usage.seconds <= 0
+    ) {
+        throw new UpstreamError(502 as ContentfulStatusCode, {
+            message:
+                "Azure transcription response did not include valid input-duration metering.",
+        });
+    }
+
+    return buildTranscriptionResponse({
+        normalized: {
+            text: transcript.text,
+            duration: transcript.usage.seconds,
+            words: [],
+            segments: [],
+            diarizedSegments: [],
+        },
+        responseFormat,
+        usageHeaders: buildUsageHeaders(
+            "gpt-transcribe",
+            createAudioSecondsUsage(transcript.usage.seconds),
+        ),
+    });
+}
+
+const ELEVENLABS_SCRIBE_SECONDS_PER_CREDIT = 2.5;
+
+function getElevenLabsScribeMeteredInputSeconds(
+    response: Response,
+    data: ElevenLabsTranscriptionResponse,
+    log: Logger,
+): number {
+    if (
+        typeof data.audio_duration_secs === "number" &&
+        Number.isFinite(data.audio_duration_secs) &&
+        data.audio_duration_secs > 0
+    ) {
+        return data.audio_duration_secs;
+    }
+
+    // Silent transcripts omit audio_duration_secs. The provider still returns
+    // its billed character-cost meter, observed at 0.4 credits per second.
+    const rawCharacterCost = response.headers.get("character-cost");
+    const characterCost = Number(rawCharacterCost);
+    if (
+        rawCharacterCost !== null &&
+        Number.isFinite(characterCost) &&
+        characterCost > 0
+    ) {
+        return characterCost * ELEVENLABS_SCRIBE_SECONDS_PER_CREDIT;
+    }
+
+    log.error(
+        "ElevenLabs scribe response missing valid duration metering: audioDuration={audioDuration}, characterCost={characterCost}",
+        {
+            audioDuration: data.audio_duration_secs,
+            characterCost: rawCharacterCost,
+        },
+    );
+    throw new UpstreamError(502 as ContentfulStatusCode, {
+        message:
+            "ElevenLabs transcription response did not include valid input-duration metering.",
+    });
+}
+
+interface XaiTranscriptionResponse {
+    text: string;
+    language?: string;
+    duration: number;
+    words?: {
+        text: string;
+        start: number;
+        end: number;
+        speaker?: number;
+    }[];
+}
+
+export async function transcribeWithXai(opts: {
+    file: File;
+    language?: string;
+    responseFormat?: string;
+    apiKey: string;
+    log: Logger;
+}): Promise<Response> {
+    const { file, language, responseFormat = "json", apiKey, log } = opts;
+
+    if (!apiKey) {
+        throw new UpstreamError(500 as ContentfulStatusCode, {
+            message: "xAI transcription service is not configured",
+        });
+    }
+    assertTranscriptionResponseFormat(responseFormat, "grok-transcribe");
+
+    const formData = new FormData();
+    if (language) {
+        formData.append("language", language);
+        formData.append("format", "true");
+    }
+    if (responseFormat === "diarized_json") {
+        formData.append("diarize", "true");
+    }
+    // xAI requires the file to be the final multipart field.
+    formData.append("file", file, file.name || "audio");
+
+    const xaiUrl = "https://api.x.ai/v1/stt";
+    const response = await ensureUpstreamOk(
+        await fetch(xaiUrl, {
+            method: "POST",
+            headers: { Authorization: `Bearer ${apiKey}` },
+            body: formData,
+        }),
+        xaiUrl,
+    );
+    const transcript = (await response.json()) as XaiTranscriptionResponse;
+    if (
+        typeof transcript.text !== "string" ||
+        typeof transcript.duration !== "number" ||
+        !Number.isFinite(transcript.duration) ||
+        transcript.duration < 0
+    ) {
+        throw new UpstreamError(502 as ContentfulStatusCode, {
+            message: "xAI returned an invalid transcription response",
+        });
+    }
+
+    log.info("xAI transcription success: {chars} chars, {duration}s", {
+        chars: transcript.text.length,
+        duration: transcript.duration,
+    });
+
+    return buildTranscriptionResponse({
+        normalized: {
+            text: transcript.text,
+            language: transcript.language || undefined,
+            duration: transcript.duration,
+            words:
+                transcript.words?.map((word) => ({
+                    word: word.text,
+                    start: word.start,
+                    end: word.end,
+                })) ?? [],
+            // xAI reports word timings but no segment boundaries;
+            // verbose_json falls back to one segment spanning the file.
+            segments: [],
+            diarizedSegments: groupXaiWordsBySpeaker(transcript.words),
+        },
+        responseFormat,
+        usageHeaders: buildUsageHeaders(
+            "grok-transcribe",
+            createAudioSecondsUsage(transcript.duration),
+        ),
+    });
+}
+
+function groupXaiWordsBySpeaker(
+    words: XaiTranscriptionResponse["words"],
+): NormalizedDiarizedSegment[] {
+    if (!words?.length) return [];
+
+    const cjk = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/u;
+    const segments: NormalizedDiarizedSegment[] = [];
+    for (const word of words) {
+        const speaker =
+            word.speaker === undefined ? null : String(word.speaker);
+        const current = segments.at(-1);
+        if (current?.speaker === speaker) {
+            const separator =
+                cjk.test(current.text.at(-1) ?? "") &&
+                cjk.test(word.text[0] ?? "")
+                    ? ""
+                    : " ";
+            current.text = `${current.text}${separator}${word.text}`;
+            current.end = word.end;
+        } else {
+            segments.push({
+                speaker,
+                text: word.text,
+                start: word.start,
+                end: word.end,
+            });
+        }
+    }
+    return segments;
 }
 
 export async function transcribeWithElevenLabs(opts: {
@@ -757,17 +1073,7 @@ export async function transcribeWithElevenLabs(opts: {
         });
     }
 
-    // Validate response format
-    if (
-        responseFormat &&
-        !["json", "text", "verbose_json", "diarized_json"].includes(
-            responseFormat,
-        )
-    ) {
-        throw new UpstreamError(400 as ContentfulStatusCode, {
-            message: `Unsupported response_format for scribe model: ${responseFormat}. Supported: json, text, verbose_json, diarized_json`,
-        });
-    }
+    assertTranscriptionResponseFormat(responseFormat, "scribe model");
 
     log.info("ElevenLabs transcription: format={format}, size={size}", {
         format: responseFormat,
@@ -806,23 +1112,33 @@ export async function transcribeWithElevenLabs(opts: {
     // with no detectable speech, the words array can be empty. Treat that as
     // a successful empty transcription rather than a server error.
     const lastWord = elevenLabsData.words?.at(-1);
-    const duration = lastWord?.end ?? 0;
+    const transcriptDuration = lastWord?.end ?? 0;
     if (!lastWord) {
         log.warn(
-            "ElevenLabs scribe returned no word timestamps; billing 0s (file size={size})",
+            "ElevenLabs scribe returned no word timestamps (file size={size})",
             { size: file.size },
         );
     }
 
-    const usageHeaders = buildUsageHeaders(
-        "scribe",
-        createAudioSecondsUsage(duration),
+    const meteredInputSeconds = getElevenLabsScribeMeteredInputSeconds(
+        response,
+        elevenLabsData,
+        log,
     );
 
-    log.info("ElevenLabs transcription success: {chars} chars, {duration}s", {
-        chars: elevenLabsData.text.length,
-        duration: Math.round(duration * 10) / 10,
-    });
+    const usageHeaders = buildUsageHeaders(
+        "scribe",
+        createAudioSecondsUsage(meteredInputSeconds),
+    );
+
+    log.info(
+        "ElevenLabs transcription success: {chars} chars, transcript={transcriptDuration}s, input={inputSeconds}s",
+        {
+            chars: elevenLabsData.text.length,
+            transcriptDuration: Math.round(transcriptDuration * 10) / 10,
+            inputSeconds: Math.round(meteredInputSeconds * 10) / 10,
+        },
+    );
 
     // Scribe word/utterance values are already in seconds — normalize and
     // hand off to the shared OpenAI-compatible response formatter.
@@ -830,13 +1146,19 @@ export async function transcribeWithElevenLabs(opts: {
         normalized: {
             text: elevenLabsData.text,
             language: elevenLabsData.language_code,
-            duration,
+            // OpenAI's duration is the input audio, not the speech span: the
+            // last word ends at 3.4s in a 10s file, and a silent file has no
+            // words at all. That is also the seconds we bill.
+            duration: meteredInputSeconds,
             words:
                 elevenLabsData.words?.map((w) => ({
                     word: w.text,
                     start: w.start,
                     end: w.end,
                 })) ?? [],
+            // Scribe reports word timings but no segment boundaries;
+            // verbose_json falls back to one segment spanning the file.
+            segments: [],
             diarizedSegments: groupScribeUtterances(elevenLabsData.words),
         },
         responseFormat,
@@ -938,12 +1260,11 @@ function createConditionedCompositionPlan(opts: {
 
 async function uploadMusicReference(opts: {
     file: File;
-    extractCompositionPlan?: boolean;
     apiKey: string;
     log: Logger;
 }): Promise<{
     song_id?: string;
-    composition_plan?: unknown;
+    composition_plan?: { chunks?: { duration_ms?: unknown }[] };
 }> {
     const uploadUrl = "https://api.elevenlabs.io/v1/music/upload";
     const formData = new FormData();
@@ -952,18 +1273,15 @@ async function uploadMusicReference(opts: {
             ? opts.file.name
             : "reference.mp3";
     formData.append("file", opts.file, filename);
-    if (opts.extractCompositionPlan) {
-        formData.append("extract_composition_plan", "music_v2");
-    }
+    // ElevenLabs does not return duration or usage headers for music uploads.
+    // The extracted v2 plan contains the provider-metered chunk durations and
+    // does not add to the $0.15/minute ingestion price.
+    formData.append("extract_composition_plan", "music_v2");
 
-    opts.log.info(
-        "ElevenLabs music upload: filename={filename}, size={size}, extractPlan={extractPlan}",
-        {
-            filename,
-            size: opts.file.size,
-            extractPlan: opts.extractCompositionPlan || false,
-        },
-    );
+    opts.log.info("ElevenLabs music upload: filename={filename}, size={size}", {
+        filename,
+        size: opts.file.size,
+    });
 
     const rawResponse = await fetch(uploadUrl, {
         method: "POST",
@@ -973,8 +1291,36 @@ async function uploadMusicReference(opts: {
     const response = await ensureUpstreamOk(rawResponse, uploadUrl);
     return (await response.json()) as {
         song_id?: string;
-        composition_plan?: unknown;
+        composition_plan?: { chunks?: { duration_ms?: unknown }[] };
     };
+}
+
+function getUploadedMusicDurationSeconds(upload: {
+    composition_plan?: { chunks?: { duration_ms?: unknown }[] };
+}): number {
+    const chunks = upload.composition_plan?.chunks;
+    if (!chunks?.length) {
+        throw new UpstreamError(502 as ContentfulStatusCode, {
+            message:
+                "ElevenLabs music upload response missing reference duration",
+        });
+    }
+
+    const totalMilliseconds = chunks.reduce((total, chunk) => {
+        if (
+            typeof chunk.duration_ms !== "number" ||
+            !Number.isFinite(chunk.duration_ms) ||
+            chunk.duration_ms <= 0
+        ) {
+            throw new UpstreamError(502 as ContentfulStatusCode, {
+                message:
+                    "ElevenLabs music upload response contained an invalid reference duration",
+            });
+        }
+        return total + chunk.duration_ms;
+    }, 0);
+
+    return totalMilliseconds / 1000;
 }
 
 export async function generateMusic(
@@ -1003,13 +1349,13 @@ export async function generateMusic(
 
     const modelId = "music_v2";
     let uploadedSongId: string | undefined;
+    let uploadedReferenceDuration: number | undefined;
     let compositionPlan = opts.compositionPlan;
     let conditioningRef = opts.conditioningRef;
 
     if (referenceAudio) {
         const upload = await uploadMusicReference({
             file: referenceAudio,
-            extractCompositionPlan: opts.extractCompositionPlan,
             apiKey,
             log,
         });
@@ -1019,9 +1365,7 @@ export async function generateMusic(
                 message: "ElevenLabs music upload response missing song_id",
             });
         }
-        if (compositionPlan === undefined && opts.extractCompositionPlan) {
-            compositionPlan = upload.composition_plan;
-        }
+        uploadedReferenceDuration = getUploadedMusicDurationSeconds(upload);
         if (conditioningRef === undefined) {
             conditioningRef = {
                 song_id: uploadedSongId,
@@ -1102,10 +1446,14 @@ export async function generateMusic(
     const estimatedDuration =
         audioBuffer.byteLength / MUSIC_MP3_BYTES_PER_SECOND;
 
-    const usageHeaders = buildUsageHeaders(
-        "elevenmusic",
-        createCompletionAudioSecondsUsage(estimatedDuration),
-    );
+    const usage = createCompletionAudioSecondsUsage(estimatedDuration);
+    if (uploadedReferenceDuration !== undefined) {
+        Object.assign(
+            usage,
+            createAudioSecondsUsage(uploadedReferenceDuration),
+        );
+    }
+    const usageHeaders = buildUsageHeaders("elevenmusic", usage);
     const responseHeaders: Record<string, string> = {
         "Content-Type": contentType,
         ...usageHeaders,
@@ -1221,11 +1569,39 @@ export async function generateSoundEffect(opts: {
 const QWEN_TTS_ENDPOINT =
     "https://dashscope-intl.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation";
 
+const XAI_TTS_ENDPOINT = "https://api.x.ai/v1/tts";
+const XAI_TTS_FORMATS = ["mp3", "wav", "pcm"] as const;
+
 const DEEPINFRA_TTS_ENDPOINT =
     "https://api.deepinfra.com/v1/openai/audio/speech";
 const LYRIA_3_CLIP_MODEL_ID = "lyria-3-clip-preview";
-const DEEPINFRA_CSM_MODEL_ID = "sesame/csm-1b";
-const CSM_AUDIO_FORMATS = ["mp3", "opus", "flac", "wav", "pcm"] as const;
+const DEEPINFRA_AUDIO_FORMATS = ["mp3", "opus", "flac", "wav", "pcm"] as const;
+const DEEPINFRA_TTS_CONFIGS = {
+    "csm-1b": {
+        modelId: "sesame/csm-1b",
+        voices: CSM_VOICES,
+        defaultVoice: "conversational_a",
+        maxCharacters: 200,
+    },
+    kokoro: {
+        modelId: "hexgrad/Kokoro-82M",
+        voices: KOKORO_VOICES,
+        defaultVoice: "af_alloy",
+        maxCharacters: 10_000,
+    },
+} as const satisfies Partial<
+    Record<
+        AudioModelName,
+        {
+            modelId: string;
+            voices: readonly string[];
+            defaultVoice: string;
+            maxCharacters: number;
+        }
+    >
+>;
+
+type DeepInfraTtsModelName = keyof typeof DEEPINFRA_TTS_CONFIGS;
 
 const QWEN_TTS_MODEL_IDS = {
     "qwen-tts": "qwen3-tts-flash",
@@ -1344,28 +1720,13 @@ export async function generateLyria3Clip(opts: {
     });
 }
 
-function requireTextToAudioModel(
-    model: string,
-    definition: ModelDefinition,
-): void {
-    const acceptsText = definition.inputModalities?.includes("text");
-    const returnsAudio = definition.outputModalities?.includes("audio");
-
-    if (acceptsText && returnsAudio) return;
-
-    throw new UpstreamError(400 as ContentfulStatusCode, {
-        message: `Model '${model}' is not supported on text-to-audio endpoints. Use /v1/audio/transcriptions for speech-to-text models.`,
-    });
-}
-
 function requireElevenMusicOptions(
     model: string,
     opts: {
-        referenceAudio?: File;
+        referenceAudio?: string;
         compositionPlan?: unknown;
         conditioningRef?: unknown;
         storeForInpainting?: boolean;
-        extractCompositionPlan?: boolean;
     },
 ): void {
     // elevenmusic supports every conditioning option.
@@ -1375,8 +1736,7 @@ function requireElevenMusicOptions(
     const usesElevenOnlyOptions =
         opts.compositionPlan !== undefined ||
         opts.conditioningRef !== undefined ||
-        opts.storeForInpainting === true ||
-        opts.extractCompositionPlan === true;
+        opts.storeForInpainting === true;
 
     // stable-audio-3-medium (fal) and stable-audio-3-large (Stability direct)
     // accept reference_audio for audio-to-audio, but not the ElevenLabs
@@ -1385,7 +1745,7 @@ function requireElevenMusicOptions(
         if (usesElevenOnlyOptions) {
             throw new UpstreamError(400 as ContentfulStatusCode, {
                 message:
-                    "conditioning_ref, composition_plan, store_for_inpainting, and extract_composition_plan are only supported with model=elevenmusic.",
+                    "conditioning_ref, composition_plan, and store_for_inpainting are only supported with model=elevenmusic.",
             });
         }
         return;
@@ -1396,7 +1756,7 @@ function requireElevenMusicOptions(
 
     throw new UpstreamError(400 as ContentfulStatusCode, {
         message:
-            "reference_audio, conditioning_ref, composition_plan, store_for_inpainting, and extract_composition_plan are only supported with model=elevenmusic (stable-audio-3-medium and stable-audio-3-large also accept reference_audio).",
+            "reference_audio, conditioning_ref, composition_plan, and store_for_inpainting are only supported with model=elevenmusic (stable-audio-3-medium and stable-audio-3-large also accept reference_audio).",
     });
 }
 
@@ -1436,12 +1796,8 @@ function parseOptionalBoolean(
     });
 }
 
-function parseCreateSpeechRequest(
-    value: unknown,
-): CreateSpeechRequest & { reference_audio?: File } {
-    const parsed = CreateSpeechRequestSchema.extend({
-        reference_audio: z.instanceof(File).optional(),
-    }).safeParse(value);
+function parseCreateSpeechRequest(value: unknown): CreateSpeechRequest {
+    const parsed = CreateSpeechRequestSchema.safeParse(value);
     if (parsed.success) return parsed.data;
 
     const firstIssue = parsed.error.issues[0];
@@ -1451,11 +1807,9 @@ function parseCreateSpeechRequest(
     });
 }
 
-async function parseSpeechRequest(c: AudioContext): Promise<
-    CreateSpeechRequest & {
-        reference_audio?: File;
-    }
-> {
+async function parseSpeechRequest(
+    c: AudioContext,
+): Promise<CreateSpeechRequest> {
     const contentType = c.req.header("content-type") || "";
 
     if (contentType.includes("multipart/form-data")) {
@@ -1470,12 +1824,17 @@ async function parseSpeechRequest(c: AudioContext): Promise<
 
         const input = formData.get("input");
         const referenceAudio =
-            (formData.get("reference_audio") as File | null) ||
-            (formData.get("file") as File | null) ||
-            undefined;
+            formData.get("reference_audio") ?? formData.get("file");
         const rawCompositionPlan = formData.get("composition_plan");
         const rawConditioningRef = formData.get("conditioning_ref");
-        const parsed: CreateSpeechRequest & { reference_audio?: File } = {
+        if (referenceAudio instanceof File) {
+            throw new UpstreamError(400 as ContentfulStatusCode, {
+                message:
+                    "reference_audio must be a public HTTP(S) URL, not a file upload",
+            });
+        }
+
+        const parsed: CreateSpeechRequest = {
             model: (formData.get("model") as string | null) || undefined,
             input: typeof input === "string" ? input : "",
             safe: (formData.get("safe") as string | undefined) || undefined,
@@ -1489,8 +1848,7 @@ async function parseSpeechRequest(c: AudioContext): Promise<
                     | "aac"
                     | "pcm") || "mp3",
             duration: parseOptionalNumber(formData.get("duration"), "duration"),
-            // stable-audio-3-medium controls (also used on the audio-to-audio
-            // multipart path, which is the only way to send reference_audio).
+            // stable-audio-3-medium controls.
             seconds: parseOptionalNumber(formData.get("seconds"), "seconds"),
             steps: parseOptionalNumber(formData.get("steps"), "steps"),
             negative_prompt:
@@ -1503,12 +1861,9 @@ async function parseSpeechRequest(c: AudioContext): Promise<
                 formData.get("store_for_inpainting"),
                 "store_for_inpainting",
             ),
-            extract_composition_plan: parseOptionalBoolean(
-                formData.get("extract_composition_plan"),
-                "extract_composition_plan",
-            ),
             seed: parseOptionalNumber(formData.get("seed"), "seed"),
-            instruct: (formData.get("instruct") as string | null) || undefined,
+            instructions:
+                (formData.get("instructions") as string | null) || undefined,
             loop: parseOptionalBoolean(formData.get("loop"), "loop"),
             prompt_influence: parseOptionalNumber(
                 formData.get("prompt_influence"),
@@ -1522,7 +1877,7 @@ async function parseSpeechRequest(c: AudioContext): Promise<
                 typeof rawCompositionPlan === "string"
                     ? parseJsonObject(rawCompositionPlan, "composition_plan")
                     : undefined,
-            reference_audio: referenceAudio,
+            reference_audio: referenceAudio || undefined,
         };
 
         return parseCreateSpeechRequest(parsed);
@@ -1543,11 +1898,11 @@ export async function generateQwenTts(opts: {
     modelName: QwenTtsModelName;
     text: string;
     voice: string;
-    instruct?: string;
+    instructions?: string;
     apiKey: string;
     log: Logger;
 }): Promise<Response> {
-    const { modelName, text, voice, instruct, apiKey, log } = opts;
+    const { modelName, text, voice, instructions, apiKey, log } = opts;
     const modelId = QWEN_TTS_MODEL_IDS[modelName];
 
     if (!apiKey) {
@@ -1556,10 +1911,10 @@ export async function generateQwenTts(opts: {
         });
     }
 
-    if (instruct && modelName !== "qwen-tts-instruct") {
+    if (instructions && modelName !== "qwen-tts-instruct") {
         throw new UpstreamError(400 as ContentfulStatusCode, {
             message:
-                "The instruct parameter is only supported by qwen-tts-instruct",
+                "The instructions parameter is only supported by qwen-tts-instruct",
         });
     }
 
@@ -1575,7 +1930,9 @@ export async function generateQwenTts(opts: {
         model: modelId,
         input: { text, voice: qwenVoice },
         parameters:
-            modelName === "qwen-tts-instruct" && instruct ? { instruct } : {},
+            modelName === "qwen-tts-instruct" && instructions
+                ? { instructions }
+                : {},
     };
 
     const rawResponse = await fetch(QWEN_TTS_ENDPOINT, {
@@ -1624,7 +1981,85 @@ export async function generateQwenTts(opts: {
     });
 }
 
-export async function generateCsmSpeech(opts: {
+const OPENROUTER_FISH_TTS_ENDPOINT =
+    "https://openrouter.ai/api/v1/audio/speech";
+const OPENROUTER_FISH_TTS_MODEL = "fish-audio/s2.1-pro";
+const OPENROUTER_FISH_TTS_FORMATS = ["mp3", "pcm"] as const;
+
+export async function generateOpenRouterFishSpeech(opts: {
+    text: string;
+    voice: string;
+    responseFormat: string;
+    apiKey: string;
+    log: Logger;
+}): Promise<Response> {
+    const { text, voice, responseFormat, apiKey, log } = opts;
+
+    if (!apiKey) {
+        throw new UpstreamError(500 as ContentfulStatusCode, {
+            message: "OpenRouter is not configured (missing API key)",
+        });
+    }
+
+    if (
+        !OPENROUTER_FISH_TTS_FORMATS.includes(
+            responseFormat as (typeof OPENROUTER_FISH_TTS_FORMATS)[number],
+        )
+    ) {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message: `Unsupported response_format for fish-audio-s2.1-pro: ${responseFormat}. Supported formats: ${OPENROUTER_FISH_TTS_FORMATS.join(", ")}.`,
+        });
+    }
+
+    const inputBytes = new TextEncoder().encode(text).byteLength;
+    log.info(
+        "Fish Audio request: voice={voice}, format={format}, utf8Bytes={utf8Bytes}",
+        { voice, format: responseFormat, utf8Bytes: inputBytes },
+    );
+
+    const response = await ensureUpstreamOk(
+        await fetch(OPENROUTER_FISH_TTS_ENDPOINT, {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${apiKey}`,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                model: OPENROUTER_FISH_TTS_MODEL,
+                input: text,
+                voice,
+                response_format: responseFormat,
+                provider: {
+                    only: ["Fish Audio"],
+                    allow_fallbacks: false,
+                },
+            }),
+        }),
+        OPENROUTER_FISH_TTS_ENDPOINT,
+    );
+
+    const generationId = response.headers.get("x-generation-id");
+    log.info("Fish Audio success: {utf8Bytes} UTF-8 bytes", {
+        utf8Bytes: inputBytes,
+    });
+
+    return new Response(response.body, {
+        status: 200,
+        headers: {
+            "Content-Type":
+                response.headers.get("content-type") ||
+                (responseFormat === "pcm" ? "audio/pcm" : "audio/mpeg"),
+            ...buildUsageHeaders(
+                "fish-audio-s2.1-pro",
+                createAudioTokenUsage(inputBytes),
+            ),
+            "x-tts-voice": voice,
+            ...(generationId ? { "x-generation-id": generationId } : {}),
+        },
+    });
+}
+
+export async function generateXaiSpeech(opts: {
     text: string;
     voice: string;
     responseFormat: string;
@@ -1632,41 +2067,132 @@ export async function generateCsmSpeech(opts: {
     log: Logger;
 }): Promise<Response> {
     const { text, responseFormat, apiKey, log } = opts;
+    const inputCharacters = [...text].length;
 
     if (!apiKey) {
         throw new UpstreamError(500 as ContentfulStatusCode, {
-            message: "CSM speech is not configured (missing DEEPINFRA_API_KEY)",
+            message: "Grok TTS is not configured (missing API key)",
         });
     }
 
-    if (text.length > 200) {
+    const voice = opts.voice === "alloy" ? "eve" : opts.voice;
+    if (!(XAI_TTS_VOICES as readonly string[]).includes(voice)) {
         throw new UpstreamError(400 as ContentfulStatusCode, {
-            message: `Input text too long: ${text.length} characters. Maximum is 200.`,
-        });
-    }
-
-    const voice = opts.voice === "alloy" ? "conversational_a" : opts.voice;
-    if (!CSM_VOICES.includes(voice as (typeof CSM_VOICES)[number])) {
-        throw new UpstreamError(400 as ContentfulStatusCode, {
-            message: `Invalid voice for csm-1b: ${opts.voice}. Supported voices: ${CSM_VOICES.join(", ")}.`,
+            message: `Invalid voice for grok-tts: ${opts.voice}. Supported voices: ${XAI_TTS_VOICES.join(", ")}.`,
         });
     }
 
     if (
-        !CSM_AUDIO_FORMATS.includes(
-            responseFormat as (typeof CSM_AUDIO_FORMATS)[number],
+        !XAI_TTS_FORMATS.includes(
+            responseFormat as (typeof XAI_TTS_FORMATS)[number],
         )
     ) {
         throw new UpstreamError(400 as ContentfulStatusCode, {
-            message: `Unsupported response_format for csm-1b: ${responseFormat}. Supported formats: ${CSM_AUDIO_FORMATS.join(", ")}.`,
+            message: `Unsupported response_format for grok-tts: ${responseFormat}. Supported formats: ${XAI_TTS_FORMATS.join(", ")}.`,
         });
     }
 
-    log.info("CSM request: voice={voice}, format={format}, chars={chars}", {
+    log.info("xAI TTS request: voice={voice}, format={format}, chars={chars}", {
         voice,
         format: responseFormat,
-        chars: text.length,
+        chars: inputCharacters,
     });
+
+    const response = await ensureUpstreamOk(
+        await fetch(XAI_TTS_ENDPOINT, {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${apiKey}`,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                text,
+                voice_id: voice,
+                language: "auto",
+                output_format: {
+                    codec: responseFormat,
+                    sample_rate: 24000,
+                    ...(responseFormat === "mp3" ? { bit_rate: 128000 } : {}),
+                },
+            }),
+        }),
+        XAI_TTS_ENDPOINT,
+    );
+
+    log.info("xAI TTS success: voice={voice}, chars={chars}", {
+        voice,
+        chars: inputCharacters,
+    });
+
+    return new Response(response.body, {
+        status: 200,
+        headers: {
+            "Content-Type":
+                response.headers.get("content-type") ||
+                (responseFormat === "wav"
+                    ? "audio/wav"
+                    : responseFormat === "pcm"
+                      ? "audio/pcm"
+                      : "audio/mpeg"),
+            ...buildUsageHeaders(
+                "grok-tts",
+                createAudioTokenUsage(inputCharacters),
+            ),
+            "x-tts-voice": voice,
+        },
+    });
+}
+
+export async function generateDeepInfraSpeech(opts: {
+    modelName: DeepInfraTtsModelName;
+    text: string;
+    voice: string;
+    responseFormat: string;
+    apiKey: string;
+    log: Logger;
+}): Promise<Response> {
+    const { modelName, text, responseFormat, apiKey, log } = opts;
+    const config = DEEPINFRA_TTS_CONFIGS[modelName];
+    const inputCharacters = [...text].length;
+
+    if (!apiKey) {
+        throw new UpstreamError(500 as ContentfulStatusCode, {
+            message: `${modelName} speech is not configured (missing DEEPINFRA_API_KEY)`,
+        });
+    }
+
+    if (inputCharacters > config.maxCharacters) {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message: `Input text too long: ${inputCharacters} characters. Maximum is ${config.maxCharacters}.`,
+        });
+    }
+
+    const voice = opts.voice === "alloy" ? config.defaultVoice : opts.voice;
+    if (!(config.voices as readonly string[]).includes(voice)) {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message: `Invalid voice for ${modelName}: ${opts.voice}. Supported voices: ${config.voices.join(", ")}.`,
+        });
+    }
+
+    if (
+        !DEEPINFRA_AUDIO_FORMATS.includes(
+            responseFormat as (typeof DEEPINFRA_AUDIO_FORMATS)[number],
+        )
+    ) {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message: `Unsupported response_format for ${modelName}: ${responseFormat}. Supported formats: ${DEEPINFRA_AUDIO_FORMATS.join(", ")}.`,
+        });
+    }
+
+    log.info(
+        "DeepInfra TTS request: model={model}, voice={voice}, format={format}, chars={chars}",
+        {
+            model: config.modelId,
+            voice,
+            format: responseFormat,
+            chars: inputCharacters,
+        },
+    );
 
     const response = await ensureUpstreamOk(
         await fetch(DEEPINFRA_TTS_ENDPOINT, {
@@ -1676,7 +2202,7 @@ export async function generateCsmSpeech(opts: {
                 "Content-Type": "application/json",
             },
             body: JSON.stringify({
-                model: DEEPINFRA_CSM_MODEL_ID,
+                model: config.modelId,
                 input: text,
                 voice,
                 response_format: responseFormat,
@@ -1686,11 +2212,14 @@ export async function generateCsmSpeech(opts: {
     );
 
     const usageHeaders = {
-        ...buildUsageHeaders("csm-1b", createAudioTokenUsage(text.length)),
+        ...buildUsageHeaders(modelName, createAudioTokenUsage(inputCharacters)),
         "x-tts-voice": voice,
     };
 
-    log.info("CSM success: {chars} characters", { chars: text.length });
+    log.info("DeepInfra TTS success: model={model}, chars={chars}", {
+        model: config.modelId,
+        chars: inputCharacters,
+    });
 
     return new Response(response.body, {
         status: 200,
@@ -1705,8 +2234,6 @@ export async function generateCsmSpeech(opts: {
 /**
  * Dispatches the resolved text-to-audio model and wraps the result in safety
  * headers. Shared by the GET /audio/:text and POST /v1/audio/speech handlers.
- * Callers normalize their inputs first (GET maps seed=-1 -> undefined since
- * only its schema permits the sentinel).
  */
 // fal synchronous inference endpoint. Stable Audio 3 Medium generates quickly,
 // so the blocking `fal.run` route returns inline without needing the queue/poll
@@ -2011,6 +2538,7 @@ export async function generateStableAudio3Large(opts: {
 
 async function dispatchAudioGeneration(
     c: AudioContext,
+    model: string,
     opts: {
         text: string;
         voice: string;
@@ -2022,16 +2550,17 @@ async function dispatchAudioGeneration(
         negativePrompt?: string;
         instrumental?: boolean;
         storeForInpainting?: boolean;
-        extractCompositionPlan?: boolean;
         conditioningRef?: unknown;
         compositionPlan?: unknown;
         referenceAudio?: File;
-        instruct?: string;
+        instructions?: string;
         loop?: boolean;
         promptInfluence?: number;
         apiKey: string;
         dashScopeApiKey: string;
         deepInfraApiKey: string;
+        xaiApiKey: string;
+        openRouterApiKey: string;
         falKey?: string;
         stabilityApiKey?: string;
         log: Logger;
@@ -2048,22 +2577,23 @@ async function dispatchAudioGeneration(
         negativePrompt,
         instrumental,
         storeForInpainting,
-        extractCompositionPlan,
         conditioningRef,
         compositionPlan,
         referenceAudio,
-        instruct,
+        instructions,
         loop,
         promptInfluence,
         apiKey,
         dashScopeApiKey,
         deepInfraApiKey,
+        xaiApiKey,
+        openRouterApiKey,
         falKey,
         stabilityApiKey,
         log,
     } = opts;
 
-    if (c.var.model.resolved === "elevenmusic") {
+    if (model === "elevenmusic") {
         return withSafetyHeaders(
             c,
             await generateMusic({
@@ -2072,7 +2602,6 @@ async function dispatchAudioGeneration(
                 forceInstrumental: instrumental,
                 seed,
                 storeForInpainting,
-                extractCompositionPlan,
                 conditioningRef,
                 compositionPlan,
                 referenceAudio,
@@ -2082,7 +2611,7 @@ async function dispatchAudioGeneration(
         );
     }
 
-    if (c.var.model.resolved === "lyria-3-clip") {
+    if (model === "lyria-3-clip") {
         const googleEnvKeys = [
             "GOOGLE_PRIVATE_KEY",
             "GOOGLE_PRIVATE_KEY_ID",
@@ -2107,7 +2636,7 @@ async function dispatchAudioGeneration(
         );
     }
 
-    if (c.var.model.resolved === "stable-audio-3-medium") {
+    if (model === "stable-audio-3-medium") {
         return withSafetyHeaders(
             c,
             await generateStableAudio3Medium({
@@ -2122,7 +2651,7 @@ async function dispatchAudioGeneration(
         );
     }
 
-    if (c.var.model.resolved === "stable-audio-3-large") {
+    if (model === "stable-audio-3-large") {
         return withSafetyHeaders(
             c,
             await generateStableAudio3Large({
@@ -2139,7 +2668,7 @@ async function dispatchAudioGeneration(
         );
     }
 
-    if (c.var.model.resolved === "eleven-sfx") {
+    if (model === "eleven-sfx") {
         return withSafetyHeaders(
             c,
             await generateSoundEffect({
@@ -2154,14 +2683,14 @@ async function dispatchAudioGeneration(
         );
     }
 
-    switch (c.var.model.resolved) {
+    switch (model) {
         case "elevenlabs":
         case "elevenflash":
         case "eleven-multilingual-v2":
             return withSafetyHeaders(
                 c,
                 await generateElevenLabsSpeech({
-                    modelName: c.var.model.resolved,
+                    modelName: model,
                     text,
                     voice,
                     responseFormat,
@@ -2175,18 +2704,42 @@ async function dispatchAudioGeneration(
             return withSafetyHeaders(
                 c,
                 await generateQwenTts({
-                    modelName: c.var.model.resolved,
+                    modelName: model,
                     text,
                     voice,
-                    instruct,
+                    instructions,
                     apiKey: dashScopeApiKey,
                     log,
                 }),
             );
-        case "csm-1b":
+        case "grok-tts":
             return withSafetyHeaders(
                 c,
-                await generateCsmSpeech({
+                await generateXaiSpeech({
+                    text,
+                    voice,
+                    responseFormat,
+                    apiKey: xaiApiKey,
+                    log,
+                }),
+            );
+        case "fish-audio-s2.1-pro":
+            return withSafetyHeaders(
+                c,
+                await generateOpenRouterFishSpeech({
+                    text,
+                    voice,
+                    responseFormat,
+                    apiKey: openRouterApiKey,
+                    log,
+                }),
+            );
+        case "csm-1b":
+        case "kokoro":
+            return withSafetyHeaders(
+                c,
+                await generateDeepInfraSpeech({
+                    modelName: model,
                     text,
                     voice,
                     responseFormat,
@@ -2196,9 +2749,111 @@ async function dispatchAudioGeneration(
             );
         default:
             throw new UpstreamError(500 as ContentfulStatusCode, {
-                message: `No audio provider route configured for model: ${c.var.model.resolved}`,
+                message: `No audio provider route configured for model: ${model}`,
             });
     }
+}
+
+async function generateAudioFromSpeechRequest(
+    c: AudioContext,
+    request: CreateSpeechRequest,
+    log: Logger,
+): Promise<Response> {
+    const {
+        input,
+        safe,
+        voice,
+        response_format,
+        duration,
+        seconds,
+        steps,
+        negative_prompt,
+        instrumental,
+        store_for_inpainting,
+        conditioning_ref,
+        composition_plan,
+        reference_audio,
+        seed,
+        instructions,
+        loop,
+        prompt_influence,
+    } = request;
+
+    requireElevenMusicOptions(c.var.model.resolved, {
+        referenceAudio: reference_audio,
+        compositionPlan: composition_plan,
+        conditioningRef: conditioning_ref,
+        storeForInpainting: store_for_inpainting,
+    });
+
+    if (c.var.model.resolved === "eleven-dialogue") {
+        const inputs = parseDialogueInput(input);
+        const safeTexts = await applySafetyToInput(
+            c,
+            inputs.map((turn) => turn.text),
+            safe,
+        );
+        const safeInputs = inputs.map((turn, index) => ({
+            ...turn,
+            text: safeTexts[index],
+        }));
+        const response = await generateElevenLabsDialogue({
+            inputs: safeInputs,
+            responseFormat: response_format,
+            seed,
+            apiKey: c.env.ELEVENLABS_API_KEY,
+            log,
+        });
+        return withSafetyHeaders(c, response);
+    }
+
+    const safeInput = await applySafetyToInput(c, input, safe);
+    const referenceAudio = reference_audio
+        ? await fetchReferenceAudio(reference_audio)
+        : undefined;
+
+    return withAudioFallback(c, async (candidate) => {
+        if (candidate.communityEndpoint) {
+            return withSafetyHeaders(
+                c,
+                await callCommunitySpeechEndpoint(
+                    candidate.communityEndpoint,
+                    {
+                        input: safeInput,
+                        voice,
+                        responseFormat: response_format,
+                    },
+                    c.env.BETTER_AUTH_SECRET,
+                ),
+            );
+        }
+        return dispatchAudioGeneration(c, candidate.id, {
+            text: safeInput,
+            voice,
+            responseFormat: response_format,
+            seed,
+            duration,
+            seconds,
+            steps,
+            negativePrompt: negative_prompt,
+            instrumental,
+            storeForInpainting: store_for_inpainting,
+            conditioningRef: conditioning_ref,
+            compositionPlan: composition_plan,
+            referenceAudio,
+            instructions,
+            loop,
+            promptInfluence: prompt_influence,
+            apiKey: c.env.ELEVENLABS_API_KEY,
+            dashScopeApiKey: c.env.DASHSCOPE_API_KEY,
+            deepInfraApiKey: c.env.DEEPINFRA_API_KEY,
+            xaiApiKey: c.env.XAI_API_KEY,
+            openRouterApiKey: c.env.OPENROUTER_API_KEY,
+            falKey: c.env.FAL_KEY,
+            stabilityApiKey: c.env.STABILITY_API_KEY,
+            log,
+        });
+    });
 }
 
 export async function handleSimpleAudio(c: AudioContext): Promise<Response> {
@@ -2216,157 +2871,318 @@ export async function handleSimpleAudio(c: AudioContext): Promise<Response> {
     }
 
     const query = c.req.valid("query" as never) as SimpleAudioQuery;
-    requireTextToAudioModel(c.var.model.resolved, c.var.model.definition);
-    text = await applySafety(c, text, query.safe);
+    return await generateAudioFromSpeechRequest(
+        c,
+        {
+            input: text,
+            safe: query.safe,
+            voice: query.voice,
+            response_format: query.response_format,
+            seed: normalizeSeed(query.seed),
+            duration: query.duration,
+            seconds: query.seconds,
+            steps: query.steps,
+            negative_prompt: query.negative_prompt,
+            instrumental: query.instrumental,
+            instructions: query.instructions,
+            loop: query.loop,
+            prompt_influence: query.prompt_influence,
+        },
+        log,
+    );
+}
 
-    const apiKey = (c.env as unknown as { ELEVENLABS_API_KEY: string })
-        .ELEVENLABS_API_KEY;
+export async function handleVoiceChanger(c: AudioContext): Promise<Response> {
+    const log = c.get("log").getChild("voice-changer");
+    const formData = c.get("formData");
+    if (!formData) {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message: "Invalid multipart form data",
+        });
+    }
 
-    // Only the GET query schema permits the -1 "random seed" sentinel; map it to
-    // undefined here so the generators only ever see a real seed or none.
-    return dispatchAudioGeneration(c, {
-        text,
-        voice: query.voice,
-        responseFormat: query.response_format,
-        seed: query.seed === -1 ? undefined : query.seed,
-        duration: query.duration,
-        seconds: query.seconds,
-        steps: query.steps,
-        negativePrompt: query.negative_prompt,
-        instrumental: query.instrumental,
-        instruct: query.instruct,
-        loop: query.loop,
-        promptInfluence: query.prompt_influence,
-        apiKey,
-        dashScopeApiKey: c.env.DASHSCOPE_API_KEY,
-        deepInfraApiKey: c.env.DEEPINFRA_API_KEY,
-        falKey: c.env.FAL_KEY,
-        stabilityApiKey: c.env.STABILITY_API_KEY,
+    const audio = formData.get("audio");
+    if (!(audio instanceof File)) {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message: "Missing required audio file.",
+        });
+    }
+    const voice = formData.get("voice");
+    const responseFormat = formData.get("response_format");
+    const resolvedFormat =
+        typeof responseFormat === "string" && responseFormat !== ""
+            ? responseFormat
+            : "mp3";
+    if (!["mp3", "opus", "aac", "wav", "pcm"].includes(resolvedFormat)) {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message: "response_format must be mp3, opus, aac, wav, or pcm.",
+        });
+    }
+
+    return changeVoiceWithElevenLabs({
+        audio,
+        voice: typeof voice === "string" && voice !== "" ? voice : "alloy",
+        responseFormat: resolvedFormat,
+        apiKey: c.env.ELEVENLABS_API_KEY,
         log,
     });
+}
+
+export async function handleVoiceIsolator(c: AudioContext): Promise<Response> {
+    const log = c.get("log").getChild("voice-isolator");
+    const formData = c.get("formData");
+    if (!formData) {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message: "Invalid multipart form data",
+        });
+    }
+    const audio = formData.get("audio");
+    if (!(audio instanceof File)) {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message: "Missing required audio file.",
+        });
+    }
+    return isolateVoiceWithElevenLabs({
+        audio,
+        apiKey: c.env.ELEVENLABS_API_KEY,
+        log,
+    });
+}
+
+export async function handleSpeech(c: AudioContext): Promise<Response> {
+    const log = c.get("log").getChild("tts");
+    return await generateAudioFromSpeechRequest(
+        c,
+        await parseSpeechRequest(c),
+        log,
+    );
+}
+
+export async function handleSpeechWithTimestamps(
+    c: AudioContext,
+): Promise<Response> {
+    const log = c.get("log").getChild("tts-timestamps");
+    const { input, safe, voice, response_format, seed } =
+        await parseSpeechRequest(c);
+    const modelName = c.var.model.resolved;
+    if (!(modelName in ELEVENLABS_TTS_MODEL_IDS)) {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message:
+                "Timestamped speech supports elevenlabs, elevenflash, and eleven-multilingual-v2.",
+        });
+    }
+    if (response_format === "flac") {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message:
+                "Timestamped speech supports mp3, opus, aac, wav, and pcm output.",
+        });
+    }
+    const safeInput = await applySafetyToInput(c, input, safe);
+    return withAudioFallback(c, (candidate) =>
+        generateElevenLabsSpeechWithTimestamps({
+            modelName: candidate.id as ElevenLabsTtsModelName,
+            text: safeInput,
+            voice,
+            responseFormat: response_format,
+            seed,
+            apiKey: c.env.ELEVENLABS_API_KEY,
+            log,
+        }),
+    );
+}
+
+export async function handleTranscription(c: AudioContext): Promise<Response> {
+    const log = c.get("log").getChild("transcription");
+    const formData = c.get("formData");
+    if (!formData) {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message: "Invalid multipart form data",
+        });
+    }
+
+    const file = formData.get("file") as File;
+    const language = formData.get("language") as string | null;
+    const prompt = formData.get("prompt") as string | null;
+    const responseFormat = formData.get("response_format") as string | null;
+    const temperatureRaw = formData.get("temperature") as string | null;
+    const temperature =
+        temperatureRaw !== null && temperatureRaw !== ""
+            ? Number(temperatureRaw)
+            : undefined;
+    const speakersExpected = parsePositiveInt(
+        formData.get("speakers_expected"),
+        "speakers_expected",
+    );
+
+    if (!file) {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message: "Missing required field: file",
+        });
+    }
+    if (speakersExpected !== undefined && responseFormat !== "diarized_json") {
+        throw new UpstreamError(400 as ContentfulStatusCode, {
+            message: "speakers_expected requires response_format=diarized_json",
+        });
+    }
+
+    c.var.track.setPricingInput({
+        hasDiarization: responseFormat === "diarized_json",
+        hasPrompt: Boolean(prompt),
+    });
+
+    const result = await withAudioFallback(c, async (candidate) => {
+        if (candidate.communityEndpoint) {
+            return callCommunityTranscriptionEndpoint(
+                candidate.communityEndpoint,
+                {
+                    file,
+                    language: language || undefined,
+                    prompt: prompt || undefined,
+                    responseFormat: responseFormat || undefined,
+                    temperature,
+                },
+                c.env.BETTER_AUTH_SECRET,
+            );
+        }
+        if (candidate.id === "grok-transcribe") {
+            return transcribeWithXai({
+                file,
+                language: language || undefined,
+                responseFormat: responseFormat || undefined,
+                apiKey: c.env.XAI_API_KEY,
+                log,
+            });
+        }
+        if (candidate.id === "gpt-transcribe") {
+            return transcribeWithAzure({
+                file,
+                language: language || undefined,
+                prompt: prompt || undefined,
+                responseFormat: responseFormat || undefined,
+                temperature,
+                apiKey: c.env.AZURE_MYCELI_PROD_SWEDEN_API_KEY,
+            });
+        }
+        if (candidate.id === "scribe") {
+            return transcribeWithElevenLabs({
+                file,
+                language: language || undefined,
+                responseFormat: responseFormat || undefined,
+                apiKey: c.env.ELEVENLABS_API_KEY,
+                log,
+                numSpeakers: speakersExpected,
+            });
+        }
+        if (
+            candidate.id === "universal-2" ||
+            candidate.id === "universal-3.5-pro"
+        ) {
+            return transcribeWithAssemblyAi({
+                file,
+                language: language || undefined,
+                prompt: prompt || undefined,
+                responseFormat: responseFormat || undefined,
+                temperature,
+                model: candidate.id,
+                apiKey: (c.env as unknown as { ASSEMBLYAI_API_KEY: string })
+                    .ASSEMBLYAI_API_KEY,
+                log,
+                speakersExpected,
+            });
+        }
+
+        const isDeepInfra = candidate.id === "whisper-deepinfra";
+        const providerApiKey = isDeepInfra
+            ? c.env.DEEPINFRA_API_KEY
+            : c.env.OVHCLOUD_API_KEY;
+        if (!providerApiKey) {
+            throw new UpstreamError(500 as ContentfulStatusCode, {
+                message:
+                    "Transcription service is not configured (missing API key)",
+            });
+        }
+        assertTranscriptionResponseFormat(
+            responseFormat,
+            "whisper model",
+            UNDIARIZED_TRANSCRIPTION_RESPONSE_FORMATS,
+        );
+
+        const whisperFormData = new FormData();
+        const filename =
+            file.name && file.name !== "blob" ? file.name : "audio.mp3";
+        whisperFormData.append("file", file, filename);
+        if (language) whisperFormData.append("language", language);
+        whisperFormData.append("response_format", "verbose_json");
+        whisperFormData.append(
+            "model",
+            isDeepInfra ? "openai/whisper-large-v3" : "whisper-large-v3",
+        );
+        whisperFormData.append(
+            isDeepInfra
+                ? "timestamp_granularities"
+                : "timestamp_granularities[]",
+            "word",
+        );
+
+        const whisperUrl = isDeepInfra
+            ? "https://api.deepinfra.com/v1/audio/transcriptions"
+            : "https://oai.endpoints.kepler.ai.cloud.ovh.net/v1/audio/transcriptions";
+        const response = await ensureUpstreamOk(
+            await fetch(whisperUrl, {
+                method: "POST",
+                headers: { Authorization: `Bearer ${providerApiKey}` },
+                body: whisperFormData,
+            }),
+            whisperUrl,
+        );
+
+        let whisper: WhisperVerboseJson;
+        try {
+            whisper = JSON.parse(await response.text());
+        } catch {
+            throw new UpstreamError(502 as ContentfulStatusCode, {
+                message: "Whisper returned an unexpected (non-JSON) response",
+            });
+        }
+        const billedSeconds = isDeepInfra
+            ? whisper.duration
+            : extractWhisperUsage(whisper, log);
+        if (typeof billedSeconds !== "number" || billedSeconds <= 0) {
+            throw new UpstreamError(502 as ContentfulStatusCode, {
+                message:
+                    "Whisper response did not include valid duration metering",
+            });
+        }
+        const usageHeaders = buildUsageHeaders(
+            candidate.id,
+            createAudioSecondsUsage(billedSeconds),
+        );
+        return buildTranscriptionResponse({
+            normalized: {
+                text: whisper.text,
+                language: whisper.language || undefined,
+                // OVH rounds usage.seconds up to a whole second, so this
+                // can exceed the audio length by under a second. Reporting
+                // the billed figure keeps duration, usage and the usage
+                // headers on one number.
+                duration: billedSeconds,
+                words: whisper.words ?? [],
+                segments: whisper.segments ?? [],
+                // OVH is not asked to diarize, so diarized_json is rejected
+                // by the undiarized format set rather than answered empty.
+                diarizedSegments: [],
+            },
+            responseFormat: responseFormat ?? "json",
+            usageHeaders,
+        });
+    });
+    c.var.track.overrideResponseTracking(result.clone());
+    return result;
 }
 
 export const audioRoutes = new Hono<Env>()
     .use("*", edgeRateLimit)
     .use("*", auth(), frontendKeyRateLimit, balance)
-    .post(
-        "/dialogue",
-        describeRoute({
-            tags: ["🔊 Audio"],
-            summary: "Generate Multi-Speaker Dialogue",
-            description:
-                "Generate one audio track from ordered text and voice pairs. Supports preset voice names and custom ElevenLabs voice IDs, with up to 10 unique voices and 2,000 total characters.",
-            requestBody: {
-                required: true,
-                content: {
-                    "application/json": {
-                        schema: {
-                            type: "object",
-                            required: ["inputs"],
-                            properties: {
-                                model: {
-                                    type: "string",
-                                    default: "eleven-dialogue",
-                                },
-                                inputs: {
-                                    type: "array",
-                                    minItems: 1,
-                                    items: {
-                                        type: "object",
-                                        required: ["text", "voice"],
-                                        properties: {
-                                            text: { type: "string" },
-                                            voice: {
-                                                type: "string",
-                                                description:
-                                                    "Preset voice name or custom ElevenLabs voice ID.",
-                                            },
-                                        },
-                                    },
-                                },
-                                response_format: {
-                                    type: "string",
-                                    enum: ["mp3", "opus", "aac", "wav", "pcm"],
-                                    default: "mp3",
-                                },
-                                seed: {
-                                    type: "integer",
-                                    minimum: 0,
-                                    maximum: 4294967295,
-                                },
-                                safe: { type: "boolean" },
-                            },
-                        },
-                    },
-                },
-            },
-            responses: {
-                200: {
-                    description: "Success - Returns dialogue audio",
-                    content: {
-                        "audio/mpeg": {
-                            schema: { type: "string", format: "binary" },
-                        },
-                        "audio/opus": {
-                            schema: { type: "string", format: "binary" },
-                        },
-                        "audio/aac": {
-                            schema: { type: "string", format: "binary" },
-                        },
-                        "audio/wav": {
-                            schema: { type: "string", format: "binary" },
-                        },
-                        "audio/pcm": {
-                            schema: { type: "string", format: "binary" },
-                        },
-                    },
-                },
-                ...errorResponseDescriptions(400, 401, 402, 403, 500),
-            },
-        }),
-        resolveModel("generate.audio", {
-            defaultModel: "eleven-dialogue",
-            supportedEndpoint: "/v1/audio/dialogue",
-        }),
-        track("generate.audio"),
-        async (c) => {
-            const log = c.get("log").getChild("dialogue");
-            await requireGenerationAccess(c.var, c.env);
-
-            let request: z.infer<typeof CreateDialogueRequestSchema>;
-            try {
-                request = CreateDialogueRequestSchema.parse(await c.req.json());
-            } catch (error) {
-                if (error instanceof z.ZodError) {
-                    throw new UpstreamError(400 as ContentfulStatusCode, {
-                        message:
-                            error.issues[0]?.message || "Invalid request body",
-                    });
-                }
-                throw new UpstreamError(400 as ContentfulStatusCode, {
-                    message: "Invalid JSON body",
-                });
-            }
-
-            const safeTexts = await applySafetyToTexts(
-                c,
-                request.inputs.map((input) => input.text),
-                request.safe,
-            );
-            const inputs = request.inputs.map((input, index) => ({
-                ...input,
-                text: safeTexts[index],
-            }));
-            const response = await generateElevenLabsDialogue({
-                inputs,
-                responseFormat: request.response_format,
-                seed: request.seed,
-                apiKey: c.env.ELEVENLABS_API_KEY,
-                log,
-            });
-            return withSafetyHeaders(c, response);
-        },
-    )
     .post(
         "/voice-changer",
         describeRoute({
@@ -2437,49 +3253,12 @@ export const audioRoutes = new Hono<Env>()
             supportedEndpoint: "/v1/audio/voice-changer",
         }),
         track("generate.audio"),
-        async (c) => {
-            const log = c.get("log").getChild("voice-changer");
-            await requireGenerationAccess(c.var, c.env);
-
-            let formData: FormData;
-            try {
-                formData = c.get("formData") || (await c.req.formData());
-            } catch {
-                throw new UpstreamError(400 as ContentfulStatusCode, {
-                    message: "Invalid multipart form data",
-                });
-            }
-
-            const audio = formData.get("audio");
-            if (!(audio instanceof File)) {
-                throw new UpstreamError(400 as ContentfulStatusCode, {
-                    message: "Missing required audio file.",
-                });
-            }
-            const voice = formData.get("voice");
-            const responseFormat = formData.get("response_format");
-            const resolvedFormat =
-                typeof responseFormat === "string" && responseFormat !== ""
-                    ? responseFormat
-                    : "mp3";
-            if (
-                !["mp3", "opus", "aac", "wav", "pcm"].includes(resolvedFormat)
-            ) {
-                throw new UpstreamError(400 as ContentfulStatusCode, {
-                    message:
-                        "response_format must be mp3, opus, aac, wav, or pcm.",
-                });
-            }
-
-            return changeVoiceWithElevenLabs({
-                audio,
-                voice:
-                    typeof voice === "string" && voice !== "" ? voice : "alloy",
-                responseFormat: resolvedFormat,
-                apiKey: c.env.ELEVENLABS_API_KEY,
-                log,
-            });
-        },
+        prepareGenerationRequest,
+        audioCache,
+        generationAccess,
+        deduplicateGeneration,
+        apiKeyBudgetReservation,
+        handleVoiceChanger,
     )
     .post(
         "/voice-isolator",
@@ -2529,152 +3308,120 @@ export const audioRoutes = new Hono<Env>()
             supportedEndpoint: "/v1/audio/voice-isolator",
         }),
         track("generate.audio"),
-        async (c) => {
-            const log = c.get("log").getChild("voice-isolator");
-            await requireGenerationAccess(c.var, c.env);
-
-            let formData: FormData;
-            try {
-                formData = c.get("formData") || (await c.req.formData());
-            } catch {
-                throw new UpstreamError(400 as ContentfulStatusCode, {
-                    message: "Invalid multipart form data",
-                });
-            }
-
-            const audio = formData.get("audio");
-            if (!(audio instanceof File)) {
-                throw new UpstreamError(400 as ContentfulStatusCode, {
-                    message: "Missing required audio file.",
-                });
-            }
-
-            return isolateVoiceWithElevenLabs({
-                audio,
-                apiKey: c.env.ELEVENLABS_API_KEY,
-                log,
-            });
-        },
-    )
-    .post(
-        "/music/upload",
-        describeRoute({
-            tags: ["🔊 Audio"],
-            summary: "Upload Music Reference",
-            description:
-                "Upload an audio file to ElevenLabs Music and receive a `song_id` for reference conditioning or inpainting. Set `extract_composition_plan=true` to return a music_v2 composition plan derived from the track.",
-            requestBody: {
-                required: true,
-                content: {
-                    "multipart/form-data": {
-                        schema: {
-                            type: "object",
-                            required: ["file"],
-                            properties: {
-                                file: {
-                                    type: "string",
-                                    format: "binary",
-                                    description: "Music file to upload.",
-                                },
-                                extract_composition_plan: {
-                                    type: "boolean",
-                                    default: false,
-                                    description:
-                                        "Return a music_v2 composition plan extracted from the uploaded track.",
-                                },
-                            },
-                        },
-                    },
-                },
-            },
-            responses: {
-                200: {
-                    description:
-                        "Success - Returns ElevenLabs song_id and optional composition_plan",
-                    content: {
-                        "application/json": {
-                            schema: {
-                                type: "object",
-                                properties: {
-                                    song_id: { type: "string" },
-                                    composition_plan: { type: "object" },
-                                },
-                            },
-                        },
-                    },
-                },
-                ...errorResponseDescriptions(400, 401, 402, 403, 500),
-            },
-        }),
-        resolveModel("generate.audio", { defaultModel: "elevenmusic" }),
-        track("generate.audio"),
-        async (c) => {
-            const log = c.get("log").getChild("music-upload");
-            await requireGenerationAccess(c.var, c.env);
-
-            if (c.var.model.resolved !== "elevenmusic") {
-                throw new UpstreamError(400 as ContentfulStatusCode, {
-                    message: "Music upload only supports model=elevenmusic",
-                });
-            }
-
-            let formData: FormData;
-            try {
-                formData = c.get("formData") || (await c.req.formData());
-            } catch {
-                throw new UpstreamError(400 as ContentfulStatusCode, {
-                    message: "Invalid multipart form data",
-                });
-            }
-
-            const file = formData.get("file") as File | null;
-            if (!file) {
-                throw new UpstreamError(400 as ContentfulStatusCode, {
-                    message: "Missing required field: file",
-                });
-            }
-
-            const apiKey = (c.env as unknown as { ELEVENLABS_API_KEY: string })
-                .ELEVENLABS_API_KEY;
-            const upload = await uploadMusicReference({
-                file,
-                extractCompositionPlan:
-                    parseOptionalBoolean(
-                        formData.get("extract_composition_plan"),
-                        "extract_composition_plan",
-                    ) || false,
-                apiKey,
-                log,
-            });
-            const usageHeaders = buildUsageHeaders(
-                "elevenmusic",
-                createCompletionAudioSecondsUsage(file.size / 16000),
-            );
-
-            return Response.json(upload, {
-                headers: {
-                    ...usageHeaders,
-                    ...(upload.song_id
-                        ? { "x-elevenlabs-song-id": upload.song_id }
-                        : {}),
-                },
-            });
-        },
+        prepareGenerationRequest,
+        audioCache,
+        generationAccess,
+        deduplicateGeneration,
+        apiKeyBudgetReservation,
+        handleVoiceIsolator,
     )
     .post(
         "/speech",
         describeRoute({
             tags: ["🔊 Audio"],
-            summary: "Text to Speech (OpenAI-compatible)",
+            summary: "Generate Audio (OpenAI-compatible)",
             description: [
-                "Generate speech or music from text. Compatible with the OpenAI TTS API for JSON requests.",
+                "Generate speech, music, sound effects, or dialogue from text. Compatible with the OpenAI TTS API for JSON requests.",
                 "",
-                "Set `model` to `elevenmusic`, `lyria-3-clip`, `stable-audio-3-medium`, or `stable-audio-3-large` to generate music. Lyria returns one fixed 30-second MP3 clip. Send multipart/form-data with `reference_audio` plus `input` to run audio-to-audio (style transfer) on `stable-audio-3-medium` or `stable-audio-3-large`, or reference-audio conditioning on `elevenmusic`; for ElevenLabs inpainting, pass a `composition_plan`.",
+                "Set `model` to `elevenmusic`, `lyria-3-clip`, `stable-audio-3-medium`, or `stable-audio-3-large` to generate music. Lyria returns one fixed 30-second MP3 clip. Pass any publicly accessible audio URL as `reference_audio` to run audio-to-audio (style transfer) on `stable-audio-3-medium` or `stable-audio-3-large`, or reference-audio conditioning on `elevenmusic`; for ElevenLabs inpainting, pass a `composition_plan`.",
+                "",
+                "For multi-speaker audio, set `model` to `eleven-dialogue` and put one turn per line in `input` as `<voice>: <text>`. Voice labels may be preset names or ElevenLabs voice IDs; the top-level `voice` field is ignored for this model. Dialogue supports up to 10 unique voices and 2,000 total text characters.",
                 "",
                 `**Available voices:** ${AUDIO_VOICES.join(", ")}`,
                 "",
                 "**Output formats:** mp3 (default), opus, aac, flac, wav, pcm",
             ].join("\n"),
+            requestBody: {
+                required: true,
+                content: {
+                    "application/json": {
+                        schema: {
+                            type: "object",
+                            required: ["input"],
+                            properties: {
+                                model: { type: "string" },
+                                input: {
+                                    type: "string",
+                                    minLength: 1,
+                                    maxLength: 10000,
+                                    description:
+                                        "Text or prompt to generate. The `eleven-dialogue` model expects one `voice: text` turn per line.",
+                                },
+                                safe: {
+                                    oneOf: [
+                                        { type: "string" },
+                                        { type: "boolean" },
+                                    ],
+                                    description:
+                                        "Optional safety features; accepts a comma-separated string or boolean shorthand.",
+                                },
+                                voice: { type: "string", default: "alloy" },
+                                response_format: {
+                                    type: "string",
+                                    enum: [
+                                        "mp3",
+                                        "opus",
+                                        "aac",
+                                        "flac",
+                                        "wav",
+                                        "pcm",
+                                    ],
+                                    default: "mp3",
+                                },
+                                duration: {
+                                    type: "number",
+                                    minimum: 0.5,
+                                    maximum: 300,
+                                },
+                                seconds: {
+                                    type: "number",
+                                    minimum: 1,
+                                    maximum: 380,
+                                },
+                                steps: {
+                                    type: "integer",
+                                    minimum: 1,
+                                    maximum: 100,
+                                },
+                                negative_prompt: { type: "string" },
+                                instrumental: { type: "boolean" },
+                                store_for_inpainting: { type: "boolean" },
+                                reference_audio: {
+                                    type: "string",
+                                    format: "uri",
+                                    description:
+                                        "Public HTTP(S) URL for reference-audio conditioning or audio-to-audio generation.",
+                                },
+                                conditioning_ref: { type: "object" },
+                                composition_plan: { type: "object" },
+                                seed: {
+                                    type: "integer",
+                                    minimum: 0,
+                                    maximum: 4294967295,
+                                },
+                                instructions: { type: "string" },
+                                loop: { type: "boolean" },
+                                prompt_influence: {
+                                    type: "number",
+                                    minimum: 0,
+                                    maximum: 1,
+                                },
+                            },
+                        },
+                        examples: {
+                            dialogue: {
+                                summary: "Multi-speaker dialogue",
+                                value: {
+                                    model: "eleven-dialogue",
+                                    input: "rachel: Hello!\nadam: Hi!",
+                                    voice: "alloy",
+                                    response_format: "mp3",
+                                },
+                            },
+                        },
+                    },
+                },
+            },
             responses: {
                 200: {
                     description: "Success - Returns audio data",
@@ -2706,73 +3453,12 @@ export const audioRoutes = new Hono<Env>()
             supportedEndpoint: "/v1/audio/speech",
         }),
         track("generate.audio"),
-        async (c) => {
-            const log = c.get("log").getChild("tts");
-            await requireGenerationAccess(c.var, c.env);
-
-            const {
-                input,
-                safe,
-                voice,
-                response_format,
-                duration,
-                seconds,
-                steps,
-                negative_prompt,
-                instrumental,
-                store_for_inpainting,
-                extract_composition_plan,
-                conditioning_ref,
-                composition_plan,
-                reference_audio,
-                seed,
-                instruct,
-                loop,
-                prompt_influence,
-            } = await parseSpeechRequest(c);
-            requireTextToAudioModel(
-                c.var.model.resolved,
-                c.var.model.definition,
-            );
-            requireElevenMusicOptions(c.var.model.resolved, {
-                referenceAudio: reference_audio,
-                compositionPlan: composition_plan,
-                conditioningRef: conditioning_ref,
-                storeForInpainting: store_for_inpainting,
-                extractCompositionPlan: extract_composition_plan,
-            });
-            const safeInput = await applySafety(c, input, safe);
-
-            const apiKey = (c.env as unknown as { ELEVENLABS_API_KEY: string })
-                .ELEVENLABS_API_KEY;
-
-            // POST schema forbids seed=-1 (.min(0)), so no sentinel mapping here.
-            return dispatchAudioGeneration(c, {
-                text: safeInput,
-                voice,
-                responseFormat: response_format,
-                seed,
-                duration,
-                seconds,
-                steps,
-                negativePrompt: negative_prompt,
-                instrumental,
-                storeForInpainting: store_for_inpainting,
-                extractCompositionPlan: extract_composition_plan,
-                conditioningRef: conditioning_ref,
-                compositionPlan: composition_plan,
-                referenceAudio: reference_audio,
-                instruct,
-                loop,
-                promptInfluence: prompt_influence,
-                apiKey,
-                dashScopeApiKey: c.env.DASHSCOPE_API_KEY,
-                deepInfraApiKey: c.env.DEEPINFRA_API_KEY,
-                falKey: c.env.FAL_KEY,
-                stabilityApiKey: c.env.STABILITY_API_KEY,
-                log,
-            });
-        },
+        prepareGenerationRequest,
+        audioCache,
+        generationAccess,
+        deduplicateGeneration,
+        apiKeyBudgetReservation,
+        handleSpeech,
     )
     .post(
         "/speech/with-timestamps",
@@ -2889,37 +3575,12 @@ export const audioRoutes = new Hono<Env>()
             supportedEndpoint: "/v1/audio/speech/with-timestamps",
         }),
         track("generate.audio"),
-        async (c) => {
-            const log = c.get("log").getChild("tts-timestamps");
-            await requireGenerationAccess(c.var, c.env);
-
-            const { input, safe, voice, response_format, seed } =
-                await parseSpeechRequest(c);
-            const modelName = c.var.model.resolved;
-            if (!(modelName in ELEVENLABS_TTS_MODEL_IDS)) {
-                throw new UpstreamError(400 as ContentfulStatusCode, {
-                    message:
-                        "Timestamped speech supports elevenlabs, elevenflash, and eleven-multilingual-v2.",
-                });
-            }
-            if (response_format === "flac") {
-                throw new UpstreamError(400 as ContentfulStatusCode, {
-                    message:
-                        "Timestamped speech supports mp3, opus, aac, wav, and pcm output.",
-                });
-            }
-            const safeInput = await applySafety(c, input, safe);
-
-            return generateElevenLabsSpeechWithTimestamps({
-                modelName: modelName as ElevenLabsTtsModelName,
-                text: safeInput,
-                voice,
-                responseFormat: response_format,
-                seed,
-                apiKey: c.env.ELEVENLABS_API_KEY,
-                log,
-            });
-        },
+        prepareGenerationRequest,
+        textCache,
+        generationAccess,
+        deduplicateGeneration,
+        apiKeyBudgetReservation,
+        handleSpeechWithTimestamps,
     )
     .post(
         "/transcriptions",
@@ -2934,7 +3595,9 @@ export const audioRoutes = new Hono<Env>()
                 "**Models:**",
                 "- `whisper-large-v3` (default) — OpenAI Whisper via OVHcloud",
                 "- `whisper-1` — Alias for whisper-large-v3",
+                "- `gpt-transcribe` — Fast multilingual speech recognition with prompt context",
                 "- `scribe` — ElevenLabs Scribe (90+ languages, word-level timestamps)",
+                "- `grok-transcribe` — xAI speech recognition with word timestamps, speaker labels, and text formatting",
                 "- `universal-2` — AssemblyAI Universal-2 (99 languages)",
                 "- `universal-3.5-pro` — AssemblyAI Universal-3.5 Pro (18 languages, code switching, prompting)",
             ].join("\n"),
@@ -2956,7 +3619,7 @@ export const audioRoutes = new Hono<Env>()
                                     type: "string",
                                     default: "whisper-large-v3",
                                     description:
-                                        "The model to use. Options: `whisper-large-v3`, `whisper-1`, `scribe`, `universal-2`, `universal-3.5-pro`.",
+                                        "The model to use. Options: `whisper-large-v3`, `whisper-1`, `gpt-transcribe`, `scribe`, `grok-transcribe`, `universal-2`, `universal-3.5-pro`.",
                                 },
                                 language: {
                                     type: "string",
@@ -2980,7 +3643,7 @@ export const audioRoutes = new Hono<Env>()
                                     ],
                                     default: "json",
                                     description:
-                                        "The format of the transcript output. Use `diarized_json` for OpenAI-compatible speaker segments on diarization-capable models.",
+                                        "The format of the transcript output. Support is model-dependent: `srt` and `vtt` require a model that renders subtitles, and `diarized_json` a diarization-capable one. Unsupported combinations return 400 naming the formats that model accepts.",
                                 },
                                 temperature: {
                                     type: "number",
@@ -3038,162 +3701,15 @@ export const audioRoutes = new Hono<Env>()
         }),
         resolveModel("generate.audio", {
             defaultModel: "whisper-large-v3",
+            supportedEndpoint: "/v1/audio/transcriptions",
         }),
         track("generate.audio"),
-        async (c) => {
-            const log = c.get("log").getChild("transcription");
-            await requireGenerationAccess(c.var, c.env);
-
-            // Get formData from middleware or parse it
-            let formData: FormData;
-            try {
-                formData = c.get("formData") || (await c.req.formData());
-            } catch (error) {
-                log.warn("Invalid multipart form data: {message}", {
-                    message:
-                        error instanceof Error ? error.message : String(error),
-                });
-                throw new UpstreamError(400 as ContentfulStatusCode, {
-                    message: "Invalid multipart form data",
-                });
-            }
-
-            const file = formData.get("file") as File;
-            const language = formData.get("language") as string | null;
-            const prompt = formData.get("prompt") as string | null;
-            const responseFormat = formData.get("response_format") as
-                | string
-                | null;
-            const temperatureRaw = formData.get("temperature") as string | null;
-            const temperature =
-                temperatureRaw !== null && temperatureRaw !== ""
-                    ? Number(temperatureRaw)
-                    : undefined;
-            const speakersExpected = parsePositiveInt(
-                formData.get("speakers_expected"),
-                "speakers_expected",
-            );
-            const wantsDiarizedJson = responseFormat === "diarized_json";
-
-            if (!file) {
-                throw new UpstreamError(400 as ContentfulStatusCode, {
-                    message: "Missing required field: file",
-                });
-            }
-
-            if (speakersExpected !== undefined && !wantsDiarizedJson) {
-                throw new UpstreamError(400 as ContentfulStatusCode, {
-                    message:
-                        "speakers_expected requires response_format=diarized_json",
-                });
-            }
-
-            // Route to ElevenLabs Scribe or Whisper based on model
-            if (c.var.model.resolved === "scribe") {
-                const elevenLabsApiKey = (
-                    c.env as unknown as { ELEVENLABS_API_KEY: string }
-                ).ELEVENLABS_API_KEY;
-                const response = await transcribeWithElevenLabs({
-                    file,
-                    language: language || undefined,
-                    responseFormat: responseFormat || undefined,
-                    apiKey: elevenLabsApiKey,
-                    log,
-                    numSpeakers: speakersExpected,
-                });
-
-                // Override tracking with final response
-                c.var.track.overrideResponseTracking(response.clone());
-                return response;
-            }
-
-            if (
-                c.var.model.resolved === "universal-2" ||
-                c.var.model.resolved === "universal-3.5-pro"
-            ) {
-                const assemblyAiApiKey = (
-                    c.env as unknown as { ASSEMBLYAI_API_KEY: string }
-                ).ASSEMBLYAI_API_KEY;
-                const response = await transcribeWithAssemblyAi({
-                    file,
-                    language: language || undefined,
-                    prompt: prompt || undefined,
-                    responseFormat: responseFormat || undefined,
-                    temperature,
-                    model: c.var.model.resolved,
-                    apiKey: assemblyAiApiKey,
-                    log,
-                    speakersExpected,
-                });
-
-                c.var.track.overrideResponseTracking(response.clone());
-                return response;
-            }
-
-            // Default: Whisper (OVHcloud)
-            const ovhApiKey = c.env.OVHCLOUD_API_KEY;
-            if (!ovhApiKey) {
-                throw new UpstreamError(500 as ContentfulStatusCode, {
-                    message:
-                        "Transcription service is not configured (missing API key)",
-                });
-            }
-            validateWhisperResponseFormat(responseFormat);
-
-            // Re-build formData for Whisper (Hono consumed the original body stream).
-            // Preserve filename — OVH needs the extension to detect format/duration.
-            const whisperFormData = new FormData();
-            const filename =
-                file.name && file.name !== "blob" ? file.name : "audio.mp3";
-            whisperFormData.append("file", file, filename);
-            if (language) whisperFormData.append("language", language);
-            // Always request verbose_json from OVH so usage.seconds (billing) and
-            // segments (srt/vtt) are present; reformat locally to the caller's
-            // requested response_format below. Forwarding e.g. `text` upstream
-            // would return a plain-text body and lose the usage object.
-            whisperFormData.append("response_format", "verbose_json");
-            whisperFormData.append("model", "whisper-large-v3");
-            whisperFormData.append("timestamp_granularities[]", "word");
-
-            // Thin proxy to OVHcloud Whisper
-            const whisperUrl =
-                "https://oai.endpoints.kepler.ai.cloud.ovh.net/v1/audio/transcriptions";
-            const rawResponse = await fetch(whisperUrl, {
-                method: "POST",
-                headers: {
-                    Authorization: `Bearer ${ovhApiKey}`,
-                },
-                body: whisperFormData,
-            });
-            const response = await ensureUpstreamOk(rawResponse, whisperUrl);
-
-            // OVH always returns verbose_json now; parse once, bill from it, then
-            // reformat to the caller's requested format.
-            const responseBody = await response.text();
-            let whisper: WhisperVerboseJson;
-            try {
-                whisper = JSON.parse(responseBody);
-            } catch {
-                throw new UpstreamError(502 as ContentfulStatusCode, {
-                    message:
-                        "Whisper returned an unexpected (non-JSON) response",
-                });
-            }
-            const duration = extractWhisperUsage(whisper, log);
-            const usageHeaders = buildUsageHeaders(
-                c.var.model.resolved,
-                createAudioSecondsUsage(duration),
-            );
-
-            const result = formatWhisperResponse(
-                whisper,
-                responseFormat,
-                usageHeaders,
-            );
-            c.var.track.overrideResponseTracking(result.clone());
-
-            return result;
-        },
+        prepareGenerationRequest,
+        textCache,
+        generationAccess,
+        deduplicateGeneration,
+        apiKeyBudgetReservation,
+        handleTranscription,
     );
 
 export function parsePositiveInt(
@@ -3211,39 +3727,13 @@ export function parsePositiveInt(
     return n;
 }
 
-interface WhisperSegment {
-    start: number;
-    end: number;
-    text: string;
-}
-
 interface WhisperVerboseJson {
     text: string;
+    language?: string;
+    duration?: number;
     usage?: { seconds?: number };
-    segments?: WhisperSegment[];
-}
-
-const WHISPER_RESPONSE_FORMATS = [
-    "json",
-    "text",
-    "verbose_json",
-    "srt",
-    "vtt",
-] as const;
-
-type WhisperResponseFormat = (typeof WHISPER_RESPONSE_FORMATS)[number];
-
-function validateWhisperResponseFormat(responseFormat: string | null): void {
-    if (
-        responseFormat &&
-        !WHISPER_RESPONSE_FORMATS.includes(
-            responseFormat as WhisperResponseFormat,
-        )
-    ) {
-        throw new UpstreamError(400 as ContentfulStatusCode, {
-            message: `Unsupported response_format for whisper model: ${responseFormat}. Supported: ${WHISPER_RESPONSE_FORMATS.join(", ")}`,
-        });
-    }
+    words?: NormalizedWord[];
+    segments?: NormalizedSegment[];
 }
 
 function extractWhisperUsage(json: WhisperVerboseJson, log: Logger): number {
@@ -3255,64 +3745,4 @@ function extractWhisperUsage(json: WhisperVerboseJson, log: Logger): number {
     }
     log.debug("Whisper usage: {seconds}s", { seconds });
     return seconds;
-}
-
-/** Format SRT/VTT timestamps from seconds. SRT uses a comma, VTT a dot. */
-function formatTimestamp(seconds: number, sep: "," | "."): string {
-    const ms = Math.round(seconds * 1000);
-    const h = String(Math.floor(ms / 3_600_000)).padStart(2, "0");
-    const m = String(Math.floor((ms % 3_600_000) / 60_000)).padStart(2, "0");
-    const s = String(Math.floor((ms % 60_000) / 1000)).padStart(2, "0");
-    const msPart = String(ms % 1000).padStart(3, "0");
-    return `${h}:${m}:${s}${sep}${msPart}`;
-}
-
-function toSubtitles(segments: WhisperSegment[], kind: "srt" | "vtt"): string {
-    const sep = kind === "srt" ? "," : ".";
-    const cues = segments.map((seg, i) => {
-        const time = `${formatTimestamp(seg.start, sep)} --> ${formatTimestamp(seg.end, sep)}`;
-        const head = kind === "srt" ? `${i + 1}\n` : "";
-        return `${head}${time}\n${seg.text.trim()}`;
-    });
-    return kind === "vtt"
-        ? `WEBVTT\n\n${cues.join("\n\n")}\n`
-        : `${cues.join("\n\n")}\n`;
-}
-
-/**
- * Reformat OVH's verbose_json into the caller's requested response_format.
- * Mirrors the ElevenLabs scribe path so behaviour is consistent across backends.
- */
-export function formatWhisperResponse(
-    json: WhisperVerboseJson,
-    responseFormat: string | null,
-    usageHeaders: Record<string, string>,
-): Response {
-    validateWhisperResponseFormat(responseFormat);
-
-    if (responseFormat === "text") {
-        return new Response(json.text, {
-            headers: {
-                "Content-Type": "text/plain; charset=utf-8",
-                ...usageHeaders,
-            },
-        });
-    }
-
-    if (responseFormat === "srt" || responseFormat === "vtt") {
-        return new Response(toSubtitles(json.segments ?? [], responseFormat), {
-            headers: {
-                "Content-Type": "text/plain; charset=utf-8",
-                ...usageHeaders,
-            },
-        });
-    }
-
-    if (responseFormat === "verbose_json") {
-        const { usage: _usage, ...rest } = json;
-        return Response.json(rest, { headers: usageHeaders });
-    }
-
-    // Default: json
-    return Response.json({ text: json.text }, { headers: usageHeaders });
 }

--- a/gen.pollinations.ai/test/community-endpoints.test.ts
+++ b/gen.pollinations.ai/test/community-endpoints.test.ts
@@ -1,0 +1,7367 @@
+import {
+    createExecutionContext,
+    env,
+    SELF,
+    waitOnExecutionContext,
+} from "cloudflare:test";
+import type { Logger } from "@logtape/logtape";
+import { verifyAgentRunToken } from "@shared/auth/agent-run-token.ts";
+import { COMMUNITY_MODEL_ALLOWED_GITHUB_IDS } from "@shared/auth/github-id-list.ts";
+import { getUserBalance } from "@shared/billing/balance.ts";
+import {
+    communityAudioTranscriptionsUrl,
+    communityChatCompletionsUrl,
+    communityEmbeddingsUrl,
+    communityImageEditsUrl,
+    communityImageGenerationsUrl,
+    communityOpenAIBaseUrl,
+    normalizeCommunityAssetUrl,
+    validateCommunityEndpointUrl,
+} from "@shared/community-endpoint-urls.ts";
+import {
+    COMMUNITY_ENDPOINT_CHANGE_DELAY_MS,
+    COMMUNITY_ENDPOINT_PRICE_FIELDS,
+    type CommunityEndpointImagePricing,
+    type CommunityEndpointModality,
+    type CommunityEndpointPrices,
+    type CommunityEndpointRuntime,
+    communityEndpointPriceFieldsForModality,
+    communityEndpointPrices,
+    communityEndpointSupportedEndpoints,
+    communityModelDefinition,
+    communityModelId,
+    communityPriceDefinition,
+    type EndpointAgentCommunityEndpointRuntime,
+    isCommunityEndpointOwnerAllowed,
+    isCommunityFallbackPricingAllowed,
+    legacyCommunityModelId,
+    MAX_COMMUNITY_PRICE_PER_IMAGE,
+    MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS,
+    MAX_COMMUNITY_PRICE_PER_SECOND,
+    MAX_COMMUNITY_PRICE_PER_TOKEN,
+    MAX_COMMUNITY_PRICE_PER_VIDEO_SECOND,
+    MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS,
+    MIN_COMMUNITY_PRICE_PER_TOKEN,
+    normalizeCommunityEndpointBearerToken,
+    normalizeCommunityEndpointImagePricing,
+    normalizeCommunityEndpointInputModalities,
+    normalizeCommunityEndpointModality,
+    normalizeCommunityProviderUrl,
+    PROMPT_AGENT_BASE_URL_PLACEHOLDER,
+    type PromptAgentListingPayload,
+    type ProxyListingPayload,
+    parseCommunityModelId,
+    parseListingPayload,
+    resolveEffectiveProxyListing,
+} from "@shared/community-endpoints.ts";
+import {
+    communityEndpoint as communityEndpointTable,
+    session as sessionTable,
+} from "@shared/db/better-auth.ts";
+import { handleError } from "@shared/error.ts";
+import { IMMUTABLE_CACHE_CONTROL } from "@shared/http/cache-control.ts";
+import { DEFAULT_AUDIO_MODEL } from "@shared/registry/audio.ts";
+import { DEFAULT_EMBEDDING_MODEL } from "@shared/registry/embeddings.ts";
+import { DEFAULT_IMAGE_MODEL } from "@shared/registry/image.ts";
+import { DEFAULT_3D_MODEL } from "@shared/registry/model3d.ts";
+import { DEFAULT_REALTIME_MODEL } from "@shared/registry/realtime.ts";
+import {
+    calculateUsageBilling,
+    getRegistryModelDefinition,
+    type ModelInputModality,
+} from "@shared/registry/registry.ts";
+import { DEFAULT_TEXT_MODEL } from "@shared/registry/text.ts";
+import {
+    FALLBACK_TARGET_HEADER,
+    MODEL_USED_HEADER,
+    USAGE_TYPE_HEADERS,
+} from "@shared/registry/usage-headers.ts";
+import { encryptSecret } from "@shared/secret-encryption.ts";
+import {
+    createTestApiKey,
+    createTestUser,
+    test as fixtureTest,
+} from "@shared/test/fixtures/index.ts";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import { Hono } from "hono";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Env } from "@/env.ts";
+import {
+    callCommunitySpeechEndpoint,
+    callCommunityTranscriptionEndpoint,
+} from "../src/audio/communityEndpoint.ts";
+import { getCommunityModelRegistryEntries } from "../src/community-models.ts";
+import {
+    callCommunityImageEndpoint,
+    callCommunityVideoEndpoint,
+} from "../src/image/communityEndpoint.ts";
+import worker from "../src/index.ts";
+import {
+    getGenerationModelRegistry,
+    resetGenerationModelRegistryCache,
+} from "../src/model-registry.ts";
+import { communityEndpointGatewayContext } from "../src/text/communityEndpoint.ts";
+import { withInlineGenerationCoordinator } from "./helpers/inline-generation-coordinator.ts";
+
+const db = drizzle(env.DB);
+
+type CommunityEndpointInsert = typeof communityEndpointTable.$inferInsert;
+type CommunityEndpointFixture = Omit<CommunityEndpointInsert, "title"> &
+    Partial<CommunityEndpointPrices> & {
+        title?: string;
+        modality?: CommunityEndpointModality;
+        imagePricing?: CommunityEndpointImagePricing;
+        inputModalities?: ModelInputModality[] | null;
+        baseUrl?: string | null;
+        upstreamModel?: string;
+        agentConfig?: PromptAgentListingPayload;
+        bearerTokenCiphertext?: string | null;
+        perUserRpm?: number | null;
+        fallbacks?: string[] | null;
+    };
+
+/**
+ * Insert rows the way Enter writes them. Tests can keep their readable flat
+ * fixtures while this helper packs the variant fields into `payload`.
+ */
+function insertCommunityEndpoints(
+    values: CommunityEndpointFixture | CommunityEndpointFixture[],
+) {
+    const rows = (Array.isArray(values) ? values : [values]).map((row) => {
+        const type = row.type ?? "proxy";
+        const {
+            modality: rawModality,
+            imagePricing: rawImagePricing,
+            inputModalities: rawInputModalities,
+            baseUrl,
+            upstreamModel,
+            agentConfig,
+            bearerTokenCiphertext,
+            perUserRpm,
+            fallbacks,
+            promptTextPrice: _promptTextPrice,
+            promptCachedPrice: _promptCachedPrice,
+            promptCacheWritePrice: _promptCacheWritePrice,
+            promptAudioPrice: _promptAudioPrice,
+            promptImagePrice: _promptImagePrice,
+            completionTextPrice: _completionTextPrice,
+            completionReasoningPrice: _completionReasoningPrice,
+            completionAudioPrice: _completionAudioPrice,
+            completionImagePrice: _completionImagePrice,
+            completionVideoPrice: _completionVideoPrice,
+            ...listing
+        } = row;
+        const modality = normalizeCommunityEndpointModality(rawModality);
+        const payload =
+            type === "prompt_agent"
+                ? (agentConfig ?? {
+                      systemPrompt: "Test prompt agent.",
+                      baseModel: "openai",
+                      mcpServers: [],
+                  })
+                : type === "endpoint_agent"
+                  ? { perUserRpm: perUserRpm ?? null }
+                  : {
+                        bearerTokenCiphertext:
+                            bearerTokenCiphertext ?? "test-ciphertext",
+                        modality,
+                        imagePricing:
+                            normalizeCommunityEndpointImagePricing(
+                                rawImagePricing,
+                            ),
+                        inputModalities:
+                            normalizeCommunityEndpointInputModalities(
+                                rawInputModalities ?? undefined,
+                                modality,
+                            ),
+                        perUserRpm: perUserRpm ?? null,
+                        fallbacks: fallbacks ?? [],
+                        prices: communityEndpointPrices(row),
+                    };
+        return {
+            ...listing,
+            title: row.title ?? row.name,
+            type,
+            baseUrl:
+                type === "prompt_agent"
+                    ? PROMPT_AGENT_BASE_URL_PLACEHOLDER
+                    : (baseUrl ?? ""),
+            upstreamModel:
+                type === "prompt_agent" ? row.id : (upstreamModel ?? row.name),
+            payload: JSON.stringify(payload),
+        };
+    });
+    return db.insert(communityEndpointTable).values(rows);
+}
+const testLog = { getChild: () => testLog } as unknown as Logger;
+const COMMUNITY_ENDPOINT_ALLOWED_TEST_GITHUB_ID = 36901823;
+// user.github_id is unique, so every test owner needs its own id. Rotate
+// through the allowlist to keep each one both distinct and allowed.
+let allowedGithubIdCursor = 0;
+function nextAllowedGithubId(): number {
+    const ids = COMMUNITY_MODEL_ALLOWED_GITHUB_IDS;
+    const id = ids[allowedGithubIdCursor % ids.length];
+    allowedGithubIdCursor += 1;
+    if (id === undefined) throw new Error("empty community model allowlist");
+    return id;
+}
+const COMMUNITY_ENDPOINT_DENIED_TEST_GITHUB_ID = 999_999_999;
+const TEST_PNG_BASE64 = "iVBORw0KGgo=";
+const TEST_PNG_BYTES = [137, 80, 78, 71, 13, 10, 26, 10];
+const TEST_INVALID_IMAGE_BASE64 = "bm90IGFuIGltYWdl";
+const TEST_COMMUNITY_IMAGE_URL = "http://api.example.com/assets/image.png";
+const TEST_INPUT_IMAGE_URL = "https://input.example.com/source.png";
+const TEST_MP4_BASE64 = "AAAAFGZ0eXBpc29tAAAAAGlzb20AAAAJbWRhdAA=";
+const TEST_BARE_MP4_BASE64 = "AAAAFGZ0eXBpc29tAAAAAGlzb20=";
+const TEST_MP4_BYTES = [
+    0, 0, 0, 20, 102, 116, 121, 112, 105, 115, 111, 109, 0, 0, 0, 0, 105, 115,
+    111, 109, 0, 0, 0, 9, 109, 100, 97, 116, 0,
+];
+
+function isPortkeyChatCompletionsRequest(request: Request): boolean {
+    return new URL(request.url).pathname === "/v1/chat/completions";
+}
+
+function isCommunityImageGenerationsRequest(request: Request): boolean {
+    return new URL(request.url).pathname.endsWith("/images/generations");
+}
+
+function isCommunityImageEditsRequest(request: Request): boolean {
+    return new URL(request.url).pathname.endsWith("/images/edits");
+}
+
+beforeEach(() => {
+    resetGenerationModelRegistryCache();
+});
+
+afterEach(() => {
+    resetGenerationModelRegistryCache();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+});
+
+async function maturePendingCommunityEndpoint(id: string): Promise<void> {
+    await db
+        .update(communityEndpointTable)
+        .set({
+            pendingAt: new Date(
+                Date.now() - COMMUNITY_ENDPOINT_CHANGE_DELAY_MS - 1,
+            ),
+        })
+        .where(eq(communityEndpointTable.id, id));
+}
+
+async function createEnterCommunityApi(): Promise<Hono<Env>> {
+    const routePath =
+        "../../enter.pollinations.ai/src/routes/community-endpoints.ts";
+    const { communityEndpointsRoutes } = (await import(routePath)) as {
+        communityEndpointsRoutes: Hono;
+    };
+    return new Hono<Env>()
+        .use("*", async (c, next) => {
+            c.set("log", testLog);
+            await next();
+        })
+        .route("/api/community-endpoints", communityEndpointsRoutes)
+        .onError(handleError);
+}
+
+async function createEnterFrontendApi(): Promise<Hono<Env>> {
+    const routePath = "../../enter.pollinations.ai/src/frontend-api.ts";
+    const { frontendApi } = (await import(routePath)) as {
+        frontendApi: Hono;
+    };
+    return (
+        new Hono<Env>()
+            .use("*", async (c, next) => {
+                c.set("log", testLog);
+                await next();
+            })
+            .route("/api", frontendApi)
+            // Mirror production: enter's root app registers handleError
+            // (enter.pollinations.ai/src/index.ts), which maps ValidationError
+            // to a 400 instead of Hono's default 500.
+            .onError(handleError)
+    );
+}
+
+async function fetchEnterApi(
+    app: Hono<Env>,
+    request: Request,
+    envOverride: typeof env = env,
+): Promise<Response> {
+    const ctx = createExecutionContext();
+    return app.fetch(request, envOverride, ctx);
+}
+
+async function fetchGen(
+    input: RequestInfo | URL,
+    init?: RequestInit,
+): Promise<Response> {
+    const ctx = createExecutionContext();
+    const response = await worker.fetch(
+        new Request(input, init),
+        withInlineGenerationCoordinator(env),
+        ctx,
+    );
+    const body = response.body ? await response.arrayBuffer() : null;
+    await waitOnExecutionContext(ctx);
+    return new Response(body, response);
+}
+
+async function signedSessionCookie(token: string): Promise<string> {
+    const key = await crypto.subtle.importKey(
+        "raw",
+        new TextEncoder().encode(env.BETTER_AUTH_SECRET),
+        { name: "HMAC", hash: "SHA-256" },
+        false,
+        ["sign"],
+    );
+    const signature = await crypto.subtle.sign(
+        "HMAC",
+        key,
+        new TextEncoder().encode(token),
+    );
+    const encodedSignature = btoa(
+        String.fromCharCode(...new Uint8Array(signature)),
+    );
+    return `better-auth.session_token=${encodeURIComponent(`${token}.${encodedSignature}`)}`;
+}
+
+async function expectCommunityPortkeyRequest(
+    input: RequestInfo | URL,
+    init: RequestInit | undefined,
+    expected: {
+        customHost: string;
+        bearerToken: string;
+        upstreamModel: string;
+        body: Record<string, unknown>;
+    },
+): Promise<void> {
+    const request = new Request(input, init);
+
+    expect(isPortkeyChatCompletionsRequest(request)).toBe(true);
+    expect(request.headers.get("authorization")).toBe(
+        `Bearer ${expected.bearerToken}`,
+    );
+    expect(request.headers.get("x-portkey-provider")).toBe("openai");
+    expect(request.headers.get("x-portkey-custom-host")).toBe(
+        expected.customHost,
+    );
+    expect(request.headers.get("x-portkey-model")).toBe(expected.upstreamModel);
+    expect(request.headers.get("x-portkey-strict-open-ai-compliance")).toBe(
+        "false",
+    );
+    await expect(request.json()).resolves.toMatchObject({
+        model: expected.upstreamModel,
+        ...expected.body,
+    });
+}
+
+async function expectCommunityImageGenerationsRequest(
+    input: RequestInfo | URL,
+    init: RequestInit | undefined,
+    expected: {
+        bearerToken: string;
+        body: Record<string, unknown>;
+    },
+): Promise<void> {
+    const request = new Request(input, init);
+
+    expect(isCommunityImageGenerationsRequest(request)).toBe(true);
+    expect(request.headers.get("authorization")).toBe(
+        `Bearer ${expected.bearerToken}`,
+    );
+    expect(request.headers.get("content-type")).toContain("application/json");
+    const body = await request.json();
+    expect(body).toMatchObject(expected.body);
+    expect(body).not.toHaveProperty("response_format");
+}
+
+function isBillingFetch(request: Request): boolean {
+    return (
+        request.url.startsWith("https://api.europe-west2.gcp.tinybird.co/") ||
+        request.url.startsWith("http://localhost:7181/")
+    );
+}
+
+/** Tinybird ingest bodies are newline-delimited JSON, one row per event. */
+function parseIngestedEvents(body: string): Record<string, unknown>[] {
+    return body
+        .split("\n")
+        .filter((line) => line.trim().length > 0)
+        .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+async function createCommunityFallbackPair({
+    prefix,
+    modality = "text",
+    primaryName = "primary",
+    fallbackName = "cheap",
+    primaryPerUserRpm,
+    fallbackPerUserRpm,
+}: {
+    prefix: string;
+    modality?: CommunityEndpointModality;
+    primaryName?: string;
+    fallbackName?: string;
+    primaryPerUserRpm?: number;
+    fallbackPerUserRpm?: number;
+}) {
+    const primaryToken = "sk_primary_token";
+    const fallbackToken = "sk_fallback_token";
+    const suffix = crypto.randomUUID().slice(0, 8);
+    const primaryOwner = `${prefix}-primary-${suffix}`;
+    const fallbackOwner = `${prefix}-fallback-${suffix}`;
+    const primaryUserId = await createTestUser({
+        githubId: nextAllowedGithubId(),
+        githubUsername: primaryOwner,
+    });
+    const fallbackUserId = await createTestUser({
+        githubId: nextAllowedGithubId(),
+        githubUsername: fallbackOwner,
+    });
+    const primaryModelId = communityModelId(primaryOwner, primaryName);
+    const fallbackModelId = communityModelId(fallbackOwner, fallbackName);
+    const primaryHostname = `${prefix}-primary.example.com`;
+    const fallbackHostname = `${prefix}-fallback.example.com`;
+    const primaryHost = `https://${primaryHostname}/v1`;
+    const fallbackHost = `https://${fallbackHostname}/v1`;
+    const primaryUpstreamModel = `${primaryName}-upstream`;
+    const fallbackUpstreamModel = `${fallbackName}-upstream`;
+    const priceFields = (price: number) =>
+        modality === "image"
+            ? {
+                  promptTextPrice: 0,
+                  completionTextPrice: 0,
+                  completionImagePrice: price,
+              }
+            : { promptTextPrice: price, completionTextPrice: price };
+    const [primaryPrice, fallbackPrice] =
+        modality === "image"
+            ? [0.02, 0.01]
+            : [0.2 / 1_000_000, 0.1 / 1_000_000];
+
+    await insertCommunityEndpoints([
+        {
+            id: `endpoint-${crypto.randomUUID()}`,
+            ownerUserId: primaryUserId,
+            visibility: "public",
+            perUserRpm: primaryPerUserRpm,
+            name: primaryName,
+            modality,
+            baseUrl: primaryHost,
+            upstreamModel: primaryUpstreamModel,
+            bearerTokenCiphertext: await encryptSecret(
+                primaryToken,
+                env.BETTER_AUTH_SECRET,
+            ),
+            ...priceFields(primaryPrice),
+            fallbacks: [fallbackModelId],
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        },
+        {
+            id: `endpoint-${crypto.randomUUID()}`,
+            ownerUserId: fallbackUserId,
+            visibility: "public",
+            perUserRpm: fallbackPerUserRpm,
+            name: fallbackName,
+            modality,
+            baseUrl: fallbackHost,
+            upstreamModel: fallbackUpstreamModel,
+            bearerTokenCiphertext: await encryptSecret(
+                fallbackToken,
+                env.BETTER_AUTH_SECRET,
+            ),
+            ...priceFields(fallbackPrice),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        },
+    ]);
+
+    return {
+        primaryModelId,
+        fallbackModelId,
+        primaryHost,
+        fallbackHost,
+        primaryHostname,
+        fallbackHostname,
+        primaryUpstreamModel,
+        fallbackUpstreamModel,
+        primaryToken,
+        fallbackToken,
+    };
+}
+
+describe("community endpoint helpers", () => {
+    it("resolves pending visibility and pricing as one effective listing", () => {
+        const current: ProxyListingPayload = {
+            bearerTokenCiphertext: "current-credential",
+            paidOnly: false,
+            modality: "text",
+            imagePricing: "request",
+            inputModalities: ["text"],
+            perUserRpm: null,
+            fallbacks: ["owner/current-fallback"],
+            prices: communityEndpointPrices({ promptTextPrice: 0.1 }),
+        };
+        const pending: ProxyListingPayload = {
+            ...current,
+            bearerTokenCiphertext: "stale-credential",
+            paidOnly: true,
+            fallbacks: ["owner/stale-fallback"],
+            prices: communityEndpointPrices({ promptTextPrice: 0.2 }),
+        };
+        const pendingAt = new Date(0);
+        const state = {
+            visibility: "private" as const,
+            payload: current,
+            pendingVisibility: "public" as const,
+            pendingPayload: pending,
+            pendingAt,
+        };
+
+        const queued = resolveEffectiveProxyListing(
+            state,
+            COMMUNITY_ENDPOINT_CHANGE_DELAY_MS - 1,
+        );
+        expect(queued).toMatchObject({
+            pendingReady: false,
+            visibility: "private",
+            payload: current,
+            pending: { visibility: "public", payload: pending },
+        });
+        expect(queued.pending?.effectiveAt.getTime()).toBe(
+            COMMUNITY_ENDPOINT_CHANGE_DELAY_MS,
+        );
+
+        const effective = resolveEffectiveProxyListing(
+            state,
+            COMMUNITY_ENDPOINT_CHANGE_DELAY_MS,
+        );
+        expect(effective).toMatchObject({
+            pendingReady: true,
+            visibility: "public",
+            pending: null,
+            payload: {
+                bearerTokenCiphertext: "current-credential",
+                paidOnly: true,
+                fallbacks: ["owner/current-fallback"],
+                prices: { promptTextPrice: 0.2 },
+            },
+        });
+    });
+
+    it("parses stored proxy payloads into the canonical schema", () => {
+        const payload = parseListingPayload(
+            "proxy",
+            JSON.stringify({
+                bearerTokenCiphertext: "ciphertext",
+                modality: "image",
+                imagePricing: "request",
+                inputModalities: ["image", "image"],
+                perUserRpm: null,
+                fallbacks: ["owner/model"],
+                prices: { completionImagePrice: 0.2 },
+            }),
+        );
+
+        expect(payload).toMatchObject({
+            bearerTokenCiphertext: "ciphertext",
+            paidOnly: false,
+            modality: "image",
+            imagePricing: "request",
+            inputModalities: ["image"],
+            perUserRpm: null,
+            fallbacks: ["owner/model"],
+            prices: {
+                promptTextPrice: 0,
+                completionImagePrice: 0.2,
+                completionVideoPrice: 0,
+            },
+        });
+    });
+
+    it("rejects stored payloads that do not match their listing schema", () => {
+        expect(parseListingPayload("proxy", "not json")).toBeNull();
+        expect(
+            parseListingPayload("proxy", JSON.stringify({ prices: {} })),
+        ).toBeNull();
+        expect(
+            parseListingPayload(
+                "prompt_agent",
+                JSON.stringify({ systemPrompt: "Missing base model" }),
+            ),
+        ).toBeNull();
+        expect(
+            parseListingPayload(
+                "endpoint_agent",
+                JSON.stringify({ perUserRpm: -1 }),
+            ),
+        ).toBeNull();
+        expect(
+            parseListingPayload(
+                "proxy",
+                JSON.stringify({
+                    bearerTokenCiphertext: "ciphertext",
+                    modality: "image",
+                    imagePricing: "request",
+                    inputModalities: ["unsupported"],
+                    perUserRpm: null,
+                    fallbacks: [],
+                    prices: {},
+                }),
+            ),
+        ).toBeNull();
+    });
+
+    it("checks the community endpoint owner GitHub ID allowlist", () => {
+        expect(
+            isCommunityEndpointOwnerAllowed({
+                githubId: COMMUNITY_ENDPOINT_ALLOWED_TEST_GITHUB_ID,
+            }),
+        ).toBe(true);
+        expect(
+            isCommunityEndpointOwnerAllowed({
+                githubId: COMMUNITY_ENDPOINT_DENIED_TEST_GITHUB_ID,
+            }),
+        ).toBe(false);
+        expect(isCommunityEndpointOwnerAllowed({ githubId: 101795137 })).toBe(
+            true,
+        );
+        expect(isCommunityEndpointOwnerAllowed({ githubId: 183505255 })).toBe(
+            true,
+        );
+        expect(isCommunityEndpointOwnerAllowed({ githubId: 235942848 })).toBe(
+            false,
+        );
+        expect(isCommunityEndpointOwnerAllowed({ githubId: null })).toBe(false);
+    });
+
+    it("normalizes bearer tokens with or without the scheme", () => {
+        expect(normalizeCommunityEndpointBearerToken("sk_test")).toBe(
+            "sk_test",
+        );
+        expect(
+            normalizeCommunityEndpointBearerToken("  Bearer sk_test  "),
+        ).toBe("sk_test");
+        expect(() => normalizeCommunityEndpointBearerToken("Bearer ")).toThrow(
+            "API bearer token is required",
+        );
+    });
+
+    it("round-trips community model ids", () => {
+        const modelId = communityModelId(
+            "voodoohop",
+            "provider/path/model-name",
+        );
+        const legacyModelId = legacyCommunityModelId(
+            "voodoohop",
+            "provider/path/model-name",
+        );
+
+        expect(modelId).toBe("voodoohop/provider/path/model-name");
+        expect(legacyModelId).toBe(
+            "community/voodoohop/provider/path/model-name",
+        );
+        expect(parseCommunityModelId(modelId)).toEqual({
+            ownerGithubUsername: "voodoohop",
+            modelName: "provider/path/model-name",
+        });
+        expect(parseCommunityModelId(legacyModelId)).toEqual({
+            ownerGithubUsername: "voodoohop",
+            modelName: "provider/path/model-name",
+        });
+        expect(parseCommunityModelId("openai")).toBeNull();
+    });
+
+    it("validates endpoint URLs without rewriting them", () => {
+        const endpoint = "https://api.example.com/v1/?version=1";
+        expect(validateCommunityEndpointUrl(endpoint)).toBe(endpoint);
+        expect(communityChatCompletionsUrl("https://api.example.com/v1")).toBe(
+            "https://api.example.com/v1/chat/completions",
+        );
+        expect(communityChatCompletionsUrl(endpoint)).toBe(
+            "https://api.example.com/v1/chat/completions?version=1",
+        );
+        expect(communityImageGenerationsUrl("https://api.example.com/v1")).toBe(
+            "https://api.example.com/v1/images/generations",
+        );
+        expect(communityImageEditsUrl("https://api.example.com/v1")).toBe(
+            "https://api.example.com/v1/images/edits",
+        );
+        expect(
+            communityChatCompletionsUrl(
+                "https://api.example.com/v1/chat/completions/?version=1",
+            ),
+        ).toBe("https://api.example.com/v1/chat/completions/?version=1");
+        expect(
+            communityImageGenerationsUrl(
+                "https://api.example.com/v1/images/generations?version=1",
+            ),
+        ).toBe("https://api.example.com/v1/images/generations?version=1");
+        expect(
+            communityImageEditsUrl(
+                "https://api.example.com/v1/images/generations",
+            ),
+        ).toBe("https://api.example.com/v1/images/edits");
+        expect(
+            communityImageGenerationsUrl(
+                "https://api.example.com/v1/images/edits",
+            ),
+        ).toBe("https://api.example.com/v1/images/generations");
+        expect(
+            normalizeCommunityAssetUrl(
+                "http://api.example.com/assets/image.png#fragment",
+                "https://api.example.com/v1",
+            ),
+        ).toBe("http://api.example.com/assets/image.png");
+        expect(() =>
+            normalizeCommunityAssetUrl(
+                "http://169.254.169.254/image.png",
+                "https://api.example.com/v1",
+            ),
+        ).toThrow("Image URL cannot target a private host");
+        expect(() =>
+            normalizeCommunityAssetUrl(
+                "http://cdn.example.com/image.png",
+                "https://api.example.com/v1",
+            ),
+        ).toThrow("HTTP image URL must use the endpoint host");
+        expect(() =>
+            validateCommunityEndpointUrl("http://api.example.com/v1"),
+        ).toThrow("Endpoint URL must use https");
+        expect(() =>
+            validateCommunityEndpointUrl("https://localhost/v1"),
+        ).toThrow("Endpoint URL cannot target a private host");
+        expect(() =>
+            validateCommunityEndpointUrl(" https://api.example.com/v1 "),
+        ).toThrow("Endpoint URL cannot include surrounding whitespace");
+        expect(() =>
+            validateCommunityEndpointUrl(`${endpoint}#section`),
+        ).toThrow("Endpoint URL cannot include a fragment");
+        expect(() =>
+            validateCommunityEndpointUrl(
+                "https://user:password@api.example.com/generate",
+            ),
+        ).toThrow("Endpoint URL cannot include credentials");
+    });
+
+    it("derives the OpenAI-compatible audio transcription URL", () => {
+        expect(
+            communityAudioTranscriptionsUrl("https://api.example.com/v1"),
+        ).toBe("https://api.example.com/v1/audio/transcriptions");
+        expect(
+            communityAudioTranscriptionsUrl(
+                "https://api.example.com/v1/audio/transcriptions",
+            ),
+        ).toBe("https://api.example.com/v1/audio/transcriptions");
+    });
+
+    it("restricts community transcription models to the transcription endpoint", () => {
+        const definition = communityModelDefinition({
+            modelId: "voodoohop/transcription",
+            title: "Transcription",
+            description: null,
+            modality: "transcription",
+            ...communityEndpointPrices({}),
+        });
+        expect(definition.supportedEndpoints).toEqual([
+            "/v1/audio/transcriptions",
+        ]);
+    });
+
+    it("advertises community videos on the existing public media routes", () => {
+        expect(communityEndpointSupportedEndpoints("video", ["text"])).toEqual([
+            "/v1/images/generations",
+            "/image/{prompt}",
+            "/video/{prompt}",
+        ]);
+    });
+
+    it("normalizes public community provider URLs", () => {
+        expect(
+            normalizeCommunityProviderUrl(" https://example.com/models#top "),
+        ).toBe("https://example.com/models");
+        expect(() =>
+            normalizeCommunityProviderUrl("http://example.com"),
+        ).toThrow("Provider URL must use https");
+        expect(() =>
+            normalizeCommunityProviderUrl("https://user:pass@example.com"),
+        ).toThrow("Provider URL cannot include credentials");
+    });
+
+    it("uses the required community endpoint title", () => {
+        const modelDefinition = communityModelDefinition({
+            modelId: "voodoohop/openai",
+            title: "OpenAI Community",
+            description: "OpenAI via community endpoint",
+            ...communityEndpointPrices({
+                promptTextPrice: 0.1,
+                completionTextPrice: 0.1,
+            }),
+        });
+
+        expect(modelDefinition.title).toBe("OpenAI Community");
+        expect(modelDefinition.aliases).toEqual(["community/voodoohop/openai"]);
+        expect(modelDefinition.description).toBe(
+            "OpenAI via community endpoint",
+        );
+    });
+
+    it("carries the owner's paid-only choice onto the model definition", () => {
+        const prices = communityEndpointPrices({ promptTextPrice: 0.1 });
+
+        expect(
+            communityModelDefinition({
+                modelId: "voodoohop/openai",
+                title: "OpenAI",
+                description: null,
+                ...prices,
+            }).paidOnly,
+        ).toBe(false);
+
+        expect(
+            communityModelDefinition({
+                modelId: "voodoohop/openai",
+                title: "OpenAI",
+                description: null,
+                paidOnly: true,
+                ...prices,
+            }).paidOnly,
+        ).toBe(true);
+    });
+
+    it("prefers a stored title over the description", () => {
+        const modelDefinition = communityModelDefinition({
+            modelId: "voodoohop/openai",
+            title: "OpenAI Fast",
+            description: "OpenAI via community endpoint",
+            ...communityEndpointPrices({ promptTextPrice: 0.1 }),
+        });
+
+        expect(modelDefinition.title).toBe("OpenAI Fast");
+        // Description stays its own field so both can render independently.
+        expect(modelDefinition.description).toBe(
+            "OpenAI via community endpoint",
+        );
+    });
+
+    it("projects a provider profile onto the community model brand", () => {
+        const modelDefinition = communityModelDefinition({
+            modelId: "voodoohop/openai",
+            title: "OpenAI Fast",
+            description: null,
+            providerName: "Example AI",
+            providerUrl: "https://example.com/",
+            ...communityEndpointPrices({}),
+        });
+
+        expect(modelDefinition.brand).toBe("Example AI");
+        expect(modelDefinition.brandUrl).toBe("https://example.com/");
+    });
+
+    it("builds community image models with one fixed per-image price", () => {
+        const modelId = "voodoohop/flux";
+        const definition = communityModelDefinition({
+            modelId,
+            title: "Community Image",
+            description: "Community image model",
+            modality: "image",
+            ...communityEndpointPrices({
+                promptTextPrice: 0.2,
+                completionImagePrice: 0.03,
+            }),
+        });
+
+        expect(definition).toMatchObject({
+            category: "image",
+            inputModalities: ["text"],
+            flatRate: true,
+            cost: { completionImageTokens: 0.03 },
+        });
+        expect(definition.cost).not.toHaveProperty("promptTextTokens");
+        expect(
+            calculateUsageBilling({
+                model: modelId,
+                usage: { completionImageTokens: 1 },
+                servedBy: definition,
+            }).price.totalPrice,
+        ).toBe(0.03);
+    });
+
+    it("advertises image edits only for models with image input", () => {
+        expect(
+            communityEndpointSupportedEndpoints("image", ["text"]),
+        ).not.toContain("/v1/images/edits");
+        expect(
+            communityEndpointSupportedEndpoints("image", ["text", "image"]),
+        ).toContain("/v1/images/edits");
+    });
+
+    it("builds token-priced community image models when the probe detected usage", () => {
+        const modelId = "voodoohop/gptimage";
+        const definition = communityModelDefinition({
+            modelId,
+            title: "GPT Image",
+            description: "Token-priced image model",
+            modality: "image",
+            imagePricing: "tokens",
+            inputModalities: ["text", "image"],
+            ...communityEndpointPrices({
+                promptTextPrice: 0.000005,
+                promptImagePrice: 0.00001,
+                completionImagePrice: 0.00004,
+            }),
+        });
+
+        expect(definition).toMatchObject({
+            category: "image",
+            inputModalities: ["text", "image"],
+            flatRate: false,
+            cost: {
+                promptTextTokens: 0.000005,
+                promptImageTokens: 0.00001,
+                completionImageTokens: 0.00004,
+            },
+        });
+        expect(
+            calculateUsageBilling({
+                model: modelId,
+                usage: {
+                    promptTextTokens: 100,
+                    promptImageTokens: 0,
+                    completionImageTokens: 1000,
+                },
+                servedBy: definition,
+            }).price.totalPrice,
+        ).toBeCloseTo(0.000005 * 100 + 0.00004 * 1000, 10);
+    });
+
+    it("builds community video models billed per generated second", () => {
+        const modelId = "voodoohop/video";
+        const definition = communityModelDefinition({
+            modelId,
+            title: "Community Video",
+            description: "Community video model",
+            modality: "video",
+            inputModalities: ["text", "image", "audio", "video"],
+            ...communityEndpointPrices({ completionVideoPrice: 0.08 }),
+        });
+
+        expect(definition).toMatchObject({
+            category: "video",
+            inputModalities: ["text", "image", "audio", "video"],
+            outputModalities: ["video"],
+            cost: { completionVideoSeconds: 0.08 },
+        });
+        expect(definition).not.toHaveProperty("videoCapabilities");
+        expect(
+            calculateUsageBilling({
+                model: modelId,
+                usage: { completionVideoSeconds: 4.5 },
+                servedBy: definition,
+            }).price.totalPrice,
+        ).toBeCloseTo(0.36, 10);
+    });
+
+    it("builds token-priced community embedding models", () => {
+        const modelId = "voodoohop/bge";
+        const definition = communityModelDefinition({
+            modelId,
+            title: "Community Embedding",
+            description: "Community embedding model",
+            modality: "embedding",
+            ...communityEndpointPrices({
+                promptTextPrice: 0.00001,
+            }),
+        });
+
+        expect(definition).toMatchObject({
+            category: "embedding",
+            inputModalities: ["text"],
+            outputModalities: ["embedding"],
+            cost: { promptTextTokens: 0.00001 },
+        });
+        expect(definition).not.toHaveProperty("flatRate");
+        expect(
+            calculateUsageBilling({
+                model: modelId,
+                usage: { promptTextTokens: 1000 },
+                servedBy: definition,
+            }).price.totalPrice,
+        ).toBeCloseTo(0.00001 * 1000, 10);
+    });
+
+    it("builds the community embeddings upstream URL from the endpoint base URL", () => {
+        expect(communityEmbeddingsUrl("https://example.com/v1")).toBe(
+            "https://example.com/v1/embeddings",
+        );
+        expect(
+            communityEmbeddingsUrl("https://example.com/v1/embeddings"),
+        ).toBe("https://example.com/v1/embeddings");
+    });
+
+    it("keeps zero prices as explicit zero rates in the price definition", () => {
+        const definition = communityPriceDefinition(
+            communityEndpointPrices({ promptTextPrice: 0.5 }),
+            "text",
+        );
+
+        expect(definition.promptTextTokens).toBe(0.5);
+        expect(definition.completionTextTokens).toBe(0);
+        expect(definition).not.toHaveProperty("completionVideoSeconds");
+        // Every usage type gets an explicit rate, so billing never treats an
+        // intentionally-free bucket as a missing conversion rate.
+        expect(Object.keys(definition)).toHaveLength(
+            communityEndpointPriceFieldsForModality("text").length,
+        );
+    });
+
+    it('defaults input modalities to ["text"] when not declared', () => {
+        const definition = communityModelDefinition({
+            modelId: "voodoohop/openai",
+            title: "OpenAI Community",
+            description: "OpenAI via community endpoint",
+            ...communityEndpointPrices({
+                promptTextPrice: 0.1,
+                completionTextPrice: 0.1,
+            }),
+        });
+
+        expect(definition.inputModalities).toEqual(["text"]);
+    });
+
+    it("preserves explicitly declared input modalities", () => {
+        const definition = communityModelDefinition({
+            modelId: "marcosfrgames08/glm-4.6v-flash",
+            title: "GLM Vision",
+            description: "Vision model",
+            inputModalities: ["image", "video"],
+            ...communityEndpointPrices({
+                promptTextPrice: 0.1,
+                completionTextPrice: 0.1,
+            }),
+        });
+
+        expect(definition.inputModalities).toEqual(["image", "video"]);
+    });
+
+    it("maps owner-declared catalog metadata onto text models", () => {
+        const definition = communityModelDefinition({
+            modelId: "voodoohop/openai",
+            title: "OpenAI Community",
+            description: "OpenAI via community endpoint",
+            advertised: {
+                capabilities: ["tool_calling", "reasoning"],
+                contextLength: 128000,
+            },
+            ...communityEndpointPrices({}),
+        });
+
+        expect(definition).toMatchObject({
+            tools: true,
+            reasoning: true,
+            contextLength: 128000,
+        });
+    });
+
+    it("does not advertise text metadata after a model changes modality", () => {
+        const definition = communityModelDefinition({
+            modelId: "voodoohop/gptimage",
+            title: "GPT Image",
+            description: "Image model",
+            modality: "image",
+            advertised: {
+                capabilities: ["tool_calling", "reasoning"],
+                contextLength: 128000,
+            },
+            ...communityEndpointPrices({}),
+        });
+
+        expect(definition.tools).toBeUndefined();
+        expect(definition.reasoning).toBeUndefined();
+        expect(definition.contextLength).toBeUndefined();
+    });
+
+    it("filters inputs that image endpoints cannot accept", () => {
+        const definition = communityModelDefinition({
+            modelId: "voodoohop/gptimage",
+            title: "GPT Image",
+            description: "Image model",
+            modality: "image",
+            inputModalities: ["text", "audio"],
+            ...communityEndpointPrices({
+                promptTextPrice: 0.2,
+                completionImagePrice: 0.03,
+            }),
+        });
+
+        expect(definition.inputModalities).toEqual(["text"]);
+    });
+
+    it("builds community transcription models billed per audio second", () => {
+        const modelId = "voodoohop/whisper";
+        const definition = communityModelDefinition({
+            modelId,
+            title: "Community Transcription",
+            description: "Community transcription model",
+            modality: "transcription",
+            ...communityEndpointPrices({ promptAudioPrice: 0.0000445 }),
+        });
+
+        expect(definition).toMatchObject({
+            category: "audio",
+            inputModalities: ["audio"],
+            outputModalities: ["text"],
+            supportedEndpoints: ["/v1/audio/transcriptions"],
+            cost: { promptAudioSeconds: 0.0000445 },
+        });
+        expect(definition).not.toHaveProperty("flatRate");
+        expect(definition.cost).not.toHaveProperty("promptTextTokens");
+        expect(
+            calculateUsageBilling({
+                model: modelId,
+                usage: { promptAudioSeconds: 60 },
+                servedBy: definition,
+            }).price.totalPrice,
+        ).toBeCloseTo(0.0000445 * 60, 10);
+    });
+
+    it("keeps the transcription price as the only billed bucket for its modality", () => {
+        const definition = communityPriceDefinition(
+            communityEndpointPrices({ promptAudioPrice: 0.00002 }),
+            "transcription",
+        );
+        expect(definition).toEqual({ promptAudioSeconds: 0.00002 });
+    });
+
+    it("prices transcription audio in per-second units, not per 1M", () => {
+        const [field] =
+            communityEndpointPriceFieldsForModality("transcription");
+        expect(field).toMatchObject({
+            key: "promptAudioPrice",
+            usageType: "promptAudioSeconds",
+            priceUnit: "second",
+        });
+        expect(MAX_COMMUNITY_PRICE_PER_SECOND).toBeGreaterThan(0);
+        expect(MAX_COMMUNITY_PRICE_PER_SECOND).toBeLessThan(
+            MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS,
+        );
+    });
+
+    describe("fallback target pricing", () => {
+        const uniformPrices = (price: number) =>
+            communityEndpointPrices(
+                Object.fromEntries(
+                    COMMUNITY_ENDPOINT_PRICE_FIELDS.map((field) => [
+                        field.key,
+                        price,
+                    ]),
+                ),
+            );
+
+        it("allows an equally priced target", () => {
+            expect(
+                isCommunityFallbackPricingAllowed(
+                    uniformPrices(0.5),
+                    uniformPrices(0.5),
+                ),
+            ).toBe(true);
+        });
+
+        it("allows a target that is cheaper on every field", () => {
+            expect(
+                isCommunityFallbackPricingAllowed(
+                    uniformPrices(0.5),
+                    uniformPrices(0.25),
+                ),
+            ).toBe(true);
+        });
+
+        it("rejects a target that is more expensive on any single field", () => {
+            // Every price column, so a newly added one cannot silently escape
+            // the same-or-lower rule.
+            for (const field of COMMUNITY_ENDPOINT_PRICE_FIELDS) {
+                expect(
+                    isCommunityFallbackPricingAllowed(uniformPrices(0.5), {
+                        ...uniformPrices(0.5),
+                        [field.key]: 0.51,
+                    }),
+                ).toBe(false);
+            }
+        });
+    });
+
+    describe("community image endpoint billing", () => {
+        afterEach(() => {
+            vi.unstubAllGlobals();
+        });
+
+        const secret = "test-secret";
+        const imageParams = {
+            model: "gpt-image-1",
+            width: 1024,
+            height: 1024,
+            quality: "medium",
+            transparent: false,
+            image: [],
+        } as unknown as Parameters<typeof callCommunityImageEndpoint>[2];
+
+        async function imageEndpoint(
+            imagePricing: CommunityEndpointRuntime["imagePricing"],
+        ): Promise<CommunityEndpointRuntime> {
+            return {
+                type: "proxy",
+                id: "community-endpoint-id",
+                ownerUserId: "owner-id",
+                modelId: "voodoohop/gptimage",
+                name: "gptimage",
+                title: "GPT Image",
+                description: null,
+                modality: "image",
+                imagePricing,
+                inputModalities: null,
+                baseUrl: "https://api.example.com/v1",
+                upstreamModel: "gpt-image-1",
+                visibility: "public",
+                paidOnly: false,
+                perUserRpm: null,
+                fallbacks: [],
+                hiddenAt: null,
+                hiddenReason: null,
+                bearerTokenCiphertext: await encryptSecret(
+                    "sk_saved_token",
+                    secret,
+                ),
+                ...communityEndpointPrices({ completionImagePrice: 0.03 }),
+            };
+        }
+
+        const OPENAI_IMAGE_USAGE = {
+            input_tokens: 12,
+            output_tokens: 1056,
+            total_tokens: 1068,
+            input_tokens_details: { text_tokens: 12, image_tokens: 0 },
+        };
+
+        it("bills request-priced endpoints one image even when usage is returned", async () => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async () =>
+                    Response.json({
+                        data: [{ b64_json: "iVBORw0KGgo=" }],
+                        usage: OPENAI_IMAGE_USAGE,
+                    }),
+                ),
+            );
+
+            const result = await callCommunityImageEndpoint(
+                await imageEndpoint("request"),
+                "a sprout",
+                imageParams,
+                secret,
+            );
+            expect(result.trackingData?.usage).toEqual({
+                completionImageTokens: 1,
+            });
+        });
+
+        it("bills token-priced endpoints with the provider-returned usage", async () => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async () =>
+                    Response.json({
+                        data: [{ b64_json: "iVBORw0KGgo=" }],
+                        usage: OPENAI_IMAGE_USAGE,
+                    }),
+                ),
+            );
+
+            const result = await callCommunityImageEndpoint(
+                await imageEndpoint("tokens"),
+                "a sprout",
+                imageParams,
+                secret,
+            );
+            expect(result.trackingData?.usage).toEqual({
+                promptTextTokens: 12,
+                promptImageTokens: 0,
+                completionImageTokens: 1056,
+            });
+        });
+
+        it("fails token-priced endpoints that stop returning usage", async () => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async () =>
+                    Response.json({
+                        data: [{ b64_json: "iVBORw0KGgo=" }],
+                    }),
+                ),
+            );
+
+            await expect(
+                callCommunityImageEndpoint(
+                    await imageEndpoint("tokens"),
+                    "a sprout",
+                    imageParams,
+                    secret,
+                ),
+            ).rejects.toMatchObject({
+                status: 502,
+                message: expect.stringContaining("image token usage"),
+            });
+        });
+
+        it("forwards edits as multipart and bills provider image-token usage", async () => {
+            const fetchMock = vi.fn(async (input, init) => {
+                const request = new Request(input, init);
+                if (request.url === TEST_INPUT_IMAGE_URL) {
+                    return new Response(new Uint8Array(TEST_PNG_BYTES));
+                }
+
+                expect(request.url).toBe(
+                    "https://api.example.com/v1/images/edits",
+                );
+                expect(request.headers.get("authorization")).toBe(
+                    "Bearer sk_saved_token",
+                );
+                expect(request.headers.get("content-type")).toContain(
+                    "multipart/form-data",
+                );
+                const formData = await request.formData();
+                expect(formData.get("model")).toBe("gpt-image-1");
+                expect(formData.get("prompt")).toBe("make it blue");
+                expect(formData.get("size")).toBe("1024x1024");
+                expect(formData.get("quality")).toBe("medium");
+                expect(formData.get("image")).toBeInstanceOf(File);
+
+                return Response.json({
+                    data: [{ b64_json: TEST_PNG_BASE64 }],
+                    usage: {
+                        input_tokens: 54,
+                        output_tokens: 1056,
+                        total_tokens: 1110,
+                        input_tokens_details: {
+                            text_tokens: 12,
+                            image_tokens: 42,
+                        },
+                    },
+                });
+            });
+            vi.stubGlobal("fetch", fetchMock);
+
+            const result = await callCommunityImageEndpoint(
+                await imageEndpoint("tokens"),
+                "make it blue",
+                { ...imageParams, image: [TEST_INPUT_IMAGE_URL] },
+                secret,
+            );
+
+            expect(result.trackingData?.usage).toEqual({
+                promptTextTokens: 12,
+                promptImageTokens: 42,
+                completionImageTokens: 1056,
+            });
+            expect(fetchMock).toHaveBeenCalledTimes(2);
+        });
+
+        it("preserves an upstream unsupported-edit error", async () => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async (input, init) => {
+                    const request = new Request(input, init);
+                    if (request.url === TEST_INPUT_IMAGE_URL) {
+                        return new Response(new Uint8Array(TEST_PNG_BYTES));
+                    }
+                    return Response.json(
+                        { error: { message: "Image edits are not supported" } },
+                        { status: 405 },
+                    );
+                }),
+            );
+
+            await expect(
+                callCommunityImageEndpoint(
+                    await imageEndpoint("request"),
+                    "make it blue",
+                    { ...imageParams, image: [TEST_INPUT_IMAGE_URL] },
+                    secret,
+                ),
+            ).rejects.toMatchObject({
+                status: 405,
+                message: expect.stringContaining(
+                    "Image edits are not supported",
+                ),
+            });
+        });
+    });
+
+    describe("community video endpoint billing", () => {
+        const secret = "test-secret";
+
+        async function videoEndpoint(): Promise<CommunityEndpointRuntime> {
+            return {
+                type: "proxy",
+                id: "community-video-endpoint-id",
+                ownerUserId: "owner-id",
+                modelId: "voodoohop/video",
+                name: "video",
+                title: "Video",
+                description: null,
+                modality: "video",
+                imagePricing: "request",
+                inputModalities: ["text"],
+                baseUrl: "https://api.example.com/generate-video",
+                upstreamModel: "video-1",
+                visibility: "public",
+                paidOnly: false,
+                perUserRpm: null,
+                fallbacks: [],
+                hiddenAt: null,
+                hiddenReason: null,
+                bearerTokenCiphertext: await encryptSecret(
+                    "sk_saved_token",
+                    secret,
+                ),
+                ...communityEndpointPrices({ completionVideoPrice: 0.08 }),
+            };
+        }
+
+        it("calls the configured URL and bills the requested duration", async () => {
+            const fetchMock = vi.fn(async (input, init) => {
+                const request = new Request(input, init);
+                expect(request.url).toBe(
+                    "https://api.example.com/generate-video",
+                );
+                expect(request.headers.get("authorization")).toBe(
+                    "Bearer sk_saved_token",
+                );
+                await expect(request.json()).resolves.toEqual({
+                    prompt: "a sprout",
+                    duration: 4,
+                    image: [
+                        "https://media.example.com/start.jpg",
+                        "https://media.example.com/end.jpg",
+                    ],
+                    reference_images: ["https://media.example.com/style.jpg"],
+                    reference_videos: ["https://media.example.com/motion.mp4"],
+                    reference_audios: ["https://media.example.com/audio.mp3"],
+                });
+                return Response.json({
+                    data: [{ b64_json: TEST_MP4_BASE64 }],
+                });
+            });
+            vi.stubGlobal("fetch", fetchMock);
+
+            const result = await callCommunityVideoEndpoint(
+                await videoEndpoint(),
+                "a sprout",
+                {
+                    duration: 4,
+                    image: [
+                        "https://media.example.com/start.jpg",
+                        "https://media.example.com/end.jpg",
+                    ],
+                    reference_images: ["https://media.example.com/style.jpg"],
+                    reference_videos: ["https://media.example.com/motion.mp4"],
+                    reference_audios: ["https://media.example.com/audio.mp3"],
+                },
+                secret,
+            );
+
+            expect(result.mimeType).toBe("video/mp4");
+            expect(result.durationSeconds).toBe(4);
+            expect(result.trackingData.usage).toEqual({
+                completionVideoSeconds: 4,
+            });
+            expect(Array.from(result.buffer)).toEqual(TEST_MP4_BYTES);
+        });
+
+        it("downloads URL responses and still validates the MP4 payload", async () => {
+            const fetchMock = vi.fn(async (input, init) => {
+                const request = new Request(input, init);
+                if (request.url.endsWith("/generate-video")) {
+                    await expect(request.json()).resolves.toEqual({
+                        prompt: "a sprout",
+                        duration: 3,
+                    });
+                    return Response.json({
+                        data: [
+                            {
+                                url: "https://api.example.com/assets/clip.mp4",
+                            },
+                        ],
+                    });
+                }
+                expect(request.url).toBe(
+                    "https://api.example.com/assets/clip.mp4",
+                );
+                expect(request.redirect).toBe("manual");
+                return new Response(new Uint8Array(TEST_MP4_BYTES), {
+                    headers: { "Content-Type": "video/mp4" },
+                });
+            });
+            vi.stubGlobal("fetch", fetchMock);
+
+            const result = await callCommunityVideoEndpoint(
+                await videoEndpoint(),
+                "a sprout",
+                { duration: 3 },
+                secret,
+            );
+
+            expect(result.durationSeconds).toBe(3);
+            expect(Array.from(result.buffer)).toEqual(TEST_MP4_BYTES);
+            expect(fetchMock).toHaveBeenCalledTimes(2);
+        });
+
+        it("maps URL response stream failures to a provider error", async () => {
+            const fetchMock = vi.fn(async (input) => {
+                const url = String(input);
+                if (url.endsWith("/generate-video")) {
+                    return Response.json({
+                        data: [
+                            {
+                                url: "https://api.example.com/assets/clip.mp4",
+                            },
+                        ],
+                    });
+                }
+                return new Response(
+                    new ReadableStream({
+                        start(controller) {
+                            controller.error(
+                                new Error("upstream stream failed"),
+                            );
+                        },
+                    }),
+                );
+            });
+            vi.stubGlobal("fetch", fetchMock);
+
+            await expect(
+                callCommunityVideoEndpoint(
+                    await videoEndpoint(),
+                    "a sprout",
+                    { duration: 3 },
+                    secret,
+                ),
+            ).rejects.toMatchObject({
+                status: 502,
+                message: "Endpoint video could not be read",
+            });
+        });
+
+        it("rejects a non-MP4 payload", async () => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async () =>
+                    Response.json({
+                        data: [{ b64_json: TEST_INVALID_IMAGE_BASE64 }],
+                    }),
+                ),
+            );
+
+            await expect(
+                callCommunityVideoEndpoint(
+                    await videoEndpoint(),
+                    "a sprout",
+                    { duration: 2 },
+                    secret,
+                ),
+            ).rejects.toMatchObject({ status: 502 });
+        });
+
+        it("rejects an MP4 brand header without media boxes", async () => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async () =>
+                    Response.json({
+                        data: [{ b64_json: TEST_BARE_MP4_BASE64 }],
+                    }),
+                ),
+            );
+
+            await expect(
+                callCommunityVideoEndpoint(
+                    await videoEndpoint(),
+                    "a sprout",
+                    { duration: 2 },
+                    secret,
+                ),
+            ).rejects.toMatchObject({ status: 502 });
+        });
+
+        it("requires a request duration before calling the endpoint", async () => {
+            const fetchMock = vi.fn();
+            vi.stubGlobal("fetch", fetchMock);
+
+            await expect(
+                callCommunityVideoEndpoint(
+                    await videoEndpoint(),
+                    "a sprout",
+                    {},
+                    secret,
+                ),
+            ).rejects.toMatchObject({ status: 400 });
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+
+        it("preserves upstream video failures", async () => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async () =>
+                    Response.json(
+                        { error: { message: "GPU unavailable" } },
+                        { status: 503 },
+                    ),
+                ),
+            );
+
+            await expect(
+                callCommunityVideoEndpoint(
+                    await videoEndpoint(),
+                    "a sprout",
+                    { duration: 3 },
+                    secret,
+                ),
+            ).rejects.toMatchObject({
+                status: 503,
+                message: expect.stringContaining("GPU unavailable"),
+            });
+        });
+    });
+
+    describe("community transcription endpoint billing", () => {
+        afterEach(() => {
+            vi.unstubAllGlobals();
+        });
+
+        const secret = "test-secret";
+
+        async function transcriptionEndpoint(): Promise<CommunityEndpointRuntime> {
+            return {
+                type: "proxy",
+                id: "community-endpoint-id",
+                ownerUserId: "owner-id",
+                modelId: "voodoohop/whisper",
+                name: "whisper",
+                title: "Whisper",
+                description: null,
+                modality: "transcription",
+                imagePricing: "request",
+                inputModalities: ["audio"],
+                baseUrl: "https://api.example.com/v1",
+                upstreamModel: "whisper-1",
+                visibility: "public",
+                paidOnly: false,
+                perUserRpm: null,
+                fallbacks: [],
+                hiddenAt: null,
+                hiddenReason: null,
+                bearerTokenCiphertext: await encryptSecret(
+                    "sk_saved_token",
+                    secret,
+                ),
+                ...communityEndpointPrices({ promptAudioPrice: 0.0000445 }),
+            };
+        }
+
+        const audioFile = new File([new Uint8Array([1, 2, 3])], "sample.wav", {
+            type: "audio/wav",
+        });
+        const transcriptionOptions = {
+            file: audioFile,
+            language: "en",
+            responseFormat: "json",
+        };
+
+        it("forwards the file and bills the upstream-reported audio seconds", async () => {
+            const fetchMock = vi.fn(async (input, init) => {
+                const request = new Request(input, init);
+                expect(request.url).toBe(
+                    "https://api.example.com/v1/audio/transcriptions",
+                );
+                expect(request.headers.get("authorization")).toBe(
+                    "Bearer sk_saved_token",
+                );
+                expect(request.headers.get("content-type")).toContain(
+                    "multipart/form-data",
+                );
+                const formData = await request.formData();
+                expect(formData.get("model")).toBe("whisper-1");
+                expect(formData.get("file")).toBeInstanceOf(File);
+                expect(formData.get("language")).toBe("en");
+                expect(formData.get("response_format")).toBe("verbose_json");
+
+                return Response.json({
+                    text: "Hello world",
+                    usage: { duration: 12.5 },
+                });
+            });
+            vi.stubGlobal("fetch", fetchMock);
+
+            const response = await callCommunityTranscriptionEndpoint(
+                await transcriptionEndpoint(),
+                transcriptionOptions,
+                secret,
+            );
+
+            expect(response.status).toBe(200);
+            // The shared formatter re-emits the OpenAI json shape: the
+            // upstream's usage block is normalized to usage.seconds.
+            expect(await response.json()).toEqual({
+                text: "Hello world",
+                usage: { type: "duration", seconds: 12.5 },
+            });
+            expect(response.headers.get(MODEL_USED_HEADER)).toBe(
+                "voodoohop/whisper",
+            );
+            expect(
+                response.headers.get(USAGE_TYPE_HEADERS.promptAudioSeconds),
+            ).toBe("12.5");
+        });
+
+        it("accepts whisper-style usage.seconds", async () => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async () =>
+                    Response.json({
+                        text: "Hello",
+                        usage: { seconds: 3 },
+                    }),
+                ),
+            );
+
+            const response = await callCommunityTranscriptionEndpoint(
+                await transcriptionEndpoint(),
+                { file: audioFile },
+                secret,
+            );
+            expect(
+                response.headers.get(USAGE_TYPE_HEADERS.promptAudioSeconds),
+            ).toBe("3");
+        });
+
+        it("accepts a top-level duration, which is where whisper verbose_json puts it", async () => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async () =>
+                    Response.json({ text: "Hello", duration: 8.25 }),
+                ),
+            );
+
+            const response = await callCommunityTranscriptionEndpoint(
+                await transcriptionEndpoint(),
+                { file: audioFile },
+                secret,
+            );
+            expect(
+                response.headers.get(USAGE_TYPE_HEADERS.promptAudioSeconds),
+            ).toBe("8.25");
+        });
+
+        it("explains the verbose_json requirement when the endpoint rejects it", async () => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async () =>
+                    Response.json(
+                        { error: { message: "unsupported response_format" } },
+                        { status: 400 },
+                    ),
+                ),
+            );
+
+            const call = callCommunityTranscriptionEndpoint(
+                await transcriptionEndpoint(),
+                { file: audioFile },
+                secret,
+            );
+            await expect(call).rejects.toThrow("response_format=verbose_json");
+            await expect(call).rejects.toMatchObject({ status: 502 });
+        });
+
+        it("fails rather than billing zero when the upstream reports no duration", async () => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async () => Response.json({ text: "Hello" })),
+            );
+
+            await expect(
+                callCommunityTranscriptionEndpoint(
+                    await transcriptionEndpoint(),
+                    { file: audioFile },
+                    secret,
+                ),
+            ).rejects.toMatchObject({ status: 502 });
+        });
+
+        it("asks upstream for verbose_json even when the caller wants text, then formats down", async () => {
+            const fetchMock = vi.fn(async (input, init) => {
+                const formData = await new Request(input, init).formData();
+                // text carries no usage object, so requesting it upstream would
+                // make the request unbillable. verbose_json is what the probe
+                // verified, and where whisper reports the duration.
+                expect(formData.get("response_format")).toBe("verbose_json");
+                return Response.json({
+                    text: "Hello world",
+                    usage: { seconds: 4 },
+                });
+            });
+            vi.stubGlobal("fetch", fetchMock);
+
+            const response = await callCommunityTranscriptionEndpoint(
+                await transcriptionEndpoint(),
+                { file: audioFile, responseFormat: "text" },
+                secret,
+            );
+
+            expect(response.headers.get("content-type")).toContain(
+                "text/plain",
+            );
+            expect(await response.text()).toBe("Hello world");
+            expect(
+                response.headers.get(USAGE_TYPE_HEADERS.promptAudioSeconds),
+            ).toBe("4");
+        });
+
+        it("serves verbose_json from the metered upstream body", async () => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async () =>
+                    Response.json({
+                        text: "Hello world",
+                        language: "en",
+                        usage: { seconds: 6 },
+                    }),
+                ),
+            );
+
+            const response = await callCommunityTranscriptionEndpoint(
+                await transcriptionEndpoint(),
+                { file: audioFile, responseFormat: "verbose_json" },
+                secret,
+            );
+
+            expect(await response.json()).toMatchObject({
+                text: "Hello world",
+                task: "transcribe",
+                language: "en",
+                duration: 6,
+            });
+        });
+
+        it("serves the endpoint's own segments and words, not an invented one", async () => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async () =>
+                    Response.json({
+                        text: "Hello world. Goodbye.",
+                        language: "en",
+                        duration: 6,
+                        segments: [
+                            { id: 0, start: 0, end: 2.5, text: "Hello world." },
+                            { id: 1, start: 3, end: 5.5, text: "Goodbye." },
+                        ],
+                        words: [
+                            { word: "Hello", start: 0, end: 0.6 },
+                            { word: "world.", start: 0.6, end: 2.5 },
+                        ],
+                    }),
+                ),
+            );
+
+            const response = await callCommunityTranscriptionEndpoint(
+                await transcriptionEndpoint(),
+                { file: audioFile, responseFormat: "verbose_json" },
+                secret,
+            );
+
+            expect(await response.json()).toMatchObject({
+                segments: [
+                    { id: 0, start: 0, end: 2.5, text: "Hello world." },
+                    { id: 1, start: 3, end: 5.5, text: "Goodbye." },
+                ],
+                words: [
+                    { word: "Hello", start: 0, end: 0.6 },
+                    { word: "world.", start: 0.6, end: 2.5 },
+                ],
+            });
+        });
+
+        it("falls back to one file-spanning segment when the endpoint reports none", async () => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async () =>
+                    Response.json({ text: "Hello world", duration: 6 }),
+                ),
+            );
+
+            const response = await callCommunityTranscriptionEndpoint(
+                await transcriptionEndpoint(),
+                { file: audioFile, responseFormat: "verbose_json" },
+                secret,
+            );
+
+            expect(await response.json()).toMatchObject({
+                segments: [{ id: 0, start: 0, end: 6, text: "Hello world" }],
+                words: [],
+            });
+        });
+
+        it("skips upstream segments that are not fully timed", async () => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async () =>
+                    Response.json({
+                        text: "Hello world",
+                        duration: 6,
+                        segments: [
+                            { start: 0, end: 2, text: "Hello" },
+                            { start: 2, text: "world" },
+                            { start: 4, end: 6 },
+                        ],
+                    }),
+                ),
+            );
+
+            const response = await callCommunityTranscriptionEndpoint(
+                await transcriptionEndpoint(),
+                { file: audioFile, responseFormat: "verbose_json" },
+                secret,
+            );
+
+            expect(await response.json()).toMatchObject({
+                segments: [{ id: 0, start: 0, end: 2, text: "Hello" }],
+            });
+        });
+
+        it("rejects diarized_json rather than answering with empty segments", async () => {
+            const fetchMock = vi.fn(async () =>
+                Response.json({ text: "Hello", usage: { seconds: 1 } }),
+            );
+            vi.stubGlobal("fetch", fetchMock);
+
+            await expect(
+                callCommunityTranscriptionEndpoint(
+                    await transcriptionEndpoint(),
+                    { file: audioFile, responseFormat: "diarized_json" },
+                    secret,
+                ),
+            ).rejects.toMatchObject({ status: 400 });
+            expect(fetchMock).not.toHaveBeenCalled();
+        });
+
+        it("asks upstream for verbose_json, the shape the probe verified", async () => {
+            const fetchMock = vi.fn(async (input, init) => {
+                const formData = await new Request(input, init).formData();
+                expect(formData.get("response_format")).toBe("verbose_json");
+                return Response.json({ text: "Hello", usage: { seconds: 2 } });
+            });
+            vi.stubGlobal("fetch", fetchMock);
+
+            const response = await callCommunityTranscriptionEndpoint(
+                await transcriptionEndpoint(),
+                { file: audioFile },
+                secret,
+            );
+            expect(
+                response.headers.get(USAGE_TYPE_HEADERS.promptAudioSeconds),
+            ).toBe("2");
+        });
+
+        it("propagates upstream transcription failures", async () => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async () =>
+                    Response.json(
+                        { error: { message: "Audio file too long" } },
+                        { status: 413 },
+                    ),
+                ),
+            );
+
+            await expect(
+                callCommunityTranscriptionEndpoint(
+                    await transcriptionEndpoint(),
+                    transcriptionOptions,
+                    secret,
+                ),
+            ).rejects.toMatchObject({
+                status: 413,
+                message: expect.stringContaining("Audio file too long"),
+            });
+        });
+    });
+
+    it("builds Portkey gateway context with the saved token", async () => {
+        const secret = "test-secret";
+        const endpoint: CommunityEndpointRuntime = {
+            type: "proxy",
+            id: "community-endpoint-id",
+            ownerUserId: "owner-id",
+            modelId: "voodoohop/openai",
+            name: "openai",
+            title: "OpenAI",
+            description: null,
+            modality: "text",
+            imagePricing: "request",
+            inputModalities: null,
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "gpt-4.1-mini",
+            visibility: "public",
+            paidOnly: false,
+            perUserRpm: null,
+            fallbacks: [],
+            hiddenAt: null,
+            hiddenReason: null,
+            bearerTokenCiphertext: await encryptSecret(
+                "sk_saved_token",
+                secret,
+            ),
+            ...communityEndpointPrices({
+                promptTextPrice: 0.1,
+                completionTextPrice: 0.1,
+            }),
+        };
+        const modelDefinition = communityModelDefinition(endpoint);
+
+        const context = await communityEndpointGatewayContext({
+            endpoint,
+            modelDefinition,
+            requestData: {
+                messages: [{ role: "user", content: "hello" }],
+                max_tokens: 5,
+            },
+            secret,
+            portkeyGatewayUrl: "https://portkey.test",
+            userApiKey: "sk_user_key",
+            parentRequestId: "parent-request-id",
+        });
+
+        expect(context).toMatchObject({
+            max_tokens: 5,
+            requestedModel: endpoint.modelId,
+            portkeyGatewayUrl: "https://portkey.test",
+            userApiKey: "sk_user_key",
+            modelConfig: {
+                provider: "openai",
+                "custom-host": communityOpenAIBaseUrl(endpoint.baseUrl),
+                authKey: "sk_saved_token",
+                model: "gpt-4.1-mini",
+            },
+        });
+        expect(context.modelDef).toBe(modelDefinition);
+        expect(context).not.toHaveProperty("messages");
+    });
+
+    describe("endpoint agents", () => {
+        const secret = "test-secret";
+
+        function endpointAgent(
+            overrides: Partial<EndpointAgentCommunityEndpointRuntime> = {},
+        ): EndpointAgentCommunityEndpointRuntime {
+            return {
+                type: "endpoint_agent",
+                id: "agent-endpoint-id",
+                ownerUserId: "owner-id",
+                modelId: "voodoohop/agent",
+                name: "agent",
+                title: "Agent",
+                description: null,
+                modality: "text",
+                imagePricing: "request",
+                inputModalities: null,
+                baseUrl: "https://agent.example.com/v1",
+                upstreamModel: "agent",
+                visibility: "public",
+                paidOnly: false,
+                perUserRpm: null,
+                hiddenAt: null,
+                hiddenReason: null,
+                fallbacks: [],
+                ...communityEndpointPrices({}),
+                ...overrides,
+            };
+        }
+
+        async function contextFor(
+            endpoint: CommunityEndpointRuntime,
+            parentApiKeyId?: string,
+            parentRequestId = "parent-request-id",
+        ) {
+            return communityEndpointGatewayContext({
+                endpoint,
+                modelDefinition: communityModelDefinition(endpoint),
+                requestData: {
+                    messages: [{ role: "user", content: "make a video" }],
+                },
+                secret,
+                portkeyGatewayUrl: "https://portkey.test",
+                userApiKey: "sk_user_key",
+                parentRequestId,
+                parentApiKeyId,
+            });
+        }
+
+        it("authenticates as a run token, not the caller's key", async () => {
+            const endpoint = endpointAgent();
+            const context = await contextFor(endpoint, "parent-key-id");
+
+            const token = String(context.modelConfig?.authKey);
+            expect(token).toMatch(/^ag_/);
+            expect(token).not.toContain("sk_user_key");
+
+            const claims = await verifyAgentRunToken(token, secret);
+            expect(claims).toMatchObject({ parentApiKeyId: "parent-key-id" });
+        });
+
+        it("carries the parent request id so a run's generations can be grouped", async () => {
+            const endpoint = endpointAgent();
+            const context = await contextFor(
+                endpoint,
+                "parent-key-id",
+                "req-abc",
+            );
+
+            const claims = await verifyAgentRunToken(
+                String(context.modelConfig?.authKey),
+                secret,
+            );
+            expect(claims.parentRequestId).toBe("req-abc");
+
+            // Fallback attempts share the parent request but still receive
+            // distinct signed credentials.
+            const second = await contextFor(
+                endpoint,
+                "parent-key-id",
+                "req-abc",
+            );
+            const secondClaims = await verifyAgentRunToken(
+                String(second.modelConfig?.authKey),
+                secret,
+            );
+            expect(secondClaims.parentRequestId).toBe("req-abc");
+            expect(String(second.modelConfig?.authKey)).not.toBe(
+                String(context.modelConfig?.authKey),
+            );
+        });
+
+        // The complement of the test above, and the reason an agent listing
+        // has nowhere to store a credential: only a proxy sends one.
+        it("sends a proxy listing's saved bearer, never a run token", async () => {
+            const { type: _type, ...base } = endpointAgent();
+            const endpoint: CommunityEndpointRuntime = {
+                ...base,
+                type: "proxy",
+                bearerTokenCiphertext: await encryptSecret(
+                    "sk_saved_token",
+                    secret,
+                ),
+            };
+            const context = await contextFor(endpoint, "parent-key-id");
+            expect(context.modelConfig?.authKey).toBe("sk_saved_token");
+        });
+
+        it("always scopes managed agents to their listing id", async () => {
+            const { type: _type, ...base } = endpointAgent();
+            const endpoint: CommunityEndpointRuntime = {
+                ...base,
+                id: "managed-agent-id",
+                type: "prompt_agent",
+                upstreamModel: "managed-agent-id",
+            };
+            const context = await contextFor(endpoint, "parent-key-id");
+            const token = String(context.modelConfig?.authKey);
+            const claims = await verifyAgentRunToken(token, secret);
+            expect(claims).toMatchObject({
+                parentApiKeyId: "parent-key-id",
+                parentRequestId: "parent-request-id",
+                managedAgentId: "managed-agent-id",
+            });
+        });
+
+        it("refuses to delegate when there is no key to bill", async () => {
+            const endpoint = endpointAgent();
+            await expect(contextFor(endpoint, undefined)).rejects.toThrow(
+                "no API key to bill",
+            );
+        });
+
+        it("refuses to delegate from an endpoint that charges a price", async () => {
+            const endpoint = endpointAgent({
+                ...communityEndpointPrices({ promptTextPrice: 0.1 }),
+            });
+            await expect(contextFor(endpoint, "parent-key-id")).rejects.toThrow(
+                "is not free",
+            );
+        });
+    });
+});
+
+fixtureTest(
+    "routes chat completions through a registered community endpoint with its saved token",
+    async ({ apiKey }) => {
+        const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;
+        const modelName = `openai-${crypto.randomUUID().slice(0, 8)}`;
+        const modelId = communityModelId(ownerGithubUsername, modelName);
+        const ownerUserId = await createTestUser({
+            githubId: nextAllowedGithubId(),
+            githubUsername: ownerGithubUsername,
+        });
+        await insertCommunityEndpoints({
+            id: `endpoint-${crypto.randomUUID()}`,
+            ownerUserId,
+            visibility: "public",
+            name: modelName,
+            description: "OpenAI via community endpoint",
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "gpt-4.1-mini",
+            bearerTokenCiphertext: await encryptSecret(
+                "Bearer sk_saved_token",
+                env.BETTER_AUTH_SECRET,
+            ),
+            promptTextPrice: 0.1,
+            completionTextPrice: 0.1,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+
+        const fetchMock = vi.fn(async (input, init) => {
+            const request = new Request(input, init);
+
+            if (isPortkeyChatCompletionsRequest(request)) {
+                await expectCommunityPortkeyRequest(input, init, {
+                    customHost: "https://api.example.com/v1",
+                    bearerToken: "sk_saved_token",
+                    upstreamModel: "gpt-4.1-mini",
+                    body: {
+                        messages: [{ role: "user", content: "hello" }],
+                        max_tokens: 5,
+                        stream: false,
+                    },
+                });
+
+                return Response.json({
+                    id: "chatcmpl_test",
+                    object: "chat.completion",
+                    // The upstream names itself, as a real provider does. Our
+                    // id has to win over it, or a community model is recorded
+                    // under whatever its owner happens to proxy.
+                    model: "gpt-4.1-mini",
+                    choices: [
+                        {
+                            index: 0,
+                            message: { role: "assistant", content: "ok" },
+                            finish_reason: "stop",
+                        },
+                    ],
+                    usage: {
+                        prompt_tokens: 2,
+                        completion_tokens: 3,
+                        total_tokens: 5,
+                    },
+                });
+            }
+
+            if (isBillingFetch(request)) {
+                return Response.json({ data: [] });
+            }
+
+            throw new Error(`Unexpected fetch: ${request.url}`);
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const response = await fetchGen(
+            new Request("https://gen.pollinations.ai/v1/chat/completions", {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${apiKey}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    model: modelId,
+                    messages: [{ role: "user", content: "hello" }],
+                    max_tokens: 5,
+                }),
+            }),
+        );
+
+        expect(response.status).toBe(200);
+        // Billing and analytics read the header, and it names OUR model even
+        // though the upstream called itself something else.
+        expect(response.headers.get("x-model-used")).toBe(modelId);
+        const body = await response.json();
+        // The OpenAI-compatible body still echoes the upstream's own name,
+        // which is what a provider's response carries. It disagrees with the
+        // header on purpose today; see the follow-up issue on aligning them.
+        expect(body).toMatchObject({
+            model: "gpt-4.1-mini",
+            choices: [{ message: { content: "ok" } }],
+            usage: { prompt_tokens: 2, completion_tokens: 3, total_tokens: 5 },
+        });
+
+        const legacyResponse = await fetchGen(
+            new Request("https://gen.pollinations.ai/v1/chat/completions", {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${apiKey}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    model: legacyCommunityModelId(
+                        ownerGithubUsername,
+                        modelName,
+                    ),
+                    messages: [{ role: "user", content: "hello" }],
+                    max_tokens: 5,
+                }),
+            }),
+        );
+        expect(legacyResponse.status).toBe(200);
+        const legacyBody = await legacyResponse.json();
+        expect(legacyBody).toMatchObject({
+            model: "gpt-4.1-mini",
+            choices: [{ message: { content: "ok" } }],
+        });
+
+        const upstreamCalls = fetchMock.mock.calls.filter(([input, init]) =>
+            isPortkeyChatCompletionsRequest(new Request(input, init)),
+        );
+        expect(upstreamCalls).toHaveLength(2);
+    },
+);
+
+fixtureTest(
+    "a private model is owner-only and a zero-priced public model is free for funded callers",
+    async ({ apiKey }) => {
+        const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;
+        const modelName = `private-${crypto.randomUUID().slice(0, 8)}`;
+        const modelId = communityModelId(ownerGithubUsername, modelName);
+        const endpointId = `endpoint-${crypto.randomUUID()}`;
+        const ownerUserId = await createTestUser({
+            githubId: nextAllowedGithubId(),
+            githubUsername: ownerGithubUsername,
+            // Owner-only private models have no Pollinations charge, but every
+            // request still needs a positive balance in some bucket.
+            tierBalance: 1,
+        });
+        // A key belonging to the endpoint owner — its calls are owner calls.
+        const { key: ownerApiKey } = await createTestApiKey({
+            name: "owner-key",
+            userId: ownerUserId,
+        });
+        await insertCommunityEndpoints({
+            id: endpointId,
+            ownerUserId,
+            visibility: "private",
+            name: modelName,
+            description: "Private community endpoint",
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "gpt-4.1-mini",
+            bearerTokenCiphertext: await encryptSecret(
+                "Bearer sk_saved_token",
+                env.BETTER_AUTH_SECRET,
+            ),
+            // A private endpoint is free (billed to its owner); prices are 0.
+            promptTextPrice: 0,
+            completionTextPrice: 0,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+
+        const fetchMock = vi.fn(async (input, init) => {
+            const request = new Request(input, init);
+            if (isPortkeyChatCompletionsRequest(request)) {
+                return Response.json({
+                    id: "chatcmpl_private",
+                    object: "chat.completion",
+                    model: "gpt-4.1-mini",
+                    choices: [
+                        {
+                            index: 0,
+                            message: { role: "assistant", content: "ok" },
+                            finish_reason: "stop",
+                        },
+                    ],
+                    usage: {
+                        prompt_tokens: 2,
+                        completion_tokens: 3,
+                        total_tokens: 5,
+                    },
+                });
+            }
+            if (isBillingFetch(request)) return Response.json({ data: [] });
+            throw new Error(`Unexpected fetch: ${request.url}`);
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        // A non-owner caller: the private model resolves to "invalid model",
+        // indistinguishable from an unknown name so it isn't discoverable.
+        const otherResponse = await fetchGen(
+            new Request("https://gen.pollinations.ai/v1/chat/completions", {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${apiKey}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    model: modelId,
+                    messages: [{ role: "user", content: "hello" }],
+                }),
+            }),
+        );
+        expect(otherResponse.status).toBe(400);
+
+        // The owner reaches their own private model.
+        const ownerResponse = await fetchGen(
+            new Request("https://gen.pollinations.ai/v1/chat/completions", {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${ownerApiKey}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    model: modelId,
+                    messages: [{ role: "user", content: "hello" }],
+                }),
+            }),
+        );
+        expect(ownerResponse.status).toBe(200);
+        await expect(ownerResponse.json()).resolves.toMatchObject({
+            choices: [{ message: { content: "ok" } }],
+        });
+
+        const catalogIncludesModel = async (authorization?: string) => {
+            const modelsResponse = await fetchGen(
+                new Request("https://gen.pollinations.ai/text/models", {
+                    headers: authorization
+                        ? { Authorization: `Bearer ${authorization}` }
+                        : undefined,
+                }),
+            );
+            expect(modelsResponse.status).toBe(200);
+            const models = (await modelsResponse.json()) as { name: string }[];
+            return models.some((model) => model.name === modelId);
+        };
+
+        // The owner's authenticated catalog includes the private model, while
+        // anonymous and other authenticated callers cannot discover it.
+        await expect(catalogIncludesModel(ownerApiKey)).resolves.toBe(true);
+        await expect(catalogIncludesModel(apiKey)).resolves.toBe(false);
+        await expect(catalogIncludesModel()).resolves.toBe(false);
+
+        // Publishing the same zero-priced endpoint makes it globally callable.
+        // It is never charged, but preflight still requires a positive balance
+        // in some bucket, so an empty wallet is rejected before the call.
+        await db
+            .update(communityEndpointTable)
+            .set({ visibility: "public" })
+            .where(eq(communityEndpointTable.id, endpointId));
+        resetGenerationModelRegistryCache();
+        const callFreePublicModel = async (callerKey: string) =>
+            fetchGen(
+                new Request("https://gen.pollinations.ai/v1/chat/completions", {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${callerKey}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({
+                        model: modelId,
+                        messages: [{ role: "user", content: "free public" }],
+                    }),
+                }),
+            );
+        const { key: zeroBalanceCallerKey } = await createTestApiKey({
+            user: { tierBalance: 0, packBalance: 0 },
+        });
+        expect((await callFreePublicModel(zeroBalanceCallerKey)).status).toBe(
+            402,
+        );
+        const { key: fundedCallerKey } = await createTestApiKey({
+            user: { tierBalance: 1, packBalance: 0 },
+        });
+        const freePublicResponse = await callFreePublicModel(fundedCallerKey);
+        expect(freePublicResponse.status).toBe(200);
+        await expect(freePublicResponse.json()).resolves.toMatchObject({
+            choices: [{ message: { content: "ok" } }],
+        });
+    },
+);
+
+fixtureTest(
+    "streams chat completions through a registered community endpoint",
+    async ({ apiKey }) => {
+        const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;
+        const modelName = `stream-${crypto.randomUUID().slice(0, 8)}`;
+        const modelId = communityModelId(ownerGithubUsername, modelName);
+        const ownerUserId = await createTestUser({
+            githubId: nextAllowedGithubId(),
+            githubUsername: ownerGithubUsername,
+        });
+        await insertCommunityEndpoints({
+            id: `endpoint-${crypto.randomUUID()}`,
+            ownerUserId,
+            visibility: "public",
+            name: modelName,
+            description: "Streaming community endpoint",
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "gpt-4.1-mini",
+            bearerTokenCiphertext: await encryptSecret(
+                "sk_saved_token",
+                env.BETTER_AUTH_SECRET,
+            ),
+            promptTextPrice: 0.1,
+            completionTextPrice: 0.1,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async (input, init) => {
+                const request = new Request(input, init);
+
+                if (isPortkeyChatCompletionsRequest(request)) {
+                    await expectCommunityPortkeyRequest(input, init, {
+                        customHost: "https://api.example.com/v1",
+                        bearerToken: "sk_saved_token",
+                        upstreamModel: "gpt-4.1-mini",
+                        body: {
+                            messages: [{ role: "user", content: "hello" }],
+                            max_tokens: 5,
+                            stream: true,
+                            stream_options: { include_usage: true },
+                        },
+                    });
+
+                    return new Response(
+                        [
+                            'data: {"id":"upstream","object":"chat.completion.chunk","created":1,"model":"gpt-4.1-mini","choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null}]}',
+                            "",
+                            'data: {"id":"upstream","object":"chat.completion.chunk","created":1,"model":"gpt-4.1-mini","choices":[],"usage":{"prompt_tokens":999,"completion_tokens":999,"total_tokens":1998}}',
+                            "",
+                            "data: [DONE]",
+                            "",
+                        ].join("\n"),
+                        {
+                            headers: {
+                                "Content-Type": "text/event-stream",
+                            },
+                        },
+                    );
+                }
+
+                if (isBillingFetch(request)) {
+                    return Response.json({ data: [] });
+                }
+
+                throw new Error(`Unexpected fetch: ${request.url}`);
+            }),
+        );
+
+        const response = await fetchGen(
+            new Request("https://gen.pollinations.ai/v1/chat/completions", {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${apiKey}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    model: modelId,
+                    messages: [{ role: "user", content: "hello" }],
+                    max_tokens: 5,
+                    stream: true,
+                }),
+            }),
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("content-type")).toContain(
+            "text/event-stream",
+        );
+        const body = await response.text();
+        expect(body).toContain('"model":"gpt-4.1-mini"');
+        expect(body).not.toContain(`"model":"${modelId}"`);
+        expect(body).toContain('"prompt_tokens":999');
+        expect(body).toContain('"completion_tokens":999');
+    },
+);
+
+fixtureTest(
+    "routes simple text requests through a registered community endpoint",
+    async ({ apiKey }) => {
+        const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;
+        const modelName = `simple-${crypto.randomUUID().slice(0, 8)}`;
+        const modelId = communityModelId(ownerGithubUsername, modelName);
+        const ownerUserId = await createTestUser({
+            githubId: nextAllowedGithubId(),
+            githubUsername: ownerGithubUsername,
+        });
+        await insertCommunityEndpoints({
+            id: `endpoint-${crypto.randomUUID()}`,
+            ownerUserId,
+            visibility: "public",
+            name: modelName,
+            description: "Simple text community endpoint",
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "gpt-4.1-mini",
+            bearerTokenCiphertext: await encryptSecret(
+                "sk_saved_token",
+                env.BETTER_AUTH_SECRET,
+            ),
+            promptTextPrice: 0.1,
+            completionTextPrice: 0.1,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async (input, init) => {
+                const request = new Request(input, init);
+
+                if (isPortkeyChatCompletionsRequest(request)) {
+                    await expectCommunityPortkeyRequest(input, init, {
+                        customHost: "https://api.example.com/v1",
+                        bearerToken: "sk_saved_token",
+                        upstreamModel: "gpt-4.1-mini",
+                        body: {
+                            messages: [{ role: "user", content: "hello" }],
+                            max_tokens: 5,
+                            stream: false,
+                        },
+                    });
+
+                    return Response.json({
+                        id: "chatcmpl_simple",
+                        object: "chat.completion",
+                        model: "gpt-4.1-mini",
+                        choices: [
+                            {
+                                index: 0,
+                                message: {
+                                    role: "assistant",
+                                    content: "simple ok",
+                                },
+                                finish_reason: "stop",
+                            },
+                        ],
+                        usage: {
+                            prompt_tokens: 2,
+                            completion_tokens: 3,
+                            total_tokens: 5,
+                        },
+                    });
+                }
+
+                if (isBillingFetch(request)) {
+                    return Response.json({ data: [] });
+                }
+
+                throw new Error(`Unexpected fetch: ${request.url}`);
+            }),
+        );
+
+        const response = await fetchGen(
+            new Request(
+                `https://gen.pollinations.ai/text/hello?model=${encodeURIComponent(
+                    modelId,
+                )}&max_tokens=5&stream=false`,
+                {
+                    headers: {
+                        Authorization: `Bearer ${apiKey}`,
+                    },
+                },
+            ),
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("cache-control")).toBe(
+            IMMUTABLE_CACHE_CONTROL,
+        );
+        expect(response.headers.get("x-cache")).toBe("HIT");
+        expect(response.headers.get("x-cache-type")).toBeNull();
+        expect(response.headers.get("x-cache-key")).toBeTruthy();
+        await expect(response.text()).resolves.toBe("simple ok");
+    },
+);
+
+fixtureTest(
+    "lists registered community endpoints in public model catalogs",
+    async () => {
+        const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;
+        const modelName = `catalog-${crypto.randomUUID().slice(0, 8)}`;
+        const modelId = communityModelId(ownerGithubUsername, modelName);
+        const ownerUserId = await createTestUser({
+            githubId: nextAllowedGithubId(),
+            githubUsername: ownerGithubUsername,
+        });
+        await insertCommunityEndpoints({
+            id: `endpoint-${crypto.randomUUID()}`,
+            ownerUserId,
+            visibility: "public",
+            name: modelName,
+            title: "Public community model",
+            description: "Public community model",
+            perUserRpm: 0.5,
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "gpt-4.1-mini",
+            bearerTokenCiphertext: await encryptSecret(
+                "sk_saved_token",
+                env.BETTER_AUTH_SECRET,
+            ),
+            promptTextPrice: 0.1 / 1_000_000,
+            completionTextPrice: 0.2 / 1_000_000,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+
+        const textResponse = await fetchGen(
+            "https://gen.pollinations.ai/text/models",
+        );
+        const allResponse = await fetchGen(
+            "https://gen.pollinations.ai/models",
+        );
+        const openaiResponse = await fetchGen(
+            "https://gen.pollinations.ai/v1/models",
+        );
+
+        expect(textResponse.status).toBe(200);
+        expect(allResponse.status).toBe(200);
+        expect(openaiResponse.status).toBe(200);
+
+        const textModels = (await textResponse.json()) as {
+            name: string;
+            aliases?: string[];
+            category?: string;
+            community?: boolean;
+            per_user_rpm?: number | null;
+            alpha?: boolean;
+            description?: string;
+            pricing?: Record<string, string>;
+            baseUrl?: string;
+            bearerTokenCiphertext?: string;
+        }[];
+        const allModels = (await allResponse.json()) as typeof textModels;
+        const openaiModels = (await openaiResponse.json()) as {
+            data: {
+                id: string;
+                supported_endpoints?: string[];
+                per_user_rpm?: number | null;
+            }[];
+        };
+
+        for (const models of [textModels, allModels]) {
+            const listed = models.find((model) => model.name === modelId);
+            expect(listed).toMatchObject({
+                name: modelId,
+                aliases: [
+                    legacyCommunityModelId(ownerGithubUsername, modelName),
+                ],
+                category: "text",
+                community: true,
+                per_user_rpm: 0.5,
+                alpha: true,
+                title: "Public community model",
+                description: "Public community model",
+                pricing: {
+                    currency: "pollen",
+                    promptTextTokens: "0.0000001",
+                    completionTextTokens: "0.0000002",
+                },
+            });
+            expect(listed).not.toHaveProperty("baseUrl");
+            expect(listed).not.toHaveProperty("bearerTokenCiphertext");
+            expect(listed).not.toHaveProperty("agent");
+        }
+
+        expect(openaiModels.data).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    id: modelId,
+                    per_user_rpm: 0.5,
+                    supported_endpoints: expect.arrayContaining([
+                        "/v1/chat/completions",
+                    ]),
+                }),
+            ]),
+        );
+    },
+);
+
+fixtureTest(
+    "orders every model catalog for practical discovery",
+    async ({ restrictedApiKey }) => {
+        const ownerGithubUsername = `order-${crypto.randomUUID().slice(0, 8)}`;
+        const ownerUserId = await createTestUser({
+            githubId: nextAllowedGithubId(),
+            githubUsername: ownerGithubUsername,
+        });
+        const newestDate = new Date("2100-01-02T00:00:00Z");
+        const tiedDate = new Date("2100-01-01T00:00:00Z");
+        for (const [name, createdAt] of [
+            ["newest", newestDate],
+            ["a-tie", tiedDate],
+            ["b-tie", tiedDate],
+        ] as const) {
+            await insertCommunityEndpoints({
+                id: `endpoint-${crypto.randomUUID()}`,
+                ownerUserId,
+                visibility: "public",
+                name,
+                description: `Ordering test ${name}`,
+                baseUrl: "https://api.example.com/v1",
+                upstreamModel: "gpt-4.1-mini",
+                bearerTokenCiphertext: await encryptSecret(
+                    "sk_saved_token",
+                    env.BETTER_AUTH_SECRET,
+                ),
+                promptTextPrice: 0,
+                completionTextPrice: 0,
+                createdAt,
+                updatedAt: createdAt,
+            });
+        }
+
+        const [allResponse, openaiResponse, textResponse, restrictedResponse] =
+            await Promise.all([
+                fetchGen("https://gen.pollinations.ai/models"),
+                fetchGen("https://gen.pollinations.ai/v1/models"),
+                fetchGen("https://gen.pollinations.ai/text/models"),
+                fetchGen("https://gen.pollinations.ai/models", {
+                    headers: {
+                        Authorization: `Bearer ${restrictedApiKey}`,
+                    },
+                }),
+            ]);
+
+        expect(allResponse.status).toBe(200);
+        expect(openaiResponse.status).toBe(200);
+        expect(textResponse.status).toBe(200);
+        expect(restrictedResponse.status).toBe(200);
+
+        type ListedModel = {
+            name: string;
+            category: string;
+            community?: boolean;
+            alpha?: boolean;
+            added_date?: number;
+        };
+        const allModels = (await allResponse.json()) as ListedModel[];
+        const openaiModels = (await openaiResponse.json()) as {
+            data: { id: string }[];
+        };
+        const textModels = (await textResponse.json()) as ListedModel[];
+        const restrictedModels =
+            (await restrictedResponse.json()) as ListedModel[];
+        const officialModels = allModels.filter((model) => !model.community);
+        const communityModels = allModels.filter((model) => model.community);
+        const allNames = allModels.map((model) => model.name);
+
+        expect(allNames).toEqual(openaiModels.data.map((model) => model.id));
+        expect(textModels.map((model) => model.name)).toEqual(
+            allModels
+                .filter((model) => model.category === "text")
+                .map((model) => model.name),
+        );
+        expect(allNames).toEqual([
+            ...officialModels.map((model) => model.name),
+            ...communityModels.map((model) => model.name),
+        ]);
+
+        const categoryOrder = [
+            "text",
+            "image",
+            "video",
+            "3d",
+            "audio",
+            "realtime",
+            "embedding",
+        ];
+        expect([
+            ...new Set(officialModels.map((model) => model.category)),
+        ]).toEqual(
+            categoryOrder.filter((category) =>
+                officialModels.some((model) => model.category === category),
+            ),
+        );
+
+        const defaults: Record<string, string> = {
+            text: DEFAULT_TEXT_MODEL,
+            image: DEFAULT_IMAGE_MODEL,
+            "3d": DEFAULT_3D_MODEL,
+            audio: DEFAULT_AUDIO_MODEL,
+            realtime: DEFAULT_REALTIME_MODEL,
+            embedding: DEFAULT_EMBEDDING_MODEL,
+        };
+        for (const category of categoryOrder) {
+            const models = officialModels.filter(
+                (model) => model.category === category,
+            );
+            const defaultModel = defaults[category];
+            if (defaultModel !== undefined) {
+                expect(models[0]?.name).toBe(defaultModel);
+            }
+            const remainingModels =
+                defaultModel === undefined ? models : models.slice(1);
+            expect(remainingModels).toEqual(
+                [...remainingModels].sort(
+                    (left, right) =>
+                        Number(left.alpha === true) -
+                            Number(right.alpha === true) ||
+                        (right.added_date ?? 0) - (left.added_date ?? 0) ||
+                        (left.name < right.name
+                            ? -1
+                            : left.name > right.name
+                              ? 1
+                              : 0),
+                ),
+            );
+        }
+
+        expect(communityModels.slice(0, 3)).toMatchObject([
+            {
+                name: communityModelId(ownerGithubUsername, "newest"),
+                added_date: newestDate.getTime(),
+            },
+            {
+                name: communityModelId(ownerGithubUsername, "a-tie"),
+                added_date: tiedDate.getTime(),
+            },
+            {
+                name: communityModelId(ownerGithubUsername, "b-tie"),
+                added_date: tiedDate.getTime(),
+            },
+        ]);
+
+        const restrictedNames = restrictedModels.map((model) => model.name);
+        expect(restrictedNames).toEqual(
+            allNames.filter((name) => restrictedNames.includes(name)),
+        );
+    },
+);
+
+fixtureTest(
+    "excludes a hidden community model from public model catalogs",
+    async () => {
+        const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;
+        const modelName = `disabled-${crypto.randomUUID().slice(0, 8)}`;
+        const modelId = communityModelId(ownerGithubUsername, modelName);
+        const ownerUserId = await createTestUser({
+            githubId: nextAllowedGithubId(),
+            githubUsername: ownerGithubUsername,
+        });
+        await insertCommunityEndpoints({
+            id: `endpoint-${crypto.randomUUID()}`,
+            ownerUserId,
+            visibility: "public",
+            name: modelName,
+            description: "Hidden community model",
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "gpt-4.1-mini",
+            bearerTokenCiphertext: await encryptSecret(
+                "sk_saved_token",
+                env.BETTER_AUTH_SECRET,
+            ),
+            promptTextPrice: 0.1 / 1_000_000,
+            completionTextPrice: 0.2 / 1_000_000,
+            hiddenAt: new Date(),
+            hiddenReason: "repeated upstream 500s",
+            hiddenBy: "monitor",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+
+        const textResponse = await fetchGen(
+            "https://gen.pollinations.ai/text/models",
+        );
+        const allResponse = await fetchGen(
+            "https://gen.pollinations.ai/models",
+        );
+        const openaiResponse = await fetchGen(
+            "https://gen.pollinations.ai/v1/models",
+        );
+
+        const textModels = (await textResponse.json()) as { name: string }[];
+        const allModels = (await allResponse.json()) as typeof textModels;
+        const openaiModels = (await openaiResponse.json()) as {
+            data: { id: string }[];
+        };
+
+        for (const models of [textModels, allModels]) {
+            expect(
+                models.find((model) => model.name === modelId),
+            ).toBeUndefined();
+        }
+        expect(
+            openaiModels.data.find((model) => model.id === modelId),
+        ).toBeUndefined();
+    },
+);
+
+fixtureTest(
+    "filters model catalogs with ?community query parameter",
+    async () => {
+        const suffix = crypto.randomUUID().slice(0, 8);
+        const textOwner = `filter-text-${suffix}`;
+        const imageOwner = `filter-img-${suffix}`;
+        const textName = `qp-text-${suffix}`;
+        const imageName = `qp-img-${suffix}`;
+        const textModelId = communityModelId(textOwner, textName);
+        const imageModelId = communityModelId(imageOwner, imageName);
+
+        const textUserId = await createTestUser({
+            githubId: nextAllowedGithubId(),
+            githubUsername: textOwner,
+        });
+        const imageUserId = await createTestUser({
+            githubId: nextAllowedGithubId(),
+            githubUsername: imageOwner,
+        });
+
+        await insertCommunityEndpoints([
+            {
+                id: `endpoint-${crypto.randomUUID()}`,
+                ownerUserId: textUserId,
+                visibility: "public",
+                name: textName,
+                description: "Community text filter test model",
+                baseUrl: "https://api.example.com/v1",
+                upstreamModel: "gpt-4.1-mini",
+                bearerTokenCiphertext: await encryptSecret(
+                    "sk_saved_token",
+                    env.BETTER_AUTH_SECRET,
+                ),
+                promptTextPrice: 0,
+                completionTextPrice: 0,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            },
+            {
+                id: `endpoint-${crypto.randomUUID()}`,
+                ownerUserId: imageUserId,
+                visibility: "public",
+                name: imageName,
+                description: "Community image filter test model",
+                modality: "image",
+                baseUrl: "https://img.example.com/v1",
+                upstreamModel: "flux-1",
+                bearerTokenCiphertext: await encryptSecret(
+                    "sk_saved_token",
+                    env.BETTER_AUTH_SECRET,
+                ),
+                promptTextPrice: 0,
+                completionTextPrice: 0,
+                completionImagePrice: 0.01,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            },
+        ]);
+
+        type ListedModel = { name: string; community?: boolean };
+
+        const [
+            allDefault,
+            allExclude,
+            allOnly,
+            textExclude,
+            textOnly,
+            openaiExclude,
+            openaiOnly,
+            imageExclude,
+            imageOnly,
+            allExcludeNumeric,
+            allOnlyNumeric,
+        ] = await Promise.all([
+            SELF.fetch("https://gen.pollinations.ai/models"),
+            SELF.fetch("https://gen.pollinations.ai/models?community=false"),
+            SELF.fetch("https://gen.pollinations.ai/models?community=true"),
+            SELF.fetch(
+                "https://gen.pollinations.ai/text/models?community=false",
+            ),
+            SELF.fetch(
+                "https://gen.pollinations.ai/text/models?community=true",
+            ),
+            SELF.fetch("https://gen.pollinations.ai/v1/models?community=false"),
+            SELF.fetch("https://gen.pollinations.ai/v1/models?community=true"),
+            SELF.fetch(
+                "https://gen.pollinations.ai/image/models?community=false",
+            ),
+            SELF.fetch(
+                "https://gen.pollinations.ai/image/models?community=true",
+            ),
+            SELF.fetch("https://gen.pollinations.ai/models?community=0"),
+            SELF.fetch("https://gen.pollinations.ai/models?community=1"),
+        ]);
+
+        for (const r of [
+            allDefault,
+            allExclude,
+            allOnly,
+            textExclude,
+            textOnly,
+            openaiExclude,
+            openaiOnly,
+            imageExclude,
+            imageOnly,
+            allExcludeNumeric,
+            allOnlyNumeric,
+        ]) {
+            expect(r.status).toBe(200);
+        }
+
+        const defaultModels = (await allDefault.json()) as ListedModel[];
+        const excludeModels = (await allExclude.json()) as ListedModel[];
+        const onlyModels = (await allOnly.json()) as ListedModel[];
+        const textExcludeModels = (await textExclude.json()) as ListedModel[];
+        const textOnlyModels = (await textOnly.json()) as ListedModel[];
+        const openaiExcludeData = (await openaiExclude.json()) as {
+            data: { id: string }[];
+        };
+        const openaiOnlyData = (await openaiOnly.json()) as {
+            data: { id: string }[];
+        };
+        const imageExcludeModels = (await imageExclude.json()) as ListedModel[];
+        const imageOnlyModels = (await imageOnly.json()) as ListedModel[];
+        const excludeNumeric =
+            (await allExcludeNumeric.json()) as ListedModel[];
+        const onlyNumeric = (await allOnlyNumeric.json()) as ListedModel[];
+
+        expect(defaultModels.some((m) => m.community)).toBe(true);
+        expect(defaultModels.some((m) => !m.community)).toBe(true);
+
+        expect(excludeModels.every((m) => !m.community)).toBe(true);
+        expect(
+            excludeModels.find((m) => m.name === textModelId),
+        ).toBeUndefined();
+
+        expect(onlyModels.every((m) => m.community === true)).toBe(true);
+        expect(onlyModels.find((m) => m.name === textModelId)).toBeDefined();
+
+        expect(textExcludeModels.every((m) => !m.community)).toBe(true);
+        expect(textOnlyModels.every((m) => m.community === true)).toBe(true);
+
+        expect(
+            openaiExcludeData.data.find((m) => m.id === textModelId),
+        ).toBeUndefined();
+        expect(
+            openaiOnlyData.data.find((m) => m.id === textModelId),
+        ).toBeDefined();
+
+        expect(imageExcludeModels.every((m) => !m.community)).toBe(true);
+        expect(
+            imageExcludeModels.find((m) => m.name === imageModelId),
+        ).toBeUndefined();
+
+        expect(imageOnlyModels.every((m) => m.community === true)).toBe(true);
+        expect(
+            imageOnlyModels.find((m) => m.name === imageModelId),
+        ).toBeDefined();
+
+        expect(excludeNumeric.map((m) => m.name)).toEqual(
+            excludeModels.map((m) => m.name),
+        );
+        expect(onlyNumeric.map((m) => m.name)).toEqual(
+            onlyModels.map((m) => m.name),
+        );
+
+        const invalidResponses = await Promise.all([
+            SELF.fetch("https://gen.pollinations.ai/models?community=tru"),
+            SELF.fetch("https://gen.pollinations.ai/models?community=yes"),
+            SELF.fetch("https://gen.pollinations.ai/v1/models?community=2"),
+            SELF.fetch(
+                "https://gen.pollinations.ai/image/models?community=nope",
+            ),
+        ]);
+        for (const r of invalidResponses) {
+            expect(r.status).toBe(400);
+        }
+    },
+);
+
+fixtureTest(
+    "routes direct calls to a hidden community model",
+    async ({ apiKey }) => {
+        const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;
+        const modelName = `disabled-call-${crypto.randomUUID().slice(0, 8)}`;
+        const modelId = communityModelId(ownerGithubUsername, modelName);
+        const legacyModelId = legacyCommunityModelId(
+            ownerGithubUsername,
+            modelName,
+        );
+        const ownerUserId = await createTestUser({
+            githubId: nextAllowedGithubId(),
+            githubUsername: ownerGithubUsername,
+        });
+        await insertCommunityEndpoints({
+            id: `endpoint-${crypto.randomUUID()}`,
+            ownerUserId,
+            visibility: "public",
+            name: modelName,
+            description: "Hidden community model",
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "gpt-4.1-mini",
+            bearerTokenCiphertext: await encryptSecret(
+                "sk_saved_token",
+                env.BETTER_AUTH_SECRET,
+            ),
+            promptTextPrice: 0.1 / 1_000_000,
+            completionTextPrice: 0.2 / 1_000_000,
+            hiddenAt: new Date(),
+            hiddenReason: "repeated upstream 500s",
+            hiddenBy: "monitor",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+
+        const fetchMock = vi.fn(async (input, init) => {
+            const request = new Request(input, init);
+
+            if (isPortkeyChatCompletionsRequest(request)) {
+                return Response.json({
+                    id: "chatcmpl_hidden",
+                    object: "chat.completion",
+                    model: "gpt-4.1-mini",
+                    choices: [
+                        {
+                            index: 0,
+                            message: { role: "assistant", content: "ok" },
+                            finish_reason: "stop",
+                        },
+                    ],
+                    usage: {
+                        prompt_tokens: 2,
+                        completion_tokens: 1,
+                        total_tokens: 3,
+                    },
+                });
+            }
+
+            if (isBillingFetch(request)) {
+                return Response.json({ data: [] });
+            }
+
+            throw new Error(`Unexpected fetch: ${request.url}`);
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        for (const requestedModel of [modelId, legacyModelId]) {
+            const response = await fetchGen(
+                "https://gen.pollinations.ai/v1/chat/completions",
+                {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${apiKey}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({
+                        model: requestedModel,
+                        messages: [{ role: "user", content: "hello" }],
+                        stream: false,
+                    }),
+                },
+            );
+
+            expect(response.status).toBe(200);
+            await expect(response.json()).resolves.toMatchObject({
+                choices: [{ message: { content: "ok" } }],
+            });
+        }
+
+        const upstreamCalls = fetchMock.mock.calls.filter(([input, init]) =>
+            isPortkeyChatCompletionsRequest(new Request(input, init)),
+        );
+        expect(upstreamCalls).toHaveLength(2);
+    },
+);
+
+fixtureTest(
+    "lets a non-allowlisted user probe an upstream and register a private model but blocks publishing",
+    async ({ apiKey }) => {
+        const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;
+        const modelName = `denied-${crypto.randomUUID().slice(0, 8)}`;
+        const privateModelName = `${modelName}-private`;
+        const modelId = communityModelId(ownerGithubUsername, modelName);
+        const ownerUserId = await createTestUser({
+            githubId: COMMUNITY_ENDPOINT_DENIED_TEST_GITHUB_ID,
+            githubUsername: ownerGithubUsername,
+        });
+        const sessionToken = `session-${crypto.randomUUID()}`;
+        await db.insert(sessionTable).values({
+            id: `session-${crypto.randomUUID()}`,
+            token: sessionToken,
+            userId: ownerUserId,
+            expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+
+        const enterApi = await createEnterCommunityApi();
+        // The probes are open to every account, so they reach the upstream
+        // instead of being refused: stub it and assert on what comes back.
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+                const request = new Request(input, init);
+                if (request.url === "https://api.example.com/v1/models") {
+                    return Response.json({
+                        data: [{ id: "gpt-4.1-mini" }, { id: "gpt-4o" }],
+                    });
+                }
+                if (
+                    request.url ===
+                    "https://api.example.com/v1/chat/completions"
+                ) {
+                    return Response.json({
+                        id: "chatcmpl_probe",
+                        choices: [
+                            {
+                                index: 0,
+                                message: { role: "assistant", content: "OK" },
+                                finish_reason: "stop",
+                            },
+                        ],
+                        usage: {
+                            prompt_tokens: 3,
+                            completion_tokens: 1,
+                            total_tokens: 4,
+                        },
+                    });
+                }
+                throw new Error(`Unexpected fetch: ${request.url}`);
+            }),
+        );
+        for (const probe of [
+            {
+                path: "models",
+                body: {
+                    baseUrl: "https://api.example.com/v1",
+                    bearerToken: "sk_saved_token",
+                },
+            },
+            {
+                path: "test",
+                body: {
+                    baseUrl: "https://api.example.com/v1",
+                    bearerToken: "sk_saved_token",
+                    model: "gpt-4.1-mini",
+                },
+            },
+        ]) {
+            const probeResponse = await fetchEnterApi(
+                enterApi,
+                new Request(
+                    `http://localhost:3000/api/community-endpoints/${probe.path}`,
+                    {
+                        method: "POST",
+                        headers: {
+                            "Content-Type": "application/json",
+                            Cookie: await signedSessionCookie(sessionToken),
+                        },
+                        body: JSON.stringify(probe.body),
+                    },
+                ),
+            );
+            expect(probeResponse.status).toBe(200);
+            const probeBody = (await probeResponse.json()) as {
+                data?: string[];
+                ok?: boolean;
+            };
+            if (probe.path === "models") {
+                expect(probeBody.data).toEqual(["gpt-4.1-mini", "gpt-4o"]);
+            } else {
+                expect(probeBody.ok).toBe(true);
+            }
+        }
+        vi.unstubAllGlobals();
+
+        const directPublishResponse = await fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/community-endpoints", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: await signedSessionCookie(sessionToken),
+                },
+                body: JSON.stringify({
+                    name: `${modelName}-direct-public`,
+                    title: "Denied Public Endpoint",
+                    description: "Denied public community endpoint",
+                    baseUrl: "https://api.example.com/v1",
+                    upstreamModel: "gpt-4.1-mini",
+                    bearerToken: "sk_saved_token",
+                    visibility: "public",
+                    promptTextPrice: 0.00001,
+                    completionTextPrice: 0.00001,
+                }),
+            }),
+        );
+        expect(directPublishResponse.status).toBe(403);
+
+        // Creation is open to everyone: a non-allowlisted user can register a
+        // private model for their own use.
+        const registerResponse = await fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/community-endpoints", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: await signedSessionCookie(sessionToken),
+                },
+                body: JSON.stringify({
+                    name: privateModelName,
+                    title: "Private Endpoint",
+                    description: "Private community endpoint",
+                    baseUrl: "https://api.example.com/v1",
+                    upstreamModel: "gpt-4.1-mini",
+                    bearerToken: "sk_saved_token",
+                }),
+            }),
+        );
+        expect(registerResponse.status).toBe(200);
+        const registered = (await registerResponse.json()) as {
+            id: string;
+            visibility: string;
+            promptTextPrice: number;
+            completionTextPrice: number;
+        };
+        expect(registered).toMatchObject({
+            visibility: "private",
+            promptTextPrice: 0,
+            completionTextPrice: 0,
+        });
+
+        // Publishing is a separate, allowlist-gated action.
+        const publishResponse = await fetchEnterApi(
+            enterApi,
+            new Request(
+                `http://localhost:3000/api/community-endpoints/${registered.id}/update`,
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Cookie: await signedSessionCookie(sessionToken),
+                    },
+                    body: JSON.stringify({
+                        visibility: "public",
+                        promptTextPrice: 0.00001,
+                        completionTextPrice: 0.00001,
+                    }),
+                },
+            ),
+        );
+        expect(publishResponse.status).toBe(403);
+
+        await insertCommunityEndpoints({
+            id: `endpoint-${crypto.randomUUID()}`,
+            ownerUserId,
+            visibility: "public",
+            name: modelName,
+            description: "Denied community model",
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "gpt-4.1-mini",
+            bearerTokenCiphertext: await encryptSecret(
+                "sk_saved_token",
+                env.BETTER_AUTH_SECRET,
+            ),
+            promptTextPrice: 0.1,
+            completionTextPrice: 0.1,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+
+        const fetchMock = vi.fn(async (input, init) => {
+            const request = new Request(input, init);
+
+            if (isPortkeyChatCompletionsRequest(request)) {
+                await expectCommunityPortkeyRequest(input, init, {
+                    customHost: "https://api.example.com/v1",
+                    bearerToken: "sk_saved_token",
+                    upstreamModel: "gpt-4.1-mini",
+                    body: {
+                        messages: [{ role: "user", content: "hello" }],
+                    },
+                });
+
+                return Response.json({
+                    id: "chatcmpl_test",
+                    object: "chat.completion",
+                    model: "gpt-4.1-mini",
+                    choices: [
+                        {
+                            index: 0,
+                            message: { role: "assistant", content: "ok" },
+                            finish_reason: "stop",
+                        },
+                    ],
+                    usage: {
+                        prompt_tokens: 2,
+                        completion_tokens: 3,
+                        total_tokens: 5,
+                    },
+                });
+            }
+
+            if (isBillingFetch(request)) {
+                return Response.json({ data: [] });
+            }
+
+            throw new Error(`Unexpected fetch: ${request.url}`);
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const modelsResponse = await fetchGen(
+            "https://gen.pollinations.ai/text/models",
+        );
+        expect(modelsResponse.status).toBe(200);
+        const models = (await modelsResponse.json()) as { name: string }[];
+        expect(models.some((model) => model.name === modelId)).toBe(true);
+
+        const generationResponse = await fetchGen(
+            new Request("https://gen.pollinations.ai/v1/chat/completions", {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${apiKey}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    model: modelId,
+                    messages: [{ role: "user", content: "hello" }],
+                }),
+            }),
+        );
+        expect(generationResponse.status).toBe(200);
+        await expect(generationResponse.json()).resolves.toMatchObject({
+            model: "gpt-4.1-mini",
+            choices: [
+                {
+                    message: { content: "ok" },
+                },
+            ],
+        });
+    },
+);
+
+fixtureTest(
+    "registers a Pollinations-compatible endpoint through Enter API and uses it through gen",
+    async ({ apiKey }) => {
+        const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;
+        const modelName = `pollinations-${crypto.randomUUID().slice(0, 8)}`;
+        const ownerUserId = await createTestUser({
+            githubId: nextAllowedGithubId(),
+            githubUsername: ownerGithubUsername,
+        });
+        const sessionToken = `session-${crypto.randomUUID()}`;
+        await db.insert(sessionTable).values({
+            id: `session-${crypto.randomUUID()}`,
+            token: sessionToken,
+            userId: ownerUserId,
+            expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+
+        const enterApi = await createEnterCommunityApi();
+        const fetchMock = vi.fn(async (input, init) => {
+            const request = new Request(input, init);
+
+            if (isPortkeyChatCompletionsRequest(request)) {
+                const isPortkeyRequest =
+                    request.headers.has("x-portkey-provider");
+                if (!isPortkeyRequest) {
+                    expect(request.headers.get("authorization")).toBe(
+                        "Bearer sk_pollinations_upstream",
+                    );
+                    await expect(request.json()).resolves.toMatchObject({
+                        model: "openai",
+                        messages: [{ role: "user", content: "Reply with OK." }],
+                        stream: false,
+                    });
+                    return Response.json({
+                        id: "chatcmpl_pollinations_upstream_test",
+                        object: "chat.completion",
+                        model: "openai",
+                        choices: [
+                            {
+                                index: 0,
+                                message: { role: "assistant", content: "OK" },
+                                finish_reason: "stop",
+                            },
+                        ],
+                        usage: {
+                            prompt_tokens: 2,
+                            completion_tokens: 3,
+                            total_tokens: 5,
+                        },
+                    });
+                }
+
+                await expectCommunityPortkeyRequest(input, init, {
+                    customHost: "https://gen.pollinations.ai/v1",
+                    bearerToken: "sk_pollinations_upstream",
+                    upstreamModel: "openai",
+                    body: {
+                        messages: [{ role: "user", content: "hello" }],
+                        max_tokens: 5,
+                        stream: false,
+                    },
+                });
+
+                return Response.json({
+                    id: "chatcmpl_pollinations_upstream",
+                    object: "chat.completion",
+                    model: "openai",
+                    choices: [
+                        {
+                            index: 0,
+                            message: { role: "assistant", content: "ok" },
+                            finish_reason: "stop",
+                        },
+                    ],
+                    usage: {
+                        prompt_tokens: 2,
+                        completion_tokens: 3,
+                        total_tokens: 5,
+                    },
+                });
+            }
+
+            if (isBillingFetch(request)) {
+                return Response.json({ data: [] });
+            }
+
+            throw new Error(`Unexpected fetch: ${request.url}`);
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const registerResponse = await fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/community-endpoints", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: await signedSessionCookie(sessionToken),
+                },
+                body: JSON.stringify({
+                    name: modelName,
+                    title: "Pollinations Upstream",
+                    description: "Pollinations upstream through community API",
+                    baseUrl: "https://gen.pollinations.ai/v1",
+                    upstreamModel: "openai",
+                    bearerToken: "Bearer sk_pollinations_upstream",
+                    visibility: "public",
+                    promptTextPrice: 0.00001,
+                    completionTextPrice: 0.00001,
+                }),
+            }),
+        );
+
+        expect(registerResponse.status).toBe(200);
+        const registered = (await registerResponse.json()) as {
+            id: string;
+            modelId: string;
+            baseUrl: string;
+            upstreamModel: string;
+            visibility: string;
+            promptTextPrice: number;
+            completionTextPrice: number;
+        };
+        expect(registered).toMatchObject({
+            modelId: communityModelId(ownerGithubUsername, modelName),
+            baseUrl: "https://gen.pollinations.ai/v1",
+            upstreamModel: "openai",
+            visibility: "private",
+            promptTextPrice: 0,
+            completionTextPrice: 0,
+            pending: {
+                visibility: "public",
+                promptTextPrice: 0.00001,
+                completionTextPrice: 0.00001,
+            },
+        });
+        await maturePendingCommunityEndpoint(registered.id);
+
+        const testResponse = await fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/community-endpoints/test", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: await signedSessionCookie(sessionToken),
+                },
+                body: JSON.stringify({
+                    baseUrl: registered.baseUrl,
+                    bearerToken: "Bearer sk_pollinations_upstream",
+                    model: registered.upstreamModel,
+                }),
+            }),
+        );
+        expect(testResponse.status).toBe(200);
+        await expect(testResponse.json()).resolves.toMatchObject({
+            message: "Endpoint responded with usage",
+            billableUsage: {
+                promptTextTokens: 2,
+                completionTextTokens: 3,
+            },
+        });
+
+        const throttledTestResponse = await fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/community-endpoints/test", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: await signedSessionCookie(sessionToken),
+                },
+                body: JSON.stringify({
+                    baseUrl: registered.baseUrl,
+                    bearerToken: "Bearer sk_pollinations_upstream",
+                    model: registered.upstreamModel,
+                }),
+            }),
+        );
+        expect(throttledTestResponse.status).toBe(429);
+        expect(throttledTestResponse.headers.get("Retry-After")).toBe("30");
+        await expect(throttledTestResponse.json()).resolves.toMatchObject({
+            error: "rate_limited",
+        });
+
+        const response = await fetchGen(
+            new Request("https://gen.pollinations.ai/v1/chat/completions", {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${apiKey}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    model: registered.modelId,
+                    messages: [{ role: "user", content: "hello" }],
+                    max_tokens: 5,
+                }),
+            }),
+        );
+
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toMatchObject({
+            model: "openai",
+            choices: [{ message: { content: "ok" } }],
+        });
+        expect(
+            fetchMock.mock.calls.filter(([input, init]) =>
+                isPortkeyChatCompletionsRequest(new Request(input, init)),
+            ),
+        ).toHaveLength(2);
+    },
+);
+
+fixtureTest(
+    "registers an OpenAI-compatible image endpoint and exposes it through image APIs",
+    async ({ apiKey }) => {
+        const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;
+        const modelName = `image-${crypto.randomUUID().slice(0, 8)}`;
+        const ownerUserId = await createTestUser({
+            githubId: nextAllowedGithubId(),
+            githubUsername: ownerGithubUsername,
+        });
+        const sessionToken = `session-${crypto.randomUUID()}`;
+        await db.insert(sessionTable).values({
+            id: `session-${crypto.randomUUID()}`,
+            token: sessionToken,
+            userId: ownerUserId,
+            expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+
+        const enterApi = await createEnterCommunityApi();
+        const fetchMock = vi.fn(async (input, init) => {
+            const request = new Request(input, init);
+
+            if (
+                request.url === TEST_INPUT_IMAGE_URL ||
+                request.url.startsWith("data:image/png;base64,")
+            ) {
+                return new Response(new Uint8Array(TEST_PNG_BYTES), {
+                    headers: { "Content-Type": "image/png" },
+                });
+            }
+
+            if (request.url === TEST_COMMUNITY_IMAGE_URL) {
+                expect(request.headers.get("authorization")).toBeNull();
+                expect(request.redirect).toBe("manual");
+                return new Response(new Uint8Array(TEST_PNG_BYTES), {
+                    headers: { "Content-Type": "image/png" },
+                });
+            }
+
+            if (isCommunityImageGenerationsRequest(request)) {
+                expect(new URL(request.url).search).toBe("?version=1");
+                const body = (await request.clone().json()) as Record<
+                    string,
+                    unknown
+                >;
+                await expectCommunityImageGenerationsRequest(input, init, {
+                    bearerToken: "sk_image_upstream",
+                    body: { model: "gpt-image-1", n: 1 },
+                });
+
+                if (
+                    body.prompt ===
+                    "A simple green sprout icon on a white background."
+                ) {
+                    expect(body).toMatchObject({
+                        size: "1024x1024",
+                        quality: "medium",
+                    });
+                } else if (body.prompt === "green sprout") {
+                    expect(body).toMatchObject({
+                        size: "512x768",
+                        quality: "medium",
+                        background: "transparent",
+                        output_format: "png",
+                    });
+                } else if (body.prompt === "blue flower") {
+                    expect(body).toMatchObject({
+                        size: "1024x1024",
+                        quality: "high",
+                    });
+                } else if (body.prompt !== "invalid media") {
+                    throw new Error(
+                        `Unexpected image prompt: ${String(body.prompt)}`,
+                    );
+                }
+
+                return Response.json({
+                    created: 1,
+                    data: [
+                        body.prompt === "invalid media"
+                            ? { b64_json: TEST_INVALID_IMAGE_BASE64 }
+                            : { url: TEST_COMMUNITY_IMAGE_URL },
+                    ],
+                });
+            }
+
+            if (isCommunityImageEditsRequest(request)) {
+                expect(new URL(request.url).search).toBe("?version=1");
+                expect(request.headers.get("authorization")).toBe(
+                    "Bearer sk_image_upstream",
+                );
+                expect(request.headers.get("content-type")).toContain(
+                    "multipart/form-data",
+                );
+                const formData = await request.formData();
+                expect(formData.get("model")).toBe("gpt-image-1");
+                expect(formData.get("n")).toBe("1");
+                expect(formData.get("image")).toBeInstanceOf(File);
+
+                const prompt = formData.get("prompt");
+                if (prompt === "make it blue") {
+                    expect(formData.get("size")).toBe("512x512");
+                    expect(formData.get("quality")).toBe("high");
+                } else if (prompt === "turn it red") {
+                    expect(formData.get("size")).toBe("384x640");
+                    expect(formData.get("quality")).toBe("medium");
+                } else if (prompt === "Add a small blue dot to the image.") {
+                    expect(formData.get("size")).toBe("1024x1024");
+                    expect(formData.get("quality")).toBe("medium");
+                } else {
+                    throw new Error(
+                        `Unexpected edit prompt: ${String(prompt)}`,
+                    );
+                }
+
+                return Response.json({
+                    created: 1,
+                    data: [{ b64_json: TEST_PNG_BASE64 }],
+                });
+            }
+
+            if (isBillingFetch(request)) {
+                return Response.json({ data: [] });
+            }
+
+            throw new Error(`Unexpected fetch: ${request.url}`);
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const registrationPayload = {
+            name: modelName,
+            title: "Community Image Endpoint",
+            description: "OpenAI-compatible image endpoint",
+            modality: "image",
+            inputModalities: ["text", "image"],
+            visibility: "public",
+            baseUrl: "https://api.example.com/v1/images/generations?version=1",
+            upstreamModel: "gpt-image-1",
+            bearerToken: "Bearer sk_image_upstream",
+            promptTextPrice: 0.000002,
+            completionImagePrice: 0.03,
+        };
+        const unsupportedInputResponse = await fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/community-endpoints", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: await signedSessionCookie(sessionToken),
+                },
+                body: JSON.stringify({
+                    ...registrationPayload,
+                    name: `${modelName}-invalid`,
+                    inputModalities: ["text", "audio"],
+                }),
+            }),
+        );
+        expect(unsupportedInputResponse.status).toBe(400);
+
+        const registerResponse = await fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/community-endpoints", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: await signedSessionCookie(sessionToken),
+                },
+                body: JSON.stringify(registrationPayload),
+            }),
+        );
+
+        expect(registerResponse.status).toBe(200);
+        const registered = (await registerResponse.json()) as {
+            id: string;
+            modelId: string;
+            modality: string;
+            inputModalities: string[];
+            baseUrl: string;
+            upstreamModel: string;
+            promptTextPrice: number;
+            completionImagePrice: number;
+        };
+        expect(registered).toMatchObject({
+            modelId: communityModelId(ownerGithubUsername, modelName),
+            modality: "image",
+            inputModalities: ["text", "image"],
+            baseUrl: "https://api.example.com/v1/images/generations?version=1",
+            upstreamModel: "gpt-image-1",
+            promptTextPrice: 0,
+            completionImagePrice: 0,
+            pending: {
+                visibility: "public",
+                promptTextPrice: 0,
+                completionImagePrice: 0.03,
+            },
+        });
+        await maturePendingCommunityEndpoint(registered.id);
+
+        const testResponse = await fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/community-endpoints/test", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: await signedSessionCookie(sessionToken),
+                },
+                body: JSON.stringify({
+                    baseUrl: registered.baseUrl,
+                    bearerToken: "Bearer sk_image_upstream",
+                    model: registered.upstreamModel,
+                    modality: "image",
+                }),
+            }),
+        );
+        expect(testResponse.status).toBe(200);
+        await expect(testResponse.json()).resolves.toMatchObject({
+            message:
+                "Generation and editing endpoints responded with image data",
+            usage: { images: 1 },
+            billableUsage: { completionImageTokens: 1 },
+            inputModalities: ["text", "image"],
+        });
+
+        const simpleImageResponse = await fetchGen(
+            new Request(
+                `https://gen.pollinations.ai/image/green%20sprout?model=${encodeURIComponent(
+                    registered.modelId,
+                )}&width=512&height=768&transparent=true`,
+                {
+                    headers: {
+                        Authorization: `Bearer ${apiKey}`,
+                    },
+                },
+            ),
+        );
+        expect(simpleImageResponse.status).toBe(200);
+        expect(simpleImageResponse.headers.get("content-type")).toBe(
+            "image/png",
+        );
+        expect(simpleImageResponse.headers.get("x-model-used")).toBe(
+            registered.modelId,
+        );
+        expect(
+            simpleImageResponse.headers.get("x-usage-prompt-text-tokens"),
+        ).toBeNull();
+        expect(
+            simpleImageResponse.headers.get("x-usage-completion-image-tokens"),
+        ).toBe("1");
+        expect(
+            Array.from(new Uint8Array(await simpleImageResponse.arrayBuffer())),
+        ).toEqual(TEST_PNG_BYTES);
+
+        const openaiImageResponse = await fetchGen(
+            new Request("https://gen.pollinations.ai/v1/images/generations", {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${apiKey}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    model: registered.modelId,
+                    prompt: "blue flower",
+                    size: "1024x1024",
+                    quality: "hd",
+                    response_format: "b64_json",
+                }),
+            }),
+        );
+        expect(openaiImageResponse.status).toBe(200);
+        await expect(openaiImageResponse.json()).resolves.toMatchObject({
+            data: [{ b64_json: TEST_PNG_BASE64 }],
+            usage: {
+                input_tokens: 0,
+                output_tokens: 1,
+                total_tokens: 1,
+                input_tokens_details: {
+                    text_tokens: 0,
+                    image_tokens: 0,
+                },
+            },
+        });
+
+        const editFormData = new FormData();
+        editFormData.append("model", registered.modelId);
+        editFormData.append("prompt", "make it blue");
+        editFormData.append("size", "512x512");
+        editFormData.append("quality", "hd");
+        editFormData.append(
+            "image",
+            new Blob([new Uint8Array(TEST_PNG_BYTES)], { type: "image/png" }),
+            "source.png",
+        );
+        const openaiEditResponse = await fetchGen(
+            new Request("https://gen.pollinations.ai/v1/images/edits", {
+                method: "POST",
+                headers: { Authorization: `Bearer ${apiKey}` },
+                body: editFormData,
+            }),
+        );
+        expect(openaiEditResponse.status).toBe(200);
+        await expect(openaiEditResponse.json()).resolves.toMatchObject({
+            data: [{ b64_json: TEST_PNG_BASE64 }],
+            usage: {
+                input_tokens: 0,
+                output_tokens: 1,
+                total_tokens: 1,
+            },
+        });
+
+        const simpleEditResponse = await fetchGen(
+            new Request(
+                `https://gen.pollinations.ai/image/turn%20it%20red?model=${encodeURIComponent(
+                    registered.modelId,
+                )}&image=${encodeURIComponent(TEST_INPUT_IMAGE_URL)}&width=384&height=640`,
+                { headers: { Authorization: `Bearer ${apiKey}` } },
+            ),
+        );
+        expect(simpleEditResponse.status).toBe(200);
+        expect(simpleEditResponse.headers.get("content-type")).toBe(
+            "image/png",
+        );
+        expect(
+            simpleEditResponse.headers.get("x-usage-completion-image-tokens"),
+        ).toBe("1");
+        expect(
+            Array.from(new Uint8Array(await simpleEditResponse.arrayBuffer())),
+        ).toEqual(TEST_PNG_BYTES);
+
+        const urlImageResponse = await fetchGen(
+            new Request("https://gen.pollinations.ai/v1/images/generations", {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${apiKey}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    model: registered.modelId,
+                    prompt: "blue flower",
+                    quality: "hd",
+                    response_format: "url",
+                }),
+            }),
+        );
+        expect(urlImageResponse.status).toBe(200);
+        await expect(urlImageResponse.json()).resolves.toMatchObject({
+            data: [
+                {
+                    url: expect.stringContaining(
+                        `/image/blue%20flower?model=${encodeURIComponent(registered.modelId)}`,
+                    ),
+                },
+            ],
+        });
+
+        const invalidMediaResponse = await fetchGen(
+            new Request("https://gen.pollinations.ai/v1/images/generations", {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${apiKey}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    model: registered.modelId,
+                    prompt: "invalid media",
+                }),
+            }),
+        );
+        expect(invalidMediaResponse.status).toBe(502);
+
+        const imageModelsResponse = await fetchGen(
+            "https://gen.pollinations.ai/image/models",
+        );
+        const textModelsResponse = await fetchGen(
+            "https://gen.pollinations.ai/text/models",
+        );
+        const allModelsResponse = await fetchGen(
+            "https://gen.pollinations.ai/models",
+        );
+        const openaiModelsResponse = await fetchGen(
+            "https://gen.pollinations.ai/v1/models",
+        );
+
+        expect(imageModelsResponse.status).toBe(200);
+        expect(textModelsResponse.status).toBe(200);
+        expect(allModelsResponse.status).toBe(200);
+        expect(openaiModelsResponse.status).toBe(200);
+
+        const imageModels = (await imageModelsResponse.json()) as {
+            name: string;
+            category?: string;
+            community?: boolean;
+            input_modalities?: string[];
+            flat_rate?: boolean;
+            pricing?: Record<string, string>;
+        }[];
+        const textModels = (await textModelsResponse.json()) as {
+            name: string;
+        }[];
+        const allModels =
+            (await allModelsResponse.json()) as typeof imageModels;
+        const openaiModels = (await openaiModelsResponse.json()) as {
+            data: {
+                id: string;
+                input_modalities?: string[];
+                supported_endpoints?: string[];
+            }[];
+        };
+
+        const listedImage = imageModels.find(
+            (model) => model.name === registered.modelId,
+        );
+        expect(listedImage).toMatchObject({
+            name: registered.modelId,
+            category: "image",
+            community: true,
+            input_modalities: ["text", "image"],
+            flat_rate: true,
+            pricing: {
+                currency: "pollen",
+                completionImageTokens: "0.03",
+            },
+        });
+        expect(
+            textModels.find((model) => model.name === registered.modelId),
+        ).toBeUndefined();
+        expect(
+            allModels.filter((model) => model.name === registered.modelId),
+        ).toHaveLength(1);
+
+        const openaiModel = openaiModels.data.find(
+            (model) => model.id === registered.modelId,
+        );
+        expect(openaiModel?.input_modalities).toEqual(["text", "image"]);
+        expect(openaiModel?.supported_endpoints).toEqual(
+            expect.arrayContaining([
+                "/v1/images/generations",
+                "/v1/images/edits",
+                "/image/{prompt}",
+            ]),
+        );
+        expect(
+            fetchMock.mock.calls.filter(([input, init]) =>
+                isCommunityImageGenerationsRequest(new Request(input, init)),
+            ),
+        ).toHaveLength(5);
+        expect(
+            fetchMock.mock.calls.filter(([input, init]) =>
+                isCommunityImageEditsRequest(new Request(input, init)),
+            ),
+        ).toHaveLength(3);
+        expect(
+            fetchMock.mock.calls.filter(
+                ([input, init]) =>
+                    new Request(input, init).url === TEST_COMMUNITY_IMAGE_URL,
+            ),
+        ).toHaveLength(4);
+
+        const maximumImagePriceResponse = await fetchEnterApi(
+            enterApi,
+            new Request(
+                `http://localhost:3000/api/community-endpoints/${registered.id}/update`,
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Cookie: await signedSessionCookie(sessionToken),
+                    },
+                    body: JSON.stringify({
+                        completionImagePrice: MAX_COMMUNITY_PRICE_PER_IMAGE,
+                    }),
+                },
+            ),
+        );
+        expect(maximumImagePriceResponse.status).toBe(200);
+
+        const excessiveImagePriceResponse = await fetchEnterApi(
+            enterApi,
+            new Request(
+                `http://localhost:3000/api/community-endpoints/${registered.id}/update`,
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Cookie: await signedSessionCookie(sessionToken),
+                    },
+                    body: JSON.stringify({
+                        completionImagePrice:
+                            MAX_COMMUNITY_PRICE_PER_IMAGE + 0.01,
+                    }),
+                },
+            ),
+        );
+        expect(excessiveImagePriceResponse.status).toBe(400);
+    },
+);
+
+fixtureTest(
+    "registers, catalogs, and serves a billed community video model",
+    async () => {
+        const ownerGithubUsername = `video-${crypto.randomUUID().slice(0, 8)}`;
+        const modelName = `clip-${crypto.randomUUID().slice(0, 8)}`;
+        const ownerUserId = await createTestUser({
+            githubId: nextAllowedGithubId(),
+            githubUsername: ownerGithubUsername,
+        });
+        const sessionToken = `session-${crypto.randomUUID()}`;
+        await db.insert(sessionTable).values({
+            id: `session-${crypto.randomUUID()}`,
+            token: sessionToken,
+            userId: ownerUserId,
+            expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+        const cookie = await signedSessionCookie(sessionToken);
+        const enterApi = await createEnterCommunityApi();
+        const videoEndpointUrl =
+            "https://api.example.com/generate-video?version=1";
+        let markGenerationStarted!: () => void;
+        const generationStarted = new Promise<void>((resolve) => {
+            markGenerationStarted = resolve;
+        });
+        let releaseGeneration!: () => void;
+        const generationReleased = new Promise<void>((resolve) => {
+            releaseGeneration = resolve;
+        });
+        let generationCalls = 0;
+        const ingestedEvents: Record<string, unknown>[] = [];
+        const fetchMock = vi.fn(async (input, init) => {
+            const request = new Request(input, init);
+            if (request.url === videoEndpointUrl) {
+                expect(request.headers.get("authorization")).toBe(
+                    "Bearer sk_video_upstream",
+                );
+                const body = (await request.json()) as {
+                    prompt: string;
+                    duration: number;
+                    reference_images?: string[];
+                };
+                const isProbe =
+                    body.prompt ===
+                    "A green sprout gently moving in the breeze.";
+                if (!isProbe) {
+                    generationCalls += 1;
+                    markGenerationStarted();
+                    await generationReleased;
+                }
+                expect(body).toEqual(
+                    isProbe
+                        ? { prompt: body.prompt, duration: 5 }
+                        : {
+                              prompt: "green sprout",
+                              duration: 4,
+                              reference_images: [
+                                  "https://media.example.com/style.jpg",
+                              ],
+                          },
+                );
+                return Response.json({
+                    data: [{ b64_json: TEST_MP4_BASE64 }],
+                });
+            }
+            if (isBillingFetch(request)) {
+                if (new URL(request.url).pathname === "/v0/events") {
+                    ingestedEvents.push(
+                        ...parseIngestedEvents(await request.text()),
+                    );
+                }
+                return Response.json({ data: [] });
+            }
+            throw new Error(`Unexpected fetch: ${request.url}`);
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const probeResponse = await fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/community-endpoints/test", {
+                method: "POST",
+                headers: { "Content-Type": "application/json", Cookie: cookie },
+                body: JSON.stringify({
+                    baseUrl: videoEndpointUrl,
+                    bearerToken: "sk_video_upstream",
+                    modality: "video",
+                }),
+            }),
+        );
+        expect(probeResponse.status).toBe(200);
+        await expect(probeResponse.json()).resolves.toMatchObject({
+            message: "Endpoint responded with playable video",
+            usage: { duration: 5 },
+            billableUsage: { completionVideoSeconds: 5 },
+        });
+
+        const registerResponse = await fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/community-endpoints", {
+                method: "POST",
+                headers: { "Content-Type": "application/json", Cookie: cookie },
+                body: JSON.stringify({
+                    name: modelName,
+                    title: "Community Video",
+                    description: "Synchronous community video endpoint",
+                    modality: "video",
+                    visibility: "public",
+                    baseUrl: videoEndpointUrl,
+                    bearerToken: "sk_video_upstream",
+                    completionVideoPrice: 0.08,
+                }),
+            }),
+        );
+        expect(registerResponse.status).toBe(200);
+        const registered = (await registerResponse.json()) as {
+            id: string;
+            modelId: string;
+            modality: string;
+            completionVideoPrice: number;
+        };
+        expect(registered).toMatchObject({
+            modelId: communityModelId(ownerGithubUsername, modelName),
+            modality: "video",
+            completionVideoPrice: 0,
+        });
+        await maturePendingCommunityEndpoint(registered.id);
+
+        const caller = await createTestApiKey({
+            user: { tierBalance: 100, packBalance: 0 },
+        });
+        const balanceBefore = await getUserBalance(db, caller.userId);
+        const coordinatedEnv = withInlineGenerationCoordinator(env);
+        const generationRequest = () =>
+            new Request(
+                `https://gen.pollinations.ai/video/green%20sprout?model=${encodeURIComponent(registered.modelId)}&duration=4&reference_images=${encodeURIComponent("https://media.example.com/style.jpg")}`,
+                { headers: { Authorization: `Bearer ${caller.key}` } },
+            );
+        const disconnectedContext = createExecutionContext();
+        const abort = new AbortController();
+        const disconnected = Promise.resolve(
+            worker.fetch(
+                new Request(generationRequest(), { signal: abort.signal }),
+                coordinatedEnv,
+                disconnectedContext,
+            ),
+        ).catch(() => null);
+        await generationStarted;
+        abort.abort();
+
+        const rejoinedContext = createExecutionContext();
+        const rejoined = worker.fetch(
+            generationRequest(),
+            coordinatedEnv,
+            rejoinedContext,
+        );
+        releaseGeneration();
+        const generationResponse = await rejoined;
+        expect(generationResponse.status).toBe(200);
+        expect(generationResponse.headers.get("x-cache")).toBe("HIT");
+        expect(generationResponse.headers.get("content-type")).toBe(
+            "video/mp4",
+        );
+        expect(
+            generationResponse.headers.get(
+                USAGE_TYPE_HEADERS.completionVideoSeconds,
+            ),
+        ).toBe("4");
+        expect(
+            Array.from(new Uint8Array(await generationResponse.arrayBuffer())),
+        ).toEqual(TEST_MP4_BYTES);
+        const disconnectedResponse = await disconnected;
+        if (disconnectedResponse) {
+            await disconnectedResponse.arrayBuffer();
+        }
+        await Promise.all([
+            waitOnExecutionContext(disconnectedContext),
+            waitOnExecutionContext(rejoinedContext),
+        ]);
+
+        const cachedContext = createExecutionContext();
+        const cachedResponse = await worker.fetch(
+            generationRequest(),
+            coordinatedEnv,
+            cachedContext,
+        );
+        expect(cachedResponse.status).toBe(200);
+        expect(cachedResponse.headers.get("x-cache")).toBe("HIT");
+        expect(
+            Array.from(new Uint8Array(await cachedResponse.arrayBuffer())),
+        ).toEqual(TEST_MP4_BYTES);
+        await waitOnExecutionContext(cachedContext);
+
+        expect(generationCalls).toBe(1);
+        const balanceAfter = await getUserBalance(db, caller.userId);
+        expect(
+            balanceBefore.tierBalance - balanceAfter.tierBalance,
+        ).toBeCloseTo(0.32, 10);
+        await vi.waitFor(() =>
+            expect(
+                ingestedEvents.filter(
+                    (event) =>
+                        event.modelUsed === registered.modelId &&
+                        event.isBilledUsage === true,
+                ),
+            ).toHaveLength(1),
+        );
+
+        const invalidDurationResponse = await fetchGen(
+            new Request(
+                `https://gen.pollinations.ai/video/green%20sprout?model=${encodeURIComponent(registered.modelId)}&duration=0`,
+                { headers: { Authorization: `Bearer ${caller.key}` } },
+            ),
+        );
+        expect(invalidDurationResponse.status).toBe(400);
+
+        const catalogResponse = await fetchGen(
+            "https://gen.pollinations.ai/video/models",
+        );
+        expect(catalogResponse.status).toBe(200);
+        const catalog = (await catalogResponse.json()) as {
+            name: string;
+            category: string;
+            output_modalities?: string[];
+            pricing: Record<string, string>;
+        }[];
+        expect(
+            catalog.find((model) => model.name === registered.modelId),
+        ).toMatchObject({
+            category: "video",
+            output_modalities: ["video"],
+            pricing: {
+                currency: "pollen",
+                completionVideoSeconds: "0.08",
+            },
+        });
+
+        const openaiCatalogResponse = await fetchGen(
+            "https://gen.pollinations.ai/v1/models",
+        );
+        expect(openaiCatalogResponse.status).toBe(200);
+        const openaiCatalog = (await openaiCatalogResponse.json()) as {
+            data: { id: string; supported_endpoints?: string[] }[];
+        };
+        expect(
+            openaiCatalog.data.find((model) => model.id === registered.modelId)
+                ?.supported_endpoints,
+        ).toEqual(communityEndpointSupportedEndpoints("video", ["text"]));
+
+        const excessivePriceResponse = await fetchEnterApi(
+            enterApi,
+            new Request(
+                `http://localhost:3000/api/community-endpoints/${registered.id}/update`,
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Cookie: cookie,
+                    },
+                    body: JSON.stringify({
+                        completionVideoPrice:
+                            MAX_COMMUNITY_PRICE_PER_VIDEO_SECOND + 0.01,
+                    }),
+                },
+            ),
+        );
+        expect(excessivePriceResponse.status).toBe(400);
+    },
+);
+
+fixtureTest(
+    "registers an OpenAI-compatible transcription endpoint and bills it through transcription APIs",
+    async ({ apiKey }) => {
+        const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;
+        const modelName = `stt-${crypto.randomUUID().slice(0, 8)}`;
+        const ownerUserId = await createTestUser({
+            githubId: nextAllowedGithubId(),
+            githubUsername: ownerGithubUsername,
+        });
+        const sessionToken = `session-${crypto.randomUUID()}`;
+        await db.insert(sessionTable).values({
+            id: `session-${crypto.randomUUID()}`,
+            token: sessionToken,
+            userId: ownerUserId,
+            expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+
+        const enterApi = await createEnterCommunityApi();
+        const transcriptionUrl =
+            "https://api.example.com/v1/audio/transcriptions";
+        const fetchMock = vi.fn(async (input, init) => {
+            const request = new Request(input, init);
+            if (request.url === transcriptionUrl) {
+                expect(request.headers.get("authorization")).toBe(
+                    "Bearer sk_transcription_upstream",
+                );
+                const formData = await request.formData();
+                expect(formData.get("model")).toBe("whisper-1");
+                expect(formData.get("file")).toBeInstanceOf(File);
+                return Response.json({
+                    text: "ok",
+                    usage: { duration: 0.5 },
+                });
+            }
+            if (isBillingFetch(request)) {
+                return Response.json({ data: [] });
+            }
+            throw new Error(`Unexpected fetch: ${request.url}`);
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const registrationPayload = {
+            name: modelName,
+            title: "Community Transcription Endpoint",
+            description: "OpenAI-compatible speech-to-text endpoint",
+            modality: "transcription",
+            inputModalities: ["audio"],
+            visibility: "public",
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "whisper-1",
+            bearerToken: "Bearer sk_transcription_upstream",
+            promptAudioPrice: 0.0000445,
+        };
+        const unsupportedInputResponse = await fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/community-endpoints", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: await signedSessionCookie(sessionToken),
+                },
+                body: JSON.stringify({
+                    ...registrationPayload,
+                    name: `${modelName}-invalid`,
+                    inputModalities: ["text"],
+                }),
+            }),
+        );
+        expect(unsupportedInputResponse.status).toBe(400);
+
+        // Omitting inputModalities must follow the modality, not fall back to
+        // text — a text default would make transcription endpoints impossible
+        // to register without naming "audio" explicitly.
+        const defaultedInputResponse = await fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/community-endpoints", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: await signedSessionCookie(sessionToken),
+                },
+                body: JSON.stringify({
+                    ...registrationPayload,
+                    name: `${modelName}-defaulted`,
+                    inputModalities: undefined,
+                }),
+            }),
+        );
+        expect(defaultedInputResponse.status).toBe(200);
+        expect(await defaultedInputResponse.json()).toMatchObject({
+            modality: "transcription",
+            inputModalities: ["audio"],
+        });
+
+        const registerResponse = await fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/community-endpoints", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: await signedSessionCookie(sessionToken),
+                },
+                body: JSON.stringify(registrationPayload),
+            }),
+        );
+        expect(registerResponse.status).toBe(200);
+        const registered = (await registerResponse.json()) as {
+            id: string;
+            modelId: string;
+            modality: string;
+            inputModalities: string[];
+            baseUrl: string;
+            upstreamModel: string;
+            promptAudioPrice: number;
+        };
+        expect(registered).toMatchObject({
+            modelId: communityModelId(ownerGithubUsername, modelName),
+            modality: "transcription",
+            inputModalities: ["audio"],
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "whisper-1",
+            promptAudioPrice: 0,
+            pending: {
+                visibility: "public",
+                promptAudioPrice: 0.0000445,
+            },
+        });
+        await maturePendingCommunityEndpoint(registered.id);
+
+        const testResponse = await fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/community-endpoints/test", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: await signedSessionCookie(sessionToken),
+                },
+                body: JSON.stringify({
+                    baseUrl: registered.baseUrl,
+                    bearerToken: "Bearer sk_transcription_upstream",
+                    model: registered.upstreamModel,
+                    modality: "transcription",
+                }),
+            }),
+        );
+        expect(testResponse.status).toBe(200);
+        await expect(testResponse.json()).resolves.toMatchObject({
+            message: "Endpoint responded with transcription text",
+            usage: { duration: 0.5 },
+            billableUsage: { promptAudioSeconds: 0.5 },
+        });
+
+        const transcriptionFormData = new FormData();
+        transcriptionFormData.append("model", registered.modelId);
+        transcriptionFormData.append("response_format", "json");
+        transcriptionFormData.append(
+            "file",
+            new Blob([new Uint8Array([1, 2, 3])], { type: "audio/wav" }),
+            "sample.wav",
+        );
+        const transcriptionResponse = await fetchGen(
+            new Request("https://gen.pollinations.ai/v1/audio/transcriptions", {
+                method: "POST",
+                headers: { Authorization: `Bearer ${apiKey}` },
+                body: transcriptionFormData,
+            }),
+        );
+        expect(transcriptionResponse.status).toBe(200);
+        await expect(transcriptionResponse.json()).resolves.toMatchObject({
+            text: "ok",
+        });
+        expect(transcriptionResponse.headers.get("x-model-used")).toBe(
+            registered.modelId,
+        );
+        expect(
+            transcriptionResponse.headers.get("x-usage-prompt-audio-seconds"),
+        ).toBe("0.5");
+
+        const openaiModelsResponse = await fetchGen(
+            "https://gen.pollinations.ai/v1/models",
+        );
+        expect(openaiModelsResponse.status).toBe(200);
+        const openaiModels = (await openaiModelsResponse.json()) as {
+            data: {
+                id: string;
+                input_modalities?: string[];
+                supported_endpoints?: string[];
+            }[];
+        };
+        const listedModel = openaiModels.data.find(
+            (model) => model.id === registered.modelId,
+        );
+        expect(listedModel?.input_modalities).toEqual(["audio"]);
+        expect(listedModel?.supported_endpoints).toEqual(
+            expect.arrayContaining(["/v1/audio/transcriptions"]),
+        );
+
+        const audioModelsResponse = await fetchGen(
+            "https://gen.pollinations.ai/audio/models",
+        );
+        expect(audioModelsResponse.status).toBe(200);
+        const audioModels = (await audioModelsResponse.json()) as {
+            name: string;
+            category?: string;
+            community?: boolean;
+            input_modalities?: string[];
+            supported_endpoints?: string[];
+            pricing?: Record<string, string>;
+        }[];
+        const listedAudioModel = audioModels.find(
+            (model) => model.name === registered.modelId,
+        );
+        expect(listedAudioModel).toMatchObject({
+            name: registered.modelId,
+            category: "audio",
+            community: true,
+            input_modalities: ["audio"],
+            pricing: { promptAudioSeconds: "0.0000445" },
+        });
+        expect(listedAudioModel?.supported_endpoints).toEqual(
+            expect.arrayContaining(["/v1/audio/transcriptions"]),
+        );
+        expect(
+            fetchMock.mock.calls.filter(
+                ([input]) => new Request(input).url === transcriptionUrl,
+            ),
+        ).toHaveLength(2);
+    },
+);
+
+fixtureTest(
+    "registers an OpenAI-compatible embedding endpoint and bills it through embeddings APIs",
+    async ({ apiKey }) => {
+        const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;
+        const modelName = `embed-${crypto.randomUUID().slice(0, 8)}`;
+        const ownerUserId = await createTestUser({
+            githubId: nextAllowedGithubId(),
+            githubUsername: ownerGithubUsername,
+        });
+        const sessionToken = `session-${crypto.randomUUID()}`;
+        await db.insert(sessionTable).values({
+            id: `session-${crypto.randomUUID()}`,
+            token: sessionToken,
+            userId: ownerUserId,
+            expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+
+        const enterApi = await createEnterCommunityApi();
+        const embeddingUrl = "https://api.example.com/v1/embeddings";
+        const fetchMock = vi.fn(async (input, init) => {
+            const request = new Request(input, init);
+            if (request.url === embeddingUrl) {
+                expect(request.headers.get("authorization")).toBe(
+                    "Bearer sk_embedding_upstream",
+                );
+                return Response.json({
+                    object: "list",
+                    data: [
+                        {
+                            object: "embedding",
+                            index: 0,
+                            embedding: Array.from({ length: 4 }, () =>
+                                Math.random(),
+                            ),
+                        },
+                    ],
+                    model: "text-embedding-3-small",
+                    usage: { prompt_tokens: 12, total_tokens: 12 },
+                });
+            }
+            if (isBillingFetch(request)) {
+                return Response.json({ data: [] });
+            }
+            throw new Error(`Unexpected fetch: ${request.url}`);
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const registrationPayload = {
+            name: modelName,
+            title: "Community Embedding Endpoint",
+            description: "OpenAI-compatible embedding endpoint",
+            modality: "embedding",
+            inputModalities: ["text"],
+            visibility: "public",
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "text-embedding-3-small",
+            bearerToken: "Bearer sk_embedding_upstream",
+            promptTextPrice: 0.00001,
+        };
+        const registerResponse = await fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/community-endpoints", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: await signedSessionCookie(sessionToken),
+                },
+                body: JSON.stringify(registrationPayload),
+            }),
+        );
+        expect(registerResponse.status).toBe(200);
+        const registered = (await registerResponse.json()) as {
+            id: string;
+            modelId: string;
+            modality: string;
+            inputModalities: string[];
+            baseUrl: string;
+            upstreamModel: string;
+            promptTextPrice: number;
+        };
+        expect(registered).toMatchObject({
+            modelId: communityModelId(ownerGithubUsername, modelName),
+            modality: "embedding",
+            inputModalities: ["text"],
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "text-embedding-3-small",
+            visibility: "private",
+            pending: {
+                visibility: "public",
+            },
+        });
+        await maturePendingCommunityEndpoint(registered.id);
+
+        const testResponse = await fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/community-endpoints/test", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: await signedSessionCookie(sessionToken),
+                },
+                body: JSON.stringify({
+                    baseUrl: registered.baseUrl,
+                    bearerToken: "Bearer sk_embedding_upstream",
+                    model: registered.upstreamModel,
+                    modality: "embedding",
+                }),
+            }),
+        );
+        expect(testResponse.status).toBe(200);
+        await expect(testResponse.json()).resolves.toMatchObject({
+            message: "Endpoint responded with embedding data",
+            usage: { prompt_tokens: 12 },
+            billableUsage: { promptTextTokens: 12 },
+        });
+
+        const embeddingsResponse = await fetchGen(
+            new Request("https://gen.pollinations.ai/v1/embeddings", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `Bearer ${apiKey}`,
+                },
+                body: JSON.stringify({
+                    model: registered.modelId,
+                    input: "A simple green sprout.",
+                }),
+            }),
+        );
+        const embeddingsBody = await embeddingsResponse.json();
+        expect(embeddingsResponse.status).toBe(200);
+        expect(embeddingsBody).toMatchObject({
+            data: expect.arrayContaining([
+                expect.objectContaining({
+                    embedding: expect.arrayContaining([expect.any(Number)]),
+                }),
+            ]),
+            model: registered.modelId,
+        });
+        expect(embeddingsResponse.headers.get("x-model-used")).toBe(
+            registered.modelId,
+        );
+        expect(
+            embeddingsResponse.headers.get("x-usage-prompt-text-tokens"),
+        ).toBe("12");
+
+        const openaiModelsResponse = await fetchGen(
+            "https://gen.pollinations.ai/v1/models",
+        );
+        expect(openaiModelsResponse.status).toBe(200);
+        const openaiModels = (await openaiModelsResponse.json()) as {
+            data: {
+                id: string;
+                input_modalities?: string[];
+                supported_endpoints?: string[];
+            }[];
+        };
+        const listedModel = openaiModels.data.find(
+            (model) => model.id === registered.modelId,
+        );
+        expect(listedModel?.input_modalities).toEqual(["text"]);
+        expect(listedModel?.supported_endpoints).toEqual(
+            expect.arrayContaining(["/v1/embeddings"]),
+        );
+
+        const embeddingModelsResponse = await fetchGen(
+            "https://gen.pollinations.ai/embeddings/models",
+        );
+        expect(embeddingModelsResponse.status).toBe(200);
+        const embeddingModels =
+            (await embeddingModelsResponse.json()) as Array<{
+                name: string;
+            }>;
+        const listedEmbeddingModel = embeddingModels.find(
+            (model) => model.name === registered.modelId,
+        );
+        expect(listedEmbeddingModel).toMatchObject({
+            name: registered.modelId,
+            category: "embedding",
+            community: true,
+            pricing: { promptTextTokens: "0.00001" },
+        });
+        expect(
+            fetchMock.mock.calls.filter(
+                ([input]) => new Request(input).url === embeddingUrl,
+            ),
+        ).toHaveLength(2);
+    },
+);
+
+fixtureTest(
+    "manages my-models through account API with a key that has account keys permission",
+    async () => {
+        const ownerGithubUsername = `pk-${crypto.randomUUID().slice(0, 8)}`;
+        const { key } = await createTestApiKey({
+            type: "publishable",
+            accountPermissions: ["keys"],
+            user: {
+                githubId: nextAllowedGithubId(),
+                githubUsername: ownerGithubUsername,
+            },
+        });
+        const denied = await createTestApiKey({
+            user: {
+                githubId: nextAllowedGithubId(),
+                githubUsername: `denied-${crypto.randomUUID().slice(0, 8)}`,
+            },
+        });
+        const enterApi = await createEnterFrontendApi();
+
+        const legacyResponse = await fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/community-endpoints", {
+                headers: {
+                    Authorization: `Bearer ${key}`,
+                },
+            }),
+        );
+        expect(legacyResponse.status).toBe(404);
+
+        const deniedResponse = await fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/account/my-models", {
+                headers: {
+                    Authorization: `Bearer ${denied.key}`,
+                },
+            }),
+        );
+        expect(deniedResponse.status).toBe(403);
+
+        const listResponse = await fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/account/my-models", {
+                headers: {
+                    Authorization: `Bearer ${key}`,
+                },
+            }),
+        );
+        expect(listResponse.status).toBe(200);
+        await expect(listResponse.json()).resolves.toEqual({
+            data: [],
+            provider: { name: null, url: null },
+        });
+
+        const incompleteProviderResponse = await fetchEnterApi(
+            enterApi,
+            new Request(
+                "http://localhost:3000/api/account/my-models/provider",
+                {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${key}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({ name: "Example AI", url: "" }),
+                },
+            ),
+        );
+        expect(incompleteProviderResponse.status).toBe(400);
+
+        const insecureProviderResponse = await fetchEnterApi(
+            enterApi,
+            new Request(
+                "http://localhost:3000/api/account/my-models/provider",
+                {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${key}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({
+                        name: "Example AI",
+                        url: "http://example.com",
+                    }),
+                },
+            ),
+        );
+        expect(insecureProviderResponse.status).toBe(400);
+
+        const providerResponse = await fetchEnterApi(
+            enterApi,
+            new Request(
+                "http://localhost:3000/api/account/my-models/provider",
+                {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${key}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({
+                        name: "Example AI",
+                        url: "https://example.com",
+                    }),
+                },
+            ),
+        );
+        expect(providerResponse.status).toBe(200);
+        await expect(providerResponse.json()).resolves.toEqual({
+            name: "Example AI",
+            url: "https://example.com/",
+        });
+
+        const createResponse = await fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/account/my-models", {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${key}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    name: "my-test-model",
+                    title: "My Test Model",
+                    description: "Account API model",
+                    baseUrl: "https://api.example.com/v1",
+                    upstreamModel: "gpt-4.1-mini",
+                    bearerToken: "sk_saved_token",
+                    perUserRpm: 0.5,
+                }),
+            }),
+        );
+        expect(createResponse.status).toBe(200);
+        const created = (await createResponse.json()) as Record<
+            string,
+            unknown
+        >;
+        expect(created).toMatchObject({
+            modelId: `${ownerGithubUsername}/my-test-model`,
+            name: "my-test-model",
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "gpt-4.1-mini",
+            visibility: "private",
+            paidOnly: false,
+            perUserRpm: 0.5,
+            promptTextPrice: 0,
+            completionTextPrice: 0,
+            hidden: false,
+            hiddenReason: null,
+            hiddenAt: null,
+        });
+        expect(created).not.toHaveProperty("bearerToken");
+        expect(created).not.toHaveProperty("bearerTokenCiphertext");
+        expect(typeof created.id).toBe("string");
+        const createdId = created.id as string;
+        await db
+            .update(communityEndpointTable)
+            .set({
+                hiddenAt: new Date(),
+                hiddenReason: "was failing",
+                hiddenBy: "monitor",
+            })
+            .where(eq(communityEndpointTable.id, createdId));
+
+        const updateResponse = await fetchEnterApi(
+            enterApi,
+            new Request(
+                `http://localhost:3000/api/account/my-models/${createdId}/update`,
+                {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${key}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({
+                        title: "Updated Model Title",
+                        description: "Updated description",
+                        visibility: "public",
+                        paidOnly: true,
+                        promptTextPrice: 0.00001,
+                        completionTextPrice: 0.00002,
+                    }),
+                },
+            ),
+        );
+        expect(updateResponse.status).toBe(200);
+        await expect(updateResponse.json()).resolves.toMatchObject({
+            title: "Updated Model Title",
+            description: "Updated description",
+            visibility: "private",
+            paidOnly: false,
+            promptTextPrice: 0,
+            completionTextPrice: 0,
+            pending: {
+                visibility: "public",
+                paidOnly: true,
+                promptTextPrice: 0.00001,
+                completionTextPrice: 0.00002,
+            },
+            hidden: true,
+            hiddenReason: "was failing",
+        });
+        const elapsedDelayAt = new Date(
+            Date.now() - COMMUNITY_ENDPOINT_CHANGE_DELAY_MS - 1,
+        );
+        await db
+            .update(communityEndpointTable)
+            .set({
+                pendingAt: elapsedDelayAt,
+                hiddenAt: elapsedDelayAt,
+            })
+            .where(eq(communityEndpointTable.id, createdId));
+
+        const relistResponse = await fetchEnterApi(
+            enterApi,
+            new Request(
+                `http://localhost:3000/api/account/my-models/${createdId}/update`,
+                {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${key}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({ hidden: false }),
+                },
+            ),
+        );
+        expect(relistResponse.status).toBe(200);
+        await expect(relistResponse.json()).resolves.toMatchObject({
+            hidden: false,
+            hiddenReason: null,
+            hiddenAt: null,
+        });
+
+        const hideResponse = await fetchEnterApi(
+            enterApi,
+            new Request(
+                `http://localhost:3000/api/account/my-models/${createdId}/update`,
+                {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${key}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({ hidden: true }),
+                },
+            ),
+        );
+        expect(hideResponse.status).toBe(200);
+        await expect(hideResponse.json()).resolves.toMatchObject({
+            hidden: true,
+            hiddenReason: "Hidden by owner",
+        });
+
+        // Minimum-price policy is independent of visibility: any non-negative
+        // owner price is accepted by this API.
+        const tinyPriceResponse = await fetchEnterApi(
+            enterApi,
+            new Request(
+                `http://localhost:3000/api/account/my-models/${createdId}/update`,
+                {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${key}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({
+                        promptTextPrice: 1e-12,
+                    }),
+                },
+            ),
+        );
+        expect(tinyPriceResponse.status).toBe(200);
+        await expect(tinyPriceResponse.json()).resolves.toMatchObject({
+            promptTextPrice: 0.00001,
+            pending: { promptTextPrice: 1e-12 },
+        });
+
+        const negativePriceResponse = await fetchEnterApi(
+            enterApi,
+            new Request(
+                `http://localhost:3000/api/account/my-models/${createdId}/update`,
+                {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${key}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({
+                        promptTextPrice: -1e-12,
+                    }),
+                },
+            ),
+        );
+        expect(negativePriceResponse.status).toBe(400);
+
+        // Partial updates persist the full effective visibility + price set,
+        // so a price-only patch keeps the other stored prices intact.
+        const priceOnlyResponse = await fetchEnterApi(
+            enterApi,
+            new Request(
+                `http://localhost:3000/api/account/my-models/${createdId}/update`,
+                {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${key}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({
+                        promptTextPrice: 0.00003,
+                    }),
+                },
+            ),
+        );
+        expect(priceOnlyResponse.status).toBe(200);
+        await expect(priceOnlyResponse.json()).resolves.toMatchObject({
+            visibility: "public",
+            paidOnly: true,
+            promptTextPrice: 0.00001,
+            completionTextPrice: 0.00002,
+            pending: {
+                promptTextPrice: 0.00003,
+                completionTextPrice: 0.00002,
+            },
+        });
+        const pendingRegistryEntry = (
+            await getCommunityModelRegistryEntries(env)
+        ).find((entry) => entry.id === `${ownerGithubUsername}/my-test-model`);
+        expect(pendingRegistryEntry?.info.pending_change).toMatchObject({
+            paid_only: true,
+            pricing: {
+                currency: "pollen",
+                promptTextTokens: "0.00003",
+                completionTextTokens: "0.00002",
+            },
+        });
+        expect(pendingRegistryEntry?.info.pending_change?.effective_at).toEqual(
+            expect.any(String),
+        );
+
+        // Making the model private clears all owner-set prices, and with them
+        // the paid-only choice: a free listing that still demanded paid balance
+        // would only gate the owner out of their own model.
+        const privatizeResponse = await fetchEnterApi(
+            enterApi,
+            new Request(
+                `http://localhost:3000/api/account/my-models/${createdId}/update`,
+                {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${key}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({
+                        visibility: "private",
+                    }),
+                },
+            ),
+        );
+        expect(privatizeResponse.status).toBe(200);
+        await expect(privatizeResponse.json()).resolves.toMatchObject({
+            visibility: "private",
+            paidOnly: false,
+            promptTextPrice: 0,
+            completionTextPrice: 0,
+        });
+
+        // Republishing remains free, but becomes visible after the notice
+        // period rather than immediately.
+        const republishResponse = await fetchEnterApi(
+            enterApi,
+            new Request(
+                `http://localhost:3000/api/account/my-models/${createdId}/update`,
+                {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${key}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({
+                        visibility: "public",
+                    }),
+                },
+            ),
+        );
+        expect(republishResponse.status).toBe(200);
+        await expect(republishResponse.json()).resolves.toMatchObject({
+            visibility: "private",
+            promptTextPrice: 0,
+            completionTextPrice: 0,
+            pending: { visibility: "public" },
+        });
+
+        const secondListResponse = await fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/account/my-models", {
+                headers: {
+                    Authorization: `Bearer ${key}`,
+                },
+            }),
+        );
+        expect(secondListResponse.status).toBe(200);
+        const secondList = (await secondListResponse.json()) as {
+            data: Record<string, unknown>[];
+            provider: { name: string | null; url: string | null };
+        };
+        expect(secondList.data).toHaveLength(1);
+        expect(secondList.provider).toEqual({
+            name: "Example AI",
+            url: "https://example.com/",
+        });
+        expect(secondList.data[0]).toMatchObject({
+            title: "Updated Model Title",
+            perUserRpm: 0.5,
+        });
+        expect(secondList.data[0]).not.toHaveProperty("bearerToken");
+        expect(secondList.data[0]).not.toHaveProperty("bearerTokenCiphertext");
+
+        const registryEntry = (
+            await getCommunityModelRegistryEntries(env)
+        ).find((entry) => entry.id === `${ownerGithubUsername}/my-test-model`);
+        expect(registryEntry?.info).toMatchObject({
+            brand: "Example AI",
+            brand_url: "https://example.com/",
+        });
+        expect(registryEntry?.communityEndpoint.perUserRpm).toBe(0.5);
+
+        const clearLimitResponse = await fetchEnterApi(
+            enterApi,
+            new Request(
+                `http://localhost:3000/api/account/my-models/${createdId}/update`,
+                {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${key}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({
+                        perUserRpm: null,
+                    }),
+                },
+            ),
+        );
+        expect(clearLimitResponse.status).toBe(200);
+        await expect(clearLimitResponse.json()).resolves.toMatchObject({
+            perUserRpm: null,
+        });
+    },
+);
+
+fixtureTest(
+    "accepts free and minimum public community prices while rejecting smaller positive prices",
+    async () => {
+        const ownerGithubUsername = `price-${crypto.randomUUID().slice(0, 8)}`;
+        const ownerUserId = await createTestUser({
+            githubId: nextAllowedGithubId(),
+            githubUsername: ownerGithubUsername,
+        });
+        const sessionToken = `session-${crypto.randomUUID()}`;
+        await db.insert(sessionTable).values({
+            id: `session-${crypto.randomUUID()}`,
+            token: sessionToken,
+            userId: ownerUserId,
+            expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+        const cookie = await signedSessionCookie(sessionToken);
+        const enterApi = await createEnterCommunityApi();
+        const createResponse = await fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/community-endpoints", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: cookie,
+                },
+                body: JSON.stringify({
+                    name: "price-floor-test",
+                    title: "Price Floor Test",
+                    baseUrl: "https://api.example.com/v1",
+                    upstreamModel: "gpt-4.1-mini",
+                    bearerToken: "sk_saved_token",
+                    visibility: "public",
+                    promptTextPrice: 0,
+                }),
+            }),
+        );
+        expect(createResponse.status).toBe(200);
+        const created = (await createResponse.json()) as {
+            id: string;
+            promptTextPrice: number;
+        };
+        expect(created.promptTextPrice).toBe(0);
+
+        const updatePrice = (price: number) =>
+            fetchEnterApi(
+                enterApi,
+                new Request(
+                    `http://localhost:3000/api/community-endpoints/${created.id}/update`,
+                    {
+                        method: "POST",
+                        headers: {
+                            "Content-Type": "application/json",
+                            Cookie: cookie,
+                        },
+                        body: JSON.stringify({
+                            promptTextPrice: price,
+                        }),
+                    },
+                ),
+            );
+
+        const minimumResponse = await updatePrice(
+            MIN_COMMUNITY_PRICE_PER_TOKEN,
+        );
+        expect(minimumResponse.status).toBe(200);
+        await expect(minimumResponse.json()).resolves.toMatchObject({
+            promptTextPrice: 0,
+            pending: {
+                promptTextPrice: MIN_COMMUNITY_PRICE_PER_TOKEN,
+            },
+        });
+
+        const maximumResponse = await updatePrice(
+            MAX_COMMUNITY_PRICE_PER_TOKEN,
+        );
+        expect(maximumResponse.status).toBe(200);
+        await expect(maximumResponse.json()).resolves.toMatchObject({
+            promptTextPrice: 0,
+            pending: {
+                promptTextPrice: MAX_COMMUNITY_PRICE_PER_TOKEN,
+            },
+        });
+
+        const aboveMaximumResponse = await updatePrice(
+            MAX_COMMUNITY_PRICE_PER_TOKEN * 1.01,
+        );
+        expect(aboveMaximumResponse.status).toBe(400);
+        expect(await aboveMaximumResponse.text()).toContain(
+            `${MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS} Pollen per 1M tokens`,
+        );
+
+        const belowMinimumResponse = await updatePrice(
+            MIN_COMMUNITY_PRICE_PER_TOKEN / 10,
+        );
+        expect(belowMinimumResponse.status).toBe(400);
+        expect(await belowMinimumResponse.text()).toContain(
+            `${MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS} per 1M tokens`,
+        );
+
+        const negativeResponse = await updatePrice(
+            -MIN_COMMUNITY_PRICE_PER_TOKEN,
+        );
+        expect(negativeResponse.status).toBe(400);
+    },
+);
+
+fixtureTest(
+    "rejects an endpoint probe when the upstream responds with a redirect",
+    async () => {
+        // Use an approved publisher so the request reaches the outbound probe;
+        // non-allowlisted accounts are rejected before any fetch occurs.
+        const ownerUserId = await createTestUser({
+            githubId: nextAllowedGithubId(),
+            githubUsername: `redir-${crypto.randomUUID().slice(0, 8)}`,
+        });
+        const sessionToken = `session-${crypto.randomUUID()}`;
+        await db.insert(sessionTable).values({
+            id: `session-${crypto.randomUUID()}`,
+            token: sessionToken,
+            userId: ownerUserId,
+            expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+
+        const enterApi = await createEnterCommunityApi();
+        const fetchMock = vi.fn(async (input, init) => {
+            const request = new Request(input, init);
+            if (
+                request.url ===
+                "https://redirecting.example.com/v1/chat/completions"
+            ) {
+                // The redirect target never went through base-URL validation,
+                // so the probe must not follow it.
+                expect(init?.redirect).toBe("manual");
+                return new Response(null, {
+                    status: 302,
+                    headers: { Location: "http://127.0.0.1/admin" },
+                });
+            }
+            throw new Error(`Unexpected fetch: ${request.url}`);
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const testResponse = await fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/community-endpoints/test", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: await signedSessionCookie(sessionToken),
+                },
+                body: JSON.stringify({
+                    baseUrl: "https://redirecting.example.com/v1",
+                    bearerToken: "Bearer sk_upstream",
+                    model: "gpt-test",
+                }),
+            }),
+        );
+
+        expect(testResponse.status).toBe(400);
+        expect(await testResponse.text()).toContain("redirect");
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    },
+);
+
+fixtureTest("rejects unsafe community model names", async () => {
+    const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;
+    const ownerUserId = await createTestUser({
+        githubId: nextAllowedGithubId(),
+        githubUsername: ownerGithubUsername,
+    });
+    const sessionToken = `session-${crypto.randomUUID()}`;
+    await db.insert(sessionTable).values({
+        id: `session-${crypto.randomUUID()}`,
+        token: sessionToken,
+        userId: ownerUserId,
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+    });
+
+    const enterApi = await createEnterCommunityApi();
+    for (const name of [
+        "inferenceport.ai/gpt-oss-20b",
+        "bad name",
+        "bad'name",
+        "$(bad)",
+    ]) {
+        const response = await fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/community-endpoints", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: await signedSessionCookie(sessionToken),
+                },
+                body: JSON.stringify({
+                    name,
+                    title: "Unsafe Name",
+                    description: "unsafe model name",
+                    baseUrl: "https://api.example.com/v1",
+                    upstreamModel: "gpt-oss-20b",
+                    bearerToken: "sk_saved_token",
+                }),
+            }),
+        );
+
+        expect(response.status).toBe(400);
+    }
+});
+
+fixtureTest(
+    "rejects proxy registration without a base URL or with agent-only fields",
+    async () => {
+        const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;
+        const ownerUserId = await createTestUser({
+            githubId: nextAllowedGithubId(),
+            githubUsername: ownerGithubUsername,
+        });
+        const sessionToken = `session-${crypto.randomUUID()}`;
+        await db.insert(sessionTable).values({
+            id: `session-${crypto.randomUUID()}`,
+            token: sessionToken,
+            userId: ownerUserId,
+            expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+
+        const enterApi = await createEnterCommunityApi();
+        const cookie = await signedSessionCookie(sessionToken);
+        const register = (body: Record<string, unknown>) =>
+            fetchEnterApi(
+                enterApi,
+                new Request("http://localhost:3000/api/community-endpoints", {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Cookie: cookie,
+                    },
+                    body: JSON.stringify({
+                        name: `bee-${crypto.randomUUID().slice(0, 8)}`,
+                        title: "Registration Test",
+                        bearerToken: "sk_saved_token",
+                        ...body,
+                    }),
+                }),
+            );
+
+        const both = await register({
+            baseUrl: "https://api.example.com/v1",
+            agentId: crypto.randomUUID(),
+        });
+        expect(both.status).toBe(400);
+
+        const neither = await register({});
+        expect(neither.status).toBe(400);
+    },
+);
+
+fixtureTest("creates, edits, routes, and deletes managed agents", async () => {
+    const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;
+    const modelName = `model-${crypto.randomUUID().slice(0, 8)}`;
+    const ownerUserId = await createTestUser({
+        githubId: nextAllowedGithubId(),
+        githubUsername: ownerGithubUsername,
+    });
+    const sessionToken = `session-${crypto.randomUUID()}`;
+    await db.insert(sessionTable).values({
+        id: `session-${crypto.randomUUID()}`,
+        token: sessionToken,
+        userId: ownerUserId,
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+    });
+
+    const enterEnv = {
+        ...env,
+        BETTER_AUTH_URL: "https://enter.test",
+        AGENT_RUNTIME_BASE_URL: env.AGENT_RUNTIME_BASE_URL,
+    };
+    const enterApi = await createEnterFrontendApi();
+    const cookie = (await signedSessionCookie(sessionToken)).replace(
+        "better-auth.session_token",
+        "__Secure-better-auth.session_token",
+    );
+    const promptAgent = {
+        systemPrompt: "You are a terse SQL tutor.",
+        baseModel: "openai-fast",
+        requiredSafetyFeatures: ["sexual"],
+        mcpServers: ["pollinations"],
+    };
+    const createAgentResponse = await fetchEnterApi(
+        enterApi,
+        new Request("https://enter.test/api/account/agents", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Cookie: cookie,
+            },
+            body: JSON.stringify({
+                ...promptAgent,
+                name: modelName,
+                title: "Managed SQL Tutor",
+            }),
+        }),
+        enterEnv,
+    );
+    expect(createAgentResponse.status).toBe(200);
+    const agent = (await createAgentResponse.json()) as {
+        id: string;
+        systemPrompt: string;
+        baseModel: string;
+        mcpServers: string[];
+    };
+    expect(agent).toMatchObject({
+        systemPrompt: "You are a terse SQL tutor.",
+        baseModel: "openai-fast",
+        mcpServers: ["pollinations"],
+    });
+    expect(agent).not.toHaveProperty("apiKeyId");
+    expect(agent).not.toHaveProperty("apiKeyCiphertext");
+    expect(agent).not.toHaveProperty("bearerTokenCiphertext");
+    expect(agent).toMatchObject({
+        name: modelName,
+        description: null,
+        visibility: "private",
+        baseUrl: env.AGENT_RUNTIME_BASE_URL,
+        upstreamModel: agent.id,
+    });
+    const [storedAgent] = await db
+        .select()
+        .from(communityEndpointTable)
+        .where(eq(communityEndpointTable.id, agent.id));
+    expect(storedAgent.id).toBe(agent.id);
+    expect(storedAgent.baseUrl).toBe(PROMPT_AGENT_BASE_URL_PLACEHOLDER);
+    expect(storedAgent.upstreamModel).toBe(agent.id);
+    expect(storedAgent.requiredSafetyFeatures).toEqual(["sexual"]);
+    expect(JSON.parse(storedAgent.payload)).toEqual({
+        systemPrompt: promptAgent.systemPrompt,
+        baseModel: promptAgent.baseModel,
+        mcpServers: promptAgent.mcpServers,
+    });
+    const partialUpdateResponse = await fetchEnterApi(
+        enterApi,
+        new Request(`https://enter.test/api/account/agents/${agent.id}`, {
+            method: "PATCH",
+            headers: {
+                "Content-Type": "application/json",
+                Cookie: cookie,
+            },
+            body: JSON.stringify({
+                systemPrompt: "You are an editable SQL tutor.",
+            }),
+        }),
+        enterEnv,
+    );
+    expect(partialUpdateResponse.status).toBe(400);
+    const updateAgentResponse = await fetchEnterApi(
+        enterApi,
+        new Request(`https://enter.test/api/account/agents/${agent.id}`, {
+            method: "PATCH",
+            headers: {
+                "Content-Type": "application/json",
+                Cookie: cookie,
+            },
+            body: JSON.stringify({
+                ...promptAgent,
+                systemPrompt: "You are an editable SQL tutor.",
+                name: modelName,
+                title: "Managed SQL Tutor",
+                description: "",
+                visibility: "public",
+            }),
+        }),
+        enterEnv,
+    );
+    expect(updateAgentResponse.status).toBe(200);
+    await expect(updateAgentResponse.json()).resolves.toMatchObject({
+        id: agent.id,
+        systemPrompt: "You are an editable SQL tutor.",
+        mcpServers: ["pollinations"],
+    });
+    const [agentAfterPromptUpdate] = await db
+        .select()
+        .from(communityEndpointTable)
+        .where(eq(communityEndpointTable.id, agent.id));
+    expect(agentAfterPromptUpdate.requiredSafetyFeatures).toEqual(["sexual"]);
+    expect(JSON.parse(agentAfterPromptUpdate.payload)).toEqual({
+        baseModel: promptAgent.baseModel,
+        mcpServers: promptAgent.mcpServers,
+        systemPrompt: "You are an editable SQL tutor.",
+    });
+    const listResponse = await fetchEnterApi(
+        enterApi,
+        new Request("https://enter.test/api/account/my-models", {
+            headers: { Cookie: cookie },
+        }),
+        enterEnv,
+    );
+    expect(listResponse.status).toBe(200);
+    const registration = (
+        (await listResponse.json()) as {
+            data: {
+                id: string;
+                modelId: string;
+                type: "prompt_agent";
+                baseUrl: string;
+                upstreamModel: string;
+            }[];
+        }
+    ).data.find((row) => row.id === agent.id);
+    expect(registration).toBeDefined();
+    if (!registration) throw new Error("Agent listing was not created");
+    expect(registration.id).toBe(agent.id);
+    expect(registration.type).toBe("prompt_agent");
+    expect(registration.baseUrl).toBe(env.AGENT_RUNTIME_BASE_URL);
+    expect(registration.upstreamModel).toBe(agent.id);
+    expect(registration).not.toHaveProperty("modality");
+    const paidUpdateResponse = await fetchEnterApi(
+        enterApi,
+        new Request(
+            `https://enter.test/api/account/my-models/${registration.id}/update`,
+            {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: cookie,
+                },
+                body: JSON.stringify({
+                    promptTextPrice: 0.00001,
+                }),
+            },
+        ),
+        enterEnv,
+    );
+    expect(paidUpdateResponse.status).toBe(400);
+    const fallbackUpdateResponse = await fetchEnterApi(
+        enterApi,
+        new Request(
+            `https://enter.test/api/account/my-models/${registration.id}/update`,
+            {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: cookie,
+                },
+                body: JSON.stringify({
+                    fallbacks: ["owner/backup"],
+                }),
+            },
+        ),
+        enterEnv,
+    );
+    expect(fallbackUpdateResponse.status).toBe(400);
+    expect(await fallbackUpdateResponse.text()).toContain(
+        'Unrecognized key: \\"fallbacks\\"',
+    );
+    const fallbackCandidatesResponse = await fetchEnterApi(
+        enterApi,
+        new Request(
+            `https://enter.test/api/account/my-models/${registration.id}/fallback-candidates`,
+            { headers: { Cookie: cookie } },
+        ),
+        enterEnv,
+    );
+    expect(fallbackCandidatesResponse.status).toBe(200);
+    await expect(fallbackCandidatesResponse.json()).resolves.toEqual({
+        data: [],
+    });
+    const registryEntry = (await getCommunityModelRegistryEntries(env)).find(
+        (entry) => entry.id === registration.modelId,
+    );
+    expect(registryEntry?.communityEndpoint).toMatchObject({
+        type: "prompt_agent",
+        baseUrl: env.AGENT_RUNTIME_BASE_URL,
+        upstreamModel: agent.id,
+    });
+    // An agent listing carries no upstream credential of its own.
+    expect(registryEntry?.communityEndpoint).not.toHaveProperty(
+        "bearerTokenCiphertext",
+    );
+    if (!registryEntry) throw new Error("Agent listing was not registered");
+    expect(registryEntry.agentConfig).toEqual({
+        baseModel: promptAgent.baseModel,
+        mcpServers: ["pollinations"],
+    });
+    expect(registryEntry.definition.cost).toMatchObject({
+        promptTextTokens: 0,
+        completionTextTokens: 0,
+    });
+    expect(registryEntry.definition.requiredSafetyFeatures).toEqual(["sexual"]);
+    const gatewayContext = await communityEndpointGatewayContext({
+        endpoint: registryEntry.communityEndpoint,
+        modelDefinition: registryEntry.definition,
+        requestData: { messages: [{ role: "user", content: "hello" }] },
+        secret: env.BETTER_AUTH_SECRET,
+        portkeyGatewayUrl: env.PORTKEY_GATEWAY_URL,
+        userApiKey: "sk_user_key",
+        parentRequestId: "caller-request-id",
+        parentApiKeyId: "caller-api-key-id",
+    });
+    const runtimeToken = String(gatewayContext.modelConfig?.authKey);
+    expect(runtimeToken).toMatch(/^ag_/);
+    await expect(
+        verifyAgentRunToken(runtimeToken, env.BETTER_AUTH_SECRET),
+    ).resolves.toMatchObject({
+        parentApiKeyId: "caller-api-key-id",
+        parentRequestId: "caller-request-id",
+        managedAgentId: agent.id,
+    });
+    expect(gatewayContext.modelConfig).toMatchObject({
+        "custom-host": env.AGENT_RUNTIME_BASE_URL,
+        model: agent.id,
+    });
+
+    const endpointAgentId = `endpoint-${crypto.randomUUID()}`;
+    await insertCommunityEndpoints({
+        id: endpointAgentId,
+        ownerUserId,
+        type: "endpoint_agent",
+        name: `endpoint-agent-${crypto.randomUUID().slice(0, 8)}`,
+        title: "Endpoint Agent",
+        baseUrl: "https://agent.example.com/v1",
+        upstreamModel: "endpoint-agent",
+        visibility: "private",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+    });
+    const updateEndpointAgentResponse = await fetchEnterApi(
+        enterApi,
+        new Request(
+            `https://enter.test/api/account/my-models/${endpointAgentId}/update`,
+            {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: cookie,
+                },
+                body: JSON.stringify({
+                    baseUrl: "https://updated-agent.example.com/v1",
+                    upstreamModel: "updated-endpoint-agent",
+                    perUserRpm: 7,
+                    requiredSafetyFeatures: ["violence"],
+                }),
+            },
+        ),
+        enterEnv,
+    );
+    expect(updateEndpointAgentResponse.status).toBe(200);
+    const endpointAgentResponse = await updateEndpointAgentResponse.json();
+    expect(endpointAgentResponse).toMatchObject({
+        id: endpointAgentId,
+        type: "endpoint_agent",
+        baseUrl: "https://updated-agent.example.com/v1",
+        upstreamModel: "updated-endpoint-agent",
+        perUserRpm: 7,
+        requiredSafetyFeatures: ["violence"],
+    });
+    expect(endpointAgentResponse).not.toHaveProperty("agentId");
+    expect(endpointAgentResponse).not.toHaveProperty("modality");
+    const invalidEndpointAgentUpdateResponse = await fetchEnterApi(
+        enterApi,
+        new Request(
+            `https://enter.test/api/account/my-models/${endpointAgentId}/update`,
+            {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: cookie,
+                },
+                body: JSON.stringify({
+                    bearerToken: "not-supported",
+                }),
+            },
+        ),
+        enterEnv,
+    );
+    expect(invalidEndpointAgentUpdateResponse.status).toBe(400);
+    const endpointAgentRegistryEntry = (
+        await getCommunityModelRegistryEntries(env)
+    ).find((entry) => entry.communityEndpoint.id === endpointAgentId);
+    expect(endpointAgentRegistryEntry?.communityEndpoint).toMatchObject({
+        type: "endpoint_agent",
+        baseUrl: "https://updated-agent.example.com/v1",
+        upstreamModel: "updated-endpoint-agent",
+        perUserRpm: 7,
+        requiredSafetyFeatures: ["violence"],
+    });
+    expect(
+        endpointAgentRegistryEntry?.definition.requiredSafetyFeatures,
+    ).toEqual(["violence"]);
+    expect(endpointAgentRegistryEntry?.communityEndpoint).not.toHaveProperty(
+        "bearerTokenCiphertext",
+    );
+
+    const [modelsResponse, openaiModelsResponse] = await Promise.all([
+        fetchGen("https://gen.pollinations.ai/models"),
+        fetchGen("https://gen.pollinations.ai/v1/models"),
+    ]);
+    const models = (await modelsResponse.json()) as {
+        name: string;
+        community?: boolean;
+        agent?: boolean;
+        base_model?: string;
+        pricing?: Record<string, string>;
+        capabilities?: string[];
+        input_modalities?: string[];
+        output_modalities?: string[];
+    }[];
+    const openaiModels = (await openaiModelsResponse.json()) as {
+        data: {
+            id: string;
+            agent?: boolean;
+            base_model?: string;
+            pricing?: Record<string, string>;
+            capabilities?: string[];
+            input_modalities?: string[];
+            output_modalities?: string[];
+            tools?: boolean;
+            reasoning?: boolean;
+            context_length?: number;
+        }[];
+    };
+    const baseModelInfo = models.find(
+        (model) => model.name === promptAgent.baseModel,
+    );
+    const agentModelInfo = models.find(
+        (model) => model.name === registration.modelId,
+    );
+    expect(baseModelInfo).toBeDefined();
+    const agentCapabilities = [
+        ...(baseModelInfo?.capabilities ?? []),
+        "pollinations_models",
+    ];
+    expect(agentModelInfo).toMatchObject({
+        community: true,
+        agent: true,
+        base_model: promptAgent.baseModel,
+        pricing: baseModelInfo?.pricing,
+        capabilities: agentCapabilities,
+        input_modalities: baseModelInfo?.input_modalities,
+        output_modalities: baseModelInfo?.output_modalities,
+    });
+    const openaiBaseModel = openaiModels.data.find(
+        (model) => model.id === promptAgent.baseModel,
+    );
+    const openaiAgentModel = openaiModels.data.find(
+        (model) => model.id === registration.modelId,
+    );
+    expect(openaiBaseModel).toBeDefined();
+    expect(openaiAgentModel).toMatchObject({
+        agent: true,
+        base_model: promptAgent.baseModel,
+        pricing: baseModelInfo?.pricing,
+        capabilities: agentCapabilities,
+        input_modalities: openaiBaseModel?.input_modalities,
+        output_modalities: openaiBaseModel?.output_modalities,
+        tools: openaiBaseModel?.tools,
+        context_length: openaiBaseModel?.context_length,
+    });
+
+    const deleteRegisteredAgentResponse = await fetchEnterApi(
+        enterApi,
+        new Request(`https://enter.test/api/account/agents/${agent.id}`, {
+            method: "DELETE",
+            headers: { Cookie: cookie },
+        }),
+        enterEnv,
+    );
+    expect(deleteRegisteredAgentResponse.status).toBe(200);
+    await expect(
+        db
+            .select()
+            .from(communityEndpointTable)
+            .where(eq(communityEndpointTable.id, agent.id)),
+    ).resolves.toEqual([]);
+});
+
+fixtureTest("validates community fallback targets on write", async () => {
+    const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;
+    const ownerUserId = await createTestUser({
+        githubId: nextAllowedGithubId(),
+        githubUsername: ownerGithubUsername,
+    });
+    const otherOwnerGithubUsername = `other-${crypto.randomUUID().slice(0, 8)}`;
+    const otherOwnerUserId = await createTestUser({
+        githubId: nextAllowedGithubId(),
+        githubUsername: otherOwnerGithubUsername,
+    });
+    const sessionToken = `session-${crypto.randomUUID()}`;
+    await db.insert(sessionTable).values({
+        id: `session-${crypto.randomUUID()}`,
+        token: sessionToken,
+        userId: ownerUserId,
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+    });
+
+    const bearerTokenCiphertext = await encryptSecret(
+        "sk_saved_token",
+        env.BETTER_AUTH_SECRET,
+    );
+    const targetNames = {
+        cheap: `cheap-${crypto.randomUUID().slice(0, 8)}`,
+        priv: `private-${crypto.randomUUID().slice(0, 8)}`,
+        otherPrivate: `other-private-${crypto.randomUUID().slice(0, 8)}`,
+        otherDisabled: `other-disabled-${crypto.randomUUID().slice(0, 8)}`,
+        disabled: `disabled-${crypto.randomUUID().slice(0, 8)}`,
+        delegating: `delegating-${crypto.randomUUID().slice(0, 8)}`,
+        image: `image-${crypto.randomUUID().slice(0, 8)}`,
+        pricey: `pricey-${crypto.randomUUID().slice(0, 8)}`,
+    };
+    for (const target of [
+        {
+            id: `endpoint-${crypto.randomUUID()}`,
+            ownerUserId,
+            visibility: "public",
+            name: targetNames.cheap,
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "cheap-upstream",
+            bearerTokenCiphertext,
+            promptTextPrice: 0.1 / 1_000_000,
+            completionTextPrice: 0.1 / 1_000_000,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        },
+        {
+            id: `endpoint-${crypto.randomUUID()}`,
+            ownerUserId: otherOwnerUserId,
+            visibility: "private",
+            name: targetNames.otherPrivate,
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "other-private-upstream",
+            bearerTokenCiphertext,
+            promptTextPrice: 0,
+            completionTextPrice: 0,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        },
+        {
+            id: `endpoint-${crypto.randomUUID()}`,
+            ownerUserId: otherOwnerUserId,
+            visibility: "public",
+            name: targetNames.otherDisabled,
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "other-disabled-upstream",
+            bearerTokenCiphertext,
+            promptTextPrice: 0,
+            completionTextPrice: 0,
+            hiddenAt: new Date(),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        },
+        {
+            id: `endpoint-${crypto.randomUUID()}`,
+            ownerUserId,
+            visibility: "public",
+            name: targetNames.disabled,
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "disabled-upstream",
+            bearerTokenCiphertext,
+            promptTextPrice: 0,
+            completionTextPrice: 0,
+            hiddenAt: new Date(),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        },
+        {
+            id: `endpoint-${crypto.randomUUID()}`,
+            ownerUserId,
+            visibility: "private",
+            name: targetNames.priv,
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "private-upstream",
+            bearerTokenCiphertext,
+            promptTextPrice: 0,
+            completionTextPrice: 0,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        },
+        {
+            id: `endpoint-${crypto.randomUUID()}`,
+            ownerUserId,
+            visibility: "public",
+            name: targetNames.delegating,
+            type: "endpoint_agent",
+            baseUrl: "https://agent.example.com/v1",
+            upstreamModel: "delegating-upstream",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        },
+        {
+            id: `endpoint-${crypto.randomUUID()}`,
+            ownerUserId,
+            visibility: "public",
+            name: targetNames.image,
+            modality: "image",
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "image-upstream",
+            bearerTokenCiphertext,
+            promptTextPrice: 0,
+            completionTextPrice: 0,
+            completionImagePrice: 0.01,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        },
+        {
+            id: `endpoint-${crypto.randomUUID()}`,
+            ownerUserId,
+            visibility: "public",
+            name: targetNames.pricey,
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "pricey-upstream",
+            bearerTokenCiphertext,
+            promptTextPrice: 0.1 / 1_000_000,
+            completionTextPrice: 0.5 / 1_000_000,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        },
+    ] satisfies CommunityEndpointFixture[]) {
+        await insertCommunityEndpoints(target);
+    }
+
+    const enterApi = await createEnterCommunityApi();
+    const primaryName = `primary-${crypto.randomUUID().slice(0, 8)}`;
+    const createWithFallback = async (name: string, ...fallbacks: string[]) =>
+        fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/community-endpoints", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: await signedSessionCookie(sessionToken),
+                },
+                body: JSON.stringify({
+                    name,
+                    title: "Primary",
+                    baseUrl: "https://api.example.com/v1",
+                    upstreamModel: "primary-upstream",
+                    bearerToken: "sk_saved_token",
+                    visibility: "public",
+                    promptTextPrice: 0.2 / 1_000_000,
+                    completionTextPrice: 0.2 / 1_000_000,
+                    fallbacks,
+                }),
+            }),
+        );
+
+    const selfReference = await createWithFallback(
+        primaryName,
+        communityModelId(ownerGithubUsername, primaryName),
+    );
+    expect(selfReference.status).toBe(400);
+    expect(await selfReference.text()).toContain(
+        "Fallback target cannot be the model itself",
+    );
+
+    const missing = await createWithFallback(
+        primaryName,
+        communityModelId(ownerGithubUsername, "does-not-exist"),
+    );
+    expect(missing.status).toBe(400);
+    expect(await missing.text()).toContain("does not exist");
+
+    const privateTarget = await createWithFallback(
+        `${primaryName}-private`,
+        communityModelId(ownerGithubUsername, targetNames.priv),
+    );
+    expect(privateTarget.status).toBe(200);
+    await expect(privateTarget.json()).resolves.toMatchObject({
+        fallbacks: [communityModelId(ownerGithubUsername, targetNames.priv)],
+    });
+
+    const otherPrivateTarget = await createWithFallback(
+        `${primaryName}-other-private`,
+        communityModelId(otherOwnerGithubUsername, targetNames.otherPrivate),
+    );
+    expect(otherPrivateTarget.status).toBe(400);
+    expect(await otherPrivateTarget.text()).toContain("does not exist");
+
+    const otherDisabledTarget = await createWithFallback(
+        `${primaryName}-other-disabled`,
+        communityModelId(otherOwnerGithubUsername, targetNames.otherDisabled),
+    );
+    expect(otherDisabledTarget.status).toBe(400);
+    expect(await otherDisabledTarget.text()).toContain("does not exist");
+
+    const disabledTarget = await createWithFallback(
+        `${primaryName}-disabled`,
+        communityModelId(ownerGithubUsername, targetNames.disabled),
+    );
+    expect(disabledTarget.status).toBe(400);
+    expect(await disabledTarget.text()).toContain("must be listed");
+
+    const delegatingTarget = await createWithFallback(
+        `${primaryName}-delegating`,
+        communityModelId(ownerGithubUsername, targetNames.delegating),
+    );
+    expect(delegatingTarget.status).toBe(400);
+    expect(await delegatingTarget.text()).toContain(
+        "cannot delegate generation",
+    );
+
+    const wrongModality = await createWithFallback(
+        `${primaryName}-modality`,
+        communityModelId(ownerGithubUsername, targetNames.image),
+    );
+    expect(wrongModality.status).toBe(400);
+    expect(await wrongModality.text()).toContain("is a image model, not text");
+
+    const overPriced = await createWithFallback(
+        `${primaryName}-price`,
+        communityModelId(ownerGithubUsername, targetNames.pricey),
+    );
+    expect(overPriced.status).toBe(400);
+    const overPricedMessage = await overPriced.text();
+    expect(overPricedMessage).toContain("completionTextPrice");
+    expect(overPricedMessage).toContain("exceeds this model's");
+    // Only the offending field is named — promptTextPrice is within budget.
+    expect(overPricedMessage).not.toContain("promptTextPrice");
+
+    const cheapModelId = communityModelId(
+        ownerGithubUsername,
+        targetNames.cheap,
+    );
+    const accepted = await createWithFallback(primaryName, cheapModelId);
+    expect(accepted.status).toBe(200);
+    const created = (await accepted.json()) as {
+        id: string;
+        modelId: string;
+        fallbacks: string[];
+    };
+    expect(created.fallbacks).toEqual([cheapModelId]);
+    await maturePendingCommunityEndpoint(created.id);
+
+    // One bad id fails the whole list, so a partial order is never stored.
+    const partiallyBad = await createWithFallback(
+        `${primaryName}-partial`,
+        cheapModelId,
+        communityModelId(ownerGithubUsername, "does-not-exist"),
+    );
+    expect(partiallyBad.status).toBe(400);
+    expect(await partiallyBad.text()).toContain("does not exist");
+
+    const duplicated = await createWithFallback(
+        `${primaryName}-dup`,
+        cheapModelId,
+        cheapModelId,
+    );
+    expect(duplicated.status).toBe(400);
+    expect(await duplicated.text()).toContain("listed more than once");
+
+    // The dashboard's dropdown is built from this list, so anything it offers
+    // must be acceptable to the update endpoint above — same rule, one function.
+    const candidates = await fetchEnterApi(
+        enterApi,
+        new Request(
+            `http://localhost:3000/api/community-endpoints/${created.id}/fallback-candidates`,
+            { headers: { Cookie: await signedSessionCookie(sessionToken) } },
+        ),
+    );
+    expect(candidates.status).toBe(200);
+    const { data: eligible } = (await candidates.json()) as { data: string[] };
+    expect(eligible).toContain(cheapModelId);
+    expect(eligible).toContain(
+        communityModelId(ownerGithubUsername, targetNames.priv),
+    );
+    // Never itself, and never a target the write path would reject.
+    expect(eligible).not.toContain(created.modelId);
+    for (const rejected of [
+        targetNames.image,
+        targetNames.pricey,
+        targetNames.disabled,
+        targetNames.delegating,
+    ]) {
+        expect(eligible).not.toContain(
+            communityModelId(ownerGithubUsername, rejected),
+        );
+    }
+
+    // An empty array clears the stored targets.
+    const cleared = await fetchEnterApi(
+        enterApi,
+        new Request(
+            `http://localhost:3000/api/community-endpoints/${created.id}/update`,
+            {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: await signedSessionCookie(sessionToken),
+                },
+                body: JSON.stringify({
+                    fallbacks: [],
+                }),
+            },
+        ),
+    );
+    expect(cleared.status).toBe(200);
+    await expect(cleared.json()).resolves.toMatchObject({
+        fallbacks: [],
+    });
+});
+
+fixtureTest(
+    "links community fallback targets in the generation registry",
+    async () => {
+        const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;
+        const ownerUserId = await createTestUser({
+            githubId: nextAllowedGithubId(),
+            githubUsername: ownerGithubUsername,
+        });
+        const bearerTokenCiphertext = await encryptSecret(
+            "sk_saved_token",
+            env.BETTER_AUTH_SECRET,
+        );
+        const suffix = crypto.randomUUID().slice(0, 8);
+        const name = (label: string) => `${label}-${suffix}`;
+        const id = (label: string) =>
+            communityModelId(ownerGithubUsername, name(label));
+        const endpoint = (
+            label: string,
+            values: Partial<CommunityEndpointFixture>,
+        ): CommunityEndpointFixture => ({
+            id: `endpoint-${crypto.randomUUID()}`,
+            ownerUserId,
+            visibility: "public" as const,
+            name: name(label),
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: `${label}-upstream`,
+            bearerTokenCiphertext,
+            promptTextPrice: 0.2 / 1_000_000,
+            completionTextPrice: 0.2 / 1_000_000,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            ...values,
+        });
+
+        // Inserted one at a time: D1 caps the bound variables per statement.
+        for (const row of [
+            endpoint("valid-primary", {
+                fallbacks: [id("valid-target")],
+            }),
+            endpoint("valid-target", {
+                promptTextPrice: 0.1 / 1_000_000,
+                completionTextPrice: 0.1 / 1_000_000,
+            }),
+            endpoint("disabled-primary", {
+                fallbacks: [id("disabled-target")],
+            }),
+            endpoint("disabled-target", {
+                hiddenAt: new Date(),
+                hiddenReason: "repeated upstream 500s",
+            }),
+            endpoint("deleted-primary", {
+                fallbacks: [
+                    communityModelId(ownerGithubUsername, "never-existed"),
+                ],
+            }),
+            endpoint("repriced-primary", {
+                fallbacks: [id("repriced-target")],
+            }),
+            // Priced above its primary since the fallback was configured.
+            endpoint("repriced-target", {
+                completionTextPrice: 0.5 / 1_000_000,
+            }),
+            endpoint("delegating-primary", {
+                fallbacks: [id("delegating-target")],
+            }),
+            endpoint("delegating-target", {
+                type: "endpoint_agent",
+            }),
+            endpoint("second-target", {
+                promptTextPrice: 0.1 / 1_000_000,
+                completionTextPrice: 0.1 / 1_000_000,
+            }),
+            endpoint("third-target", {
+                promptTextPrice: 0.1 / 1_000_000,
+                completionTextPrice: 0.1 / 1_000_000,
+            }),
+            endpoint("fourth-target", {
+                promptTextPrice: 0.1 / 1_000_000,
+                completionTextPrice: 0.1 / 1_000_000,
+            }),
+            endpoint("multi-primary", {
+                fallbacks: [id("valid-target"), id("second-target")],
+                // Its own targets declare fallbacks too; none of them may leak
+                // into this model's routing.
+            }),
+            endpoint("greedy-primary", {
+                fallbacks: [
+                    id("valid-target"),
+                    id("second-target"),
+                    id("third-target"),
+                    id("fourth-target"),
+                ],
+            }),
+            endpoint("gappy-primary", {
+                fallbacks: [
+                    id("valid-target"),
+                    communityModelId(ownerGithubUsername, "never-existed"),
+                    id("second-target"),
+                ],
+            }),
+            endpoint("image-primary", {
+                modality: "image",
+                imagePricing: "request",
+                promptTextPrice: 0,
+                completionTextPrice: 0,
+                completionImagePrice: 0.02,
+                fallbacks: [id("image-target")],
+            }),
+            endpoint("image-target", {
+                modality: "image",
+                imagePricing: "request",
+                promptTextPrice: 0,
+                completionTextPrice: 0,
+                completionImagePrice: 0.01,
+            }),
+            endpoint("image-request-primary", {
+                modality: "image",
+                imagePricing: "request",
+                promptTextPrice: 0,
+                completionTextPrice: 0,
+                // 0.02 Pollen per generated image.
+                completionImagePrice: 0.02,
+                fallbacks: [id("image-tokens-target")],
+            }),
+            // Switched itself to token pricing after being picked as a target:
+            // the same column now means Pollen per token (0.00005 = the 50
+            // Pollen/1M cap), so the raw numbers are no longer comparable and
+            // a 1568-token image would bill 0.0784 against a 0.02 quote.
+            endpoint("image-tokens-target", {
+                modality: "image",
+                imagePricing: "tokens",
+                promptTextPrice: 0,
+                completionTextPrice: 0,
+                completionImagePrice: 0.00005,
+            }),
+        ]) {
+            await insertCommunityEndpoints(row);
+        }
+
+        resetGenerationModelRegistryCache();
+        const registry = await getGenerationModelRegistry(env);
+
+        const fallbackIds = (model: string) =>
+            registry.resolve(model)?.fallbackEntries?.map((e) => e.id);
+
+        expect(fallbackIds(id("valid-primary"))).toEqual([id("valid-target")]);
+        expect(fallbackIds(id("disabled-primary"))).toBeUndefined();
+        expect(fallbackIds(id("deleted-primary"))).toBeUndefined();
+        expect(fallbackIds(id("repriced-primary"))).toBeUndefined();
+        expect(fallbackIds(id("delegating-primary"))).toBeUndefined();
+
+        // Same image pricing mode on both sides: the price columns mean the
+        // same thing, so the link stands.
+        expect(fallbackIds(id("image-primary"))).toEqual([id("image-target")]);
+        // Different modes: comparing per-image against per-token prices is
+        // meaningless, so the link is dropped rather than billed across units.
+        expect(fallbackIds(id("image-request-primary"))).toBeUndefined();
+        // The declared list is kept in order, and only what this owner
+        // declared: a target's own list is never appended.
+        expect(fallbackIds(id("multi-primary"))).toEqual([
+            id("valid-target"),
+            id("second-target"),
+        ]);
+        // Over the cap: the extras are dropped rather than the request
+        // spending an unbounded number of upstream timeouts.
+        expect(fallbackIds(id("greedy-primary"))).toEqual([
+            id("valid-target"),
+            id("second-target"),
+            id("third-target"),
+        ]);
+        // A dead id in the middle is skipped, keeping the survivors' order.
+        expect(fallbackIds(id("gappy-primary"))).toEqual([
+            id("valid-target"),
+            id("second-target"),
+        ]);
+    },
+);
+
+fixtureTest(
+    "uses the served model's transform for a registry fallback",
+    async ({ apiKey }) => {
+        const suffix = crypto.randomUUID().slice(0, 8);
+        const ownerGithubUsername = `transform-owner-${suffix}`;
+        const ownerUserId = await createTestUser({
+            githubId: nextAllowedGithubId(),
+            githubUsername: ownerGithubUsername,
+        });
+        const fallbackModelId = communityModelId(
+            ownerGithubUsername,
+            `plain-${suffix}`,
+        );
+
+        await insertCommunityEndpoints({
+            id: `endpoint-${crypto.randomUUID()}`,
+            ownerUserId,
+            visibility: "public",
+            name: `plain-${suffix}`,
+            baseUrl: "https://plain.example.com/v1",
+            upstreamModel: "plain-upstream",
+            bearerTokenCiphertext: await encryptSecret(
+                "sk_plain_token",
+                env.BETTER_AUTH_SECRET,
+            ),
+            promptTextPrice: 0.1 / 1_000_000,
+            completionTextPrice: 0.1 / 1_000_000,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+
+        const source = getRegistryModelDefinition("qwen-coder");
+        const previousFallbacks = source.fallbacks;
+        try {
+            source.fallbacks = [fallbackModelId];
+            resetGenerationModelRegistryCache();
+
+            const messageRoles: string[][] = [];
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async (input, init) => {
+                    const request = new Request(input, init);
+                    if (isPortkeyChatCompletionsRequest(request)) {
+                        const body = (await request.json()) as {
+                            messages: { role: string }[];
+                        };
+                        messageRoles.push(
+                            body.messages.map((message) => message.role),
+                        );
+                        if (
+                            request.headers.get("x-portkey-custom-host") !==
+                            "https://plain.example.com/v1"
+                        ) {
+                            return Response.json(
+                                { error: { message: "rate limited" } },
+                                { status: 429 },
+                            );
+                        }
+                        return Response.json({
+                            id: "chatcmpl_fallback_transform",
+                            object: "chat.completion",
+                            choices: [
+                                {
+                                    index: 0,
+                                    message: {
+                                        role: "assistant",
+                                        content: "ok",
+                                    },
+                                    finish_reason: "stop",
+                                },
+                            ],
+                            usage: {
+                                prompt_tokens: 1,
+                                completion_tokens: 1,
+                                total_tokens: 2,
+                            },
+                        });
+                    }
+                    if (isBillingFetch(request)) {
+                        return Response.json({ data: [] });
+                    }
+                    throw new Error(`Unexpected fetch: ${request.url}`);
+                }),
+            );
+
+            const response = await fetchGen(
+                new Request("https://gen.pollinations.ai/v1/chat/completions", {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${apiKey}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({
+                        model: "qwen-coder",
+                        messages: [{ role: "user", content: "hello" }],
+                    }),
+                }),
+            );
+
+            expect(response.status).toBe(200);
+            expect(response.headers.get("x-model-used")).toBe(fallbackModelId);
+            expect(messageRoles).toEqual([["system", "user"], ["user"]]);
+        } finally {
+            source.fallbacks = previousFallbacks;
+            resetGenerationModelRegistryCache();
+        }
+    },
+);
+
+fixtureTest(
+    "serves a failed community model from its fallback and bills the fallback",
+    async ({ apiKey }) => {
+        const {
+            primaryModelId,
+            fallbackModelId,
+            primaryHost,
+            fallbackHost,
+            primaryUpstreamModel,
+            fallbackUpstreamModel,
+            primaryToken,
+            fallbackToken,
+        } = await createCommunityFallbackPair({
+            prefix: "text-success",
+            fallbackPerUserRpm: 1,
+        });
+
+        // Read inside the mock: request bodies cannot cross isolates.
+        const gatewayCalls: {
+            customHost: string | null;
+            bearerToken: string | null;
+            upstreamModel: string | null;
+        }[] = [];
+        const ingestedEvents: Record<string, unknown>[] = [];
+        const fetchMock = vi.fn(async (input, init) => {
+            const request = new Request(input, init);
+            if (isPortkeyChatCompletionsRequest(request)) {
+                const customHost = request.headers.get("x-portkey-custom-host");
+                gatewayCalls.push({
+                    customHost,
+                    bearerToken: request.headers.get("authorization"),
+                    upstreamModel: request.headers.get("x-portkey-model"),
+                });
+                // The primary is rate limited — the failure the fallback exists
+                // for.
+                if (customHost === primaryHost) {
+                    return Response.json(
+                        { error: { message: "rate limited" } },
+                        { status: 429 },
+                    );
+                }
+                return Response.json({
+                    id: "chatcmpl_fallback",
+                    object: "chat.completion",
+                    choices: [
+                        {
+                            index: 0,
+                            message: { role: "assistant", content: "ok" },
+                            finish_reason: "stop",
+                        },
+                    ],
+                    usage: {
+                        prompt_tokens: 2,
+                        completion_tokens: 3,
+                        total_tokens: 5,
+                    },
+                });
+            }
+            if (isBillingFetch(request)) {
+                if (new URL(request.url).pathname === "/v0/events") {
+                    ingestedEvents.push(
+                        ...parseIngestedEvents(await request.text()),
+                    );
+                }
+                return Response.json({ data: [] });
+            }
+            throw new Error(`Unexpected fetch: ${request.url}`);
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const request = (content: string) =>
+            fetchGen(
+                new Request("https://gen.pollinations.ai/v1/chat/completions", {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${apiKey}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({
+                        model: primaryModelId,
+                        messages: [{ role: "user", content }],
+                    }),
+                }),
+            );
+
+        const response = await request("hello-first");
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get(FALLBACK_TARGET_HEADER)).toBe(
+            "config.targets[1]",
+        );
+        // The served model, not the requested one, is reported as used.
+        expect(response.headers.get("x-model-used")).toBe(fallbackModelId);
+
+        // Each endpoint is called once, in the order the owner declared, and
+        // each attempt carries only its own endpoint's credential.
+        expect(gatewayCalls).toEqual([
+            {
+                customHost: primaryHost,
+                bearerToken: `Bearer ${primaryToken}`,
+                upstreamModel: primaryUpstreamModel,
+            },
+            {
+                customHost: fallbackHost,
+                bearerToken: `Bearer ${fallbackToken}`,
+                upstreamModel: fallbackUpstreamModel,
+            },
+        ]);
+
+        // Two rows for the one request: the primary's failure, unbilled, and the
+        // model that served. Without the first, a model rescued on every request
+        // reads as healthy. The 429 is recorded as the 502 the caller would have
+        // seen, so it counts as a server error rather than the caller's fault.
+        await vi.waitFor(() => expect(ingestedEvents).toHaveLength(2));
+        expect(
+            ingestedEvents.map((event) => [
+                event.modelUsed,
+                event.responseStatus,
+                event.isBilledUsage,
+            ]),
+        ).toContainEqual([primaryModelId, 502, false]);
+        expect(
+            ingestedEvents.map((event) => [
+                event.modelUsed,
+                event.responseStatus,
+                event.isBilledUsage,
+            ]),
+        ).toContainEqual([fallbackModelId, 200, true]);
+        // Both rows belong to the same request, so the pair can be joined.
+        expect(
+            new Set(ingestedEvents.map((event) => event.requestId)).size,
+        ).toBe(1);
+
+        const limitedResponse = await request("hello-second");
+        expect(limitedResponse.status).toBe(429);
+        expect(limitedResponse.headers.get("Retry-After")).toBeTruthy();
+        await expect(limitedResponse.json()).resolves.toMatchObject({
+            error: { code: "community_model_rate_limit" },
+        });
+        // The primary was attempted again, but its limited fallback was not.
+        expect(gatewayCalls).toHaveLength(3);
+        expect(gatewayCalls[2]?.customHost).toBe(primaryHost);
+    },
+);
+
+fixtureTest(
+    "names the model that failed last when every candidate fails",
+    async ({ apiKey }) => {
+        const { primaryModelId, fallbackModelId } =
+            await createCommunityFallbackPair({
+                prefix: "text-all-fail",
+            });
+
+        const ingestedEvents: Record<string, unknown>[] = [];
+        const fetchMock = vi.fn(async (input, init) => {
+            const request = new Request(input, init);
+            if (isPortkeyChatCompletionsRequest(request)) {
+                // Nothing rescues this request: every endpoint is rate limited.
+                return Response.json(
+                    { error: { message: "rate limited" } },
+                    { status: 429 },
+                );
+            }
+            if (isBillingFetch(request)) {
+                if (new URL(request.url).pathname === "/v0/events") {
+                    ingestedEvents.push(
+                        ...parseIngestedEvents(await request.text()),
+                    );
+                }
+                return Response.json({ data: [] });
+            }
+            throw new Error(`Unexpected fetch: ${request.url}`);
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const response = await fetchGen(
+            new Request("https://gen.pollinations.ai/v1/chat/completions", {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${apiKey}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    model: primaryModelId,
+                    messages: [{ role: "user", content: "hello" }],
+                }),
+            }),
+        );
+
+        expect(response.status).toBe(502);
+
+        // Two upstream calls, two rows, and each names the model it reached.
+        // The row that records how the request ended must name the fallback:
+        // naming the primary would count it twice and leave a permanently
+        // broken fallback invisible in every per-model view.
+        // A 5xx also emits an unrelated server-error event to Tinybird, so
+        // narrow to the generation rows.
+        const generationRows = () =>
+            ingestedEvents.filter((event) => "requestId" in event);
+        await vi.waitFor(() => expect(generationRows()).toHaveLength(2));
+        expect(
+            generationRows().map((event) => [
+                event.modelUsed,
+                event.isFinal,
+                event.isBilledUsage,
+            ]),
+        ).toEqual(
+            expect.arrayContaining([
+                [primaryModelId, false, false],
+                [fallbackModelId, true, false],
+            ]),
+        );
+        // Both rows belong to the same request, so the pair can be joined.
+        expect(
+            new Set(generationRows().map((event) => event.requestId)).size,
+        ).toBe(1);
+    },
+);
+
+fixtureTest(
+    "retries a failed community image endpoint against its fallback",
+    async ({ apiKey }) => {
+        const {
+            primaryModelId,
+            fallbackModelId,
+            primaryHostname,
+            fallbackHostname,
+        } = await createCommunityFallbackPair({
+            prefix: "image-retry",
+            modality: "image",
+            primaryName: "primary-image",
+            fallbackName: "cheap-image",
+        });
+
+        const upstreamHosts: string[] = [];
+        const fetchMock = vi.fn(async (input, init) => {
+            const request = new Request(input, init);
+            if (isCommunityImageGenerationsRequest(request)) {
+                const host = new URL(request.url).host;
+                upstreamHosts.push(host);
+                if (host === primaryHostname) {
+                    return Response.json(
+                        { error: "upstream timed out" },
+                        {
+                            status: 524,
+                        },
+                    );
+                }
+                return Response.json({
+                    created: 1,
+                    data: [{ b64_json: TEST_PNG_BASE64 }],
+                });
+            }
+            if (isBillingFetch(request)) return Response.json({ data: [] });
+            throw new Error(`Unexpected fetch: ${request.url}`);
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const response = await fetchGen(
+            new Request(
+                `https://gen.pollinations.ai/image/green%20sprout?model=${encodeURIComponent(primaryModelId)}`,
+                { headers: { Authorization: `Bearer ${apiKey}` } },
+            ),
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("content-type")).toBe("image/png");
+        expect(upstreamHosts).toEqual([primaryHostname, fallbackHostname]);
+        expect(response.headers.get("x-model-used")).toBe(fallbackModelId);
+        expect(response.headers.get(FALLBACK_TARGET_HEADER)).toBe(
+            "config.targets[1]",
+        );
+        expect(
+            Array.from(new Uint8Array(await response.arrayBuffer())),
+        ).toEqual(TEST_PNG_BYTES);
+    },
+);
+
+fixtureTest(
+    "tries every declared image fallback and bills the model that served",
+    async ({ apiKey }) => {
+        const suffix = crypto.randomUUID().slice(0, 8);
+        const owners = ["one", "two", "three"].map(
+            (label) => `chain-${label}-${suffix}`,
+        );
+        const userIds: string[] = [];
+        for (const owner of owners) {
+            userIds.push(
+                await createTestUser({
+                    githubId: nextAllowedGithubId(),
+                    githubUsername: owner,
+                }),
+            );
+        }
+        const bearerTokenCiphertext = await encryptSecret(
+            "sk_image_upstream",
+            env.BETTER_AUTH_SECRET,
+        );
+        // Descending prices, as the same-or-lower rule requires of every target.
+        const prices = [0.03, 0.02, 0.01];
+        const modelIds = owners.map((owner, index) =>
+            communityModelId(owner, `chain-image-${index}`),
+        );
+
+        for (const [index, owner] of owners.entries()) {
+            await insertCommunityEndpoints({
+                id: `endpoint-${crypto.randomUUID()}`,
+                ownerUserId: userIds[index],
+                visibility: "public" as const,
+                name: `chain-image-${index}`,
+                modality: "image",
+                baseUrl: `https://${owner}.example.com/v1`,
+                upstreamModel: `${owner}-upstream`,
+                bearerTokenCiphertext,
+                promptTextPrice: 0,
+                completionTextPrice: 0,
+                completionImagePrice: prices[index],
+                // The primary declares BOTH fallbacks itself; neither target
+                // declares anything, so nothing but this list is followed.
+                ...(index === 0
+                    ? { fallbacks: [modelIds[1], modelIds[2]] }
+                    : {}),
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            });
+        }
+
+        const upstreamHosts: string[] = [];
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async (input, init) => {
+                const request = new Request(input, init);
+                if (isCommunityImageGenerationsRequest(request)) {
+                    const host = new URL(request.url).host;
+                    upstreamHosts.push(host);
+                    // Only the last link works, so a 200 proves both hops ran.
+                    if (host !== `${owners[2]}.example.com`) {
+                        return Response.json(
+                            { error: "upstream down" },
+                            { status: 500 },
+                        );
+                    }
+                    return Response.json({
+                        created: 1,
+                        data: [{ b64_json: TEST_PNG_BASE64 }],
+                    });
+                }
+                if (isBillingFetch(request)) return Response.json({ data: [] });
+                throw new Error(`Unexpected fetch: ${request.url}`);
+            }),
+        );
+
+        const response = await fetchGen(
+            new Request(
+                `https://gen.pollinations.ai/image/green%20sprout?model=${encodeURIComponent(modelIds[0])}`,
+                { headers: { Authorization: `Bearer ${apiKey}` } },
+            ),
+        );
+
+        expect(response.status).toBe(200);
+        // In declared order, each endpoint contacted exactly once — no model
+        // is ever retried against itself.
+        expect(upstreamHosts).toEqual(
+            owners.map((owner) => `${owner}.example.com`),
+        );
+        expect(response.headers.get("x-model-used")).toBe(modelIds[2]);
+        expect(response.headers.get(FALLBACK_TARGET_HEADER)).toBe(
+            "config.targets[2]",
+        );
+        expect(
+            Array.from(new Uint8Array(await response.arrayBuffer())),
+        ).toEqual(TEST_PNG_BYTES);
+
+        // The OpenAI-compatible route replaces the generated response with
+        // JSON, so it has to carry the fallback marker across itself —
+        // otherwise tracking reads the rescue as a plain first-try success.
+        const openaiResponse = await fetchGen(
+            new Request("https://gen.pollinations.ai/v1/images/generations", {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${apiKey}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    model: modelIds[0],
+                    prompt: "green sprout",
+                }),
+            }),
+        );
+
+        expect(openaiResponse.status).toBe(200);
+        expect(openaiResponse.headers.get("x-model-used")).toBe(modelIds[2]);
+        expect(openaiResponse.headers.get(FALLBACK_TARGET_HEADER)).toBe(
+            "config.targets[2]",
+        );
+    },
+);
+
+fixtureTest(
+    "does not replay image caller errors or moderation refusals on the fallback",
+    async ({ apiKey }) => {
+        const { primaryModelId, primaryHostname } =
+            await createCommunityFallbackPair({
+                prefix: "image-strict",
+                modality: "image",
+                primaryName: "strict-image",
+                fallbackName: "loose-image",
+            });
+        let upstreamHosts: string[] = [];
+        let primaryFailure = {
+            status: 400,
+            body: { error: { message: "size must be at most 1536x1536" } },
+        };
+        const fetchMock = vi.fn(async (input, init) => {
+            const request = new Request(input, init);
+            if (isCommunityImageGenerationsRequest(request)) {
+                const host = new URL(request.url).host;
+                upstreamHosts.push(host);
+                if (host === primaryHostname) {
+                    return Response.json(primaryFailure.body, {
+                        status: primaryFailure.status,
+                    });
+                }
+                return Response.json({
+                    created: 1,
+                    data: [{ b64_json: TEST_PNG_BASE64 }],
+                });
+            }
+            if (isBillingFetch(request)) return Response.json({ data: [] });
+            throw new Error(`Unexpected fetch: ${request.url}`);
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const generate = async () => {
+            const response = await fetchGen(
+                new Request(
+                    `https://gen.pollinations.ai/image/green%20sprout?model=${encodeURIComponent(primaryModelId)}`,
+                    { headers: { Authorization: `Bearer ${apiKey}` } },
+                ),
+            );
+            // Drain before asserting: an unread body keeps the isolate alive.
+            await response.arrayBuffer();
+            return response;
+        };
+
+        // A caller error cannot succeed on a replay: the fallback is never
+        // called and the primary's own 400 reaches the client.
+        const callerError = await generate();
+        expect(callerError.status).toBe(400);
+        expect(upstreamHosts).toEqual([primaryHostname]);
+
+        // A moderation refusal must not be routed around, whatever status the
+        // provider wrapped it in — it stays a 422 content-policy rejection.
+        upstreamHosts = [];
+        primaryFailure = {
+            status: 500,
+            body: {
+                error: { message: "Prompt flagged by our content filter" },
+            },
+        };
+        const moderationRefusal = await generate();
+        expect(moderationRefusal.status).toBe(422);
+        expect(upstreamHosts).toEqual([primaryHostname]);
+    },
+);
+
+fixtureTest(
+    "does not serve a fallback the API key is not allowed to use",
+    async () => {
+        const { primaryModelId, fallbackModelId, primaryHost } =
+            await createCommunityFallbackPair({
+                prefix: "scoped",
+            });
+
+        // Scoped to the primary only — calling the fallback directly is a 403.
+        const { key } = await createTestApiKey({
+            allowedModels: [primaryModelId],
+            user: { tierBalance: 100 },
+        });
+
+        const gatewayCalls: {
+            config: string | null;
+            provider: string | null;
+            customHost: string | null;
+        }[] = [];
+        const fetchMock = vi.fn(async (input, init) => {
+            const request = new Request(input, init);
+            if (isPortkeyChatCompletionsRequest(request)) {
+                gatewayCalls.push({
+                    config: request.headers.get("x-portkey-config"),
+                    provider: request.headers.get("x-portkey-provider"),
+                    customHost: request.headers.get("x-portkey-custom-host"),
+                });
+                return Response.json({
+                    id: "chatcmpl_primary",
+                    object: "chat.completion",
+                    choices: [
+                        {
+                            index: 0,
+                            message: { role: "assistant", content: "ok" },
+                            finish_reason: "stop",
+                        },
+                    ],
+                    usage: {
+                        prompt_tokens: 2,
+                        completion_tokens: 3,
+                        total_tokens: 5,
+                    },
+                });
+            }
+            if (isBillingFetch(request)) return Response.json({ data: [] });
+            throw new Error(`Unexpected fetch: ${request.url}`);
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const response = await fetchGen(
+            new Request("https://gen.pollinations.ai/v1/chat/completions", {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${key}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    model: primaryModelId,
+                    messages: [{ role: "user", content: "hello" }],
+                }),
+            }),
+        );
+
+        expect(response.status).toBe(200);
+        expect(gatewayCalls).toHaveLength(1);
+        // No strategy/targets config: the request runs against the primary
+        // alone, so the key can never be served the model it cannot call.
+        expect(gatewayCalls[0].config).toBeNull();
+        expect(gatewayCalls[0].provider).toBe("openai");
+        expect(gatewayCalls[0].customHost).toBe(primaryHost);
+
+        // The same key calling the fallback directly is refused.
+        const direct = await fetchGen(
+            new Request("https://gen.pollinations.ai/v1/chat/completions", {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${key}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    model: fallbackModelId,
+                    messages: [{ role: "user", content: "hello" }],
+                }),
+            }),
+        );
+        expect(direct.status).toBe(403);
+    },
+);
+
+describe("community speech endpoint billing", () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    const secret = "test-secret";
+
+    async function speechEndpoint(): Promise<CommunityEndpointRuntime> {
+        return {
+            type: "proxy",
+            id: "community-endpoint-id",
+            ownerUserId: "owner-id",
+            modelId: "voodoohop/tts",
+            name: "tts",
+            title: "TTS",
+            description: null,
+            modality: "speech",
+            imagePricing: "request",
+            inputModalities: ["text"],
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "tts-1",
+            visibility: "public",
+            paidOnly: false,
+            perUserRpm: null,
+            fallbacks: [],
+            hiddenAt: null,
+            hiddenReason: null,
+            bearerTokenCiphertext: await encryptSecret(
+                "sk_saved_token",
+                secret,
+            ),
+            ...communityEndpointPrices({ completionAudioPrice: 0.015 }),
+        };
+    }
+
+    it("forwards input, voice, and response_format and bills character count", async () => {
+        const fetchMock = vi.fn(async (input, init) => {
+            const request = new Request(input, init);
+            expect(request.url).toBe("https://api.example.com/v1/audio/speech");
+            expect(request.headers.get("authorization")).toBe(
+                "Bearer sk_saved_token",
+            );
+            const body = await request.json();
+            expect(body).toMatchObject({
+                model: "tts-1",
+                input: "Hello world",
+                voice: "nova",
+                response_format: "opus",
+            });
+            return new Response(new Uint8Array([79, 103, 103, 83]), {
+                headers: { "Content-Type": "audio/opus" },
+            });
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const response = await callCommunitySpeechEndpoint(
+            await speechEndpoint(),
+            { input: "Hello world", voice: "nova", responseFormat: "opus" },
+            secret,
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("content-type")).toBe("audio/opus");
+        expect(
+            response.headers.get(USAGE_TYPE_HEADERS.completionAudioTokens),
+        ).toBe("11");
+        expect(response.headers.get(MODEL_USED_HEADER)).toBe("voodoohop/tts");
+    });
+
+    it("defaults voice to alloy and response_format to mp3", async () => {
+        const fetchMock = vi.fn(async (input, init) => {
+            const body = (await new Request(input, init).json()) as Record<
+                string,
+                unknown
+            >;
+            expect(body.voice).toBe("alloy");
+            expect(body.response_format).toBe("mp3");
+            return new Response(new Uint8Array([255, 251, 144, 0]), {
+                headers: { "Content-Type": "audio/mpeg" },
+            });
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const response = await callCommunitySpeechEndpoint(
+            await speechEndpoint(),
+            { input: "Hi" },
+            secret,
+        );
+
+        expect(
+            response.headers.get(USAGE_TYPE_HEADERS.completionAudioTokens),
+        ).toBe("2");
+    });
+
+    it("propagates upstream failures", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () =>
+                Response.json(
+                    { error: { message: "model not found" } },
+                    { status: 404 },
+                ),
+            ),
+        );
+
+        await expect(
+            callCommunitySpeechEndpoint(
+                await speechEndpoint(),
+                { input: "Hello" },
+                secret,
+            ),
+        ).rejects.toMatchObject({ status: 502 });
+    });
+});

--- a/shared/community-endpoint-urls.ts
+++ b/shared/community-endpoint-urls.ts
@@ -1,0 +1,135 @@
+export function validateCommunityEndpointUrl(value: string): string {
+    if (value !== value.trim()) {
+        throw new Error("Endpoint URL cannot include surrounding whitespace");
+    }
+    const url = new URL(value);
+    if (url.protocol !== "https:") {
+        throw new Error("Endpoint URL must use https");
+    }
+    if (url.username || url.password) {
+        throw new Error("Endpoint URL cannot include credentials");
+    }
+    if (isBlockedHostname(url.hostname)) {
+        throw new Error("Endpoint URL cannot target a private host");
+    }
+    if (url.hash) {
+        throw new Error("Endpoint URL cannot include a fragment");
+    }
+    return value;
+}
+
+export function normalizeCommunityAssetUrl(
+    value: string,
+    endpointBaseUrl: string,
+): string {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+        throw new Error("Image URL must use http or https");
+    }
+    if (url.username || url.password || isBlockedHostname(url.hostname)) {
+        throw new Error("Image URL cannot target a private host");
+    }
+    if (
+        url.protocol === "http:" &&
+        url.hostname !== new URL(endpointBaseUrl).hostname
+    ) {
+        throw new Error("HTTP image URL must use the endpoint host");
+    }
+    url.hash = "";
+    return url.toString();
+}
+
+export function communityChatCompletionsUrl(baseUrl: string): string {
+    return communityOpenAIEndpointUrl(baseUrl, "/chat/completions");
+}
+
+export function communityImageGenerationsUrl(baseUrl: string): string {
+    return communityOpenAIEndpointUrl(baseUrl, "/images/generations");
+}
+
+export function communityImageEditsUrl(baseUrl: string): string {
+    return communityOpenAIEndpointUrl(baseUrl, "/images/edits");
+}
+
+export function communityAudioTranscriptionsUrl(baseUrl: string): string {
+    return communityOpenAIEndpointUrl(baseUrl, "/audio/transcriptions");
+}
+
+export function communityAudioSpeechUrl(baseUrl: string): string {
+    return communityOpenAIEndpointUrl(baseUrl, "/audio/speech");
+}
+
+export function communityEmbeddingsUrl(baseUrl: string): string {
+    return communityOpenAIEndpointUrl(baseUrl, "/embeddings");
+}
+
+export function communityOpenAIBaseUrl(baseUrl: string): string {
+    const validated = validateCommunityEndpointUrl(baseUrl);
+    const url = new URL(validated);
+    const suffix = configuredCommunityEndpointSuffix(url);
+    if (!suffix) return validated;
+    const pathname = url.pathname.replace(/\/+$/, "");
+    url.pathname = pathname.slice(0, -suffix.length);
+    return url.toString();
+}
+
+const COMMUNITY_OPENAI_ENDPOINT_SUFFIXES = [
+    "/chat/completions",
+    "/images/generations",
+    "/images/edits",
+    "/audio/transcriptions",
+    "/audio/speech",
+    "/embeddings",
+] as const;
+
+function configuredCommunityEndpointSuffix(url: URL): string | undefined {
+    const pathname = url.pathname.replace(/\/+$/, "");
+    return COMMUNITY_OPENAI_ENDPOINT_SUFFIXES.find((suffix) =>
+        pathname.endsWith(suffix),
+    );
+}
+
+function communityOpenAIEndpointUrl(baseUrl: string, suffix: string): string {
+    const validated = validateCommunityEndpointUrl(baseUrl);
+    if (configuredCommunityEndpointSuffix(new URL(validated)) === suffix) {
+        return validated;
+    }
+    const url = new URL(communityOpenAIBaseUrl(validated));
+    url.pathname = `${url.pathname.replace(/\/+$/, "")}${suffix}`;
+    return url.toString();
+}
+
+function isBlockedHostname(hostname: string): boolean {
+    const host = hostname
+        .replace(/^\[|\]$/g, "")
+        .replace(/\.$/, "")
+        .toLowerCase();
+    if (host === "localhost" || host.endsWith(".localhost")) return true;
+    if (host.endsWith(".local")) return true;
+    if (host.includes(":")) return true;
+    if (host.startsWith("127.") || host.startsWith("10.")) return true;
+    if (host.startsWith("169.254.")) return true;
+    if (host.startsWith("100.")) {
+        const second = Number(host.split(".")[1]);
+        if (second >= 64 && second <= 127) return true;
+    }
+    if (host.startsWith("192.168.")) return true;
+    const ipv4 = host.split(".").map(Number);
+    if (
+        ipv4.length === 4 &&
+        ipv4.every(
+            (part) => Number.isInteger(part) && part >= 0 && part <= 255,
+        ) &&
+        (ipv4[0] === 0 ||
+            (ipv4[0] ?? 0) >= 224 ||
+            (ipv4[0] === 198 && (ipv4[1] === 18 || ipv4[1] === 19)))
+    ) {
+        return true;
+    }
+    const match172 = host.match(/^172\.(\d+)\./);
+    if (match172) {
+        const second = Number(match172[1]);
+        if (second >= 16 && second <= 31) return true;
+    }
+    return false;
+}

--- a/shared/community-endpoints.ts
+++ b/shared/community-endpoints.ts
@@ -1,14 +1,34 @@
+import { z } from "zod";
 import { isCommunityModelAllowedGithubId } from "./auth/github-id-list.ts";
-import type { ModelDefinition, PriceDefinition } from "./registry/registry.ts";
+import { MCP_SERVER_IDS } from "./registry/mcp.ts";
+import type { ModelCapability } from "./registry/model-info.ts";
+import {
+    type Category,
+    MODEL_INPUT_MODALITIES,
+    type ModelDefinition,
+    type ModelInputModality,
+    type ModelOutputModality,
+    type PriceDefinition,
+} from "./registry/registry.ts";
 import {
     OPENAI_CHAT_USAGE_PATHS,
     OPENAI_CHAT_USAGE_TYPES,
+    OPENAI_EMBEDDING_USAGE_PATHS,
     type OpenAIChatUsageType,
 } from "./registry/usage-headers.ts";
+import type { SafetyFeature } from "./schemas/safety.ts";
 
 export const LEGACY_COMMUNITY_MODEL_PREFIX = "community/";
 export const COMMUNITY_MODEL_REWARD_RATE = 0.75;
-export const COMMUNITY_ENDPOINT_MODALITIES = ["text", "image"] as const;
+export const COMMUNITY_ENDPOINT_CHANGE_DELAY_MS = 12 * 60 * 60 * 1000;
+export const COMMUNITY_ENDPOINT_MODALITIES = [
+    "text",
+    "image",
+    "video",
+    "transcription",
+    "embedding",
+    "speech",
+] as const;
 // How a community image endpoint is billed. "request" charges the fixed
 // per-image price once per generation; "tokens" charges the provider-returned
 // OpenAI image token usage against per-1M prices. The mode is detected by the
@@ -22,6 +42,8 @@ export const COMMUNITY_ENDPOINT_IMAGE_PRICING_MODES = [
 // slug (`name`) and the optional longer `description`.
 export const COMMUNITY_ENDPOINT_TITLE_MAX_LENGTH = 42;
 export const COMMUNITY_ENDPOINT_DESCRIPTION_MAX_LENGTH = 160;
+export const COMMUNITY_PROVIDER_NAME_MAX_LENGTH = 42;
+export const COMMUNITY_PROVIDER_URL_MAX_LENGTH = 2048;
 // Zero is free; positive owner-declared prices start at this floor.
 export const MIN_COMMUNITY_PRICE_PER_MILLION_TOKENS = 0.000001;
 export const MIN_COMMUNITY_PRICE_PER_TOKEN =
@@ -32,10 +54,70 @@ export const MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS = 50;
 export const MAX_COMMUNITY_PRICE_PER_TOKEN =
     MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS / 1_000_000;
 export const MAX_COMMUNITY_PRICE_PER_IMAGE = 0.25;
+// Community publishers need room for premium video backends while callers
+// still need protection from accidental or abusive per-second prices.
+export const MAX_COMMUNITY_PRICE_PER_VIDEO_SECOND = 0.5;
+// Per-second audio (STT/TTS) prices are tiny compared to per-token rates, so
+// this ceiling is written per minute and divided down: $0.012/min is ~2x
+// OpenAI whisper ($0.006/min) and ~3x the priciest first-party STT model
+// (scribe, $0.00367/min). Keep the division visible — a bare 0.006 here reads
+// like OpenAI's per-minute rate but would bill 60x that per second.
+export const MAX_COMMUNITY_PRICE_PER_SECOND = 0.012 / 60;
+// How long we wait on a community endpoint before giving up. Generous because
+// these are self-hosted hobby GPUs that cold-start, and in line with the text
+// providers (Portkey and Azure both use 290s). Workers impose no wall-clock
+// limit of their own, so without this a hung endpoint would hold the request
+// open until the caller disconnects.
+export const COMMUNITY_ENDPOINT_TIMEOUT_MS = 300_000;
 const BEARER_PREFIX = /^Bearer(?:\s+|$)/i;
 
 export type CommunityEndpointModality =
     (typeof COMMUNITY_ENDPOINT_MODALITIES)[number];
+
+export const MAX_COMMUNITY_CONTEXT_LENGTH = 10_000_000;
+
+export const COMMUNITY_ENDPOINT_CAPABILITIES = [
+    "tool_calling",
+    "reasoning",
+] as const satisfies readonly ModelCapability[];
+
+export type CommunityEndpointCapability =
+    (typeof COMMUNITY_ENDPOINT_CAPABILITIES)[number];
+
+export const CommunityEndpointAdvertisedSchema = z
+    .object({
+        capabilities: z
+            .array(z.enum(COMMUNITY_ENDPOINT_CAPABILITIES))
+            .optional(),
+        contextLength: z
+            .number()
+            .int()
+            .positive()
+            .max(MAX_COMMUNITY_CONTEXT_LENGTH)
+            .optional(),
+    })
+    .strict();
+
+export type CommunityEndpointAdvertised = z.infer<
+    typeof CommunityEndpointAdvertisedSchema
+>;
+
+export function normalizeCommunityEndpointAdvertised(
+    value: CommunityEndpointAdvertised | null | undefined,
+    modality: CommunityEndpointModality,
+): CommunityEndpointAdvertised {
+    if (!value || modality !== "text") return {};
+    const advertised: CommunityEndpointAdvertised = {};
+    if (value.capabilities?.length) {
+        const declared = new Set<string>(value.capabilities);
+        const capabilities = COMMUNITY_ENDPOINT_CAPABILITIES.filter(
+            (capability) => declared.has(capability),
+        );
+        if (capabilities.length) advertised.capabilities = capabilities;
+    }
+    if (value.contextLength) advertised.contextLength = value.contextLength;
+    return advertised;
+}
 
 export type CommunityEndpointImagePricing =
     (typeof COMMUNITY_ENDPOINT_IMAGE_PRICING_MODES)[number];
@@ -135,33 +217,179 @@ const COMMUNITY_IMAGE_TOKEN_PRICE_FIELDS = [
     },
 ] as const;
 
+// Transcription endpoints bill audio input duration in seconds against the
+// same prompt audio price column, mirroring the first-party whisper/scribe
+// models (cost keyed on promptAudioSeconds at a per-second rate).
+const COMMUNITY_TRANSCRIPTION_PRICE_FIELD = {
+    key: "promptAudioPrice",
+    usageType: "promptAudioSeconds",
+    label: "Prompt audio",
+    priceUnit: "second",
+    // Paths are relative to the stored usage object, same as the chat fields
+    // ("prompt_tokens", not "usage.prompt_tokens"). The probe normalizes every
+    // upstream duration shape to `duration`, so that is the only key here.
+    rawUsagePaths: ["duration"],
+} as const;
+
+// Community video endpoints are billed from the duration Pollinations sends.
+const COMMUNITY_VIDEO_PRICE_FIELD = {
+    key: "completionVideoPrice",
+    usageType: "completionVideoSeconds",
+    label: "Generated video",
+    priceUnit: "video_second",
+    rawUsagePaths: ["duration"],
+} as const;
+
+// Speech endpoints are billed by character count of the synthesized input text,
+// mirroring ElevenLabs TTS billing (completionAudioTokens at a per-character rate).
+const COMMUNITY_SPEECH_PRICE_FIELD = {
+    key: "completionAudioPrice",
+    usageType: "completionAudioTokens",
+    label: "Generated speech",
+    priceUnit: "million",
+    rawUsagePaths: ["characters"],
+} as const;
+
+const COMMUNITY_SPEECH_ENDPOINT_PRICE_FIELDS = [
+    COMMUNITY_SPEECH_PRICE_FIELD,
+] as const;
+
 export const COMMUNITY_ENDPOINT_PRICE_FIELDS = [
     ...COMMUNITY_TEXT_PRICE_FIELDS,
     COMMUNITY_IMAGE_PRICE_FIELD,
+    COMMUNITY_TRANSCRIPTION_PRICE_FIELD,
+    COMMUNITY_VIDEO_PRICE_FIELD,
 ] as const;
-
-const COMMUNITY_TEXT_ENDPOINT_PRICE_FIELDS =
-    COMMUNITY_ENDPOINT_PRICE_FIELDS.filter(
-        (field) => field.usageType !== "completionImageTokens",
-    );
 
 const COMMUNITY_IMAGE_ENDPOINT_PRICE_FIELDS = [
     COMMUNITY_IMAGE_PRICE_FIELD,
 ] as const;
 
-export function communityEndpointPriceFieldsForModality(
-    modality: CommunityEndpointModality,
-    imagePricing: CommunityEndpointImagePricing = "request",
-) {
-    if (modality !== "image") return COMMUNITY_TEXT_ENDPOINT_PRICE_FIELDS;
-    return imagePricing === "tokens"
-        ? COMMUNITY_IMAGE_TOKEN_PRICE_FIELDS
-        : COMMUNITY_IMAGE_ENDPOINT_PRICE_FIELDS;
-}
+const COMMUNITY_TRANSCRIPTION_ENDPOINT_PRICE_FIELDS = [
+    COMMUNITY_TRANSCRIPTION_PRICE_FIELD,
+] as const;
+
+const COMMUNITY_VIDEO_ENDPOINT_PRICE_FIELDS = [
+    COMMUNITY_VIDEO_PRICE_FIELD,
+] as const;
+
+// Embedding endpoints bill token usage per 1M like text models. Token-only
+// billing through promptTextPrice — no fixed per-request mode.
+const COMMUNITY_EMBEDDING_ENDPOINT_PRICE_FIELDS = [
+    {
+        key: "promptTextPrice",
+        usageType: "promptTextTokens",
+        label: "Prompt text",
+        priceUnit: "million",
+        rawUsagePaths: OPENAI_EMBEDDING_USAGE_PATHS.promptTextTokens,
+    },
+] as const;
 
 export type CommunityEndpointPriceField =
     | (typeof COMMUNITY_ENDPOINT_PRICE_FIELDS)[number]
-    | (typeof COMMUNITY_IMAGE_TOKEN_PRICE_FIELDS)[number];
+    | (typeof COMMUNITY_IMAGE_TOKEN_PRICE_FIELDS)[number]
+    | (typeof COMMUNITY_TRANSCRIPTION_ENDPOINT_PRICE_FIELDS)[number]
+    | (typeof COMMUNITY_EMBEDDING_ENDPOINT_PRICE_FIELDS)[number]
+    | (typeof COMMUNITY_SPEECH_ENDPOINT_PRICE_FIELDS)[number];
+
+type CommunityModalitySpec = {
+    category: Category;
+    inputModalities: readonly ModelInputModality[];
+    outputModalities: readonly ModelOutputModality[];
+    supportedEndpoints: readonly string[];
+    // Specialized categories such as transcription must reject sibling routes
+    // unless the route explicitly opts into this endpoint list.
+    restrictDefinitionEndpoints?: boolean;
+    endpointsByInputModality?: Partial<
+        Record<ModelInputModality, readonly string[]>
+    >;
+    priceFields: readonly CommunityEndpointPriceField[];
+    tokenPriceFields?: readonly CommunityEndpointPriceField[];
+};
+
+/**
+ * Maps each community upstream API shape to the ordinary catalog contract it
+ * publishes. The upstream modality deliberately remains distinct from the
+ * catalog category: transcription endpoints, for example, are catalogued as
+ * audio models with text output.
+ */
+export const COMMUNITY_MODALITY_SPEC = {
+    text: {
+        category: "text",
+        inputModalities: MODEL_INPUT_MODALITIES,
+        outputModalities: ["text"],
+        supportedEndpoints: ["/v1/chat/completions", "/text", "/text/{prompt}"],
+        priceFields: COMMUNITY_TEXT_PRICE_FIELDS,
+    },
+    image: {
+        category: "image",
+        inputModalities: ["text", "image"],
+        outputModalities: ["image"],
+        supportedEndpoints: ["/v1/images/generations", "/image/{prompt}"],
+        endpointsByInputModality: { image: ["/v1/images/edits"] },
+        priceFields: COMMUNITY_IMAGE_ENDPOINT_PRICE_FIELDS,
+        tokenPriceFields: COMMUNITY_IMAGE_TOKEN_PRICE_FIELDS,
+    },
+    video: {
+        category: "video",
+        inputModalities: MODEL_INPUT_MODALITIES,
+        outputModalities: ["video"],
+        supportedEndpoints: [
+            "/v1/images/generations",
+            "/image/{prompt}",
+            "/video/{prompt}",
+        ],
+        priceFields: COMMUNITY_VIDEO_ENDPOINT_PRICE_FIELDS,
+    },
+    transcription: {
+        category: "audio",
+        inputModalities: ["audio"],
+        outputModalities: ["text"],
+        supportedEndpoints: ["/v1/audio/transcriptions"],
+        restrictDefinitionEndpoints: true,
+        priceFields: COMMUNITY_TRANSCRIPTION_ENDPOINT_PRICE_FIELDS,
+    },
+    embedding: {
+        category: "embedding",
+        inputModalities: ["text"],
+        outputModalities: ["embedding"],
+        supportedEndpoints: ["/v1/embeddings"],
+        priceFields: COMMUNITY_EMBEDDING_ENDPOINT_PRICE_FIELDS,
+    },
+    speech: {
+        category: "audio",
+        inputModalities: ["text"],
+        outputModalities: ["audio"],
+        supportedEndpoints: ["/v1/audio/speech"],
+        restrictDefinitionEndpoints: true,
+        priceFields: COMMUNITY_SPEECH_ENDPOINT_PRICE_FIELDS,
+    },
+} as const satisfies Record<CommunityEndpointModality, CommunityModalitySpec>;
+
+export function communityEndpointPriceFieldsForModality(
+    modality: CommunityEndpointModality,
+    imagePricing: CommunityEndpointImagePricing = "request",
+): readonly CommunityEndpointPriceField[] {
+    const spec: CommunityModalitySpec = COMMUNITY_MODALITY_SPEC[modality];
+    if (imagePricing === "tokens" && spec.tokenPriceFields) {
+        return spec.tokenPriceFields;
+    }
+    return spec.priceFields;
+}
+
+export function communityEndpointSupportedEndpoints(
+    modality: CommunityEndpointModality,
+    inputModalities: readonly ModelInputModality[],
+): string[] {
+    const spec: CommunityModalitySpec = COMMUNITY_MODALITY_SPEC[modality];
+    const endpoints = [...spec.supportedEndpoints];
+    for (const inputModality of inputModalities) {
+        endpoints.push(
+            ...(spec.endpointsByInputModality?.[inputModality] ?? []),
+        );
+    }
+    return endpoints;
+}
 
 export type CommunityEndpointPriceKey =
     (typeof COMMUNITY_ENDPOINT_PRICE_FIELDS)[number]["key"];
@@ -209,16 +437,73 @@ export function communityEndpointPricesForModality(
     ) as CommunityEndpointPrices;
 }
 
+/**
+ * Bounds how much latency one request can spend failing before it gives up:
+ * every extra target is another upstream timeout the caller waits through.
+ * Enforced on write and re-applied when the generation registry links entries.
+ */
+export const MAX_FALLBACK_TARGETS = 3;
+
+/**
+ * True when `target` costs no more than `primary` on every price field.
+ *
+ * The caller is charged the primary's price whichever endpoint serves, so this
+ * bounds the PAYOUT rather than the invoice: a rescuer is paid on their own
+ * listing, and this rule is what guarantees that stays at or below what was
+ * charged. It also stops an owner routing traffic to a pricier model whose
+ * owner would then earn more than the caller was quoted.
+ */
+export function isCommunityFallbackPricingAllowed(
+    primary: CommunityEndpointPrices,
+    target: CommunityEndpointPrices,
+): boolean {
+    return COMMUNITY_ENDPOINT_PRICE_FIELDS.every(
+        (field) => target[field.key] <= primary[field.key],
+    );
+}
+
+/**
+ * A fallback cannot require a balance bucket the caller was never required to
+ * have for the primary model. A paid-only primary may fall back to either kind.
+ */
+export function isCommunityFallbackBalanceAllowed(
+    primary: { paidOnly: boolean },
+    target: { paidOnly: boolean },
+): boolean {
+    return !target.paidOnly || primary.paidOnly;
+}
+
 export function normalizeCommunityEndpointModality(
     value: string | null | undefined,
 ): CommunityEndpointModality {
-    return value === "image" ? "image" : "text";
+    if (value === "transcription") return "transcription";
+    if (value === "video") return "video";
+    if (value === "image") return "image";
+    if (value === "embedding") return "embedding";
+    if (value === "speech") return "speech";
+    return "text";
 }
 
 export function normalizeCommunityEndpointImagePricing(
     value: string | null | undefined,
 ): CommunityEndpointImagePricing {
     return value === "tokens" ? "tokens" : "request";
+}
+
+export function normalizeCommunityEndpointInputModalities(
+    value: readonly ModelInputModality[] | null | undefined,
+    endpointModality: CommunityEndpointModality,
+): ModelInputModality[] {
+    // Both empty cases — nothing declared, and a declared set that shares
+    // nothing with this modality — fall back to the modality's own first
+    // input: text for text, image, and video endpoints; audio for transcription.
+    // Falling back to a bare "text" would hand a transcription endpoint the
+    // one input it cannot accept, which the write path then rejects with a
+    // 400 naming an input the owner never chose.
+    const permitted = COMMUNITY_MODALITY_SPEC[endpointModality].inputModalities;
+    const declared = new Set(value ?? []);
+    const normalized = permitted.filter((modality) => declared.has(modality));
+    return normalized.length ? [...normalized] : [permitted[0]];
 }
 
 // Access/visibility of a registered endpoint. Private is the default; choosing
@@ -230,36 +515,313 @@ export const COMMUNITY_ENDPOINT_VISIBILITIES = ["private", "public"] as const;
 export type CommunityEndpointVisibility =
     (typeof COMMUNITY_ENDPOINT_VISIBILITIES)[number];
 
-export type CommunityEndpointRuntime = {
+/* -------------------------------------------------------------------------
+ * Listing storage
+ *
+ * A row carries what every listing has — who owns it, what it is called,
+ * whether it is published — plus one `payload` whose shape `type` selects.
+ * A field that belongs to one kind of listing exists only in that kind's
+ * payload, so a listing cannot store a price it never charges or a credential
+ * it never sends. The invariants that used to be checked field by field on
+ * write are now the absence of somewhere to put the value.
+ * ---------------------------------------------------------------------- */
+
+export const LISTING_TYPES = [
+    "proxy",
+    "prompt_agent",
+    "endpoint_agent",
+] as const;
+
+// Prompt agents all share one deployment-specific worker. Store this safe,
+// environment-neutral URL in the common target column, then replace it with
+// AGENT_RUNTIME_BASE_URL when a row crosses the API/runtime boundary. The
+// reserved .invalid host guarantees a missed replacement cannot call another
+// environment by accident.
+export const PROMPT_AGENT_BASE_URL_PLACEHOLDER =
+    "https://agent-runtime.invalid/api/agent-runtime/v1";
+
+export type ListingType = (typeof LISTING_TYPES)[number];
+
+/**
+ * The owner's own OpenAI-compatible server, reached with the upstream bearer
+ * secret registered for that server. This is never the owner's or caller's
+ * Pollinations credential. The only kind that names a price, because it is the
+ * only kind whose caller is buying something from the owner.
+ */
+const StoredCommunityEndpointPricesSchema = z.object(
+    Object.fromEntries(
+        COMMUNITY_ENDPOINT_PRICE_FIELDS.map((field) => [
+            field.key,
+            z.number().finite().min(0).default(0),
+        ]),
+    ) as Record<CommunityEndpointPriceKey, z.ZodDefault<z.ZodNumber>>,
+);
+
+export const ProxyListingPayloadSchema = z
+    .object({
+        bearerTokenCiphertext: z.string().min(1),
+        // Owner-set: callers may only spend Paid Pollen on this model. Rows
+        // from before paid-only support are public-spend by default.
+        paidOnly: z.boolean().default(false),
+        modality: z.enum(COMMUNITY_ENDPOINT_MODALITIES),
+        imagePricing: z.enum(COMMUNITY_ENDPOINT_IMAGE_PRICING_MODES),
+        inputModalities: z.array(z.enum(MODEL_INPUT_MODALITIES)).min(1),
+        perUserRpm: z.number().finite().positive().nullable(),
+        fallbacks: z
+            .array(z.string().min(1))
+            .transform((fallbacks) => fallbacks.slice(0, MAX_FALLBACK_TARGETS)),
+        advertised: CommunityEndpointAdvertisedSchema.optional(),
+        prices: StoredCommunityEndpointPricesSchema,
+    })
+    .transform(({ advertised: storedAdvertised, ...payload }) => {
+        const advertised = normalizeCommunityEndpointAdvertised(
+            storedAdvertised,
+            payload.modality,
+        );
+        return {
+            ...payload,
+            inputModalities: normalizeCommunityEndpointInputModalities(
+                payload.inputModalities,
+                payload.modality,
+            ),
+            ...(Object.keys(advertised).length ? { advertised } : {}),
+        };
+    });
+
+export type ProxyListingPayload = z.infer<typeof ProxyListingPayloadSchema>;
+
+/**
+ * An agent Enter runs itself. Its row id is also the model sent to the shared
+ * runtime, which loads this configuration from the same row.
+ */
+export const BuiltinMcpServerIdSchema = z.enum(MCP_SERVER_IDS);
+export const PromptAgentConfigSchema = z.object({
+    systemPrompt: z.string().trim().min(1).max(8000),
+    baseModel: z.string().trim().min(1).max(253),
+    mcpServers: z
+        .array(BuiltinMcpServerIdSchema)
+        .max(MCP_SERVER_IDS.length)
+        .refine((servers) => new Set(servers).size === servers.length, {
+            message: "Duplicate MCP servers are not allowed",
+        })
+        .optional()
+        .default([]),
+});
+export const PromptAgentInputSchema = PromptAgentConfigSchema.strict();
+
+export type PromptAgentListingPayload = z.infer<typeof PromptAgentConfigSchema>;
+
+/**
+ * An agent on the owner's own server. It is sent a run token rather than a
+ * credential. The rate limit remains gateway policy, not an upstream secret.
+ */
+export const EndpointAgentListingPayloadSchema = z
+    .object({
+        perUserRpm: z.number().finite().positive().nullable().default(null),
+    })
+    .strict();
+
+export type EndpointAgentListingPayload = z.infer<
+    typeof EndpointAgentListingPayloadSchema
+>;
+
+export type ListingPayloadByType = {
+    proxy: ProxyListingPayload;
+    prompt_agent: PromptAgentListingPayload;
+    endpoint_agent: EndpointAgentListingPayload;
+};
+
+const LISTING_PAYLOAD_SCHEMA_BY_TYPE = {
+    proxy: ProxyListingPayloadSchema,
+    prompt_agent: PromptAgentConfigSchema,
+    endpoint_agent: EndpointAgentListingPayloadSchema,
+} as const;
+
+/**
+ * Read a stored payload back into its typed shape.
+ *
+ * Storage is the only place a payload arrives untyped, so it is normalized
+ * once here and every reader downstream gets a complete value. A payload
+ * missing what its type requires returns null, which leaves the listing out of
+ * the catalog rather than in it half-populated.
+ */
+export function parseListingPayload<K extends ListingType>(
+    type: K,
+    raw: string | null,
+): ListingPayloadByType[K] | null {
+    let parsed: unknown;
+    try {
+        parsed = raw === null ? null : JSON.parse(raw);
+    } catch {
+        return null;
+    }
+    const result = LISTING_PAYLOAD_SCHEMA_BY_TYPE[type].safeParse(parsed);
+    return result.success ? (result.data as ListingPayloadByType[K]) : null;
+}
+
+export function pendingCommunityEndpointChangeIsReady(
+    pendingAt: Date | null,
+    now = Date.now(),
+): boolean {
+    return (
+        pendingAt !== null &&
+        now >= pendingAt.getTime() + COMMUNITY_ENDPOINT_CHANGE_DELAY_MS
+    );
+}
+
+export function effectiveCommunityEndpointVisibility(
+    visibility: CommunityEndpointVisibility,
+    pendingVisibility: CommunityEndpointVisibility | null,
+    pendingAt: Date | null,
+    now = Date.now(),
+): CommunityEndpointVisibility {
+    return pendingVisibility &&
+        pendingCommunityEndpointChangeIsReady(pendingAt, now)
+        ? pendingVisibility
+        : visibility;
+}
+
+/** Apply only the delayed price policy, preserving newer credentials/settings. */
+export function applyPendingProxyPricing(
+    current: ProxyListingPayload,
+    pending: ProxyListingPayload | null,
+): ProxyListingPayload {
+    return pending
+        ? {
+              ...current,
+              paidOnly: pending.paidOnly,
+              imagePricing: pending.imagePricing,
+              prices: pending.prices,
+          }
+        : current;
+}
+
+export function resolveEffectiveProxyListing(
+    state: {
+        visibility: CommunityEndpointVisibility;
+        payload: ProxyListingPayload;
+        pendingVisibility: CommunityEndpointVisibility | null;
+        pendingPayload: ProxyListingPayload | null;
+        pendingAt: Date | null;
+    },
+    now = Date.now(),
+) {
+    const pendingAt = state.pendingAt;
+    const pendingReady = pendingCommunityEndpointChangeIsReady(pendingAt, now);
+    const hasPending =
+        pendingAt !== null &&
+        (state.pendingVisibility !== null || state.pendingPayload !== null);
+    return {
+        pendingReady,
+        visibility:
+            pendingReady && state.pendingVisibility
+                ? state.pendingVisibility
+                : state.visibility,
+        payload: pendingReady
+            ? applyPendingProxyPricing(state.payload, state.pendingPayload)
+            : state.payload,
+        pending:
+            !pendingReady && hasPending
+                ? {
+                      effectiveAt: new Date(
+                          pendingAt.getTime() +
+                              COMMUNITY_ENDPOINT_CHANGE_DELAY_MS,
+                      ),
+                      visibility: state.pendingVisibility,
+                      payload: state.pendingPayload,
+                  }
+                : null,
+    };
+}
+
+type CommunityEndpointRuntimeBase = {
     id: string;
     ownerUserId: string;
     modelId: string;
     name: string;
-    // Null on rows created before titles existed; read paths go through
-    // communityEndpointTitle() rather than using this directly.
-    title: string | null;
+    title: string;
     description: string | null;
+    providerName?: string | null;
+    providerUrl?: string | null;
     modality: CommunityEndpointModality;
     imagePricing: CommunityEndpointImagePricing;
-    supportsImageEdits: boolean;
+    inputModalities: ModelInputModality[] | null;
+    // Where the gateway sends the request, and the model name it asks for.
+    // All variants resolve these when the row is read, so routing never has
+    // to know which kind it is holding.
     baseUrl: string;
     upstreamModel: string;
-    bearerTokenCiphertext: string;
     visibility: CommunityEndpointVisibility;
-    /** Admin-granted: may spend an agent run token on the caller's behalf. */
-    delegatesGeneration: boolean;
-    disabledAt: number | null;
-    disabledReason: string | null;
+    requiredSafetyFeatures?: SafetyFeature[];
+    paidOnly: boolean;
+    // Exact gateway-side cap per Pollinations user. Null delegates capacity
+    // limits to the upstream, whose 429 then remains a model failure.
+    perUserRpm: number | null;
+    // Community model ids tried in order when this endpoint's upstream fails.
+    // A target's own list is never followed: the owner declares the full order.
+    fallbacks: string[];
+    hiddenAt: number | null;
+    hiddenReason: string | null;
 } & CommunityEndpointPrices;
+
+/** A third-party server, reached with its registered upstream bearer secret. */
+export type ProxyCommunityEndpointRuntime = CommunityEndpointRuntimeBase & {
+    type: "proxy";
+    bearerTokenCiphertext: string;
+    advertised?: CommunityEndpointAdvertised;
+};
+
+/** An agent Enter runs on its own runtime, named by its listing id. */
+export type PromptAgentCommunityEndpointRuntime =
+    CommunityEndpointRuntimeBase & {
+        type: "prompt_agent";
+    };
+
+/** An agent on the owner's own server, sent a run token instead of a key. */
+export type EndpointAgentCommunityEndpointRuntime =
+    CommunityEndpointRuntimeBase & {
+        type: "endpoint_agent";
+    };
+
+export type CommunityEndpointRuntime =
+    | ProxyCommunityEndpointRuntime
+    | PromptAgentCommunityEndpointRuntime
+    | EndpointAgentCommunityEndpointRuntime;
+
+/**
+ * Whether calls to this endpoint spend the caller's balance downstream.
+ *
+ * Both agent kinds do — one runs here, one on the owner's server, and either
+ * way the work is charged to whoever called. A proxy never does: its owner
+ * pays their own upstream and charges the caller a declared price. This is the
+ * fact that decides which credential goes on the wire, so it has one name.
+ */
+export function usesAgentRunToken(endpoint: CommunityEndpointRuntime): boolean {
+    return endpoint.type !== "proxy";
+}
 
 export type CommunityModelDefinitionInput = {
     modelId: string;
-    title?: string | null;
+    addedDate?: number;
+    perUserRpm?: number | null;
+    title: string;
     description: string | null;
+    providerName?: string | null;
+    providerUrl?: string | null;
     modality?: CommunityEndpointModality;
     imagePricing?: CommunityEndpointImagePricing;
-    supportsImageEdits?: boolean;
+    inputModalities?: ModelInputModality[] | null;
+    requiredSafetyFeatures?: SafetyFeature[];
+    fallbacks?: string[];
+    advertised?: CommunityEndpointAdvertised | null;
+    hidden?: boolean;
+    paidOnly?: boolean;
 } & CommunityEndpointPrices;
+
+export type CommunityProviderProfile = {
+    name: string | null;
+    url: string | null;
+};
 
 export type CommunityModelParts = {
     ownerGithubUsername: string;
@@ -293,6 +855,24 @@ export function normalizeCommunityEndpointBearerToken(value: string): string {
     return token;
 }
 
+export function communityEndpointErrorDetail(body: unknown): string | null {
+    if (!body || typeof body !== "object") return null;
+    if (
+        "error" in body &&
+        body.error &&
+        typeof body.error === "object" &&
+        "message" in body.error &&
+        typeof body.error.message === "string"
+    ) {
+        return body.error.message;
+    }
+    if ("error" in body && typeof body.error === "string") return body.error;
+    if ("message" in body && typeof body.message === "string") {
+        return body.message;
+    }
+    return null;
+}
+
 export function isCommunityEndpointOwnerAllowed(
     owner: CommunityEndpointOwnerLike | null | undefined,
 ): boolean {
@@ -314,64 +894,41 @@ export function parseCommunityModelId(
     return { ownerGithubUsername, modelName };
 }
 
-export function normalizeCommunityEndpointBaseUrl(value: string): string {
-    const url = new URL(value);
+export function normalizeCommunityProviderUrl(value: string): string {
+    const url = new URL(value.trim());
     if (url.protocol !== "https:") {
-        throw new Error("Endpoint URL must use https");
+        throw new Error("Provider URL must use https");
     }
-    if (isBlockedHostname(url.hostname)) {
-        throw new Error("Endpoint URL cannot target a private host");
-    }
-    url.search = "";
-    url.hash = "";
-    return url.toString().replace(/\/+$/, "");
-}
-
-export function normalizeCommunityAssetUrl(
-    value: string,
-    endpointBaseUrl: string,
-): string {
-    const url = new URL(value);
-    if (url.protocol !== "http:" && url.protocol !== "https:") {
-        throw new Error("Image URL must use http or https");
-    }
-    if (url.username || url.password || isBlockedHostname(url.hostname)) {
-        throw new Error("Image URL cannot target a private host");
-    }
-    if (
-        url.protocol === "http:" &&
-        url.hostname !== new URL(endpointBaseUrl).hostname
-    ) {
-        throw new Error("HTTP image URL must use the endpoint host");
+    if (url.username || url.password) {
+        throw new Error("Provider URL cannot include credentials");
     }
     url.hash = "";
     return url.toString();
 }
 
-export function communityChatCompletionsUrl(baseUrl: string): string {
-    return `${communityOpenAIBaseUrl(baseUrl)}/chat/completions`;
-}
-
-export function communityImageGenerationsUrl(baseUrl: string): string {
-    return `${communityOpenAIBaseUrl(baseUrl)}/images/generations`;
-}
-
-export function communityImageEditsUrl(baseUrl: string): string {
-    return `${communityOpenAIBaseUrl(baseUrl)}/images/edits`;
-}
-
-export function communityOpenAIBaseUrl(baseUrl: string): string {
-    const normalized = normalizeCommunityEndpointBaseUrl(baseUrl);
-    for (const suffix of [
-        "/chat/completions",
-        "/images/generations",
-        "/images/edits",
-    ]) {
-        if (normalized.endsWith(suffix)) {
-            return normalized.slice(0, -suffix.length);
+/**
+ * Audio duration reported by an OpenAI-compatible transcription response.
+ *
+ * The three shapes in the wild: gpt-4o-transcribe reports `usage.seconds`,
+ * whisper-style servers report `usage.duration`, and stock whisper
+ * `verbose_json` puts `duration` at the top level. Returns null when none of
+ * them carry a usable number — callers decide what that means, and both the
+ * registration probe and the request path treat it as a failure so an endpoint
+ * that cannot be metered is never billed at zero.
+ */
+export function communityTranscriptionSeconds(body: unknown): number | null {
+    if (!body || typeof body !== "object") return null;
+    const record = body as Record<string, unknown>;
+    const usage =
+        record.usage && typeof record.usage === "object"
+            ? (record.usage as Record<string, unknown>)
+            : undefined;
+    for (const value of [usage?.duration, usage?.seconds, record.duration]) {
+        if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+            return value;
         }
     }
-    return normalized;
+    return null;
 }
 
 export function communityPriceDefinition(
@@ -395,24 +952,6 @@ export function communityPriceDefinition(
     return pricing;
 }
 
-// Titles became a required field after these rows were created, so older
-// endpoints have no stored title. Fall back to what the catalog showed before
-// the column existed (description, then the model slug) so `/models` output is
-// unchanged for un-backfilled rows.
-export function communityEndpointTitle(endpoint: {
-    modelId: string;
-    title?: string | null;
-    description?: string | null;
-}): string {
-    const title = endpoint.title?.trim();
-    if (title) return title;
-    const description = endpoint.description?.trim();
-    if (description) return description;
-    return (
-        parseCommunityModelId(endpoint.modelId)?.modelName ?? endpoint.modelId
-    );
-}
-
 export function communityModelDefinition(
     endpoint: CommunityModelDefinitionInput,
 ): ModelDefinition {
@@ -427,65 +966,54 @@ export function communityModelDefinition(
     const imagePricing = normalizeCommunityEndpointImagePricing(
         endpoint.imagePricing,
     );
+    const spec: CommunityModalitySpec = COMMUNITY_MODALITY_SPEC[modality];
     const isImage = modality === "image";
     // Token-priced image endpoints bill like text models (usage × per-token
     // rates), so only fixed per-request image endpoints are flat-rate.
     const isFlatRateImage = isImage && imagePricing === "request";
+    const inputModalities = normalizeCommunityEndpointInputModalities(
+        endpoint.inputModalities,
+        modality,
+    );
+    const providerName = endpoint.providerName?.trim();
+    const providerUrl = endpoint.providerUrl?.trim();
+    const { capabilities = [], ...advertised } =
+        normalizeCommunityEndpointAdvertised(endpoint.advertised, modality);
     return {
         aliases,
         provider: "community",
-        brand: "Community",
-        category: isImage ? "image" : "text",
+        perUserRpm: endpoint.perUserRpm,
+        brand: providerName || "Community",
+        brandUrl: providerName && providerUrl ? providerUrl : undefined,
+        category: spec.category,
         cost: communityPriceDefinition(endpoint, modality, imagePricing),
         priceMultiplier: 1,
-        addedDate: 0,
-        title: communityEndpointTitle(endpoint),
+        addedDate: endpoint.addedDate ?? 0,
+        title: endpoint.title,
         description: description || undefined,
-        inputModalities:
-            isImage && endpoint.supportsImageEdits
-                ? ["text", "image"]
-                : ["text"],
-        outputModalities: isImage ? ["image"] : ["text"],
-        paidOnly: false,
+        inputModalities,
+        outputModalities: [...spec.outputModalities],
+        ...(spec.restrictDefinitionEndpoints
+            ? {
+                  supportedEndpoints: communityEndpointSupportedEndpoints(
+                      modality,
+                      inputModalities,
+                  ),
+              }
+            : {}),
+        requiredSafetyFeatures: endpoint.requiredSafetyFeatures,
+        hidden: endpoint.hidden,
+        ...(endpoint.fallbacks?.length
+            ? { fallbacks: endpoint.fallbacks }
+            : {}),
+        paidOnly: endpoint.paidOnly ?? false,
         alpha: true,
         // Explicit false (not omitted) for token-priced image endpoints: the
         // catalog only renders per-1M prices when flat_rate === false or a
         // prompt token price is set.
         ...(isImage ? { flatRate: isFlatRateImage } : {}),
+        ...(capabilities.includes("tool_calling") ? { tools: true } : {}),
+        ...(capabilities.includes("reasoning") ? { reasoning: true } : {}),
+        ...advertised,
     };
-}
-
-function isBlockedHostname(hostname: string): boolean {
-    const host = hostname
-        .replace(/^\[|\]$/g, "")
-        .replace(/\.$/, "")
-        .toLowerCase();
-    if (host === "localhost" || host.endsWith(".localhost")) return true;
-    if (host.endsWith(".local")) return true;
-    if (host.includes(":")) return true;
-    if (host.startsWith("127.") || host.startsWith("10.")) return true;
-    if (host.startsWith("169.254.")) return true;
-    if (host.startsWith("100.")) {
-        const second = Number(host.split(".")[1]);
-        if (second >= 64 && second <= 127) return true;
-    }
-    if (host.startsWith("192.168.")) return true;
-    const ipv4 = host.split(".").map(Number);
-    if (
-        ipv4.length === 4 &&
-        ipv4.every(
-            (part) => Number.isInteger(part) && part >= 0 && part <= 255,
-        ) &&
-        (ipv4[0] === 0 ||
-            (ipv4[0] ?? 0) >= 224 ||
-            (ipv4[0] === 198 && (ipv4[1] === 18 || ipv4[1] === 19)))
-    ) {
-        return true;
-    }
-    const match172 = host.match(/^172\.(\d+)\./);
-    if (match172) {
-        const second = Number(match172[1]);
-        if (second >= 16 && second <= 31) return true;
-    }
-    return false;
 }


### PR DESCRIPTION
## Summary

- Adds `speech` to `COMMUNITY_ENDPOINT_MODALITIES` with category `audio`, text input, audio output, and `/v1/audio/speech` as its supported endpoint
- Registration probe POSTs a short sample to the upstream TTS endpoint and validates a non-empty `audio/*` response
- Generation in `gen.pollinations.ai` forwards `model`, `input`, `voice`, and `response_format`; preserves the returned `Content-Type`
- Bills by character count via the existing `completionAudioTokens` → `completionAudioPrice` path — no schema changes needed
- Reuses the auth, caching, timeout, fallback, and per-user rate-limit paths shared by all community modalities
- Adds concise publisher contract to `BRING_YOUR_OWN_MODEL.md`
- Adds focused tests: registration probe (valid audio, non-audio rejection, empty audio), generation (param forwarding + billing, voice/format defaults, upstream failure propagation)

Fixes #14347