### PR TITLE
fix: generate monthly diary once

### DIFF
--- a/.github/workflows/news-generate-summary.yml
+++ b/.github/workflows/news-generate-summary.yml
@@ -74,9 +74,6 @@ jobs:
             fi
             if [ "$DOM" = "01" ]; then
               RUN_MONTHLY=true
-            elif [ "$DOW" = "7" ]; then
-              RUN_MONTHLY=true
-              MONTHLY_TARGET=$(date -u +%Y-%m)
             fi
           elif [ "$MODE" = "daily" ]; then
             RUN_DAILY=true


### PR DESCRIPTION
- Runs the monthly website diary only on the first day of each month
- Keeps manual monthly generation available for recovery
- Leaves daily, weekly, Buffer, Discord, and Reddit behavior unchanged