### PR TITLE
feat: add text-to-speech as a community model modality

### DIFF
--- a/BRING_YOUR_OWN_MODEL.md
+++ b/BRING_YOUR_OWN_MODEL.md
@@ -12,6 +12,7 @@ Model publishing and [connecting user wallets](./BRING_YOUR_OWN_POLLEN.md) solve
 | Image | `POST /v1/images/generations` | `GET /image/{prompt}` or `POST /v1/images/generations` |
 | Image editing | `POST /v1/images/edits` in addition to image generation | `POST /v1/images/edits` |
 | Video | Exact endpoint URL entered at registration | `GET /video/{prompt}`, `GET /image/{prompt}`, or `POST /v1/images/generations` |
+| Text to speech | `POST /v1/audio/speech` | `POST /v1/audio/speech` |
 | Speech to text | `POST /v1/audio/transcriptions` | `POST /v1/audio/transcriptions` |
 | Embeddings | `POST /v1/embeddings` | `POST /v1/embeddings` |
 
@@ -46,7 +47,7 @@ Return one completed MP4 within 300 seconds as `b64_json` or a public `url`:
 
 Pollinations sends no upstream model id and bills the accepted request duration. Inline and downloaded responses are limited to 20 MB. Do not return an async job id; polling must finish inside the publisher endpoint before it responds.
 
-Text-to-speech, realtime, and 3D endpoints cannot currently be registered through this workflow.
+Realtime and 3D endpoints cannot currently be registered through this workflow.
 
 ## Private and Public Models
 
@@ -60,6 +61,7 @@ Public models appear in the model catalog and can be called by other Pollination
 - Image models use per-token pricing when the registration test finds valid OpenAI image usage; otherwise they use a fixed price per generated image.
 - Video models are priced from the requested duration in seconds.
 - Transcription models are priced from reported audio duration.
+- Speech models are priced by input characters through the existing completion-audio price.
 - Embedding models use the prompt-token count reported by the upstream endpoint.
 - A zero price makes the public model free.
 
@@ -69,7 +71,7 @@ Owners receive 75% of the Pollen spent on their models. Paid and Quest Pollen ea
 
 1. Open [My Models](https://enter.pollinations.ai/my-models).
 2. Choose **Add model**.
-3. Select text, image, transcription, or embedding and enter the upstream base URL, model id, and bearer token. For video, enter the exact generation URL and bearer token.
+3. Select text, image, speech, transcription, or embedding and enter the upstream base URL, model id, and bearer token. For video, enter the exact generation URL and bearer token.
 4. Fetch the upstream model list or run the endpoint test before saving.
 5. Save the model as private, then call its `owner/model` id through the normal Pollinations endpoint.
 6. If your account has publisher access, change visibility to public and set prices when it is ready for other users.
@@ -109,6 +111,8 @@ Use `polli my-models list`, `update`, and `delete` for the rest of the lifecycle
 
 Embedding models use `--modality embedding`. For example, `--prompt-text-price 0.000001` charges 1 Pollen per 1M input tokens.
 
+Speech models use `--modality speech`. For example, `--completion-audio-price 0.000015` charges 15 Pollen per 1M input characters.
+
 ## Publishing Controls
 
 Public models support these owner controls in the dashboard or Account API:
@@ -119,7 +123,7 @@ Public models support these owner controls in the dashboard or Account API:
 - The provider profile at `POST /account/my-models/provider` sets the public provider name and service URL shared by your models.
 - Owners can hide or relist their models without deleting them.
 
-Token prices cannot exceed 50 Pollen per 1M tokens. Fixed image prices cannot exceed 0.25 Pollen per image, video prices cannot exceed 0.5 Pollen per generated second, and transcription prices cannot exceed 0.012 Pollen per minute. See the [Community Models API reference](https://gen.pollinations.ai/docs#tag/community-models) for the exact fields.
+Token prices cannot exceed 50 Pollen per 1M tokens. Fixed image prices cannot exceed 0.25 Pollen per image, video prices cannot exceed 0.5 Pollen per generated second, and transcription prices cannot exceed 0.012 Pollen per minute. Speech uses the existing completion-audio price per 1M input characters. See the [Community Models API reference](https://gen.pollinations.ai/docs#tag/community-models) for the exact fields.
 
 ## Call Your Model
 

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-dialog.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-dialog.tsx
@@ -219,7 +219,9 @@ export function CommunityEndpointDialog({
                           ? "Endpoint responded, but did not return playable video"
                           : form.modality === "transcription"
                             ? "Endpoint responded, but did not return transcription text or usage"
-                            : "Endpoint responded, but did not return billable usage",
+                            : form.modality === "speech"
+                              ? "Endpoint responded, but did not return audio"
+                              : "Endpoint responded, but did not return billable usage",
                 );
             }
             setForm((current) => ({
@@ -442,6 +444,7 @@ export function CommunityEndpointDialog({
                                         "text",
                                         "image",
                                         "video",
+                                        "speech",
                                         "transcription",
                                         "embedding",
                                     ] as const
@@ -506,7 +509,7 @@ export function CommunityEndpointDialog({
                             helper={
                                 form.modality === "video"
                                     ? "The exact URL Pollinations calls to generate a video."
-                                    : "OpenAI-compatible /v1 base URL, or full chat/image/edit/transcription URL."
+                                    : "OpenAI-compatible /v1 base URL, or full chat/image/edit/speech/transcription URL."
                             }
                             alignLabelRow
                         >
@@ -585,11 +588,14 @@ export function CommunityEndpointDialog({
                                     placeholder={
                                         form.modality === "image"
                                             ? "gpt-image-2"
-                                            : form.modality === "transcription"
-                                              ? "whisper-1"
-                                              : form.modality === "embedding"
-                                                ? "text-embedding-3-small"
-                                                : "gpt-4o-mini"
+                                            : form.modality === "speech"
+                                              ? "tts-1"
+                                              : form.modality ===
+                                                  "transcription"
+                                                ? "whisper-1"
+                                                : form.modality === "embedding"
+                                                  ? "text-embedding-3-small"
+                                                  : "gpt-4o-mini"
                                     }
                                     align="end"
                                     open={providerModelMenuOpen}

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/price-table.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/price-table.tsx
@@ -352,11 +352,13 @@ export function basePriceKeysForModality(
         ? ["completionImagePrice"]
         : modality === "video"
           ? BASE_VIDEO_PRICE_KEYS
-          : modality === "transcription"
-            ? BASE_TRANSCRIPTION_PRICE_KEYS
-            : modality === "embedding"
-              ? BASE_EMBEDDING_PRICE_KEYS
-              : BASE_TEXT_PRICE_KEYS;
+          : modality === "speech"
+            ? ["completionAudioPrice"]
+            : modality === "transcription"
+              ? BASE_TRANSCRIPTION_PRICE_KEYS
+              : modality === "embedding"
+                ? BASE_EMBEDDING_PRICE_KEYS
+                : BASE_TEXT_PRICE_KEYS;
 }
 
 export function returnedPriceFields(

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/types.ts
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/types.ts
@@ -139,6 +139,7 @@ export function publicCommunityFallbackOptions(
         type: string;
         community?: boolean;
         agent?: boolean;
+        outputModalities?: string[];
     }[],
 ): FallbackModelOption[] {
     return models
@@ -160,7 +161,11 @@ export function publicCommunityFallbackOptions(
                     : model.type === "video"
                       ? "video"
                       : model.type === "audio"
-                        ? "transcription"
+                        ? // Both speech and transcription endpoints publish as
+                          // audio models; the output modality tells them apart.
+                          model.outputModalities?.includes("audio")
+                            ? "speech"
+                            : "transcription"
                         : model.type === "embedding"
                           ? "embedding"
                           : "text",

--- a/enter.pollinations.ai/src/routes/community-endpoints.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints.ts
@@ -30,6 +30,7 @@ import {
     testCommunityEmbeddingEndpoint,
     testCommunityEndpoint,
     testCommunityImageEndpoint,
+    testCommunitySpeechEndpoint,
     testCommunityTranscriptionEndpoint,
     testCommunityVideoEndpoint,
 } from "../services/community-endpoint-openai.ts";
@@ -498,7 +499,7 @@ export const communityEndpointsRoutes = new Hono<Env>()
             tags: ["🧩 Community Models"],
             summary: "Create My Model",
             description:
-                "Register a private or public community text, image, video, transcription, or embedding model. Private is the default. Public models require an allowlisted account and become public after 3 hours. API keys require `account:keys`. The upstream bearer token is encrypted and never returned.",
+                "Register a private or public community text, image, video, speech, transcription, or embedding model. Private is the default. Public models require an allowlisted account and become public after 3 hours. API keys require `account:keys`. The upstream bearer token is encrypted and never returned.",
             responses: {
                 200: {
                     description: "Created community model",
@@ -686,11 +687,13 @@ export const communityEndpointsRoutes = new Hono<Env>()
                               ? await testCommunityTranscriptionEndpoint(
                                     modelInput,
                                 )
-                              : input.modality === "embedding"
-                                ? await testCommunityEmbeddingEndpoint(
-                                      modelInput,
-                                  )
-                                : await testCommunityEndpoint(modelInput);
+                              : input.modality === "speech"
+                                ? await testCommunitySpeechEndpoint(modelInput)
+                                : input.modality === "embedding"
+                                  ? await testCommunityEmbeddingEndpoint(
+                                        modelInput,
+                                    )
+                                  : await testCommunityEndpoint(modelInput);
                 }
                 return c.json({
                     ok: true,
@@ -703,9 +706,11 @@ export const communityEndpointsRoutes = new Hono<Env>()
                               ? "Endpoint responded with playable video"
                               : input.modality === "transcription"
                                 ? "Endpoint responded with transcription text"
-                                : input.modality === "embedding"
-                                  ? "Endpoint responded with embedding data"
-                                  : "Endpoint responded with usage",
+                                : input.modality === "speech"
+                                  ? "Endpoint responded with audio"
+                                  : input.modality === "embedding"
+                                    ? "Endpoint responded with embedding data"
+                                    : "Endpoint responded with usage",
                     ...result,
                 });
             } catch (error) {

--- a/enter.pollinations.ai/src/routes/community-endpoints/schemas.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints/schemas.ts
@@ -21,7 +21,7 @@ import { z } from "zod";
 const ModalitySchema = z
     .enum(COMMUNITY_ENDPOINT_MODALITIES)
     .describe(
-        'Upstream API family. "text" uses `/v1/chat/completions`; "image" uses `/v1/images/generations` and optionally `/v1/images/edits`; "video" calls the exact configured URL; "transcription" uses `/v1/audio/transcriptions`.',
+        'Upstream API family. "text" uses `/v1/chat/completions`; "image" uses `/v1/images/generations` and optionally `/v1/images/edits`; "video" calls the exact configured URL; "speech" uses `/v1/audio/speech`; "transcription" uses `/v1/audio/transcriptions`.',
     );
 const ImagePricingSchema = z
     .enum(COMMUNITY_ENDPOINT_IMAGE_PRICING_MODES)
@@ -113,7 +113,7 @@ const EndpointFieldsSchema = {
         .string()
         .url()
         .describe(
-            "OpenAI-compatible `/v1` base URL or full chat, image, or transcription URL. For video, the exact generation URL.",
+            "OpenAI-compatible `/v1` base URL or full chat, image, speech, or transcription URL. For video, the exact generation URL.",
         ),
     upstreamModel: z.string().trim().min(1).max(253).optional(),
     bearerToken: z.string().min(1),

--- a/enter.pollinations.ai/src/services/community-endpoint-openai.ts
+++ b/enter.pollinations.ai/src/services/community-endpoint-openai.ts
@@ -1,4 +1,5 @@
 import {
+    communityAudioSpeechUrl,
     communityAudioTranscriptionsUrl,
     communityChatCompletionsUrl,
     communityEmbeddingsUrl,
@@ -18,6 +19,7 @@ import {
     firstCommunityImageBytes,
     firstCommunityVideoBytes,
     MAX_COMMUNITY_MEDIA_RESPONSE_BYTES,
+    readCommunityAudioResponse,
 } from "@shared/community-media.ts";
 import { detectImageMimeType } from "@shared/image-mime.ts";
 import type { ModelInputModality, Usage } from "@shared/registry/registry.ts";
@@ -336,6 +338,54 @@ export async function testCommunityTranscriptionEndpoint({
         // usage object that may not carry it.
         usage: { duration: promptAudioSeconds },
         billableUsage: { promptAudioSeconds },
+    };
+}
+
+/** Probe an OpenAI-compatible text-to-speech endpoint. */
+export async function testCommunitySpeechEndpoint({
+    baseUrl,
+    bearerToken,
+    model,
+}: ModelEndpointTestInput): Promise<CommunityEndpointTestResult> {
+    const input = "Reply with a short greeting.";
+    let response: Response;
+    try {
+        response = await fetch(communityAudioSpeechUrl(baseUrl), {
+            method: "POST",
+            headers: {
+                ...authorizationHeaders(bearerToken),
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                model,
+                input,
+                voice: "alloy",
+                response_format: "mp3",
+            }),
+            redirect: "manual",
+            signal: AbortSignal.timeout(COMMUNITY_ENDPOINT_TIMEOUT_MS),
+        });
+    } catch {
+        throw new Error("Endpoint request timed out or could not connect");
+    }
+    if (!response.ok) {
+        const body = parseJson(
+            await readResponseText(
+                response,
+                MAX_COMMUNITY_MEDIA_RESPONSE_BYTES,
+                () => new Error("Endpoint response is too large"),
+            ),
+        );
+        throw new Error(endpointErrorMessage(response.status, body));
+    }
+    // The response must be real audio to be billable: an OpenAI-shaped JSON
+    // body is a provider misconfiguration, not a free pass.
+    await readCommunityAudioResponse(response);
+    return {
+        // The character count of the probe input is what speech is billed on,
+        // so report it directly rather than trusting upstream usage.
+        usage: { characters: input.length },
+        billableUsage: { completionAudioTokens: input.length },
     };
 }
 

--- a/gen.pollinations.ai/src/audio/communityEndpoint.ts
+++ b/gen.pollinations.ai/src/audio/communityEndpoint.ts
@@ -1,15 +1,25 @@
-import { communityAudioTranscriptionsUrl } from "@shared/community-endpoint-urls.ts";
+import {
+    communityAudioSpeechUrl,
+    communityAudioTranscriptionsUrl,
+} from "@shared/community-endpoint-urls.ts";
 import {
     COMMUNITY_ENDPOINT_TIMEOUT_MS,
     type CommunityEndpointRuntime,
     communityTranscriptionSeconds,
     normalizeCommunityEndpointBearerToken,
 } from "@shared/community-endpoints.ts";
+import {
+    MAX_COMMUNITY_MEDIA_RESPONSE_BYTES,
+    readCommunityAudioResponse,
+} from "@shared/community-media.ts";
 import { ensureUpstreamOk, UpstreamError } from "@shared/error.ts";
+import { HttpError } from "@shared/http-error.ts";
 import {
     buildUsageHeaders,
     createAudioSecondsUsage,
+    createAudioTokenUsage,
 } from "@shared/registry/usage-headers.ts";
+import { readResponseText } from "@shared/response-bytes.ts";
 import { decryptSecret } from "@shared/secret-encryption.ts";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import {
@@ -27,6 +37,104 @@ export type CommunityTranscriptionOptions = {
     responseFormat?: string;
     temperature?: number;
 };
+
+export type CommunitySpeechOptions = {
+    input: string;
+    voice: string;
+    responseFormat: string;
+};
+
+/**
+ * Forward an OpenAI-compatible `/v1/audio/speech` request to a community
+ * endpoint and relay its audio back. Speech is billed by the characters of the
+ * input text we sent, so the meter is known before the call and the response
+ * only has to be real, non-empty audio to be billable.
+ */
+export async function callCommunitySpeechEndpoint(
+    endpoint: CommunityEndpointRuntime,
+    options: CommunitySpeechOptions,
+    secret: string,
+): Promise<Response> {
+    // Managed agents are text-only, so a speech endpoint is always external.
+    if (endpoint.type !== "proxy") {
+        throw new Error(
+            `Community speech endpoint '${endpoint.modelId}' is a managed agent`,
+        );
+    }
+    const bearerToken = await decryptSecret(
+        endpoint.bearerTokenCiphertext,
+        secret,
+    );
+    const upstreamUrl = communityAudioSpeechUrl(endpoint.baseUrl);
+    let response: Response;
+    try {
+        response = await fetch(upstreamUrl, {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${normalizeCommunityEndpointBearerToken(bearerToken)}`,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                model: endpoint.upstreamModel,
+                input: options.input,
+                voice: options.voice,
+                response_format: options.responseFormat,
+            }),
+            redirect: "manual",
+            signal: AbortSignal.timeout(COMMUNITY_ENDPOINT_TIMEOUT_MS),
+        });
+    } catch (error) {
+        throw new UpstreamError(502 as ContentfulStatusCode, {
+            message: "Community speech endpoint timed out or could not connect",
+            cause: error,
+            requestUrl: new URL(upstreamUrl),
+        });
+    }
+    if (!response.ok) {
+        // Bound provider error bodies before passing them to the shared error
+        // classifier; an untrusted endpoint must not make us buffer forever.
+        const responseBody = await readResponseText(
+            response,
+            MAX_COMMUNITY_MEDIA_RESPONSE_BYTES,
+            () =>
+                new HttpError(
+                    "Community speech endpoint response is too large",
+                    502,
+                ),
+        );
+        response = new Response(responseBody, {
+            status: response.status,
+            statusText: response.statusText,
+            headers: response.headers,
+        });
+    }
+    response = await ensureUpstreamOk(response, upstreamUrl);
+    let audio: { bytes: Uint8Array; contentType: string };
+    try {
+        audio = await readCommunityAudioResponse(response);
+    } catch (error) {
+        if (error instanceof HttpError) throw error;
+        throw new UpstreamError(502 as ContentfulStatusCode, {
+            message: "Community speech endpoint returned invalid audio",
+            cause: error,
+            requestUrl: new URL(upstreamUrl),
+        });
+    }
+    // Copy into a plain ArrayBuffer: Cloudflare's Response constructor does
+    // not accept a Uint8Array backed by an arbitrary ArrayBufferLike.
+    const body = new Uint8Array(audio.bytes.byteLength);
+    body.set(audio.bytes);
+    return new Response(body.buffer, {
+        status: 200,
+        headers: {
+            "Content-Type": audio.contentType,
+            ...buildUsageHeaders(
+                endpoint.modelId,
+                createAudioTokenUsage(options.input.length),
+            ),
+        },
+    });
+}
 
 export async function callCommunityTranscriptionEndpoint(
     endpoint: CommunityEndpointRuntime,

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -40,7 +40,10 @@ import {
     apiKeyBudgetReservation,
     generationAccess,
 } from "@/utils/generation-access.ts";
-import { callCommunityTranscriptionEndpoint } from "../audio/communityEndpoint.ts";
+import {
+    callCommunitySpeechEndpoint,
+    callCommunityTranscriptionEndpoint,
+} from "../audio/communityEndpoint.ts";
 import {
     type FallbackCandidate,
     withModelFallbackResponse,
@@ -2809,8 +2812,15 @@ async function generateAudioFromSpeechRequest(
         ? await fetchReferenceAudio(reference_audio)
         : undefined;
 
-    return withAudioFallback(c, (candidate) =>
-        dispatchAudioGeneration(c, candidate.id, {
+    return withAudioFallback(c, (candidate) => {
+        if (candidate.communityEndpoint) {
+            return callCommunitySpeechEndpoint(
+                candidate.communityEndpoint,
+                { input: safeInput, voice, responseFormat: response_format },
+                c.env.BETTER_AUTH_SECRET,
+            );
+        }
+        return dispatchAudioGeneration(c, candidate.id, {
             text: safeInput,
             voice,
             responseFormat: response_format,
@@ -2835,8 +2845,8 @@ async function generateAudioFromSpeechRequest(
             falKey: c.env.FAL_KEY,
             stabilityApiKey: c.env.STABILITY_API_KEY,
             log,
-        }),
-    );
+        });
+    });
 }
 
 export async function handleSimpleAudio(c: AudioContext): Promise<Response> {

--- a/gen.pollinations.ai/test/community-endpoints.test.ts
+++ b/gen.pollinations.ai/test/community-endpoints.test.ts
@@ -9,6 +9,7 @@ import { verifyAgentRunToken } from "@shared/auth/agent-run-token.ts";
 import { COMMUNITY_MODEL_ALLOWED_GITHUB_IDS } from "@shared/auth/github-id-list.ts";
 import { getUserBalance } from "@shared/billing/balance.ts";
 import {
+    communityAudioSpeechUrl,
     communityAudioTranscriptionsUrl,
     communityChatCompletionsUrl,
     communityEmbeddingsUrl,
@@ -54,6 +55,7 @@ import {
     parseListingPayload,
     resolveEffectiveProxyListing,
 } from "@shared/community-endpoints.ts";
+import { MAX_COMMUNITY_MEDIA_RESPONSE_BYTES } from "@shared/community-media.ts";
 import {
     communityEndpoint as communityEndpointTable,
     session as sessionTable,
@@ -87,7 +89,10 @@ import { drizzle } from "drizzle-orm/d1";
 import { Hono } from "hono";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Env } from "@/env.ts";
-import { callCommunityTranscriptionEndpoint } from "../src/audio/communityEndpoint.ts";
+import {
+    callCommunitySpeechEndpoint,
+    callCommunityTranscriptionEndpoint,
+} from "../src/audio/communityEndpoint.ts";
 import { getCommunityModelRegistryEntries } from "../src/community-models.ts";
 import {
     callCommunityImageEndpoint,
@@ -757,6 +762,15 @@ describe("community endpoint helpers", () => {
         ).toBe("https://api.example.com/v1/audio/transcriptions");
     });
 
+    it("derives the OpenAI-compatible speech URL", () => {
+        expect(communityAudioSpeechUrl("https://api.example.com/v1")).toBe(
+            "https://api.example.com/v1/audio/speech",
+        );
+        expect(
+            communityAudioSpeechUrl("https://api.example.com/v1/audio/speech"),
+        ).toBe("https://api.example.com/v1/audio/speech");
+    });
+
     it("restricts community transcription models to the transcription endpoint", () => {
         const definition = communityModelDefinition({
             modelId: "voodoohop/transcription",
@@ -768,6 +782,23 @@ describe("community endpoint helpers", () => {
         expect(definition.supportedEndpoints).toEqual([
             "/v1/audio/transcriptions",
         ]);
+    });
+
+    it("builds speech models that output audio on the speech endpoint only", () => {
+        const definition = communityModelDefinition({
+            modelId: "voodoohop/tts",
+            title: "Speech",
+            description: null,
+            modality: "speech",
+            ...communityEndpointPrices({}),
+        });
+        expect(definition).toMatchObject({
+            category: "audio",
+            inputModalities: ["text"],
+            outputModalities: ["audio"],
+            supportedEndpoints: ["/v1/audio/speech"],
+        });
+        expect(definition).not.toHaveProperty("flatRate");
     });
 
     it("advertises community videos on the existing public media routes", () => {
@@ -1147,6 +1178,44 @@ describe("community endpoint helpers", () => {
         expect(MAX_COMMUNITY_PRICE_PER_SECOND).toBeLessThan(
             MAX_COMMUNITY_PRICE_PER_MILLION_TOKENS,
         );
+    });
+
+    it("bills speech input characters through the completion audio price", () => {
+        const definition = communityModelDefinition({
+            modelId: "voodoohop/tts",
+            title: "Community Speech",
+            description: "Community text-to-speech model",
+            modality: "speech",
+            ...communityEndpointPrices({ completionAudioPrice: 0.00002 }),
+        });
+
+        expect(definition).toMatchObject({
+            category: "audio",
+            inputModalities: ["text"],
+            outputModalities: ["audio"],
+            supportedEndpoints: ["/v1/audio/speech"],
+            cost: { completionAudioTokens: 0.00002 },
+        });
+        const [field] = communityEndpointPriceFieldsForModality("speech");
+        expect(field).toMatchObject({
+            key: "completionAudioPrice",
+            usageType: "completionAudioTokens",
+            rawUsagePaths: ["characters"],
+        });
+        // The field must stay a single price column even though completion
+        // audio also appears on text models.
+        expect(
+            COMMUNITY_ENDPOINT_PRICE_FIELDS.filter(
+                (priceField) => priceField.key === "completionAudioPrice",
+            ),
+        ).toHaveLength(1);
+        expect(
+            calculateUsageBilling({
+                model: "voodoohop/tts",
+                usage: { completionAudioTokens: 1000 },
+                servedBy: definition,
+            }).price.totalPrice,
+        ).toBeCloseTo(0.00002 * 1000, 10);
     });
 
     describe("fallback target pricing", () => {
@@ -1991,6 +2060,174 @@ describe("community endpoint helpers", () => {
             ).rejects.toMatchObject({
                 status: 413,
                 message: expect.stringContaining("Audio file too long"),
+            });
+        });
+    });
+
+    describe("community speech endpoint billing", () => {
+        afterEach(() => {
+            vi.unstubAllGlobals();
+        });
+
+        const secret = "test-secret";
+
+        async function speechEndpoint(): Promise<CommunityEndpointRuntime> {
+            return {
+                type: "proxy",
+                id: "community-speech-endpoint-id",
+                ownerUserId: "owner-id",
+                modelId: "voodoohop/tts",
+                name: "tts",
+                title: "TTS",
+                description: null,
+                modality: "speech",
+                imagePricing: "request",
+                inputModalities: ["text"],
+                baseUrl: "https://api.example.com/v1",
+                upstreamModel: "tts-1",
+                visibility: "public",
+                paidOnly: false,
+                perUserRpm: null,
+                fallbacks: [],
+                hiddenAt: null,
+                hiddenReason: null,
+                bearerTokenCiphertext: await encryptSecret(
+                    "sk_saved_token",
+                    secret,
+                ),
+                ...communityEndpointPrices({ completionAudioPrice: 0.00002 }),
+            };
+        }
+
+        it("forwards the OpenAI speech request and bills the input characters", async () => {
+            const fetchMock = vi.fn(async (input, init) => {
+                const request = new Request(input, init);
+                expect(request.url).toBe(
+                    "https://api.example.com/v1/audio/speech",
+                );
+                expect(request.headers.get("authorization")).toBe(
+                    "Bearer sk_saved_token",
+                );
+                expect(await request.json()).toEqual({
+                    model: "tts-1",
+                    input: "Hello world",
+                    voice: "alloy",
+                    response_format: "mp3",
+                });
+                return new Response(new Uint8Array([1, 2, 3]), {
+                    headers: { "Content-Type": "audio/mpeg" },
+                });
+            });
+            vi.stubGlobal("fetch", fetchMock);
+
+            const response = await callCommunitySpeechEndpoint(
+                await speechEndpoint(),
+                { input: "Hello world", voice: "alloy", responseFormat: "mp3" },
+                secret,
+            );
+
+            expect(response.status).toBe(200);
+            expect(response.headers.get("content-type")).toBe("audio/mpeg");
+            expect(
+                Array.from(new Uint8Array(await response.arrayBuffer())),
+            ).toEqual([1, 2, 3]);
+            expect(response.headers.get(MODEL_USED_HEADER)).toBe(
+                "voodoohop/tts",
+            );
+            expect(
+                response.headers.get(USAGE_TYPE_HEADERS.completionAudioTokens),
+            ).toBe("11");
+        });
+
+        it("rejects non-audio and empty upstream responses", async () => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(
+                    async () =>
+                        new Response("not audio", {
+                            headers: { "Content-Type": "text/plain" },
+                        }),
+                ),
+            );
+            await expect(
+                callCommunitySpeechEndpoint(
+                    await speechEndpoint(),
+                    { input: "Hello", voice: "alloy", responseFormat: "mp3" },
+                    secret,
+                ),
+            ).rejects.toMatchObject({
+                status: 502,
+                message: "Community speech endpoint did not return audio data",
+            });
+
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(
+                    async () =>
+                        new Response(new Uint8Array(), {
+                            headers: { "Content-Type": "audio/mpeg" },
+                        }),
+                ),
+            );
+            await expect(
+                callCommunitySpeechEndpoint(
+                    await speechEndpoint(),
+                    { input: "Hello", voice: "alloy", responseFormat: "mp3" },
+                    secret,
+                ),
+            ).rejects.toMatchObject({
+                status: 502,
+                message: "Community speech endpoint returned empty audio",
+            });
+        });
+
+        it("propagates upstream speech failures", async () => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(async () =>
+                    Response.json(
+                        { error: { message: "voice unavailable" } },
+                        { status: 503 },
+                    ),
+                ),
+            );
+            await expect(
+                callCommunitySpeechEndpoint(
+                    await speechEndpoint(),
+                    { input: "Hello", voice: "alloy", responseFormat: "mp3" },
+                    secret,
+                ),
+            ).rejects.toMatchObject({
+                status: 503,
+                message: expect.stringContaining("voice unavailable"),
+            });
+        });
+
+        it("bounds oversized upstream error bodies", async () => {
+            vi.stubGlobal(
+                "fetch",
+                vi.fn(
+                    async () =>
+                        new Response("provider error", {
+                            status: 500,
+                            headers: {
+                                "Content-Length": String(
+                                    MAX_COMMUNITY_MEDIA_RESPONSE_BYTES + 1,
+                                ),
+                            },
+                        }),
+                ),
+            );
+
+            await expect(
+                callCommunitySpeechEndpoint(
+                    await speechEndpoint(),
+                    { input: "Hello", voice: "alloy", responseFormat: "mp3" },
+                    secret,
+                ),
+            ).rejects.toMatchObject({
+                status: 502,
+                message: "Community speech endpoint response is too large",
             });
         });
     });
@@ -4757,6 +4994,177 @@ fixtureTest(
         expect(
             fetchMock.mock.calls.filter(
                 ([input]) => new Request(input).url === transcriptionUrl,
+            ),
+        ).toHaveLength(2);
+    },
+);
+
+fixtureTest(
+    "registers an OpenAI-compatible speech endpoint and bills it through speech APIs",
+    async ({ apiKey }) => {
+        const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;
+        const modelName = `tts-${crypto.randomUUID().slice(0, 8)}`;
+        const ownerUserId = await createTestUser({
+            githubId: nextAllowedGithubId(),
+            githubUsername: ownerGithubUsername,
+        });
+        const sessionToken = `session-${crypto.randomUUID()}`;
+        await db.insert(sessionTable).values({
+            id: `session-${crypto.randomUUID()}`,
+            token: sessionToken,
+            userId: ownerUserId,
+            expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+
+        const enterApi = await createEnterCommunityApi();
+        const speechUrl = "https://api.example.com/v1/audio/speech";
+        const audioBytes = new Uint8Array([1, 2, 3, 4]);
+        const fetchMock = vi.fn(async (input, init) => {
+            const request = new Request(input, init);
+            if (request.url === speechUrl) {
+                expect(request.headers.get("authorization")).toBe(
+                    "Bearer sk_speech_upstream",
+                );
+                const body = (await request.json()) as Record<string, unknown>;
+                expect(body.model).toBe("tts-1");
+                expect(body.voice).toBe("alloy");
+                expect(body.response_format).toBe("mp3");
+                return new Response(audioBytes, {
+                    headers: { "Content-Type": "audio/mpeg" },
+                });
+            }
+            if (isBillingFetch(request)) return Response.json({ data: [] });
+            throw new Error(`Unexpected fetch: ${request.url}`);
+        });
+        vi.stubGlobal("fetch", fetchMock);
+
+        const registrationPayload = {
+            name: modelName,
+            title: "Community Speech Endpoint",
+            description: "OpenAI-compatible text-to-speech endpoint",
+            modality: "speech",
+            inputModalities: ["text"],
+            visibility: "public",
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "tts-1",
+            bearerToken: "Bearer sk_speech_upstream",
+            completionAudioPrice: 0.00002,
+        };
+        const registerResponse = await fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/community-endpoints", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: await signedSessionCookie(sessionToken),
+                },
+                body: JSON.stringify(registrationPayload),
+            }),
+        );
+        expect(registerResponse.status).toBe(200);
+        const registered = (await registerResponse.json()) as {
+            id: string;
+            modelId: string;
+            modality: string;
+            inputModalities: string[];
+            baseUrl: string;
+            upstreamModel: string;
+            completionAudioPrice: number;
+            pending: { visibility: string; completionAudioPrice: number };
+        };
+        expect(registered).toMatchObject({
+            modelId: communityModelId(ownerGithubUsername, modelName),
+            modality: "speech",
+            inputModalities: ["text"],
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "tts-1",
+            completionAudioPrice: 0,
+            pending: {
+                visibility: "public",
+                completionAudioPrice: 0.00002,
+            },
+        });
+
+        const testResponse = await fetchEnterApi(
+            enterApi,
+            new Request("http://localhost:3000/api/community-endpoints/test", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Cookie: await signedSessionCookie(sessionToken),
+                },
+                body: JSON.stringify({
+                    baseUrl: registered.baseUrl,
+                    bearerToken: "Bearer sk_speech_upstream",
+                    model: registered.upstreamModel,
+                    modality: "speech",
+                }),
+            }),
+        );
+        expect(testResponse.status).toBe(200);
+        await expect(testResponse.json()).resolves.toMatchObject({
+            message: "Endpoint responded with audio",
+            usage: { characters: expect.any(Number) },
+            billableUsage: { completionAudioTokens: expect.any(Number) },
+        });
+
+        await maturePendingCommunityEndpoint(registered.id);
+        const speechResponse = await fetchGen(
+            new Request("https://gen.pollinations.ai/v1/audio/speech", {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${apiKey}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    model: registered.modelId,
+                    input: "hello there",
+                    voice: "alloy",
+                    response_format: "mp3",
+                }),
+            }),
+        );
+        expect(speechResponse.status).toBe(200);
+        expect(speechResponse.headers.get("content-type")).toBe("audio/mpeg");
+        expect(speechResponse.headers.get("x-model-used")).toBe(
+            registered.modelId,
+        );
+        expect(
+            speechResponse.headers.get("x-usage-completion-audio-tokens"),
+        ).toBe("11");
+        expect(
+            Array.from(new Uint8Array(await speechResponse.arrayBuffer())),
+        ).toEqual(Array.from(audioBytes));
+
+        const audioModelsResponse = await fetchGen(
+            "https://gen.pollinations.ai/audio/models",
+        );
+        expect(audioModelsResponse.status).toBe(200);
+        const audioModels = (await audioModelsResponse.json()) as {
+            name: string;
+            category?: string;
+            community?: boolean;
+            input_modalities?: string[];
+            output_modalities?: string[];
+            supported_endpoints?: string[];
+            pricing?: Record<string, string>;
+        }[];
+        expect(
+            audioModels.find((model) => model.name === registered.modelId),
+        ).toMatchObject({
+            name: registered.modelId,
+            category: "audio",
+            community: true,
+            input_modalities: ["text"],
+            output_modalities: ["audio"],
+            supported_endpoints: ["/v1/audio/speech"],
+            pricing: { completionAudioTokens: "0.00002" },
+        });
+        expect(
+            fetchMock.mock.calls.filter(
+                ([input]) => new Request(input).url === speechUrl,
             ),
         ).toHaveLength(2);
     },

--- a/packages/polli-cli/README.md
+++ b/packages/polli-cli/README.md
@@ -95,7 +95,7 @@ polli usage --daily          # daily spend
 polli earnings               # developer earnings (default 30 days, --days up to 90)
 polli quests --claimable     # only rewards ready to claim
 polli agents list            # managed prompt agents
-polli my-models list         # invite-only community text, image, and transcription models
+polli my-models list         # invite-only community text, image, speech, and transcription models
 ```
 
 Manage agents with API-shaped JSON config files plus their callable model name

--- a/packages/polli-cli/SKILL.md
+++ b/packages/polli-cli/SKILL.md
@@ -167,7 +167,7 @@ polli my-models update <id> --paid-only            # only accept Paid Pollen; --
 polli my-models update <id> --required-safety privacy,secrets,sexual,violence,shield
 polli my-models delete <id>
 ```
-`my-models` manages owned community text, image, and transcription models. Any account can create private models; `communityEndpointsAllowed: true` is required only to publish them. API keys require `account:keys`. Use `account:usage` for narrow read-only usage and `polli quests`; use both permissions when a client needs both read-only account state and admin operations. Quest claiming is dashboard-only; `polli quests` is read-only and account-aware.
+`my-models` manages owned community text, image, speech, and transcription models. Any account can create private models; `communityEndpointsAllowed: true` is required only to publish them. API keys require `account:keys`. Use `account:usage` for narrow read-only usage and `polli quests`; use both permissions when a client needs both read-only account state and admin operations. Quest claiming is dashboard-only; `polli quests` is read-only and account-aware.
 
 ### Register an image my-model
 ```bash

--- a/packages/polli-cli/src/commands/my-models.test.ts
+++ b/packages/polli-cli/src/commands/my-models.test.ts
@@ -77,6 +77,25 @@ describe("modelBody", () => {
         });
     });
 
+    it("supports speech model registration", () => {
+        expect(
+            modelBody(
+                {
+                    name: "tts-provider",
+                    title: "TTS Provider",
+                    baseUrl: "https://example.com/v1",
+                    bearerToken: "upstream-token",
+                    modality: "speech",
+                    completionAudioPrice: "0.00001",
+                },
+                true,
+            ),
+        ).toMatchObject({
+            modality: "speech",
+            completionAudioPrice: 0.00001,
+        });
+    });
+
     it("supports transcription model registration", () => {
         expect(
             modelBody(

--- a/packages/polli-cli/src/commands/my-models.ts
+++ b/packages/polli-cli/src/commands/my-models.ts
@@ -60,7 +60,13 @@ interface MyModelBase {
 interface ProxyMyModel extends MyModelBase {
     type: "proxy";
     paidOnly: boolean;
-    modality: "text" | "image" | "video" | "transcription" | "embedding";
+    modality:
+        | "text"
+        | "image"
+        | "video"
+        | "speech"
+        | "transcription"
+        | "embedding";
     imagePricing: "request" | "tokens";
     completionImagePrice: number;
     completionVideoPrice: number;
@@ -143,11 +149,12 @@ export function modelBody(
             opts.modality !== "text" &&
             opts.modality !== "image" &&
             opts.modality !== "video" &&
+            opts.modality !== "speech" &&
             opts.modality !== "transcription" &&
             opts.modality !== "embedding"
         ) {
             fail(
-                "--modality must be 'text', 'image', 'video', 'transcription', or 'embedding'",
+                "--modality must be 'text', 'image', 'video', 'speech', 'transcription', or 'embedding'",
             );
         }
         body.modality = opts.modality;
@@ -303,7 +310,7 @@ const create = addPriceOptions(
         )
         .option(
             "--modality <modality>",
-            "Model family: text (default), image, video, transcription, or embedding",
+            "Model family: text (default), image, video, speech, transcription, or embedding",
         )
         .option(
             "--image-pricing <mode>",
@@ -451,7 +458,7 @@ const test = new Command("test")
     .option("--model <model>", "Upstream model id (not used for video)")
     .option(
         "--modality <modality>",
-        "Model family: text (default), image, video, transcription, or embedding",
+        "Model family: text (default), image, video, speech, transcription, or embedding",
     )
     .action(async (opts) => {
         const key = requireKey();
@@ -460,11 +467,12 @@ const test = new Command("test")
             opts.modality !== "text" &&
             opts.modality !== "image" &&
             opts.modality !== "video" &&
+            opts.modality !== "speech" &&
             opts.modality !== "transcription" &&
             opts.modality !== "embedding"
         ) {
             fail(
-                "--modality must be 'text', 'image', 'video', 'transcription', or 'embedding'",
+                "--modality must be 'text', 'image', 'video', 'speech', 'transcription', or 'embedding'",
             );
         }
         const modality = opts.modality ?? "text";
@@ -493,7 +501,7 @@ const test = new Command("test")
 
 export const myModelsCommand = new Command("my-models")
     .description(
-        "Manage private and published community text, image, video, transcription, and embedding models",
+        "Manage private and published community text, image, video, speech, transcription, and embedding models",
     )
     .addCommand(list)
     .addCommand(create)

--- a/shared/community-endpoint-urls.ts
+++ b/shared/community-endpoint-urls.ts
@@ -55,6 +55,10 @@ export function communityAudioTranscriptionsUrl(baseUrl: string): string {
     return communityOpenAIEndpointUrl(baseUrl, "/audio/transcriptions");
 }
 
+export function communityAudioSpeechUrl(baseUrl: string): string {
+    return communityOpenAIEndpointUrl(baseUrl, "/audio/speech");
+}
+
 export function communityEmbeddingsUrl(baseUrl: string): string {
     return communityOpenAIEndpointUrl(baseUrl, "/embeddings");
 }
@@ -74,6 +78,7 @@ const COMMUNITY_OPENAI_ENDPOINT_SUFFIXES = [
     "/images/generations",
     "/images/edits",
     "/audio/transcriptions",
+    "/audio/speech",
     "/embeddings",
 ] as const;
 

--- a/shared/community-endpoints.ts
+++ b/shared/community-endpoints.ts
@@ -25,6 +25,7 @@ export const COMMUNITY_ENDPOINT_MODALITIES = [
     "text",
     "image",
     "video",
+    "speech",
     "transcription",
     "embedding",
 ] as const;
@@ -230,6 +231,21 @@ const COMMUNITY_TRANSCRIPTION_PRICE_FIELD = {
     rawUsagePaths: ["duration"],
 } as const;
 
+// Speech endpoints bill the input text by character through the existing
+// completion-audio price column shared with the first-party TTS models, so an
+// owner sets one price and the request path meters the characters it sends.
+const COMMUNITY_SPEECH_PRICE_FIELDS = [
+    {
+        key: "completionAudioPrice",
+        usageType: "completionAudioTokens",
+        label: "Completion audio",
+        priceUnit: "million",
+        // The probe reports the input length itself, so "characters" is the
+        // only key it normalizes to.
+        rawUsagePaths: ["characters"],
+    },
+] as const;
+
 // Community video endpoints are billed from the duration Pollinations sends.
 const COMMUNITY_VIDEO_PRICE_FIELD = {
     key: "completionVideoPrice",
@@ -254,6 +270,10 @@ const COMMUNITY_TRANSCRIPTION_ENDPOINT_PRICE_FIELDS = [
     COMMUNITY_TRANSCRIPTION_PRICE_FIELD,
 ] as const;
 
+const COMMUNITY_SPEECH_ENDPOINT_PRICE_FIELDS = [
+    ...COMMUNITY_SPEECH_PRICE_FIELDS,
+] as const;
+
 const COMMUNITY_VIDEO_ENDPOINT_PRICE_FIELDS = [
     COMMUNITY_VIDEO_PRICE_FIELD,
 ] as const;
@@ -274,6 +294,7 @@ export type CommunityEndpointPriceField =
     | (typeof COMMUNITY_ENDPOINT_PRICE_FIELDS)[number]
     | (typeof COMMUNITY_IMAGE_TOKEN_PRICE_FIELDS)[number]
     | (typeof COMMUNITY_TRANSCRIPTION_ENDPOINT_PRICE_FIELDS)[number]
+    | (typeof COMMUNITY_SPEECH_ENDPOINT_PRICE_FIELDS)[number]
     | (typeof COMMUNITY_EMBEDDING_ENDPOINT_PRICE_FIELDS)[number];
 
 type CommunityModalitySpec = {
@@ -332,6 +353,14 @@ export const COMMUNITY_MODALITY_SPEC = {
         supportedEndpoints: ["/v1/audio/transcriptions"],
         restrictDefinitionEndpoints: true,
         priceFields: COMMUNITY_TRANSCRIPTION_ENDPOINT_PRICE_FIELDS,
+    },
+    speech: {
+        category: "audio",
+        inputModalities: ["text"],
+        outputModalities: ["audio"],
+        supportedEndpoints: ["/v1/audio/speech"],
+        restrictDefinitionEndpoints: true,
+        priceFields: COMMUNITY_SPEECH_ENDPOINT_PRICE_FIELDS,
     },
     embedding: {
         category: "embedding",
@@ -453,6 +482,7 @@ export function normalizeCommunityEndpointModality(
     value: string | null | undefined,
 ): CommunityEndpointModality {
     if (value === "transcription") return "transcription";
+    if (value === "speech") return "speech";
     if (value === "video") return "video";
     if (value === "image") return "image";
     if (value === "embedding") return "embedding";

--- a/shared/community-media.ts
+++ b/shared/community-media.ts
@@ -5,10 +5,45 @@ import { readResponseBytes } from "./response-bytes.ts";
 
 export const MAX_COMMUNITY_IMAGE_BYTES = 20 * 1024 * 1024;
 export const MAX_COMMUNITY_VIDEO_BYTES = 20 * 1024 * 1024;
+export const MAX_COMMUNITY_AUDIO_BYTES = 20 * 1024 * 1024;
 // A JSON envelope carrying a 20 MB base64 clip is at most ~28 MB; leave a
 // small amount of room for the envelope while still bounding provider output.
 export const MAX_COMMUNITY_MEDIA_RESPONSE_BYTES =
     Math.ceil((MAX_COMMUNITY_VIDEO_BYTES * 4) / 3) + 64 * 1024;
+
+/**
+ * Read a community text-to-speech response with a bounded body and a validated
+ * audio content type. The meter for speech is the input length, not the
+ * returned bytes, so a body that is not audio — or is empty — is a provider
+ * regression rather than a billable result.
+ */
+export async function readCommunityAudioResponse(
+    response: Response,
+): Promise<{ bytes: Uint8Array; contentType: string }> {
+    const contentType = response.headers
+        .get("content-type")
+        ?.split(";", 1)[0]
+        .trim()
+        .toLowerCase();
+    if (!contentType?.startsWith("audio/")) {
+        throw new HttpError(
+            "Community speech endpoint did not return audio data",
+            502,
+        );
+    }
+    const bytes = await readResponseBytes(
+        response,
+        MAX_COMMUNITY_AUDIO_BYTES,
+        () => new HttpError("Community audio is larger than 20 MB", 502),
+    );
+    if (bytes.byteLength === 0) {
+        throw new HttpError(
+            "Community speech endpoint returned empty audio",
+            502,
+        );
+    }
+    return { bytes, contentType };
+}
 
 /**
  * Pull the first usable image out of an OpenAI images response: inline base64


### PR DESCRIPTION
## Summary

Closes #14347 — lets community publishers register OpenAI-compatible text-to-speech endpoints (`POST /v1/audio/speech`) and serve them to callers through the normal audio APIs, mirroring the existing transcription flow.

Speech is billed per **input character** through the existing completion-audio price column shared with first-party TTS models, so an owner sets one rate and the request path meters the characters it sends.

## Changes

**shared**
- `community-endpoints.ts`: new `"speech"` modality (input `text` → output `audio`, endpoint `/v1/audio/speech`) with its own price field (`completionAudioPrice`, keyed on `characters`)
- `community-endpoint-urls.ts`: `communityAudioSpeechUrl()` helper + endpoint suffix
- `community-media.ts`: `readCommunityAudioResponse()` with a 20 MB bound and audio content-type validation

**gen.pollinations.ai**
- `audio/communityEndpoint.ts`: `callCommunitySpeechEndpoint()` forwards the OpenAI speech request with the saved bearer token and relays validated audio with character usage headers
- `routes/audio.ts`: `/v1/audio/speech` dispatches to a community endpoint when the requested model is one

**enter.pollinations.ai**
- Registration/probe: `testCommunitySpeechEndpoint()` plus wiring in the `/test` route
- Dashboard: speech modality option, per-character completion-audio price field, and speech vs transcription fallback classification by `output_modalities`

**CLI + docs**
- `polli my-models` accepts `--modality speech` with `--completion-audio-price`
- `BRING_YOUR_OWN_MODEL.md`, CLI README/SKILL updated

## Tests

- Unit: URL derivation, model definition/billing, and `callCommunitySpeechEndpoint` (happy path, non-audio/empty rejection, upstream failure propagation, oversized error bodies)
- End-to-end fixture: registers a speech endpoint through the Enter API, probes it, then generates through `/v1/audio/speech` and checks the audio-models listing and `x-usage-completion-audio-tokens` billing header
- `gen` community-endpoints suite: 103 passed; CLI my-models suite: 8 passed; `tsc --noEmit` and Biome clean

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>