### PR TITLE
feat: add text-to-speech as a community-model modality, closes #14347

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-dialog.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-dialog.tsx
@@ -437,6 +437,7 @@ export function CommunityEndpointDialog({
                                         "image",
                                         "video",
                                         "transcription",
+                                        "speech",
                                         "embedding",
                                     ] as const
                                 ).map((modality) => (

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/price-table.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/price-table.tsx
@@ -345,6 +345,12 @@ export const BASE_TRANSCRIPTION_PRICE_KEYS: PriceFieldKey[] = [
 
 export const BASE_VIDEO_PRICE_KEYS: PriceFieldKey[] = ["completionVideoPrice"];
 
+// Speech (TTS) models bill per character through the completion-audio price
+// column, revealed alongside the text fields once the model is public.
+export const BASE_SPEECH_PRICE_KEYS: PriceFieldKey[] = [
+    "completionAudioPrice",
+];
+
 export function basePriceKeysForModality(
     modality: CommunityEndpointModality,
 ): PriceFieldKey[] {
@@ -354,9 +360,11 @@ export function basePriceKeysForModality(
           ? BASE_VIDEO_PRICE_KEYS
           : modality === "transcription"
             ? BASE_TRANSCRIPTION_PRICE_KEYS
-            : modality === "embedding"
-              ? BASE_EMBEDDING_PRICE_KEYS
-              : BASE_TEXT_PRICE_KEYS;
+            : modality === "speech"
+              ? BASE_SPEECH_PRICE_KEYS
+              : modality === "embedding"
+                ? BASE_EMBEDDING_PRICE_KEYS
+                : BASE_TEXT_PRICE_KEYS;
 }
 
 export function returnedPriceFields(

--- a/enter.pollinations.ai/src/routes/community-endpoints.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints.ts
@@ -30,6 +30,7 @@ import {
     testCommunityEmbeddingEndpoint,
     testCommunityEndpoint,
     testCommunityImageEndpoint,
+    testCommunitySpeechEndpoint,
     testCommunityTranscriptionEndpoint,
     testCommunityVideoEndpoint,
 } from "../services/community-endpoint-openai.ts";
@@ -498,7 +499,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
             tags: ["🧩 Community Models"],
             summary: "Create My Model",
             description:
-                "Register a private or public community text, image, video, transcription, or embedding model. Private is the default. Public models require an allowlisted account and become public after 12 hours. API keys require `account:keys`. The upstream bearer token is encrypted and never returned.",
+                "Register a private or public community text, image, video, transcription, speech, or embedding model. Private is the default. Public models require an allowlisted account and become public after 12 hours. API keys require `account:keys`. The upstream bearer token is encrypted and never returned.",
             responses: {
                 200: {
                     description: "Created community model",
@@ -686,11 +687,13 @@ export const communityEndpointsRoutes = new Hono<Env>()
                               ? await testCommunityTranscriptionEndpoint(
                                     modelInput,
                                 )
-                              : input.modality === "embedding"
-                                ? await testCommunityEmbeddingEndpoint(
-                                      modelInput,
-                                  )
-                                : await testCommunityEndpoint(modelInput);
+                              : input.modality === "speech"
+                                ? await testCommunitySpeechEndpoint(modelInput)
+                                : input.modality === "embedding"
+                                  ? await testCommunityEmbeddingEndpoint(
+                                        modelInput,
+                                    )
+                                  : await testCommunityEndpoint(modelInput);
                 }
                 return c.json({
                     ok: true,
@@ -703,9 +706,11 @@ export const communityEndpointsRoutes = new Hono<Env>()
                               ? "Endpoint responded with playable video"
                               : input.modality === "transcription"
                                 ? "Endpoint responded with transcription text"
-                                : input.modality === "embedding"
-                                  ? "Endpoint responded with embedding data"
-                                  : "Endpoint responded with usage",
+                                : input.modality === "speech"
+                                  ? "Endpoint responded with valid binary audio"
+                                  : input.modality === "embedding"
+                                    ? "Endpoint responded with embedding data"
+                                    : "Endpoint responded with usage",
                     ...result,
                 });
             } catch (error) {

--- a/enter.pollinations.ai/src/routes/community-endpoints/schemas.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints/schemas.ts
@@ -21,7 +21,7 @@ import { z } from "zod";
 const ModalitySchema = z
     .enum(COMMUNITY_ENDPOINT_MODALITIES)
     .describe(
-        'Upstream API family. "text" uses `/v1/chat/completions`; "image" uses `/v1/images/generations` and optionally `/v1/images/edits`; "video" calls the exact configured URL; "transcription" uses `/v1/audio/transcriptions`.',
+        'Upstream API family. "text" uses `/v1/chat/completions`; "image" uses `/v1/images/generations` and optionally `/v1/images/edits`; "video" calls the exact configured URL; "transcription" uses `/v1/audio/transcriptions`; "speech" uses `/v1/audio/speech`.',
     );
 const ImagePricingSchema = z
     .enum(COMMUNITY_ENDPOINT_IMAGE_PRICING_MODES)

--- a/enter.pollinations.ai/src/services/community-endpoint-openai.ts
+++ b/enter.pollinations.ai/src/services/community-endpoint-openai.ts
@@ -1,4 +1,5 @@
 import {
+    communityAudioSpeechUrl,
     communityAudioTranscriptionsUrl,
     communityChatCompletionsUrl,
     communityEmbeddingsUrl,
@@ -18,6 +19,7 @@ import {
     firstCommunityImageBytes,
     firstCommunityVideoBytes,
     MAX_COMMUNITY_MEDIA_RESPONSE_BYTES,
+    readCommunityAudioBytes,
 } from "@shared/community-media.ts";
 import { detectImageMimeType } from "@shared/image-mime.ts";
 import type { ModelInputModality, Usage } from "@shared/registry/registry.ts";
@@ -336,6 +338,66 @@ export async function testCommunityTranscriptionEndpoint({
         // usage object that may not carry it.
         usage: { duration: promptAudioSeconds },
         billableUsage: { promptAudioSeconds },
+    };
+}
+
+// Speech (TTS) endpoints are billed on the characters Pollinations sends
+// (completionAudioTokens), mirroring first-party TTS. The probe submits a
+// short OpenAI speech request and validates the raw audio bytes it gets back;
+// it does not trust the upstream's reported usage because speech billing is on
+// the input we send, not what the endpoint reports.
+export async function testCommunitySpeechEndpoint({
+    baseUrl,
+    bearerToken,
+    model,
+}: ModelEndpointTestInput): Promise<CommunityEndpointTestResult> {
+    const input = "The quick brown fox jumps over the lazy dog.";
+    let response: Response;
+    try {
+        // Unlike the JSON probes above, /v1/audio/speech returns raw audio
+        // bytes, so we fetch directly rather than through fetchJson.
+        response = await fetch(communityAudioSpeechUrl(baseUrl), {
+            method: "POST",
+            headers: {
+                ...authorizationHeaders(bearerToken),
+                "Content-Type": "application/json",
+                Accept: "audio/*",
+            },
+            body: JSON.stringify({ model, input, voice: "alloy" }),
+            redirect: "manual",
+            signal: AbortSignal.timeout(COMMUNITY_ENDPOINT_TIMEOUT_MS),
+        });
+    } catch {
+        throw new Error("Endpoint request timed out or could not connect");
+    }
+    if (!response.ok) {
+        const detail = communityEndpointErrorDetail(
+            parseJson(
+                await readResponseText(
+                    response,
+                    MAX_COMMUNITY_MEDIA_RESPONSE_BYTES,
+                    () => new Error("Endpoint response is too large"),
+                ),
+            ),
+        );
+        const prefix =
+            response.status === 401
+                ? "Endpoint responded 401 after we sent Authorization"
+                : response.status >= 300 && response.status < 400
+                  ? `Endpoint responded ${response.status} with a redirect, which is not supported`
+                  : `Endpoint responded ${response.status}`;
+        throw new Error(detail ? `${prefix}: ${detail}` : prefix);
+    }
+
+    const audio = await readCommunityAudioBytes(response);
+    if (!audio) {
+        throw new Error("Endpoint did not return valid binary audio");
+    }
+
+    const completionAudioTokens = input.length;
+    return {
+        usage: { completion_audio_tokens: completionAudioTokens },
+        billableUsage: { completionAudioTokens },
     };
 }
 

--- a/enter.pollinations.ai/test/community-endpoint-openai.test.ts
+++ b/enter.pollinations.ai/test/community-endpoint-openai.test.ts
@@ -5,6 +5,7 @@ import {
     testCommunityEmbeddingEndpoint,
     testCommunityEndpoint,
     testCommunityImageEndpoint,
+    testCommunitySpeechEndpoint,
     testCommunityTranscriptionEndpoint,
     testCommunityVideoEndpoint,
 } from "../src/services/community-endpoint-openai.ts";
@@ -540,6 +541,102 @@ describe("community endpoint OpenAI service", () => {
                 model: "whisper-1",
             }),
         ).rejects.toThrow("Endpoint did not return OpenAI transcription text");
+    });
+
+    it("probes speech endpoints against /v1/audio/speech and bills the input characters", async () => {
+        const fetchMock = vi.fn(async (input, init) => {
+            const request = new Request(input, init);
+            expect(request.url).toBe("https://api.example.com/v1/audio/speech");
+            expect(request.headers.get("authorization")).toBe(
+                "Bearer sk_saved_token",
+            );
+            expect(request.headers.get("content-type")).toContain(
+                "application/json",
+            );
+            const body = await request.json();
+            expect(body).toEqual({
+                model: "tts-1",
+                input: "The quick brown fox jumps over the lazy dog.",
+                voice: "alloy",
+            });
+            // IEC bytes stand in for real MP3 frames; the probe only needs a
+            // recognizable audio container.
+            const mp3 = new Uint8Array([
+                0x49, 0x44, 0x33, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            ]);
+            return new Response(mp3, {
+                status: 200,
+                headers: { "Content-Type": "audio/mpeg" },
+            });
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        await expect(
+            testCommunitySpeechEndpoint({
+                baseUrl: "https://api.example.com/v1",
+                bearerToken: "sk_saved_token",
+                model: "tts-1",
+            }),
+        ).resolves.toEqual({
+            usage: { completion_audio_tokens: 44 },
+            billableUsage: { completionAudioTokens: 44 },
+        });
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("probes speech endpoints that are missing a content-type via audio magic bytes", async () => {
+        const wav = new Uint8Array(12);
+        wav.set([0x52, 0x49, 0x46, 0x46], 0);
+        wav.set([0x57, 0x41, 0x56, 0x45], 8);
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => new Response(wav, { status: 200 })),
+        );
+
+        await expect(
+            testCommunitySpeechEndpoint({
+                baseUrl: "https://api.example.com/v1",
+                bearerToken: "sk_saved_token",
+                model: "tts-1",
+            }),
+        ).resolves.toMatchObject({
+            billableUsage: { completionAudioTokens: 44 },
+        });
+    });
+
+    it("refuses to register a speech endpoint that returns no audio", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => Response.json({ ok: true })),
+        );
+
+        await expect(
+            testCommunitySpeechEndpoint({
+                baseUrl: "https://api.example.com/v1",
+                bearerToken: "sk_saved_token",
+                model: "tts-1",
+            }),
+        ).rejects.toThrow("did not return valid binary audio");
+    });
+
+    it("surfaces upstream speech errors with the endpoint detail", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () =>
+                Response.json(
+                    { error: { message: "voice not found" } },
+                    { status: 400 },
+                ),
+            ),
+        );
+
+        await expect(
+            testCommunitySpeechEndpoint({
+                baseUrl: "https://api.example.com/v1",
+                bearerToken: "sk_saved_token",
+                model: "tts-1",
+            }),
+        ).rejects.toThrow("voice not found");
     });
 
     it("probes embedding endpoints and returns billable prompt tokens", async () => {

--- a/enter.pollinations.ai/test/community-endpoint-price-input.test.ts
+++ b/enter.pollinations.ai/test/community-endpoint-price-input.test.ts
@@ -32,6 +32,20 @@ describe("community endpoint price input", () => {
         ).toBe(true);
     });
 
+    it("prices speech on the completion-audio (character) column", () => {
+        const visiblePriceKeys = new Set(
+            basePriceKeysForModality("speech"),
+        );
+
+        expect([...visiblePriceKeys]).toEqual(["completionAudioPrice"]);
+        expect(
+            hasValidVisibleFormPrices(
+                { ...emptyForm, modality: "speech" },
+                visiblePriceKeys,
+            ),
+        ).toBe(true);
+    });
+
     it("accepts free and minimum prices", () => {
         expect(isValidPriceInput("")).toBe(true);
         expect(isValidPriceInput("0")).toBe(true);

--- a/gen.pollinations.ai/src/audio/communityEndpoint.ts
+++ b/gen.pollinations.ai/src/audio/communityEndpoint.ts
@@ -1,14 +1,19 @@
-import { communityAudioTranscriptionsUrl } from "@shared/community-endpoint-urls.ts";
+import {
+    communityAudioSpeechUrl,
+    communityAudioTranscriptionsUrl,
+} from "@shared/community-endpoint-urls.ts";
 import {
     COMMUNITY_ENDPOINT_TIMEOUT_MS,
     type CommunityEndpointRuntime,
     communityTranscriptionSeconds,
     normalizeCommunityEndpointBearerToken,
 } from "@shared/community-endpoints.ts";
+import { readCommunityAudioBytes } from "@shared/community-media.ts";
 import { ensureUpstreamOk, UpstreamError } from "@shared/error.ts";
 import {
     buildUsageHeaders,
     createAudioSecondsUsage,
+    createAudioTokenUsage,
 } from "@shared/registry/usage-headers.ts";
 import { decryptSecret } from "@shared/secret-encryption.ts";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
@@ -125,6 +130,82 @@ export async function callCommunityTranscriptionEndpoint(
             endpoint.modelId,
             createAudioSecondsUsage(transcript.duration),
         ),
+    });
+}
+
+export type CommunitySpeechOptions = {
+    text: string;
+    voice?: string;
+    responseFormat?: string;
+};
+
+export async function callCommunitySpeechEndpoint(
+    endpoint: CommunityEndpointRuntime,
+    options: CommunitySpeechOptions,
+    secret: string,
+): Promise<Response> {
+    if (endpoint.type !== "proxy") {
+        throw new Error(
+            `Community speech endpoint '${endpoint.modelId}' is a managed agent`,
+        );
+    }
+    const bearerToken = await decryptSecret(
+        endpoint.bearerTokenCiphertext,
+        secret,
+    );
+    const upstreamUrl = communityAudioSpeechUrl(endpoint.baseUrl);
+
+    const body: Record<string, string> = {
+        model: endpoint.upstreamModel,
+        input: options.text,
+    };
+    if (options.voice) body.voice = options.voice;
+    if (options.responseFormat) body.response_format = options.responseFormat;
+
+    let response: Response;
+    try {
+        response = await fetch(upstreamUrl, {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${normalizeCommunityEndpointBearerToken(
+                    bearerToken,
+                )}`,
+                "Content-Type": "application/json",
+                Accept: "audio/*",
+            },
+            body: JSON.stringify(body),
+            redirect: "manual",
+            signal: AbortSignal.timeout(COMMUNITY_ENDPOINT_TIMEOUT_MS),
+        });
+    } catch (error) {
+        throw new UpstreamError(502 as ContentfulStatusCode, {
+            message: "Community speech endpoint timed out or could not connect",
+            cause: error,
+            requestUrl: new URL(upstreamUrl),
+        });
+    }
+    response = await ensureUpstreamOk(response, upstreamUrl);
+
+    // /v1/audio/speech returns raw audio bytes. Anything that is not a
+    // recognizable audio container is a provider regression rather than a free
+    // response — the same stance the image and transcription paths take on
+    // missing usage — and the registration probe rejects it up front.
+    const audio = await readCommunityAudioBytes(response);
+    if (!audio) {
+        throw new UpstreamError(502 as ContentfulStatusCode, {
+            message: `Community speech endpoint '${endpoint.modelId}' did not return valid binary audio`,
+            requestUrl: new URL(upstreamUrl),
+        });
+    }
+    return new Response(audio.bytes, {
+        status: 200,
+        headers: {
+            "Content-Type": audio.mime,
+            ...buildUsageHeaders(
+                endpoint.modelId,
+                createAudioTokenUsage(options.text.length),
+            ),
+        },
     });
 }
 

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -40,7 +40,10 @@ import {
     apiKeyBudgetReservation,
     generationAccess,
 } from "@/utils/generation-access.ts";
-import { callCommunityTranscriptionEndpoint } from "../audio/communityEndpoint.ts";
+import {
+    callCommunitySpeechEndpoint,
+    callCommunityTranscriptionEndpoint,
+} from "../audio/communityEndpoint.ts";
 import {
     type FallbackCandidate,
     withModelFallbackResponse,
@@ -2809,8 +2812,19 @@ async function generateAudioFromSpeechRequest(
         ? await fetchReferenceAudio(reference_audio)
         : undefined;
 
-    return withAudioFallback(c, (candidate) =>
-        dispatchAudioGeneration(c, candidate.id, {
+    return withAudioFallback(c, async (candidate) => {
+        if (candidate.communityEndpoint) {
+            return callCommunitySpeechEndpoint(
+                candidate.communityEndpoint,
+                {
+                    text: safeInput,
+                    voice,
+                    responseFormat: response_format,
+                },
+                c.env.BETTER_AUTH_SECRET,
+            );
+        }
+        return dispatchAudioGeneration(c, candidate.id, {
             text: safeInput,
             voice,
             responseFormat: response_format,
@@ -2835,8 +2849,8 @@ async function generateAudioFromSpeechRequest(
             falKey: c.env.FAL_KEY,
             stabilityApiKey: c.env.STABILITY_API_KEY,
             log,
-        }),
-    );
+        });
+    });
 }
 
 export async function handleSimpleAudio(c: AudioContext): Promise<Response> {

--- a/gen.pollinations.ai/test/community-endpoints.test.ts
+++ b/gen.pollinations.ai/test/community-endpoints.test.ts
@@ -87,7 +87,10 @@ import { drizzle } from "drizzle-orm/d1";
 import { Hono } from "hono";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Env } from "@/env.ts";
-import { callCommunityTranscriptionEndpoint } from "../src/audio/communityEndpoint.ts";
+import {
+    callCommunitySpeechEndpoint,
+    callCommunityTranscriptionEndpoint,
+} from "../src/audio/communityEndpoint.ts";
 import { getCommunityModelRegistryEntries } from "../src/community-models.ts";
 import {
     callCommunityImageEndpoint,
@@ -1991,6 +1994,164 @@ describe("community endpoint helpers", () => {
             ).rejects.toMatchObject({
                 status: 413,
                 message: expect.stringContaining("Audio file too long"),
+            });
+        });
+    });
+
+    describe("community speech endpoint billing", () => {
+        afterEach(() => {
+            vi.unstubAllGlobals();
+        });
+
+        const secret = "test-secret";
+
+        async function speechEndpoint(): Promise<CommunityEndpointRuntime> {
+            return {
+                type: "proxy",
+                id: "community-endpoint-id",
+                ownerUserId: "owner-id",
+                modelId: "voodoohop/tts",
+                name: "tts",
+                title: "TTS",
+                description: null,
+                modality: "speech",
+                imagePricing: "request",
+                inputModalities: ["text"],
+                baseUrl: "https://api.example.com/v1",
+                upstreamModel: "tts-1",
+                visibility: "public",
+                paidOnly: false,
+                perUserRpm: null,
+                fallbacks: [],
+                hiddenAt: null,
+                hiddenReason: null,
+                bearerTokenCiphertext: await encryptSecret(
+                    "sk_saved_token",
+                    secret,
+                ),
+                ...communityEndpointPrices({ completionAudioPrice: 0.03 }),
+            };
+        }
+
+        const mp3 = new Uint8Array([
+            0x49, 0x44, 0x33, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ]);
+
+        it("forwards model/input/voice and bills the input characters", async () => {
+            const fetchMock = vi.fn(async (input, init) => {
+                const request = new Request(input, init);
+                expect(request.url).toBe(
+                    "https://api.example.com/v1/audio/speech",
+                );
+                expect(request.headers.get("authorization")).toBe(
+                    "Bearer sk_saved_token",
+                );
+                expect(request.headers.get("accept")).toContain("audio/");
+                const body = await request.json();
+                expect(body).toEqual({
+                    model: "tts-1",
+                    input: "Hello, world!",
+                    voice: "nova",
+                });
+                return new Response(mp3, {
+                    status: 200,
+                    headers: { "Content-Type": "audio/mpeg" },
+                });
+            });
+            vi.stubGlobal("fetch", fetchMock);
+
+            const response = await callCommunitySpeechEndpoint(
+                await speechEndpoint(),
+                { text: "Hello, world!", voice: "nova" },
+                secret,
+            );
+
+            expect(response.status).toBe(200);
+            expect(response.headers.get("content-type")).toBe("audio/mpeg");
+            expect(
+                response.headers.get(USAGE_TYPE_HEADERS.completionAudioTokens),
+            ).toBe(String("Hello, world!".length));
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+        });
+
+        it("forwards and preserves the response format", async () => {
+            const fetchMock = vi.fn(async (input, init) => {
+                const body = await new Request(input, init).json();
+                expect(body.response_format).toBe("wav");
+                return new Response(mp3, {
+                    status: 200,
+                    headers: { "Content-Type": "audio/wav" },
+                });
+            });
+            vi.stubGlobal("fetch", fetchMock);
+
+            const response = await callCommunitySpeechEndpoint(
+                await speechEndpoint(),
+                { text: "Hello", responseFormat: "wav" },
+                secret,
+            );
+
+            expect(response.headers.get("content-type")).toBe("audio/wav");
+        });
+
+        it("falls back to magic-byte detection when upstream omits a content type", async () => {
+            const wav = new Uint8Array(12);
+            wav.set([0x52, 0x49, 0x46, 0x46], 0);
+            wav.set([0x57, 0x41, 0x56, 0x45], 8);
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async () => new Response(wav, { status: 200 })),
+            );
+
+            const response = await callCommunitySpeechEndpoint(
+                await speechEndpoint(),
+                { text: "Hello, world!" },
+                secret,
+            );
+
+            expect(response.headers.get("content-type")).toBe("audio/wav");
+        });
+
+        it("rejects a speech response that is not valid binary audio", async () => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async () => Response.json({ ok: true })),
+            );
+
+            await expect(
+                callCommunitySpeechEndpoint(
+                    await speechEndpoint(),
+                    { text: "Hello" },
+                    secret,
+                ),
+            ).rejects.toMatchObject({
+                status: 502,
+                message: expect.stringContaining(
+                    "did not return valid binary audio",
+                ),
+            });
+        });
+
+        it("propagates upstream speech failures", async () => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async () =>
+                    Response.json(
+                        { error: { message: "voice not found" } },
+                        { status: 400 },
+                    ),
+                ),
+            );
+
+            await expect(
+                callCommunitySpeechEndpoint(
+                    await speechEndpoint(),
+                    { text: "Hello", voice: "nope" },
+                    secret,
+                ),
+            ).rejects.toMatchObject({
+                status: 400,
+                message: expect.stringContaining("voice not found"),
             });
         });
     });

--- a/packages/polli-cli/src/commands/my-models.ts
+++ b/packages/polli-cli/src/commands/my-models.ts
@@ -60,7 +60,7 @@ interface MyModelBase {
 interface ProxyMyModel extends MyModelBase {
     type: "proxy";
     paidOnly: boolean;
-    modality: "text" | "image" | "video" | "transcription" | "embedding";
+    modality: "text" | "image" | "video" | "transcription" | "speech" | "embedding";
     imagePricing: "request" | "tokens";
     completionImagePrice: number;
     completionVideoPrice: number;
@@ -144,10 +144,11 @@ export function modelBody(
             opts.modality !== "image" &&
             opts.modality !== "video" &&
             opts.modality !== "transcription" &&
+            opts.modality !== "speech" &&
             opts.modality !== "embedding"
         ) {
             fail(
-                "--modality must be 'text', 'image', 'video', 'transcription', or 'embedding'",
+                "--modality must be 'text', 'image', 'video', 'transcription', 'speech', or 'embedding'",
             );
         }
         body.modality = opts.modality;
@@ -303,7 +304,7 @@ const create = addPriceOptions(
         )
         .option(
             "--modality <modality>",
-            "Model family: text (default), image, video, transcription, or embedding",
+            "Model family: text (default), image, video, transcription, speech, or embedding",
         )
         .option(
             "--image-pricing <mode>",
@@ -451,7 +452,7 @@ const test = new Command("test")
     .option("--model <model>", "Upstream model id (not used for video)")
     .option(
         "--modality <modality>",
-        "Model family: text (default), image, video, transcription, or embedding",
+        "Model family: text (default), image, video, transcription, speech, or embedding",
     )
     .action(async (opts) => {
         const key = requireKey();
@@ -461,10 +462,11 @@ const test = new Command("test")
             opts.modality !== "image" &&
             opts.modality !== "video" &&
             opts.modality !== "transcription" &&
+            opts.modality !== "speech" &&
             opts.modality !== "embedding"
         ) {
             fail(
-                "--modality must be 'text', 'image', 'video', 'transcription', or 'embedding'",
+                "--modality must be 'text', 'image', 'video', 'transcription', 'speech', or 'embedding'",
             );
         }
         const modality = opts.modality ?? "text";
@@ -493,7 +495,7 @@ const test = new Command("test")
 
 export const myModelsCommand = new Command("my-models")
     .description(
-        "Manage private and published community text, image, video, transcription, and embedding models",
+        "Manage private and published community text, image, video, transcription, speech, and embedding models",
     )
     .addCommand(list)
     .addCommand(create)

--- a/shared/community-endpoint-urls.ts
+++ b/shared/community-endpoint-urls.ts
@@ -55,6 +55,10 @@ export function communityAudioTranscriptionsUrl(baseUrl: string): string {
     return communityOpenAIEndpointUrl(baseUrl, "/audio/transcriptions");
 }
 
+export function communityAudioSpeechUrl(baseUrl: string): string {
+    return communityOpenAIEndpointUrl(baseUrl, "/audio/speech");
+}
+
 export function communityEmbeddingsUrl(baseUrl: string): string {
     return communityOpenAIEndpointUrl(baseUrl, "/embeddings");
 }
@@ -74,6 +78,7 @@ const COMMUNITY_OPENAI_ENDPOINT_SUFFIXES = [
     "/images/generations",
     "/images/edits",
     "/audio/transcriptions",
+    "/audio/speech",
     "/embeddings",
 ] as const;
 

--- a/shared/community-endpoints.ts
+++ b/shared/community-endpoints.ts
@@ -26,6 +26,7 @@ export const COMMUNITY_ENDPOINT_MODALITIES = [
     "image",
     "video",
     "transcription",
+    "speech",
     "embedding",
 ] as const;
 // How a community image endpoint is billed. "request" charges the fixed
@@ -239,11 +240,26 @@ const COMMUNITY_VIDEO_PRICE_FIELD = {
     rawUsagePaths: ["duration"],
 } as const;
 
+// Speech (TTS) endpoints bill the characters Pollinations sends against the
+// completion audio price column, mirroring first-party TTS models (cost keyed
+// on completionAudioTokens = input character count at a per-1M rate). The
+// completion audio price column already exists because it is a chat usage
+// type; speech reuses it. There is no upstream usage path to read back — the
+// charge is on the input we send, not usage the upstream returns.
+const COMMUNITY_SPEECH_PRICE_FIELD = {
+    key: "completionAudioPrice",
+    usageType: "completionAudioTokens",
+    label: "Generated audio",
+    priceUnit: "million",
+    rawUsagePaths: [],
+} as const;
+
 export const COMMUNITY_ENDPOINT_PRICE_FIELDS = [
     ...COMMUNITY_TEXT_PRICE_FIELDS,
     COMMUNITY_IMAGE_PRICE_FIELD,
     COMMUNITY_TRANSCRIPTION_PRICE_FIELD,
     COMMUNITY_VIDEO_PRICE_FIELD,
+    COMMUNITY_SPEECH_PRICE_FIELD,
 ] as const;
 
 const COMMUNITY_IMAGE_ENDPOINT_PRICE_FIELDS = [
@@ -256,6 +272,10 @@ const COMMUNITY_TRANSCRIPTION_ENDPOINT_PRICE_FIELDS = [
 
 const COMMUNITY_VIDEO_ENDPOINT_PRICE_FIELDS = [
     COMMUNITY_VIDEO_PRICE_FIELD,
+] as const;
+
+const COMMUNITY_SPEECH_ENDPOINT_PRICE_FIELDS = [
+    COMMUNITY_SPEECH_PRICE_FIELD,
 ] as const;
 
 // Embedding endpoints bill token usage per 1M like text models. Token-only
@@ -274,6 +294,7 @@ export type CommunityEndpointPriceField =
     | (typeof COMMUNITY_ENDPOINT_PRICE_FIELDS)[number]
     | (typeof COMMUNITY_IMAGE_TOKEN_PRICE_FIELDS)[number]
     | (typeof COMMUNITY_TRANSCRIPTION_ENDPOINT_PRICE_FIELDS)[number]
+    | (typeof COMMUNITY_SPEECH_ENDPOINT_PRICE_FIELDS)[number]
     | (typeof COMMUNITY_EMBEDDING_ENDPOINT_PRICE_FIELDS)[number];
 
 type CommunityModalitySpec = {
@@ -332,6 +353,14 @@ export const COMMUNITY_MODALITY_SPEC = {
         supportedEndpoints: ["/v1/audio/transcriptions"],
         restrictDefinitionEndpoints: true,
         priceFields: COMMUNITY_TRANSCRIPTION_ENDPOINT_PRICE_FIELDS,
+    },
+    speech: {
+        category: "audio",
+        inputModalities: ["text"],
+        outputModalities: ["audio"],
+        supportedEndpoints: ["/v1/audio/speech"],
+        restrictDefinitionEndpoints: true,
+        priceFields: COMMUNITY_SPEECH_ENDPOINT_PRICE_FIELDS,
     },
     embedding: {
         category: "embedding",
@@ -453,6 +482,7 @@ export function normalizeCommunityEndpointModality(
     value: string | null | undefined,
 ): CommunityEndpointModality {
     if (value === "transcription") return "transcription";
+    if (value === "speech") return "speech";
     if (value === "video") return "video";
     if (value === "image") return "image";
     if (value === "embedding") return "embedding";
@@ -471,10 +501,10 @@ export function normalizeCommunityEndpointInputModalities(
 ): ModelInputModality[] {
     // Both empty cases — nothing declared, and a declared set that shares
     // nothing with this modality — fall back to the modality's own first
-    // input: text for text, image, and video endpoints; audio for transcription.
-    // Falling back to a bare "text" would hand a transcription endpoint the
-    // one input it cannot accept, which the write path then rejects with a
-    // 400 naming an input the owner never chose.
+    // input: text for text, image, video, and speech endpoints; audio for
+    // transcription. Falling back to a bare "text" would hand a transcription
+    // endpoint the one input it cannot accept, which the write path then
+    // rejects with a 400 naming an input the owner never chose.
     const permitted = COMMUNITY_MODALITY_SPEC[endpointModality].inputModalities;
     const declared = new Set(value ?? []);
     const normalized = permitted.filter((modality) => declared.has(modality));

--- a/shared/community-media.ts
+++ b/shared/community-media.ts
@@ -5,6 +5,7 @@ import { readResponseBytes } from "./response-bytes.ts";
 
 export const MAX_COMMUNITY_IMAGE_BYTES = 20 * 1024 * 1024;
 export const MAX_COMMUNITY_VIDEO_BYTES = 20 * 1024 * 1024;
+export const MAX_COMMUNITY_AUDIO_BYTES = 20 * 1024 * 1024;
 // A JSON envelope carrying a 20 MB base64 clip is at most ~28 MB; leave a
 // small amount of room for the envelope while still bounding provider output.
 export const MAX_COMMUNITY_MEDIA_RESPONSE_BYTES =
@@ -102,6 +103,62 @@ export async function firstCommunityVideoBytes(
         }
     }
     return null;
+}
+
+/**
+ * OpenAI /v1/audio/speech returns raw audio bytes (not the JSON envelope that
+ * image/video endpoints use), so the probe and request path read the body
+ * directly. Returns null when the bytes are not a recognizable audio
+ * container, so each caller can phrase that in its own words.
+ */
+export async function readCommunityAudioBytes(
+    response: Response,
+): Promise<{ bytes: Uint8Array<ArrayBuffer>; mime: string } | null> {
+    const bytes = await readResponseBytes(
+        response,
+        MAX_COMMUNITY_AUDIO_BYTES,
+        () => new HttpError("Endpoint audio is larger than 20 MB", 502),
+    );
+    const headerMime = response.headers.get("content-type");
+    const mime = headerMime?.startsWith("audio/")
+        ? headerMime
+        : detectAudioMimeType(bytes);
+    return mime ? { bytes, mime } : null;
+}
+
+export function detectAudioMimeType(bytes: Uint8Array): string | null {
+    // WAV: RIFF....WAVE
+    if (
+        bytes.byteLength >= 12 &&
+        bytesToAscii(bytes, 0, 4) === "RIFF" &&
+        bytesToAscii(bytes, 8, 4) === "WAVE"
+    ) {
+        return "audio/wav";
+    }
+    // MP3: an ID3 tag, or a frame-sync byte (0xFF Ex).
+    if (
+        (bytes.byteLength >= 3 && bytesToAscii(bytes, 0, 3) === "ID3") ||
+        (bytes.byteLength >= 2 &&
+            bytes[0] === 0xff &&
+            (bytes[1] & 0xe0) === 0xe0)
+    ) {
+        return "audio/mpeg";
+    }
+    if (bytes.byteLength >= 4 && bytesToAscii(bytes, 0, 4) === "OggS") {
+        return "audio/ogg";
+    }
+    if (bytes.byteLength >= 4 && bytesToAscii(bytes, 0, 4) === "fLaC") {
+        return "audio/flac";
+    }
+    return null;
+}
+
+function bytesToAscii(
+    bytes: Uint8Array,
+    start: number,
+    length: number,
+): string {
+    return String.fromCharCode(...bytes.subarray(start, start + length));
 }
 
 export function decodeCommunityBase64(value: string): Uint8Array | null {


### PR DESCRIPTION
- Adds speech modality to community endpoints: registration, pricing, catalog, dispatch
- Registration probes upstream TTS with a short sample and validates binary audio response
- Generation forwards standard model/input/voice/response_format fields
- Publisher pricing uses existing character-based TTS fields
- Reuses auth, caching, publisher rewards, timeout, fallback, rate-limit paths
- Frontend price table supports speech with per-1000-character pricing
- Focused test coverage: enter (26 tests), gen (100 tests), price input (9 tests)

Fixes #14347