### PR TITLE
fix: omit unsupported seed from social text requests

### DIFF
--- a/operations/social/scripts/common.py
+++ b/operations/social/scripts/common.py
@@ -306,21 +306,18 @@ def call_pollinations_api(
     last_error = None
 
     for attempt in range(MAX_RETRIES):
-        seed = random.randint(0, MAX_SEED)
-
         payload = {
             "model": MODEL,
             "messages": [
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": user_prompt}
             ],
-            "temperature": temperature,
-            "seed": seed
+            "temperature": temperature
         }
 
         if attempt > 0:
             backoff_delay = INITIAL_RETRY_DELAY * (2 ** attempt)
-            print(f"  Retry {attempt}/{MAX_RETRIES - 1} with new seed: {seed} (waiting {backoff_delay}s)")
+            print(f"  Retry {attempt}/{MAX_RETRIES - 1} (waiting {backoff_delay}s)")
             time.sleep(backoff_delay)
 
         try:


### PR DESCRIPTION
- Removes the unsupported `seed` parameter from shared social text requests
- Keeps the existing retry and exponential-backoff behavior
- Fixes News gist generation with `gpt-5.6-terra` after the stateless Responses rollout
- Leaves image-generation seeds unchanged