### PR TITLE
feat: allow community fallback to static registry targets by price

### DIFF
--- a/gen.pollinations.ai/src/fallback.ts
+++ b/gen.pollinations.ai/src/fallback.ts
@@ -1,11 +1,14 @@
 import {
     type CommunityEndpointRuntime,
     isCommunityFallbackBalanceAllowed,
-    isCommunityFallbackPricingAllowed,
     MAX_FALLBACK_TARGETS,
     usesAgentRunToken,
 } from "@shared/community-endpoints.ts";
-import type { ModelDefinition } from "@shared/registry/registry.ts";
+import {
+    getPriceDefinitionForModel,
+    isFallbackPricingAllowed,
+    type ModelDefinition,
+} from "@shared/registry/registry.ts";
 import { FALLBACK_TARGET_HEADER } from "@shared/registry/usage-headers.ts";
 import { firstContentPolicyMessage } from "./image/utils/contentModeration.ts";
 import type { GenerationModelEntry } from "./model-registry.ts";
@@ -250,18 +253,35 @@ export function fallbackCandidates(
     return candidates;
 }
 
+/**
+ * Whether `target` can serve as a fallback for a community-owned `from`.
+ *
+ * `from` is always a community endpoint here — a registry-declared (static)
+ * primary is maintainer-authored and skips this check entirely (see the
+ * `entry.communityEndpoint` gate in linkFallbackEntries). `target` may be
+ * either a community endpoint or a static Pollinations model: either way,
+ * `getPriceDefinitionForModel(target.definition)` is what it is billed at —
+ * a community definition's `cost` is already its resolved
+ * `communityPriceDefinition` (see `communityModelDefinition`) — so the same
+ * pricing and balance rule applies whichever kind serves.
+ */
 function isUsableCommunityFallback(
     from: GenerationModelEntry,
     target: GenerationModelEntry,
 ): target is GenerationModelEntry {
     if (target.eventType !== from.eventType) return false;
     const primary = from.communityEndpoint;
+    if (!primary) return false;
     const candidate = target.communityEndpoint;
-    if (!primary || !candidate) return false;
-    if (primary.modality !== candidate.modality) return false;
-    if (usesAgentRunToken(candidate)) return false;
-    if (primary.imagePricing !== candidate.imagePricing) return false;
-    if (!isCommunityFallbackBalanceAllowed(primary, candidate)) return false;
+    if (candidate) {
+        if (usesAgentRunToken(candidate)) return false;
+        if (primary.modality !== candidate.modality) return false;
+        if (primary.imagePricing !== candidate.imagePricing) return false;
+    } else if (from.definition.category !== target.definition.category) {
+        // No community-side modality/imagePricing to compare against a
+        // static target; the resolved registry category is the equivalent.
+        return false;
+    }
     if (
         !from.supportedEndpoints.every((endpoint) =>
             target.supportedEndpoints.includes(endpoint),
@@ -269,7 +289,20 @@ function isUsableCommunityFallback(
     ) {
         return false;
     }
-    return isCommunityFallbackPricingAllowed(primary, candidate);
+    const targetPaidOnly = candidate
+        ? candidate.paidOnly
+        : (target.definition.paidOnly ?? false);
+    if (
+        !isCommunityFallbackBalanceAllowed(primary, {
+            paidOnly: targetPaidOnly,
+        })
+    ) {
+        return false;
+    }
+    return isFallbackPricingAllowed(
+        getPriceDefinitionForModel(from.definition),
+        getPriceDefinitionForModel(target.definition),
+    );
 }
 
 /** Resolves every model's declared ids once, before the request hot path. */
@@ -288,6 +321,12 @@ export function linkFallbackEntries(
             const target = byIdOrAlias.get(targetId);
             if (!target || target === entry) continue;
             if (entry.communityEndpoint) {
+                // A community owner's declared targets are validated below.
+                // A registry (static) primary's declared targets are not:
+                // they are maintainer-authored config, not user input, and
+                // are trusted the same way regardless of what kind of model
+                // they point at (see "trusts registry declarations" in
+                // fallback.test.ts).
                 const targetEndpoint = target.communityEndpoint;
                 if (targetEndpoint?.hiddenAt != null) continue;
                 if (

--- a/gen.pollinations.ai/test/fallback.test.ts
+++ b/gen.pollinations.ai/test/fallback.test.ts
@@ -289,6 +289,104 @@ describe("registry fallback linking", () => {
 
         expect(primary.fallbackEntries).toBeUndefined();
     });
+
+    describe("community primary falling back to a static registry target", () => {
+        it("links a static target that costs no more than the primary", () => {
+            const primary = communityEntry(
+                "owner/primary",
+                "owner",
+                "public",
+                null,
+                ["static-cheap"],
+                20,
+            );
+            const target = registryEntry("static-cheap", [], 20);
+            const entries = [primary, target];
+
+            linkFallbackEntries(
+                entries,
+                new Map(entries.map((entry) => [entry.id, entry])),
+            );
+
+            expect(primary.fallbackEntries?.map((entry) => entry.id)).toEqual([
+                "static-cheap",
+            ]);
+        });
+
+        it("rejects a static target that costs more than the primary", () => {
+            const primary = communityEntry(
+                "owner/primary",
+                "owner",
+                "public",
+                null,
+                ["static-expensive"],
+                10,
+            );
+            const target = registryEntry("static-expensive", [], 20);
+            const entries = [primary, target];
+
+            linkFallbackEntries(
+                entries,
+                new Map(entries.map((entry) => [entry.id, entry])),
+            );
+
+            expect(primary.fallbackEntries).toBeUndefined();
+        });
+
+        it("rejects a static target in a different category", () => {
+            const primary = communityEntry(
+                "owner/primary",
+                "owner",
+                "public",
+                null,
+                ["static-image"],
+                10,
+            );
+            const target = registryEntry("static-image", [], 10);
+            target.definition.category = "image";
+            const entries = [primary, target];
+
+            linkFallbackEntries(
+                entries,
+                new Map(entries.map((entry) => [entry.id, entry])),
+            );
+
+            expect(primary.fallbackEntries).toBeUndefined();
+        });
+
+        it("rejects a paid-only static target for a primary that takes Quest Pollen", () => {
+            const anyPollen = communityEntry(
+                "owner/any",
+                "owner",
+                "public",
+                null,
+                ["static-paid"],
+                10,
+            );
+            const paidPrimary = communityEntry(
+                "owner/paid",
+                "owner",
+                "public",
+                null,
+                ["static-paid"],
+                10,
+                true,
+            );
+            const staticPaid = registryEntry("static-paid", [], 10);
+            staticPaid.definition.paidOnly = true;
+            const entries = [anyPollen, paidPrimary, staticPaid];
+
+            linkFallbackEntries(
+                entries,
+                new Map(entries.map((entry) => [entry.id, entry])),
+            );
+
+            expect(anyPollen.fallbackEntries).toBeUndefined();
+            expect(
+                paidPrimary.fallbackEntries?.map((entry) => entry.id),
+            ).toEqual(["static-paid"]);
+        });
+    });
 });
 
 describe("formatFallbackTarget", () => {

--- a/shared/community-endpoints.ts
+++ b/shared/community-endpoints.ts
@@ -428,6 +428,12 @@ export const MAX_FALLBACK_TARGETS = 3;
  * listing, and this rule is what guarantees that stays at or below what was
  * charged. It also stops an owner routing traffic to a pricier model whose
  * owner would then earn more than the caller was quoted.
+ *
+ * Used for the write-path check on raw stored `CommunityEndpointPrices`
+ * columns (enter's `fallbackTargetRejection`). The gen-side registry linker
+ * compares resolved `PriceDefinition`s instead — see
+ * `isFallbackPricingAllowed` in `registry.ts`, which also covers a static
+ * registry target and so is not community-prices-shaped.
  */
 export function isCommunityFallbackPricingAllowed(
     primary: CommunityEndpointPrices,

--- a/shared/registry/registry.ts
+++ b/shared/registry/registry.ts
@@ -612,6 +612,32 @@ export function getPriceDefinitionForModel(
 }
 
 /**
+ * True when `target` costs no more than `primary` on every priced dimension.
+ *
+ * Static and community models both reduce to a `PriceDefinition` keyed by
+ * `UsageType` (static via `getPriceDefinitionForModel`, community via
+ * `communityPriceDefinition`), so this one comparison covers every
+ * static/community fallback pair instead of a kind-specific comparator.
+ * A dimension absent from either side is treated as free (`?? 0`): a target
+ * that omits a dimension the primary charges for is cheaper, and a target
+ * that charges for a dimension the primary never billed is rejected — the
+ * caller would otherwise be billed for something the requested model never
+ * charged for.
+ */
+export function isFallbackPricingAllowed(
+    primary: PriceDefinition,
+    target: PriceDefinition,
+): boolean {
+    const dimensions = new Set([
+        ...Object.keys(primary),
+        ...Object.keys(target),
+    ]) as Set<UsageType>;
+    return [...dimensions].every(
+        (dimension) => (target[dimension] ?? 0) <= (primary[dimension] ?? 0),
+    );
+}
+
+/**
  * Get cost definition for a public model name
  */
 export function getCostDefinition(model: ModelName): CostDefinition | null {


### PR DESCRIPTION
Addresses #12854 (scoped implementation).

## Summary
- Generalizes the community-fallback price check so a community-owned model can declare a static (Pollinations-owned) registry model as a fallback target, not just another community model.
- Adds `isFallbackPricingAllowed(primary, target)` in `shared/registry/registry.ts`: one `PriceDefinition`-based comparator that works for both static and community definitions, per the issue's own proposal.
- `isUsableCommunityFallback` now accepts a static target when: same event type, matching category (in place of community modality/imagePricing), the target's endpoints are a superset of the primary's, the target is billed no more than the primary on every dimension, and a Quest-Pollen primary isn't routed to a paid-only static target.
- Registry-declared (static) primaries are untouched. That path already trusts maintainer-authored config by design (see the existing "trusts registry declarations" tests), and this PR does not change it.

## Out of scope
- Letting a community owner self-declare a static model as a fallback target via enter.pollinations.ai is not included here. The write-path validation there (`fallbackTargetRejection`) only understands `<owner>/<name>` community ids and would need new resolution logic against the shared registry to support this — left as a follow-up to keep this PR small and focused.

## Testing
- Added 4 unit tests in `gen.pollinations.ai/test/fallback.test.ts`: static target within/over the price budget, category mismatch, and the Quest-Pollen paid-only static target case.
- I was not able to run `npm run test` / vitest in my environment (network egress to the npm registry was blocked), so these tests are not verified by an actual run. I manually traced each test against the implementation and against `communityPriceDefinition`'s modality handling, and separately ran a standalone check of the new `isFallbackPricingAllowed` logic against the existing price-comparison assertions in this file. Please run the suite before merging.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DjnW5z8otuq2F1K5iU38dM