### PR TITLE
feat: add Muse Spark 1.3

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -1437,6 +1437,18 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.00000025,
     },
   },
+  "meta/muse-spark-1.3": {
+    "cost": {
+      "completionTextTokens": 0.00000425,
+      "promptCachedTokens": 0.00000015,
+      "promptTextTokens": 0.00000125,
+    },
+    "price": {
+      "completionTextTokens": 0.00000425,
+      "promptCachedTokens": 0.00000015,
+      "promptTextTokens": 0.00000125,
+    },
+  },
   "midijourney": {
     "cost": {
       "completionTextTokens": 0.0000045,

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -600,6 +600,10 @@ const models: ModelDefinition[] = [
         config: portkeyConfig["meta/muse-spark-1.2"],
     },
     {
+        name: "meta/muse-spark-1.3",
+        config: portkeyConfig["meta/muse-spark-1.3"],
+    },
+    {
         name: "llama",
         config: portkeyConfig["Llama-3.3-70B-Instruct"],
         // No reasoning mode; Azure 422/400s on reasoning_effort.

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -614,6 +614,10 @@ export const portkeyConfig: PortkeyConfigMap = {
         createVercelAIGatewayModelConfig({
             model: "meta/muse-spark-1.2",
         }),
+    "meta/muse-spark-1.3": () =>
+        createVercelAIGatewayModelConfig({
+            model: "meta/muse-spark-1.3",
+        }),
 
     // -- Azure (Myceli Prod — eastus, Meta Llama) ----------------------------
     "Llama-3.3-70B-Instruct": () =>

--- a/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
+++ b/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
@@ -294,6 +294,19 @@ describe("resolveModelConfig", () => {
         expect(result.options.provider).toBeUndefined();
     });
 
+    it("routes Muse Spark 1.3 directly through Vercel without fallback", () => {
+        const result = resolveModelConfig(messages, {
+            model: "meta/muse-spark-1.3",
+        });
+
+        expect(result.options.model).toBe("meta/muse-spark-1.3");
+        expect(result.options.modelConfig).toMatchObject({
+            provider: "openai",
+            "custom-host": "https://ai-gateway.vercel.sh/v1",
+        });
+        expect(result.options.provider).toBeUndefined();
+    });
+
     it("routes Grok 4.6 directly to its Azure deployment", () => {
         const result = resolveModelConfig(messages, { model: "grok-4.6" });
 

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -2045,6 +2045,30 @@ const TEXT_BASE_SERVICES = {
         contextLength: 1048576,
         isSpecialized: false,
     },
+    "meta/muse-spark-1.3": {
+        aliases: [],
+        provider: "vercel",
+        brand: "Meta",
+        category: "text",
+        addedDate: new Date("2026-09-03").getTime(),
+        paidOnly: true,
+        priceMultiplier: 1,
+        cost: {
+            // Vercel AI Gateway Meta route, verified 2026-09-03.
+            promptTextTokens: perMillion(1.25),
+            promptCachedTokens: perMillion(0.15),
+            completionTextTokens: perMillion(4.25),
+        },
+        title: "Muse Spark 1.3",
+        description:
+            "Long-horizon multimodal reasoning for coding, agents and tool-driven workflows",
+        inputModalities: ["text", "image"],
+        outputModalities: ["text"],
+        tools: true,
+        reasoning: true,
+        contextLength: 1048576,
+        isSpecialized: false,
+    },
     "mistral-large": {
         aliases: ["mistral-large-3", "mistralai/mistral-large-3"],
         provider: "azure",


### PR DESCRIPTION
- Adds canonical `meta/muse-spark-1.3` as a separate paid-only model; Muse Spark 1.2 is unchanged.
- Routes to Vercel AI Gateway model `meta/muse-spark-1.3` (Meta backend only); no alias, Pollinations fallback, or GPU.
- Prices input at $1.25/M, cache reads at $0.15/M, and output/reasoning at $4.25/M with multiplier 1.
- Advertises only proven text/image input, text output, reasoning, automatic tools, structured output, streaming, and 1M context.

Verified:
- Direct provider and authenticated local E2E: chat, simple text, Responses, streaming, JSON schema, image/multi-image, reasoning none/low/high, automatic tool call, useful 400s, and 10/10 burst (1.65–3.60s).
- Catalog and paid-only enforcement are correct. Exact duplicate returns identical cached output with one debit and one Tinybird event.
- Tinybird records provider `vercel`; cached-input sample (21,603 cached + 8 uncached + 174 output tokens) reconciles exactly to 0.00398995 Pollen; cost equals price.

Draft gate:
- Resolve downstream age compliance before launch. [Vercel AI Product Terms](https://vercel.com/legal/ai-product-terms) require users to be at least 16 (or local digital-consent age), with guardian permission under 18; Pollinations has no matching gate today.

OpenRouter was not selected because its account is blocked by the 18+ attestation.