### PR TITLE
fix: preserve upstream unsupported media status

### DIFF
--- a/gen.pollinations.ai/test/text/genericOpenAIClient.test.ts
+++ b/gen.pollinations.ai/test/text/genericOpenAIClient.test.ts
@@ -391,6 +391,28 @@ describe("genericOpenAIClient", () => {
         ).rejects.toMatchObject({ status: 502, upstreamStatus: 429 });
     });
 
+    it("maps an unsupported image URL format to a client error", async () => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+            Response.json(
+                {
+                    error: {
+                        message:
+                            "Unsupported image format for URL: https://example.com/video.mp4",
+                    },
+                },
+                { status: 415, statusText: "Unsupported Media Type" },
+            ),
+        );
+
+        await expect(
+            genericOpenAIClient(
+                [{ role: "user", content: "hello" }],
+                { model: "provider-model" },
+                { endpoint: "https://portkey.test/chat" },
+            ),
+        ).rejects.toMatchObject({ status: 415, upstreamStatus: 415 });
+    });
+
     it("maps unsupported multimodal input errors to a client error", async () => {
         vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
             Response.json(

--- a/gen.pollinations.ai/test/upstream-status.test.ts
+++ b/gen.pollinations.ai/test/upstream-status.test.ts
@@ -5,6 +5,10 @@ test("maps upstream payment failures to bad gateway", () => {
     expect(remapUpstreamStatus(402)).toBe(502);
 });
 
+test("preserves upstream unsupported media type errors", () => {
+    expect(remapUpstreamStatus(415)).toBe(415);
+});
+
 test("maps upstream Cloudflare timeouts to bad gateway", () => {
     expect(remapUpstreamStatus(524)).toBe(502);
 });

--- a/shared/error.ts
+++ b/shared/error.ts
@@ -371,11 +371,11 @@ function createUpstreamErrorResponse(
 /**
  * Remap upstream statuses that are our operational concern (auth, routing,
  * quota, conflicts, proxy timeouts) to 502 Bad Gateway. Leaves input-content
- * errors (400/413/422) as-is since those can reflect user input we failed to
+ * errors (400/413/415/422) as-is since those can reflect user input we failed to
  * validate.
  */
 export function remapUpstreamStatus(status: number): ContentfulStatusCode {
-    const remapTo502 = new Set([401, 402, 403, 404, 409, 415, 429, 524]);
+    const remapTo502 = new Set([401, 402, 403, 404, 409, 429, 524]);
     if (remapTo502.has(status)) return 502;
     return status as ContentfulStatusCode;
 }
@@ -389,6 +389,7 @@ export function getErrorCode(status: number): string {
         404: "NOT_FOUND",
         405: "METHOD_NOT_ALLOWED",
         409: "CONFLICT",
+        415: "UNSUPPORTED_MEDIA_TYPE",
         422: "UNPROCESSABLE_ENTITY",
         429: "RATE_LIMITED",
         500: "INTERNAL_ERROR",
@@ -399,7 +400,7 @@ export function getErrorCode(status: number): string {
 }
 
 export const KNOWN_ERROR_STATUS_CODES = [
-    400, 401, 402, 403, 404, 405, 409, 422, 426, 429, 500, 502, 503,
+    400, 401, 402, 403, 404, 405, 409, 415, 422, 426, 429, 500, 502, 503,
 ] as const;
 
 export type ErrorStatusCode = (typeof KNOWN_ERROR_STATUS_CODES)[number];
@@ -413,6 +414,7 @@ export function getDefaultErrorMessage(status: number): string {
         404: "Oh no, there's nothing here.",
         405: "That HTTP method isn't supported here. Please check the API docs.",
         409: "Something with these details already exists. Maybe update it instead?",
+        415: "The request media type isn't supported.",
         422: "Your request looks good, but some required fields are missing or invalid.",
         426: "This endpoint requires a WebSocket upgrade request.",
         429: "You're making requests too quickly. Please slow down a bit.",


### PR DESCRIPTION
- Keeps upstream HTTP 415 responses as caller-facing 415 errors instead of remapping them to 502
- Adds the stable `UNSUPPORTED_MEDIA_TYPE` error code and default message
- Covers the OpenRouter unsupported-image-URL response and shared status mapping

Fixes misleading model-health failures for invalid media URLs.