### PR TITLE
fix: use community model metadata

### DIFF
--- a/operations/community-monitor/leaderboard/build-image-leaderboard.mjs
+++ b/operations/community-monitor/leaderboard/build-image-leaderboard.mjs
@@ -54,7 +54,7 @@ async function fetchLeaderboardData() {
     WHERE environment = 'production'
       AND start_time > now() - INTERVAL 24 HOUR
       AND event_type = 'generate.image'
-      AND position(resolved_model_requested, '/') > 0
+      AND model_provider_used = 'community'
       AND is_final
     GROUP BY model
     HAVING requests >= ${MIN_REQUESTS} AND images > 0
@@ -71,7 +71,7 @@ async function fetchLeaderboardData() {
     WHERE environment = 'production'
       AND start_time > now() - INTERVAL 24 HOUR
       AND event_type = 'generate.image'
-      AND position(resolved_model_requested, '/') > 0
+      AND model_provider_used = 'community'
       AND is_final
     FORMAT JSON
   `)

--- a/operations/community-monitor/leaderboard/build-leaderboard.mjs
+++ b/operations/community-monitor/leaderboard/build-leaderboard.mjs
@@ -49,7 +49,7 @@ async function fetchLeaderboardData() {
       round(medianIf((token_count_completion_text + token_count_completion_reasoning) / (response_time / 1000), response_status < 300 AND response_time > 0 AND token_count_completion_text + token_count_completion_reasoning >= 20), 1) AS median_tps,
       round(100 * countIf(response_status >= 200 AND response_status < 300) / greatest(countIf(response_status < 400 OR response_status >= 500), 1), 2) AS success
     FROM generation_event_v2
-    WHERE start_time > now() - INTERVAL 24 HOUR AND event_type = 'generate.text' AND model_requested LIKE '%/%' AND is_final
+    WHERE start_time > now() - INTERVAL 24 HOUR AND event_type = 'generate.text' AND model_provider_used = 'community' AND is_final
     GROUP BY model
     HAVING requests >= ${MIN_REQUESTS}
     ORDER BY total_tokens DESC
@@ -62,7 +62,7 @@ async function fetchLeaderboardData() {
            sum(token_count_prompt_text + token_count_prompt_cached + token_count_completion_text + token_count_completion_reasoning) AS total_tokens,
            uniq(model_requested) AS models
     FROM generation_event_v2
-    WHERE start_time > now() - INTERVAL 24 HOUR AND event_type = 'generate.text' AND model_requested LIKE '%/%' AND is_final
+    WHERE start_time > now() - INTERVAL 24 HOUR AND event_type = 'generate.text' AND model_provider_used = 'community' AND is_final
     FORMAT JSON
   `)
     )[0];

--- a/operations/model-monitor/src/hooks/useModelMonitor.js
+++ b/operations/model-monitor/src/hooks/useModelMonitor.js
@@ -173,7 +173,7 @@ export function useModelMonitor(aggregationWindow = "60m") {
         if (endpointStatus.catalog === false) {
             modelMeta = {
                 name: s.model || "(unknown)",
-                community: s.model?.includes("/") || false,
+                community: s.provider === "community",
                 type: statsType,
                 endpointType: statsType,
                 provider: s.provider,
@@ -196,7 +196,7 @@ export function useModelMonitor(aggregationWindow = "60m") {
         } else {
             modelMeta = {
                 name: s.model || "(unknown)",
-                community: s.model?.includes("/") || false,
+                community: s.provider === "community",
                 type: statsType,
                 endpointType: statsType,
                 provider: s.provider,

--- a/packages/polli-cli/src/harnesses/keys.test.ts
+++ b/packages/polli-cli/src/harnesses/keys.test.ts
@@ -24,6 +24,23 @@ beforeAll(async () => {
                             context_length: 100,
                         },
                         {
+                            id: "publisher/chat",
+                            input_modalities: ["text"],
+                            output_modalities: ["text"],
+                            supported_endpoints: ["/v1/chat/completions"],
+                            tools: true,
+                            context_length: 200,
+                        },
+                        {
+                            id: "owner/community-chat",
+                            community: true,
+                            input_modalities: ["text"],
+                            output_modalities: ["text"],
+                            supported_endpoints: ["/v1/chat/completions"],
+                            tools: true,
+                            context_length: 300,
+                        },
+                        {
                             id: "realtime",
                             input_modalities: ["text"],
                             output_modalities: ["text"],
@@ -78,6 +95,11 @@ describe("harness models", () => {
     it("only includes models supporting chat completions", async () => {
         await expect(fetchHarnessModels()).resolves.toEqual([
             { id: "chat", contextWindow: 100, input: ["text"] },
+            {
+                id: "publisher/chat",
+                contextWindow: 200,
+                input: ["text"],
+            },
         ]);
     });
 });

--- a/packages/polli-cli/src/harnesses/models.ts
+++ b/packages/polli-cli/src/harnesses/models.ts
@@ -3,6 +3,7 @@ import type { HarnessModel } from "./types.js";
 
 interface CatalogModel {
     id: string;
+    community?: boolean;
     input_modalities?: string[];
     output_modalities?: string[];
     supported_endpoints?: string[];
@@ -13,7 +14,7 @@ interface CatalogModel {
 
 /**
  * First-party text models with tool calling — what an agentic harness can
- * drive. Community models (`owner/name`) and published agents are left out:
+ * drive. Community models and published agents are left out:
  * they come and go, and they would triple the list.
  */
 export const fetchHarnessModels = async (): Promise<HarnessModel[]> => {
@@ -26,7 +27,7 @@ export const fetchHarnessModels = async (): Promise<HarnessModel[]> => {
                 m.supported_endpoints?.includes("/v1/chat/completions") &&
                 m.context_length &&
                 !m.agent &&
-                !m.id.includes("/"),
+                m.community !== true,
         )
         .map((m) => ({
             id: m.id,


### PR DESCRIPTION
- Uses the generation event provider field for community leaderboards
- Uses catalog/provider metadata in model monitoring and CLI filtering
- Keeps official publisher-qualified model IDs from being mistaken for community models

Tests: `npm test --prefix packages/polli-cli -- src/harnesses/keys.test.ts`