### PR TITLE
fix: refine zero-pollen authorization notice

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/auth/authorize.tsx
+++ b/enter.pollinations.ai/frontend/src/components/auth/authorize.tsx
@@ -6,9 +6,9 @@ import {
     ExternalLinkIcon,
     InlineLink,
     MailIcon,
+    SadFaceIcon,
     ScrollArea,
     useScrollLock,
-    WarningIcon,
 } from "@pollinations/ui";
 import {
     AuthInfoCard,
@@ -622,10 +622,11 @@ export function Authorize() {
                         {totalBalance !== null && totalBalance <= 0 && (
                             <div className="py-4">
                                 <Alert
-                                    intent="danger"
+                                    intent="info"
+                                    className="!bg-intent-danger-bg-light"
                                     title={
                                         <span className="inline-flex items-center gap-1.5">
-                                            <WarningIcon className="h-4 w-4 shrink-0" />
+                                            <SadFaceIcon className="h-4 w-4 shrink-0" />
                                             You’re out of Pollen
                                         </span>
                                     }

--- a/enter.pollinations.ai/frontend/src/components/auth/authorize.tsx
+++ b/enter.pollinations.ai/frontend/src/components/auth/authorize.tsx
@@ -6,9 +6,9 @@ import {
     ExternalLinkIcon,
     InlineLink,
     MailIcon,
-    SadFaceIcon,
     ScrollArea,
     useScrollLock,
+    WalletIcon,
 } from "@pollinations/ui";
 import {
     AuthInfoCard,
@@ -625,8 +625,8 @@ export function Authorize() {
                                     intent="info"
                                     className="!bg-intent-danger-bg-light"
                                     title={
-                                        <span className="inline-flex items-center gap-1.5">
-                                            <SadFaceIcon className="h-4 w-4 shrink-0" />
+                                        <span className="inline-flex items-center gap-1.5 leading-none">
+                                            <WalletIcon className="h-4 w-4 shrink-0" />
                                             You’re out of Pollen
                                         </span>
                                     }

--- a/enter.pollinations.ai/frontend/src/components/auth/authorize.tsx
+++ b/enter.pollinations.ai/frontend/src/components/auth/authorize.tsx
@@ -8,6 +8,7 @@ import {
     MailIcon,
     ScrollArea,
     useScrollLock,
+    WarningIcon,
 } from "@pollinations/ui";
 import {
     AuthInfoCard,
@@ -619,10 +620,15 @@ export function Authorize() {
                 ) : (
                     <div>
                         {totalBalance !== null && totalBalance <= 0 && (
-                            <div className="px-4 py-4">
+                            <div className="py-4">
                                 <Alert
-                                    intent="info"
-                                    title="You’re out of Pollen"
+                                    intent="danger"
+                                    title={
+                                        <span className="inline-flex items-center gap-1.5">
+                                            <WarningIcon className="h-4 w-4 shrink-0" />
+                                            You’re out of Pollen
+                                        </span>
+                                    }
                                 >
                                     Complete a free{" "}
                                     <InlineLink

--- a/packages/ui/src/compositions/Alert.tsx
+++ b/packages/ui/src/compositions/Alert.tsx
@@ -10,7 +10,7 @@ const intentClasses: Record<AlertIntent, string> = {
     danger: "polli:bg-intent-danger-bg-light polli:text-intent-danger-text",
 };
 
-export type AlertProps = ComponentPropsWithoutRef<"div"> & {
+export type AlertProps = Omit<ComponentPropsWithoutRef<"div">, "title"> & {
     intent?: AlertIntent;
     title?: ReactNode;
 };

--- a/packages/ui/src/primitives/icons/index.tsx
+++ b/packages/ui/src/primitives/icons/index.tsx
@@ -279,6 +279,15 @@ export function PlusIcon(props: IconProps) {
     );
 }
 
+export function SadFaceIcon(props: IconProps) {
+    return (
+        <svg aria-hidden="true" viewBox="0 0 24 24" {...strokeProps} {...props}>
+            <circle cx="12" cy="12" r="9" />
+            <path d="M9 9h.01M15 9h.01M8.5 17c.8-2 2-3 3.5-3s2.7 1 3.5 3" />
+        </svg>
+    );
+}
+
 export function TerminalIcon(props: IconProps) {
     return (
         <svg aria-hidden="true" viewBox="0 0 24 24" {...strokeProps} {...props}>

--- a/packages/ui/src/primitives/icons/index.tsx
+++ b/packages/ui/src/primitives/icons/index.tsx
@@ -279,15 +279,6 @@ export function PlusIcon(props: IconProps) {
     );
 }
 
-export function SadFaceIcon(props: IconProps) {
-    return (
-        <svg aria-hidden="true" viewBox="0 0 24 24" {...strokeProps} {...props}>
-            <circle cx="12" cy="12" r="9" />
-            <path d="M9 9h.01M15 9h.01M8.5 17c.8-2 2-3 3.5-3s2.7 1 3.5 3" />
-        </svg>
-    );
-}
-
 export function TerminalIcon(props: IconProps) {
     return (
         <svg aria-hidden="true" viewBox="0 0 24 24" {...strokeProps} {...props}>


### PR DESCRIPTION
- Uses a wider, softly highlighted zero-Pollen notice on the authorization screen
- Aligns the shared wallet icon with the notice title and keeps the text neutral
- Preserves the existing Quest and Top up links that open in a new tab
- Fixes the shared Alert title typing for composed React content

Checks:
- `npm run typecheck --prefix packages/ui`
- `npx tsc --noEmit`
- `npx vite build --config frontend/vite.config.ts`