### PR TITLE
fix: clean up model monitor UI

### DIFF
--- a/operations/model-monitor/src/App.jsx
+++ b/operations/model-monitor/src/App.jsx
@@ -10,6 +10,7 @@ import {
     GitHubIcon,
     Heading,
     IconButton,
+    StarIcon,
     Surface,
     TabButton,
     Table,
@@ -18,6 +19,7 @@ import {
     TableHead,
     TableHeaderCell,
     TableRow,
+    Text,
 } from "@pollinations/ui";
 import { ModalityChip } from "@pollinations/ui/gen";
 import { useCallback, useEffect, useState } from "react";
@@ -45,24 +47,6 @@ function saveFavorites(list) {
 
 function modelKey(model) {
     return `${model.type}-${model.name}`;
-}
-
-function StarIcon({ filled }) {
-    return (
-        <svg
-            viewBox="0 0 24 24"
-            className="h-4 w-4"
-            fill={filled ? "currentColor" : "none"}
-            stroke="currentColor"
-            strokeWidth={2}
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            role="img"
-            aria-label={filled ? "Favorited" : "Not favorited"}
-        >
-            <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
-        </svg>
-    );
 }
 
 const WINDOW_OPTIONS = [
@@ -637,38 +621,38 @@ function App() {
     };
 
     return (
-        <div className="min-h-dvh min-w-fit bg-app-bg text-theme-text-base">
+        <div className="min-h-dvh bg-app-bg text-theme-text-base">
             <AppHeader
                 navLabel="Model Monitor links"
                 autoHide
-                innerClassName="polli:max-w-6xl polli:flex-row polli:items-center polli:justify-between"
+                innerClassName="polli:max-w-6xl"
             >
                 {EXTERNAL_LINKS.map((link) => (
                     <HeaderLink key={link.href} {...link} />
                 ))}
                 <ColorModeToggle />
             </AppHeader>
-            <main className="mx-auto flex w-full min-w-fit max-w-6xl flex-col gap-4 px-4 py-5 sm:px-6 md:py-7">
-                <section className="flex flex-row items-end justify-between gap-3">
+            <main className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-4 py-5 sm:px-6 md:py-7">
+                <section className="flex flex-col items-start gap-3 sm:flex-row sm:items-end sm:justify-between">
                     <div className="flex min-w-0 flex-col gap-1">
                         <Heading
                             as="h1"
                             size="title"
-                            className="polli-model-monitor-title polli:m-0 polli:text-theme-text-strong"
+                            className="polli:m-0 sm:text-5xl"
                         >
                             Model Monitor
                         </Heading>
-                        <p className="m-0 max-w-3xl text-base leading-relaxed text-theme-text-base">
+                        <Text className="m-0 max-w-3xl">
                             Real-time health monitoring for Pollinations AI
                             models.
-                        </p>
+                        </Text>
                     </div>
                     <div className="flex flex-col items-start gap-2 sm:items-end">
                         <WindowTabs
                             value={aggregationWindow}
                             onChange={setAggregationWindow}
                         />
-                        <p className="m-0 text-xs leading-normal text-theme-text-soft">
+                        <Text size="xs" tone="soft" className="m-0">
                             Data as of:{" "}
                             {lastUpdated?.toLocaleTimeString("en-GB", {
                                 timeZone: "UTC",
@@ -677,7 +661,7 @@ function App() {
                                 second: "2-digit",
                             }) || "-"}{" "}
                             UTC
-                        </p>
+                        </Text>
                     </div>
                 </section>
 
@@ -709,12 +693,11 @@ function App() {
 
                 {favorites.length > 0 && (
                     <div className="flex items-center gap-2">
-                        <Button
-                            type="button"
+                        <TabButton
+                            active={favoritesOnly}
+                            variant="ghost"
                             size="sm"
-                            intent={favoritesOnly ? "info" : undefined}
-                            aria-pressed={favoritesOnly}
-                            aria-label={`Show favorites only (${favorites.length})`}
+                            ariaLabel={`Show favorites only (${favorites.length})`}
                             onClick={() => setFavoritesOnly((prev) => !prev)}
                         >
                             <span className="inline-flex items-center gap-1">
@@ -724,15 +707,20 @@ function App() {
                                     {favorites.length}
                                 </span>
                             </span>
-                        </Button>
+                        </TabButton>
                     </div>
                 )}
 
-                <Surface variant="card" className="p-0">
-                    <Table>
+                <Surface
+                    variant="card"
+                    className="max-w-full overflow-x-auto p-0"
+                >
+                    <Table className="min-w-[64rem]">
                         <TableHead>
                             <tr>
-                                <TableHeaderCell className="w-8" />
+                                <TableHeaderCell className="w-8">
+                                    <span className="sr-only">Favorite</span>
+                                </TableHeaderCell>
                                 <SortableTh
                                     label="Type"
                                     sortKey="type"
@@ -858,6 +846,9 @@ function App() {
                                     const showCanonicalId =
                                         model.title ||
                                         model.name !== modelLabel;
+                                    const isFavorite = favorites.includes(
+                                        modelKey(model),
+                                    );
 
                                     return (
                                         <TableRow
@@ -866,12 +857,17 @@ function App() {
                                         >
                                             <TableCell className="w-8">
                                                 <IconButton
+                                                    variant="ghost"
+                                                    pressed={isFavorite}
                                                     title={
-                                                        favorites.includes(
-                                                            modelKey(model),
-                                                        )
+                                                        isFavorite
                                                             ? "Remove from favorites"
                                                             : "Add to favorites"
+                                                    }
+                                                    className={
+                                                        isFavorite
+                                                            ? "polli:text-theme-text-soft polli:hover:text-theme-text-soft"
+                                                            : undefined
                                                     }
                                                     onClick={() =>
                                                         toggleFavorite(
@@ -880,9 +876,8 @@ function App() {
                                                     }
                                                 >
                                                     <StarIcon
-                                                        filled={favorites.includes(
-                                                            modelKey(model),
-                                                        )}
+                                                        filled={isFavorite}
+                                                        className="h-4 w-4"
                                                     />
                                                 </IconButton>
                                             </TableCell>

--- a/operations/model-monitor/src/index.css
+++ b/operations/model-monitor/src/index.css
@@ -1,7 +1,1 @@
 @import "@pollinations/ui/app.css";
-
-@media (min-width: 640px) {
-    .polli-model-monitor-title {
-        font-size: 3rem;
-    }
-}

--- a/packages/ui/src/compositions/AppHeader.tsx
+++ b/packages/ui/src/compositions/AppHeader.tsx
@@ -121,7 +121,7 @@ export function AppHeader({
                     <nav
                         aria-label={navLabel}
                         className={cn(
-                            "polli:flex polli:min-w-0 polli:flex-wrap polli:gap-2",
+                            "polli:flex polli:min-w-0 polli:flex-wrap polli:items-center polli:gap-2",
                             navClassName,
                         )}
                     >

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -83,6 +83,7 @@ export {
     IconButton,
     type IconButtonIntent,
     type IconButtonProps,
+    type IconButtonVariant,
 } from "./primitives/IconButton.tsx";
 export { InlineLink, type InlineLinkProps } from "./primitives/InlineLink.tsx";
 export { Input, type InputProps } from "./primitives/Input.tsx";

--- a/packages/ui/src/primitives/IconButton.tsx
+++ b/packages/ui/src/primitives/IconButton.tsx
@@ -4,6 +4,7 @@ import { Tooltip } from "./Tooltip.tsx";
 
 /** `danger` (delete, red) and `info` (edit/links, blue). */
 export type IconButtonIntent = "danger" | "info";
+export type IconButtonVariant = "tile" | "ghost";
 
 const intentClasses: Record<IconButtonIntent, string> = {
     danger:
@@ -14,13 +15,19 @@ const intentClasses: Record<IconButtonIntent, string> = {
         "polli:text-intent-info-text",
 };
 
-// Default (no intent): cascade-driven theme tile, deeper on hover.
-const defaultClasses =
-    "polli:bg-theme-bg-active polli:hover:bg-theme-bg-hover " +
-    "polli:text-theme-text-soft polli:hover:text-theme-text-strong";
+const variantClasses: Record<IconButtonVariant, string> = {
+    tile:
+        "polli:bg-theme-bg-active polli:hover:bg-theme-bg-hover " +
+        "polli:text-theme-text-soft polli:hover:text-theme-text-strong",
+    ghost:
+        "polli:bg-transparent polli:hover:bg-transparent " +
+        "polli:text-theme-text-muted polli:hover:text-theme-text-soft",
+};
 
 export type IconButtonProps = {
     intent?: IconButtonIntent;
+    variant?: IconButtonVariant;
+    pressed?: boolean;
     title?: string;
     tooltip?: ReactNode;
     tooltipAlign?: "start" | "center";
@@ -40,6 +47,8 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
     (
         {
             intent,
+            variant = "tile",
+            pressed,
             title,
             tooltip,
             tooltipAlign,
@@ -57,11 +66,12 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
                 type="button"
                 onClick={onClick}
                 aria-label={title}
+                aria-pressed={pressed}
                 data-intent={intent}
                 className={cn(
                     "polli-control polli:inline-flex polli:cursor-pointer polli:items-center polli:justify-center polli:transition-colors",
                     sizeClasses[size],
-                    intent ? intentClasses[intent] : defaultClasses,
+                    intent ? intentClasses[intent] : variantClasses[variant],
                     className,
                 )}
             >

--- a/packages/ui/src/primitives/Table.tsx
+++ b/packages/ui/src/primitives/Table.tsx
@@ -125,7 +125,17 @@ export const TableHeaderCell: FC<TableHeaderCellProps> = ({
     }
 
     return (
-        <th {...rest} className={classes}>
+        <th
+            {...rest}
+            aria-sort={
+                active && sortDirection
+                    ? sortDirection === "asc"
+                        ? "ascending"
+                        : "descending"
+                    : "none"
+            }
+            className={classes}
+        >
             <button
                 type="button"
                 onClick={onSort}

--- a/packages/ui/src/primitives/controls-accessibility.test.tsx
+++ b/packages/ui/src/primitives/controls-accessibility.test.tsx
@@ -1,0 +1,37 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { IconButton } from "./IconButton.tsx";
+import { TableHeaderCell } from "./Table.tsx";
+
+describe("shared control accessibility", () => {
+    it("exposes the pressed state of toggle icon buttons", () => {
+        const markup = renderToStaticMarkup(
+            <IconButton title="Favorite" pressed onClick={() => undefined}>
+                ★
+            </IconButton>,
+        );
+
+        expect(markup).toContain('aria-label="Favorite"');
+        expect(markup).toContain('aria-pressed="true"');
+    });
+
+    it("exposes the direction of sortable table headers", () => {
+        const markup = renderToStaticMarkup(
+            <table>
+                <thead>
+                    <tr>
+                        <TableHeaderCell
+                            active
+                            sortDirection="desc"
+                            onSort={() => undefined}
+                        >
+                            Requests
+                        </TableHeaderCell>
+                    </tr>
+                </thead>
+            </table>,
+        );
+
+        expect(markup).toContain('aria-sort="descending"');
+    });
+});

--- a/packages/ui/src/primitives/icons/index.tsx
+++ b/packages/ui/src/primitives/icons/index.tsx
@@ -490,6 +490,23 @@ export function SparkleIcon(props: IconProps) {
     );
 }
 
+export function StarIcon({
+    filled = false,
+    ...props
+}: IconProps & { filled?: boolean }) {
+    return (
+        <svg
+            aria-hidden="true"
+            viewBox="0 0 24 24"
+            {...strokeProps}
+            fill={filled ? "currentColor" : "none"}
+            {...props}
+        >
+            <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+        </svg>
+    );
+}
+
 export function CodeIcon(props: IconProps) {
     return (
         <svg aria-hidden="true" viewBox="0 0 24 24" {...strokeProps} {...props}>


### PR DESCRIPTION
- Uses shared UI primitives for the favorite star, text, filters, and icon-button states
- Vertically centers mixed-height controls in the shared app header
- Makes the monitor responsive while containing horizontal scrolling to the data table
- Adds accessible pressed and sort states with focused UI package tests
- Verifies light/dark favorite styling, responsive layouts, typecheck, tests, and production build