### PR TITLE
feat: refine account app connections

### DIFF
--- a/apps/composio-mcp/worker.js
+++ b/apps/composio-mcp/worker.js
@@ -61,13 +61,32 @@ async function listConnections(userId, env, fetchImpl) {
         env,
         fetchImpl,
     );
-    return Array.isArray(body?.items) ? body.items : [];
+    const accounts = Array.isArray(body?.items) ? body.items : [];
+    const toolkitSlugs = [
+        ...new Set(accounts.map((account) => account.toolkit?.slug)),
+    ].filter(Boolean);
+    if (toolkitSlugs.length === 0) return [];
+
+    const toolkitBody = await callComposio("/toolkits/multi", env, fetchImpl, {
+        method: "POST",
+        body: JSON.stringify({ toolkits: toolkitSlugs }),
+    });
+    const toolkitsBySlug = new Map(
+        (Array.isArray(toolkitBody?.items) ? toolkitBody.items : []).map(
+            (toolkit) => [toolkit.slug, toolkit],
+        ),
+    );
+    return accounts.map((account) =>
+        connectionSummary(account, toolkitsBySlug.get(account.toolkit?.slug)),
+    );
 }
 
-function connectionSummary(account) {
+function connectionSummary(account, toolkit) {
     return {
         id: account.id,
         toolkit: account.toolkit?.slug,
+        name: toolkit?.name || null,
+        logo: toolkit?.meta?.logo || null,
         alias: account.alias || null,
         status: account.status,
     };
@@ -296,9 +315,7 @@ async function handleManagement(request, userId, env, fetchImpl) {
     const url = new URL(request.url);
     if (request.method === "GET" && url.pathname === "/connections") {
         return Response.json({
-            data: (await listConnections(userId, env, fetchImpl)).map(
-                connectionSummary,
-            ),
+            data: await listConnections(userId, env, fetchImpl),
         });
     }
     if (request.method === "GET" && url.pathname === "/toolkits") {

--- a/apps/composio-mcp/worker.test.js
+++ b/apps/composio-mcp/worker.test.js
@@ -193,3 +193,63 @@ test("creates a hosted connection link with the current session contract", async
         redirectUrl: "https://connect.example",
     });
 });
+
+test("includes toolkit names and logos with connected accounts", async () => {
+    const requests = [];
+    const worker = createWorker({
+        fetchImpl: async (url, init) => {
+            const parsed = new URL(url);
+            requests.push({ url: parsed, init });
+            if (parsed.pathname.endsWith("/connected_accounts")) {
+                return Response.json({
+                    items: [
+                        {
+                            id: "ca_github",
+                            toolkit: { slug: "github" },
+                            alias: "octocat",
+                            status: "ACTIVE",
+                        },
+                    ],
+                });
+            }
+            if (parsed.pathname.endsWith("/toolkits/multi")) {
+                return Response.json({
+                    items: [
+                        {
+                            slug: "github",
+                            name: "GitHub",
+                            meta: {
+                                logo: "https://logos.composio.test/github",
+                            },
+                        },
+                    ],
+                });
+            }
+            return new Response("Not found", { status: 404 });
+        },
+    });
+
+    const response = await worker.fetch(
+        new Request("https://composio.internal/connections", {
+            headers: { [MCP_USER_ID_HEADER]: "user-1" },
+        }),
+        { COMPOSIO_API_KEY: "test-key" },
+    );
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+        data: [
+            {
+                id: "ca_github",
+                toolkit: "github",
+                name: "GitHub",
+                logo: "https://logos.composio.test/github",
+                alias: "octocat",
+                status: "ACTIVE",
+            },
+        ],
+    });
+    assert.deepEqual(JSON.parse(requests[1].init.body), {
+        toolkits: ["github"],
+    });
+});

--- a/enter.pollinations.ai/frontend/src/components/account/connected-apps.tsx
+++ b/enter.pollinations.ai/frontend/src/components/account/connected-apps.tsx
@@ -1,7 +1,12 @@
 import {
+    Alert,
+    AppIcon,
     Button,
+    CheckIcon,
+    ExternalLinkButton,
     InlineLink,
     Input,
+    LockIcon,
     SearchIcon,
     Section,
     Surface,
@@ -13,6 +18,8 @@ import { apiClient } from "../../api.ts";
 type Connection = {
     id: string;
     toolkit: string;
+    name: string | null;
+    logo: string | null;
     alias: string | null;
 };
 
@@ -43,6 +50,7 @@ type AppCardProps = {
     pendingLabel: string;
     pending: boolean;
     onAction: () => void;
+    connected?: boolean;
 };
 
 function AppCard({
@@ -53,28 +61,66 @@ function AppCard({
     pendingLabel,
     pending,
     onAction,
+    connected = false,
 }: AppCardProps) {
     return (
         <Surface
             variant="card"
-            className="flex items-center justify-between gap-3"
+            className={`flex h-full justify-between gap-3 ${
+                connected ? "items-center" : "min-h-24 items-start"
+            }`}
         >
-            <div className="flex min-w-0 items-center gap-3">
-                {logo && (
-                    <img
-                        src={logo}
-                        alt=""
-                        className="h-8 w-8 shrink-0 rounded-md"
-                    />
-                )}
-                <div className="min-w-0">
+            <div
+                className={`flex min-w-0 gap-3 ${
+                    connected ? "items-center" : "items-start"
+                }`}
+            >
+                <div className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-lg bg-[#fff] shadow-sm ring-1 ring-[rgba(0,0,0,0.18)]">
+                    {logo ? (
+                        <img
+                            src={logo}
+                            alt=""
+                            loading="lazy"
+                            className="h-7 w-7 object-contain drop-shadow-sm"
+                        />
+                    ) : (
+                        <AppIcon className="h-5 w-5 text-black/50" />
+                    )}
+                </div>
+                <div
+                    className={
+                        connected
+                            ? "flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1"
+                            : "min-w-0"
+                    }
+                >
                     <Text tone="strong" weight="semibold">
                         {name}
                     </Text>
-                    {details}
+                    {connected && details}
+                    {connected ? (
+                        <div className="flex items-center gap-1.5">
+                            <CheckIcon className="h-3.5 w-3.5 shrink-0 text-intent-success-text" />
+                            <Text size="sm" tone="muted">
+                                Ready to use
+                            </Text>
+                        </div>
+                    ) : (
+                        details
+                    )}
                 </div>
             </div>
-            <Button type="button" disabled={pending} onClick={onAction}>
+            <Button
+                type="button"
+                size="sm"
+                intent={connected ? "danger" : undefined}
+                className={`shrink-0 ${
+                    connected ? "self-center" : "self-start"
+                }`}
+                disabled={pending}
+                aria-label={`${actionLabel} ${name}`}
+                onClick={onAction}
+            >
                 {pending ? pendingLabel : actionLabel}
             </Button>
         </Surface>
@@ -84,13 +130,15 @@ function AppCard({
 export function ConnectedApps() {
     const [connections, setConnections] = useState<Connection[]>([]);
     const [toolkits, setToolkits] = useState<Toolkit[]>([]);
-    const [knownToolkits, setKnownToolkits] = useState<Record<string, Toolkit>>(
-        {},
-    );
     const [search, setSearch] = useState("");
     const [pendingId, setPendingId] = useState<string | null>(null);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState<string | null>(null);
+    const [connectionsLoading, setConnectionsLoading] = useState(true);
+    const [toolkitsLoading, setToolkitsLoading] = useState(true);
+    const [connectionsError, setConnectionsError] = useState<string | null>(
+        null,
+    );
+    const [toolkitsError, setToolkitsError] = useState<string | null>(null);
+    const [actionError, setActionError] = useState<string | null>(null);
 
     const loadConnections = useCallback(async () => {
         const response = await apiClient.account.integrations.$get();
@@ -109,38 +157,36 @@ export function ConnectedApps() {
     }, []);
 
     useEffect(() => {
-        void loadConnections().catch((loadError) =>
-            setError(errorMessage(loadError, "Could not load connected apps.")),
-        );
+        void loadConnections()
+            .catch((loadError) =>
+                setConnectionsError(
+                    errorMessage(loadError, "Could not load connected apps."),
+                ),
+            )
+            .finally(() => setConnectionsLoading(false));
     }, [loadConnections]);
 
     useEffect(() => {
         const query = search.trim();
         let cancelled = false;
         const timeout = window.setTimeout(() => {
-            setError(null);
-            setLoading(true);
+            setToolkitsError(null);
+            setToolkitsLoading(true);
             void loadToolkits(query)
                 .then((results) => {
                     if (cancelled) return;
                     setToolkits(results);
-                    setKnownToolkits((current) => {
-                        const next = { ...current };
-                        for (const toolkit of results) {
-                            next[toolkit.slug] = toolkit;
-                        }
-                        return next;
-                    });
                 })
                 .catch((searchError) => {
                     if (!cancelled) {
-                        setError(
+                        setToolkits([]);
+                        setToolkitsError(
                             errorMessage(searchError, "Could not search apps."),
                         );
                     }
                 })
                 .finally(() => {
-                    if (!cancelled) setLoading(false);
+                    if (!cancelled) setToolkitsLoading(false);
                 });
         }, 200);
 
@@ -152,7 +198,7 @@ export function ConnectedApps() {
 
     async function connect(toolkit: string) {
         setPendingId(toolkit);
-        setError(null);
+        setActionError(null);
         try {
             const response = await apiClient.account.integrations.$post({
                 json: { toolkit },
@@ -163,14 +209,16 @@ export function ConnectedApps() {
                     .redirectUrl,
             );
         } catch (connectError) {
-            setError(errorMessage(connectError, "Could not connect this app."));
+            setActionError(
+                errorMessage(connectError, "Could not connect this app."),
+            );
             setPendingId(null);
         }
     }
 
     async function disconnect(connection: Connection) {
         setPendingId(connection.id);
-        setError(null);
+        setActionError(null);
         try {
             const response = await apiClient.account.integrations[
                 ":id"
@@ -182,7 +230,7 @@ export function ConnectedApps() {
                 current.filter(({ id }) => id !== connection.id),
             );
         } catch (disconnectError) {
-            setError(
+            setActionError(
                 errorMessage(disconnectError, "Could not disconnect this app."),
             );
         } finally {
@@ -199,78 +247,98 @@ export function ConnectedApps() {
     const displayedToolkits = search.trim()
         ? availableToolkits
         : availableToolkits.slice(0, 6);
+    const searchQuery = search.trim();
 
     return (
-        <Section title="MCP Connectors" framed>
-            <Text size="sm" tone="muted">
-                Connect apps for your agents. Supported by{" "}
-                <InlineLink href="https://composio.dev">Composio</InlineLink>.
+        <Section title="Connect apps" framed>
+            <Text>
+                Let Pollinations agents work with the apps you already use.
             </Text>
 
-            {connections.length > 0 && (
+            {actionError && <Alert intent="danger">{actionError}</Alert>}
+            {connectionsError && (
+                <Alert intent="danger">{connectionsError}</Alert>
+            )}
+
+            {connectionsLoading && (
+                <Text size="sm" tone="muted" role="status">
+                    Loading connected apps…
+                </Text>
+            )}
+
+            {!connectionsLoading && connections.length > 0 && (
                 <div className="space-y-2">
-                    <Text tone="strong" weight="semibold">
-                        Connected
-                    </Text>
+                    <div className="flex items-center justify-between gap-3">
+                        <Text tone="strong" weight="semibold">
+                            Connected
+                        </Text>
+                        <Text size="sm" tone="muted">
+                            {connections.length}{" "}
+                            {connections.length === 1 ? "app" : "apps"}
+                        </Text>
+                    </div>
                     <div className="grid gap-2 sm:grid-cols-2">
-                        {connections.map((connection) => {
-                            const toolkit = knownToolkits[connection.toolkit];
-                            return (
-                                <AppCard
-                                    key={connection.id}
-                                    name={
-                                        toolkit?.name ||
-                                        readableSlug(connection.toolkit)
-                                    }
-                                    logo={toolkit?.logo || null}
-                                    details={
-                                        connection.alias ? (
-                                            <Text size="sm" tone="muted">
-                                                {connection.alias}
-                                            </Text>
-                                        ) : undefined
-                                    }
-                                    actionLabel="Disconnect"
-                                    pendingLabel="Disconnecting..."
-                                    pending={pendingId === connection.id}
-                                    onAction={() => void disconnect(connection)}
-                                />
-                            );
-                        })}
+                        {connections.map((connection) => (
+                            <AppCard
+                                key={connection.id}
+                                name={
+                                    connection.name ||
+                                    readableSlug(connection.toolkit)
+                                }
+                                logo={connection.logo}
+                                details={
+                                    connection.alias ? (
+                                        <Text size="sm" tone="muted">
+                                            {connection.alias}
+                                        </Text>
+                                    ) : undefined
+                                }
+                                actionLabel="Disconnect"
+                                pendingLabel="Disconnecting..."
+                                pending={pendingId === connection.id}
+                                onAction={() => void disconnect(connection)}
+                                connected
+                            />
+                        ))}
                     </div>
                 </div>
             )}
 
-            <div className="space-y-2">
-                <div className="flex items-center justify-between gap-2">
-                    <Text tone="strong" weight="semibold">
-                        Add
-                    </Text>
-                    <InlineLink href="https://composio.dev/toolkits">
-                        View all connectors
-                    </InlineLink>
-                </div>
-                <div className="relative max-w-md">
-                    <SearchIcon className="pointer-events-none absolute left-3 top-1/2 z-10 h-4 w-4 -translate-y-1/2 text-theme-text-muted" />
-                    <Input
-                        value={search}
-                        placeholder="Search connectors…"
-                        aria-label="Search connectors"
-                        autoComplete="off"
-                        className="pl-9"
-                        onChange={(event) =>
-                            setSearch(event.currentTarget.value)
-                        }
-                        onBlur={() => setSearch(search.trim())}
-                    />
+            <div className="space-y-3">
+                <Text tone="strong" weight="semibold">
+                    Available
+                </Text>
+                <div className="flex flex-wrap items-center gap-2">
+                    <div className="relative min-w-64 max-w-lg flex-1">
+                        <SearchIcon className="pointer-events-none absolute left-3 top-1/2 z-10 h-4 w-4 -translate-y-1/2 text-theme-text-muted" />
+                        <Input
+                            value={search}
+                            placeholder="Search apps…"
+                            aria-label="Search available apps"
+                            autoComplete="off"
+                            className="w-full pl-9"
+                            onChange={(event) =>
+                                setSearch(event.currentTarget.value)
+                            }
+                            onBlur={() => setSearch(search.trim())}
+                        />
+                    </div>
+                    <ExternalLinkButton
+                        href="https://composio.dev/toolkits"
+                        className="shrink-0"
+                    >
+                        Browse all apps
+                    </ExternalLinkButton>
                 </div>
             </div>
 
-            {!loading && (
-                <div>
+            {toolkitsError && <Alert intent="danger">{toolkitsError}</Alert>}
+
+            {!toolkitsLoading && !toolkitsError && (
+                <div aria-live="polite">
                     {displayedToolkits.length > 0 ? (
-                        <div className="space-y-2">
-                            <div className="grid gap-2 sm:grid-cols-2">
+                        <div className="space-y-3">
+                            <div className="grid items-stretch gap-2 sm:grid-cols-2">
                                 {displayedToolkits.map((toolkit) => (
                                     <AppCard
                                         key={toolkit.slug}
@@ -294,31 +362,38 @@ export function ConnectedApps() {
                                     />
                                 ))}
                             </div>
-                            {!search.trim() && (
-                                <Text size="sm" tone="muted">
-                                    Showing {displayedToolkits.length} popular
-                                    connectors.
-                                </Text>
-                            )}
                         </div>
                     ) : (
                         <Text size="sm" tone="muted">
-                            No connectors found. Try another search.
+                            {searchQuery
+                                ? `No apps found for “${searchQuery}”. Try another search.`
+                                : "No more apps to show. Search for another app to connect."}
                         </Text>
                     )}
                 </div>
             )}
 
-            {loading && (
-                <Text size="sm" tone="muted">
-                    Loading apps...
+            {toolkitsLoading && (
+                <Text size="sm" tone="muted" role="status">
+                    {searchQuery ? "Searching apps…" : "Loading apps…"}
                 </Text>
             )}
-            {error && (
-                <Text size="sm" tone="muted">
-                    {error}
-                </Text>
-            )}
+
+            <p className="mt-4 flex items-start gap-1.5 border-t border-divider pt-4 text-[13px] leading-snug text-theme-text-muted">
+                <LockIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                <span className="space-y-0.5">
+                    <span className="block">
+                        Review the access requested by each app before
+                        connecting.
+                    </span>
+                    <span className="block text-theme-text-soft">
+                        Connections powered by{" "}
+                        <InlineLink href="https://composio.dev">
+                            Composio
+                        </InlineLink>
+                    </span>
+                </span>
+            </p>
         </Section>
     );
 }

--- a/enter.pollinations.ai/frontend/src/routes/_dashboard.account.tsx
+++ b/enter.pollinations.ai/frontend/src/routes/_dashboard.account.tsx
@@ -8,10 +8,10 @@ import {
     GitHubIcon,
     Heading,
     Input,
-    LockIcon,
     Section,
     Surface,
     Text,
+    TrashIcon,
 } from "@pollinations/ui";
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
@@ -280,7 +280,7 @@ function AccountPage() {
                 </div>
                 <div className="space-y-2 border-t border-divider pt-4 text-[13px] leading-snug text-theme-text-muted">
                     <p className="flex items-start gap-1.5">
-                        <LockIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                        <TrashIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
                         <span>
                             Permanently close your account and revoke access.
                         </span>

--- a/enter.pollinations.ai/src/routes/integrations.ts
+++ b/enter.pollinations.ai/src/routes/integrations.ts
@@ -13,6 +13,8 @@ import { requireAccountPermission } from "./account-permissions.ts";
 const ConnectionSchema = z.object({
     id: z.string(),
     toolkit: z.string(),
+    name: z.string().nullable(),
+    logo: z.string().nullable(),
     alias: z.string().nullable(),
     status: z.string(),
 });

--- a/enter.pollinations.ai/test/integration/integrations.test.ts
+++ b/enter.pollinations.ai/test/integration/integrations.test.ts
@@ -19,6 +19,8 @@ test("manages connected apps through the authenticated account", async ({
             {
                 id: "ca_test",
                 toolkit: "github",
+                name: "GitHub",
+                logo: "https://logos.composio.test/github",
                 status: "ACTIVE",
             },
         ],

--- a/enter.pollinations.ai/vitest.config.ts
+++ b/enter.pollinations.ai/vitest.config.ts
@@ -70,6 +70,8 @@ export default defineWorkersConfig(async ({ mode }) => {
                                             {
                                                 id: "ca_test",
                                                 toolkit: "github",
+                                                name: "GitHub",
+                                                logo: "https://logos.composio.test/github",
                                                 alias: null,
                                                 status: "ACTIVE",
                                                 userId,

--- a/packages/ui/src/primitives/icons/index.tsx
+++ b/packages/ui/src/primitives/icons/index.tsx
@@ -392,6 +392,17 @@ export function XIcon(props: IconProps) {
     );
 }
 
+export function TrashIcon(props: IconProps) {
+    return (
+        <svg aria-hidden="true" viewBox="0 0 24 24" {...strokeProps} {...props}>
+            <path d="M4 7h16" />
+            <path d="M9 7V4h6v3" />
+            <path d="m6 7 1 14h10l1-14" />
+            <path d="M10 11v6M14 11v6" />
+        </svg>
+    );
+}
+
 // --- Model modality / capability / price glyphs (single-ink, replace emoji) ---
 
 export function ChatIcon(props: IconProps) {


### PR DESCRIPTION
- Refines the Account connect section with clearer hierarchy, compact connected cards, and responsive discovery controls
- Uses Composio toolkit metadata so connected and available apps show their correct logos on theme-safe tiles
- Uses shared UI components and adds a reusable trash icon for the account deletion footer
- Adds connector metadata coverage and updates the Account integration contract

Tests:
- `npm test` in `packages/ui`
- `npm test` in `apps/composio-mcp`
- `npx vitest run test/integration/integrations.test.ts` in `enter.pollinations.ai`
- UI and Enter TypeScript checks
- `npm run build:frontend` in `enter.pollinations.ai`