### PR TITLE
fix: reduce community publishing delay

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-dialog.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-dialog.tsx
@@ -415,7 +415,7 @@ export function CommunityEndpointDialog({
                             title="Queued changes will be cancelled"
                         >
                             Saving this model as Private removes its queued
-                            changes. Publishing it again starts a new 12-hour
+                            changes. Publishing it again starts a new 3-hour
                             wait.
                         </Alert>
                     )}

--- a/enter.pollinations.ai/src/routes/community-endpoints.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints.ts
@@ -430,7 +430,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
             tags: ["🤖 Community Agents"],
             summary: "Create Endpoint Agent",
             description:
-                "Register an agent running on an external OpenAI-compatible endpoint. Pollinations sends a short-lived agent run token instead of a stored bearer credential. Private is the default; public agents require an allowlisted account and become public after 12 hours. API keys require `account:keys`.",
+                "Register an agent running on an external OpenAI-compatible endpoint. Pollinations sends a short-lived agent run token instead of a stored bearer credential. Private is the default; public agents require an allowlisted account and become public after 3 hours. API keys require `account:keys`.",
             responses: {
                 200: {
                     description: "Created endpoint agent",
@@ -498,7 +498,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
             tags: ["🧩 Community Models"],
             summary: "Create My Model",
             description:
-                "Register a private or public community text, image, video, transcription, or embedding model. Private is the default. Public models require an allowlisted account and become public after 12 hours. API keys require `account:keys`. The upstream bearer token is encrypted and never returned.",
+                "Register a private or public community text, image, video, transcription, or embedding model. Private is the default. Public models require an allowlisted account and become public after 3 hours. API keys require `account:keys`. The upstream bearer token is encrypted and never returned.",
             responses: {
                 200: {
                     description: "Created community model",
@@ -719,7 +719,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
             tags: ["🧩 Community Models"],
             summary: "Update My Model",
             description:
-                "Update a community model owned by the authenticated account. Changing visibility to public requires an allowlisted account and takes effect after 12 hours; public models may be free or priced. API keys require `account:keys`.",
+                "Update a community model owned by the authenticated account. Changing visibility to public requires an allowlisted account and takes effect after 3 hours; public models may be free or priced. API keys require `account:keys`.",
             responses: {
                 200: {
                     description: "Updated community model",
@@ -795,7 +795,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
                 ) {
                     throw new HTTPException(400, {
                         message:
-                            "Community models can be relisted 12 hours after they were hidden",
+                            "Community models can be relisted 3 hours after they were hidden",
                     });
                 }
                 update.hiddenAt = input.hidden ? new Date() : null;

--- a/enter.pollinations.ai/test/integration/community-endpoint-policy.test.ts
+++ b/enter.pollinations.ai/test/integration/community-endpoint-policy.test.ts
@@ -37,7 +37,7 @@ async function postModel(
     return response.json<Record<string, unknown>>();
 }
 
-async function advancePendingPast12Hours(id: string): Promise<void> {
+async function advancePendingPastDelay(id: string): Promise<void> {
     await drizzle(env.DB)
         .update(schema.communityEndpoint)
         .set({
@@ -52,7 +52,7 @@ async function publishPendingModel(
     sessionToken: string,
     id: string,
 ): Promise<Record<string, unknown>> {
-    await advancePendingPast12Hours(id);
+    await advancePendingPastDelay(id);
     return postModel(sessionToken, `/${id}/update`, {});
 }
 
@@ -247,7 +247,7 @@ describe("community endpoint configuration policy", () => {
             bearerToken: "test-provider-token",
             promptTextPrice: 0.000001,
         });
-        await advancePendingPast12Hours(cheaper.id as string);
+        await advancePendingPastDelay(cheaper.id as string);
         const expensive = await postModel(sessionToken, "", {
             name: "expensive-fallback",
             title: "Expensive fallback",

--- a/enter.pollinations.ai/test/integration/community-endpoint-price-delay.test.ts
+++ b/enter.pollinations.ai/test/integration/community-endpoint-price-delay.test.ts
@@ -36,7 +36,7 @@ async function postModel(
     return response.json<Record<string, unknown>>();
 }
 
-async function advancePendingPast12Hours(id: string): Promise<void> {
+async function advancePendingPastDelay(id: string): Promise<void> {
     await drizzle(env.DB)
         .update(schema.communityEndpoint)
         .set({
@@ -51,12 +51,16 @@ async function publishPendingModel(
     sessionToken: string,
     id: string,
 ): Promise<Record<string, unknown>> {
-    await advancePendingPast12Hours(id);
+    await advancePendingPastDelay(id);
     return postModel(sessionToken, `/${id}/update`, {});
 }
 
-describe("community endpoint 12-hour price-change delay", () => {
-    test("first public model creation is queued for 12 hours", async ({
+describe("community endpoint 3-hour price-change delay", () => {
+    test("uses a 3-hour delay", () => {
+        expect(COMMUNITY_ENDPOINT_CHANGE_DELAY_MS).toBe(3 * 60 * 60 * 1000);
+    });
+
+    test("first public model creation is queued for 3 hours", async ({
         sessionToken,
     }) => {
         await approveCommunityModels();
@@ -78,7 +82,7 @@ describe("community endpoint 12-hour price-change delay", () => {
             },
         });
 
-        await advancePendingPast12Hours(created.id as string);
+        await advancePendingPastDelay(created.id as string);
         const visibleModels = await getVisibleModelIdsForUser(
             env.DB,
             "another-user",
@@ -134,7 +138,7 @@ describe("community endpoint 12-hour price-change delay", () => {
         });
     });
 
-    test("price change on a public model is queued for 12 hours", async ({
+    test("price change on a public model is queued for 3 hours", async ({
         sessionToken,
     }) => {
         await approveCommunityModels();
@@ -183,7 +187,7 @@ describe("community endpoint 12-hour price-change delay", () => {
             promptTextPrice: 0.000003,
         });
 
-        await advancePendingPast12Hours(created.id as string);
+        await advancePendingPastDelay(created.id as string);
 
         // Read the model list; the effective price should now reflect the pending change.
         const listResponse = await SELF.fetch(endpointUrl, {
@@ -226,7 +230,7 @@ describe("community endpoint 12-hour price-change delay", () => {
         );
     });
 
-    test("private-to-public transition is queued for 12 hours", async ({
+    test("private-to-public transition is queued for 3 hours", async ({
         sessionToken,
     }) => {
         await approveCommunityModels();
@@ -268,7 +272,7 @@ describe("community endpoint 12-hour price-change delay", () => {
             visibility: "public",
         });
 
-        await advancePendingPast12Hours(created.id as string);
+        await advancePendingPastDelay(created.id as string);
 
         const listResponse = await SELF.fetch(endpointUrl, {
             headers: { Cookie: `better-auth.session_token=${sessionToken}` },
@@ -359,7 +363,7 @@ describe("community endpoint 12-hour price-change delay", () => {
         });
         expect(early.status).toBe(400);
         expect(await early.text()).toContain(
-            "can be relisted 12 hours after they were hidden",
+            "can be relisted 3 hours after they were hidden",
         );
 
         await db

--- a/operations/community-monitor/CYCLE.md
+++ b/operations/community-monitor/CYCLE.md
@@ -125,7 +125,7 @@ You are the pollinations community-model monitor bot (Discord identity: el405b).
    ```
    The 250-char style guidance above still applies to the surrounding commentary (if any) — the panel itself is exempt from the char limit, same as the existing factual-list exemption.
 
-   **If someone asks to relist a hidden model** (or says they fixed it): look up the D1 row. For a monitor-hidden text/image model, run `node probe.mjs --model '<owner/name>' --category '<text|image>'`; one passing result is enough to relist it with the recovery update above. A failed or inconclusive probe leaves it hidden. Owner- and maintainer-hidden rows are never changed. Owners can also use **Relist** in Models → My Models themselves after the normal 12-hour publication delay.
+   **If someone asks to relist a hidden model** (or says they fixed it): look up the D1 row. For a monitor-hidden text/image model, run `node probe.mjs --model '<owner/name>' --category '<text|image>'`; one passing result is enough to relist it with the recovery update above. A failed or inconclusive probe leaves it hidden. Owner- and maintainer-hidden rows are never changed. Owners can also use **Relist** in Models → My Models themselves after the normal 3-hour publication delay.
 
    When tagging anyone, resolve their Discord id via people_mapping.json first — never mention a GitHub username's numeric id as if it were a Discord snowflake, and never fabricate a discord_id.
 

--- a/shared/community-endpoints.ts
+++ b/shared/community-endpoints.ts
@@ -20,7 +20,7 @@ import type { SafetyFeature } from "./schemas/safety.ts";
 
 export const LEGACY_COMMUNITY_MODEL_PREFIX = "community/";
 export const COMMUNITY_MODEL_REWARD_RATE = 0.75;
-export const COMMUNITY_ENDPOINT_CHANGE_DELAY_MS = 12 * 60 * 60 * 1000;
+export const COMMUNITY_ENDPOINT_CHANGE_DELAY_MS = 3 * 60 * 60 * 1000;
 export const COMMUNITY_ENDPOINT_MODALITIES = [
     "text",
     "image",

--- a/shared/db/better-auth.ts
+++ b/shared/db/better-auth.ts
@@ -234,7 +234,7 @@ export const communityEndpoint = sqliteTable("community_endpoint", {
     .default("private")
     .notNull(),
   // A public price change or private-to-public transition becomes effective
-  // 12 hours after it is submitted. The pending payload is only meaningful
+  // 3 hours after it is submitted. The pending payload is only meaningful
   // for proxy listings; visibility applies to every listing type.
   pendingPayload: text("pending_payload"),
   pendingVisibility: text("pending_visibility", {


### PR DESCRIPTION
- Reduces the community model publication and price-change delay from 12 hours to 3 hours
- Applies the same delay to owner relisting and endpoint agents
- Updates API/UI/monitor wording and focused assertions

Tests: exact 3-hour constant assertion passes; 16/18 wider focused tests passed locally, with two unchanged error-path tests blocked by unavailable local Tinybird error ingestion.