### PR TITLE
feat: require fallback proposals for model changes

### DIFF
--- a/.claude/skills/model-management/SKILL.md
+++ b/.claude/skills/model-management/SKILL.md
@@ -49,11 +49,12 @@ Show one complete row per model:
 | Pollinations GPU | `yes` only if Pollinations operates the production hardware |
 | Registry provider | Configured primary provider |
 | Primary route | Provider, deployment/host, and exact upstream model ID |
-| Pollinations fallback | Complete alternative route or `none` |
+| Best fallback candidate | Provider, deployment/host, exact upstream model ID, and why it is the best viable alternative; or `none found` with the searched routes |
+| Pollinations fallback | `use <candidate>` or `none`, with the reason for declining or lacking a viable candidate |
 
 Ask:
 
-> Please confirm: canonical name **X**, aliases **A/none**, price multiplier **M**, paid-only **yes/no**, Pollinations GPU **yes/no**, registry provider **P**, primary route **R**, and Pollinations fallback **F/none**. Are all of these correct?
+> Please confirm: canonical name **X**, aliases **A/none**, price multiplier **M**, paid-only **yes/no**, Pollinations GPU **yes/no**, registry provider **P**, primary route **R**, best fallback candidate **C/none found**, and Pollinations fallback decision **use C/none**. Are all of these correct?
 
 An answer approves only the values shown. If a value is unknown, inferred, conflicting, or route-dependent, label it `UNKNOWN`, explain the evidence, and wait for that exact decision. A batch approval is valid only when every row is complete.
 
@@ -97,6 +98,7 @@ Model approval never authorizes adding, rotating, synchronizing, deploying, revo
 - Deduplicate the canonical model across providers.
 - List material route differences. Equal model names do not prove equal capabilities.
 - Probe the exact deployment and request shape Pollinations will use.
+- For every addition or modification, enumerate viable fallback routes and compare exact checkpoint identity, capabilities, parameters, formats, safety/privacy, availability, latency, price, permissions, and billing. Recommend the best candidate or state `none found`; never omit the fallback decision because the primary route is healthy.
 - Inspect provider-managed routing/fallback defaults and controls. Report identity, capability, pricing, residency, and observability tradeoffs.
 
 ### 3. Confirm the contract
@@ -109,7 +111,7 @@ Present the mandatory row and obtain explicit confirmation before editing. If a 
   `<publisher-slug>/<official-model-slug>` and preserve the official family
   and version. Keep provider deployment IDs and routing internal.
 - Reuse existing handlers, transforms, provider configs, schemas, and generic fallback infrastructure.
-- Do not add speculative abstractions, compatibility shims, or fallbacks.
+- Implement only the explicitly approved fallback decision. Use the shared generic fallback system for an approved pair; do not add a model-specific retry layer or an unapproved fallback.
 - Expose a confirmed new public capability (per the API-change confirmation above) through two surfaces backed by one implementation: a Pollinations-native route outside `/v1` and a standard-compatible route under `/v1`.
 - Resolve the compatibility contract in this order: (1) current official OpenAI API; (2) if OpenAI defines no equivalent, the current published OpenRouter contract — a protocol-design reference here, not an inference-provider fallback; (3) if neither defines the capability, stop for an explicit API-contract decision. Document the exact reference checked.
 - Treat `/v1` as a compatibility namespace: match the selected standard's route, transport, request, response, streaming, and event contracts exactly, and keep provider-specific protocols behind the route adapters — never a Pollinations-specific or upstream-provider schema under `/v1`.
@@ -144,6 +146,7 @@ Present the mandatory row and obtain explicit confirmation before editing. If a 
 - Run the relevant rows in [change-and-test-matrix.md](references/change-and-test-matrix.md).
 - For new models and provider/model-ID changes, run the full declared-modality matrix and [billing-verification.md](references/billing-verification.md).
 - Test aliases, permissions, errors, caching, capacity, and `/models` metadata.
+- When a fallback is configured, probe it directly and run the same applicable E2E matrix through a forced fallback, including capabilities, parameters, permissions, cache behavior, billing, provider attribution, errors, and expected burst. When no fallback is approved, record the researched candidate and rejection reason.
 - Verify all media is fully returned within the supported request-lifetime budget, including the durable-media checks when applicable.
 - Record exact evidence and uncertainty in the PR.
 
@@ -154,7 +157,7 @@ Before publishing:
 - Format changed files with the repository formatter.
 - Run focused tests and type checks for every touched service.
 - Review the complete diff for unrelated changes and dead code.
-- Include the approved contract, exact provider/model ID, pricing source, live probes, E2E results, billing evidence, capacity results, limitations, and deprecation/quota gates.
+- Include the approved contract, exact primary and fallback candidates, fallback decision, pricing sources, live probes, E2E results, billing evidence, capacity results, limitations, and deprecation/quota gates.
 - Leave the PR draft when a live, quota, latency, safety, or product decision remains unresolved.
 
 ## Completion gate
@@ -163,6 +166,7 @@ A model change is not complete until all applicable statements are true:
 
 - The configured model, aliases, provider, route, price, access, modalities, and capabilities match the approved contract.
 - Direct-provider and local E2E requests passed for every declared surface.
+- The best fallback candidate and use/decline decision are documented; every configured fallback passed direct and forced-fallback E2E verification.
 - No existing capability disappeared unless explicitly approved.
 - Every non-zero usage field is accounted for and billed at the confirmed rate.
 - Malformed or rejected requests return useful 4xx responses rather than opaque 5xx responses.

--- a/.claude/skills/model-management/SKILL.md
+++ b/.claude/skills/model-management/SKILL.md
@@ -98,7 +98,7 @@ Model approval never authorizes adding, rotating, synchronizing, deploying, revo
 - Deduplicate the canonical model across providers.
 - List material route differences. Equal model names do not prove equal capabilities.
 - Probe the exact deployment and request shape Pollinations will use.
-- For every addition or modification, enumerate viable fallback routes and compare exact checkpoint identity, capabilities, parameters, formats, safety/privacy, availability, latency, price, permissions, and billing. Recommend the best candidate or state `none found`; never omit the fallback decision because the primary route is healthy.
+- For every addition or modification, run a fresh web search across provider catalogs and official documentation to discover viable fallback routes; do not rely only on repository integrations or remembered availability. Verify each serious candidate against its current official model page and pricing, then probe the exact route. Compare checkpoint identity, capabilities, parameters, formats, safety/privacy, availability, latency, price, permissions, and billing. Recommend the best candidate or state `none found`; never omit the fallback decision because the primary route is healthy.
 - Inspect provider-managed routing/fallback defaults and controls. Report identity, capability, pricing, residency, and observability tradeoffs.
 
 ### 3. Confirm the contract

--- a/.claude/skills/model-management/references/change-and-test-matrix.md
+++ b/.claude/skills/model-management/references/change-and-test-matrix.md
@@ -6,8 +6,9 @@ Every change starts with the confirmation gate in `SKILL.md`. Test the exact con
 
 | Change | Required verification |
 |---|---|
+| Any model addition or modification | Research viable fallback routes; document the best exact candidate and use/decline decision. If configured, directly probe it and run forced-fallback E2E for every applicable capability, parameter, permission, billing field, cache path, error path, and expected burst |
 | Add model | Full declared-modality matrix, aliases, permissions, provider price, billing audit, cache, errors, burst, catalog entry, description, logo |
-| Provider or upstream model ID | Full declared-modality matrix, every previously supported capability, params, price, usage fields, cache, errors, latency, quotas, provider-managed fallback |
+| Provider or upstream model ID | Full declared-modality matrix, every previously supported capability, params, price, usage fields, cache, errors, latency, quotas, and provider-managed fallback behavior |
 | Price or multiplier | Official exact-route price, one real request per declared modality, usage headers/body, billing row, displayed price, no missing conversion |
 | Canonical name or alias | Audit every registry plus model changes between production and `main`; count stored aliases in production and staging; when non-zero, merge the D1 migration before the registry rename and promote a revision containing both so D1 runs immediately before the Worker; verify all old-ID counts reach zero, API-key create/update writes aliases canonically while preserving unknown/community IDs, restricted keys retain access, catalogs display canonical permissions, and removed IDs return model-not-found when no alias was approved |
 | Description or brand | Catalog returns developer-facing copy without the title; brand mapping resolves to a real SVG; `addedDate` unchanged |

--- a/.claude/skills/model-management/references/operating-policy.md
+++ b/.claude/skills/model-management/references/operating-policy.md
@@ -21,7 +21,7 @@ These are strategic defaults. The user's explicit, confirmed contract for a spec
 
 ## Fallbacks
 
-- For every model addition or modification, research viable fallback routes and present the best candidate's exact provider, deployment, and upstream model ID. Compare identity, capabilities, parameters, formats, safety/privacy, reliability, latency, price, permissions, billing, and expected load.
+- For every model addition or modification, use a fresh web search to discover viable fallback routes across current provider catalogs. Treat search results as discovery only: verify availability and exact-route pricing with current official provider sources and a live probe. Present the best candidate's exact provider, deployment, and upstream model ID, comparing identity, capabilities, parameters, formats, safety/privacy, reliability, latency, price, permissions, billing, and expected load.
 - Recommend whether to configure the candidate. A fallback is not automatic: use `none found` when no viable route exists, or recommend `none` with the concrete reason when the best candidate is unacceptable. Flag the resulting reliability gap explicitly.
 - Add or change a fallback only after explicit confirmation of the exact pair. Use the shared generic fallback system; do not build a model-specific retry layer.
 - Directly probe both routes and force the configured fallback through the full applicable local E2E matrix. Prove permissions, billing, provider attribution, cache behavior, errors, and burst capacity independently for the fallback.

--- a/.claude/skills/model-management/references/operating-policy.md
+++ b/.claude/skills/model-management/references/operating-policy.md
@@ -21,9 +21,10 @@ These are strategic defaults. The user's explicit, confirmed contract for a spec
 
 ## Fallbacks
 
-- Default to **no Pollinations fallback** for new routes.
-- Add or change a fallback only with explicit confirmation of the exact pair and proof of model identity, capabilities, parameters, permissions, billing, provider attribution, and economics.
-- Use the shared generic fallback system when an already-approved production pair needs migration; do not build a model-specific retry layer.
+- For every model addition or modification, research viable fallback routes and present the best candidate's exact provider, deployment, and upstream model ID. Compare identity, capabilities, parameters, formats, safety/privacy, reliability, latency, price, permissions, billing, and expected load.
+- Recommend whether to configure the candidate. A fallback is not automatic: use `none found` when no viable route exists, or recommend `none` with the concrete reason when the best candidate is unacceptable. Flag the resulting reliability gap explicitly.
+- Add or change a fallback only after explicit confirmation of the exact pair. Use the shared generic fallback system; do not build a model-specific retry layer.
+- Directly probe both routes and force the configured fallback through the full applicable local E2E matrix. Prove permissions, billing, provider attribution, cache behavior, errors, and burst capacity independently for the fallback.
 - Provider-managed fallback is distinct from Pollinations fallback. Preserve the provider default unless its tradeoffs require a product decision, and disclose those tradeoffs before editing.
 - Never add a more expensive fallback when users are billed from the cheaper primary quote unless the economics are explicitly accepted.
 

--- a/.claude/skills/model-management/references/repository-and-local-testing.md
+++ b/.claude/skills/model-management/references/repository-and-local-testing.md
@@ -41,6 +41,8 @@ Use `npm run dev`, not a bare Worker command, so the current bundle and persiste
 
 Test tokens are references in `_local/.env`; provider credentials are not. Never print secret values. Any provider-secret mutation requires the separate approval and PR process in `AGENTS.md`.
 
+In an isolated worktree, locate the primary checkout with `git worktree list` and use its existing `POLLINATIONS_TOKEN_LOCAL` directly at execution time without copying it into the worktree or printing it. This is read-only use of an already-authorized credential, so it does not require secret-mutation approval. If the token is absent or invalid, do not create, replace, or deploy one without the separate approval required by `AGENTS.md`.
+
 ## Minimum smoke
 
 Call the public route shape through local Gen with the canonical model ID and authenticated local token. A successful direct-provider probe is not a substitute for this test: local E2E must prove registry resolution, request transforms, handler behavior, permissions, billing, and response mapping together.


### PR DESCRIPTION
- Requires every model addition or modification to run fresh web research, verify candidates against official catalogs/pricing and a live route probe, then present the best exact fallback candidate
- Keeps fallback configuration as an explicit use/decline decision and flags cases with no acceptable route
- Requires direct and forced-fallback E2E verification when a fallback is configured
- Reuses the existing local Pollinations test token read-only from the primary checkout, avoiding repeated copy approval while preserving secret-mutation gates
- Updates the operating policy and test matrix consistently; skill validation passes
