### PR TITLE
feat: add Stripe top-up to authorization flow

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/auth/authorize.tsx
+++ b/enter.pollinations.ai/frontend/src/components/auth/authorize.tsx
@@ -688,9 +688,7 @@ export function Authorize() {
                                         {formatUsdCentsCompact(
                                             selectedTopUpFeeCents,
                                         )}{" "}
-                                        service fee. Tax is calculated at
-                                        checkout. You won&apos;t be charged
-                                        until you confirm there.
+                                        service fee. Tax calculated at checkout.
                                     </p>
                                 </Alert>
                             </div>

--- a/enter.pollinations.ai/frontend/src/components/auth/authorize.tsx
+++ b/enter.pollinations.ai/frontend/src/components/auth/authorize.tsx
@@ -26,6 +26,12 @@ import {
     sanitizeAuthorizeAccountPermissions,
 } from "@shared/auth/authorize-config.ts";
 import { redirectUriMatchesAllowlistExact } from "@shared/auth/redirect-uri.ts";
+import {
+    calculateServiceFeeCents,
+    formatUsdCentsCompact,
+    getPollenPackByAmount,
+    POLLEN_PACKS,
+} from "@shared/pollen-packs.ts";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
 import { apiClient } from "../../api.ts";
@@ -40,6 +46,7 @@ import { PollenBudgetInput } from "../keys/pollen-budget-input.tsx";
 import { computeCategoryModalities } from "../models/model-categories.ts";
 import { useModelCategories } from "../models/use-model-categories.ts";
 import { useOwnCommunityModels } from "../models/use-own-community-models.ts";
+import { PollenPackSlider } from "../pollen/pollen-pack-controls.tsx";
 import { AppAttribution } from "./app-attribution.tsx";
 
 type Attribution = {
@@ -101,7 +108,24 @@ export function Authorize() {
         "pending" | "approved" | "denied"
     >("pending");
     const [totalBalance, setTotalBalance] = useState<number | null>(null);
+    const [selectedTopUpAmount, setSelectedTopUpAmount] = useState(5);
     const [permissionsExpanded, setPermissionsExpanded] = useState(false);
+
+    const selectedTopUpPack =
+        getPollenPackByAmount(selectedTopUpAmount) ?? POLLEN_PACKS[0];
+    const selectedTopUpFeeCents = calculateServiceFeeCents(
+        selectedTopUpPack.amountUsd * 100,
+    );
+    const selectedTopUpSubtotal = formatUsdCentsCompact(
+        selectedTopUpPack.amountUsd * 100 + selectedTopUpFeeCents,
+    );
+    const stripeCheckoutUrl = new URL(
+        `${config.baseUrl}/api/stripe/checkout/${selectedTopUpPack.packKey}`,
+    );
+    stripeCheckoutUrl.searchParams.set(
+        "return_to",
+        `${window.location.pathname}${window.location.search}`,
+    );
 
     const parsedRedirectUrl = redirect_url ? safeParseUrl(redirect_url) : null;
     const redirectHostname = parsedRedirectUrl?.hostname ?? "";
@@ -631,19 +655,43 @@ export function Authorize() {
                                         </span>
                                     }
                                 >
-                                    Complete a free{" "}
-                                    <InlineLink
-                                        href={`${config.baseUrl}/quests`}
+                                    <p>
+                                        Complete a free{" "}
+                                        <InlineLink
+                                            href={`${config.baseUrl}/quests`}
+                                        >
+                                            Quest
+                                        </InlineLink>{" "}
+                                        or top up instantly before using this
+                                        app.
+                                    </p>
+                                    <div className="mt-3 pb-14">
+                                        <PollenPackSlider
+                                            value={selectedTopUpPack.amountUsd}
+                                            onChange={setSelectedTopUpAmount}
+                                            label="Choose a Pollen top-up amount"
+                                            showSelectedBadge={false}
+                                        />
+                                    </div>
+                                    <Button
+                                        as="a"
+                                        size="sm"
+                                        className="w-full"
+                                        href={stripeCheckoutUrl.toString()}
+                                        target="_self"
                                     >
-                                        Quest
-                                    </InlineLink>{" "}
-                                    or{" "}
-                                    <InlineLink
-                                        href={`${config.baseUrl}/pollen#buy-pollen`}
-                                    >
-                                        top up instantly
-                                    </InlineLink>{" "}
-                                    before using this app.
+                                        Continue to Stripe ·{" "}
+                                        {selectedTopUpSubtotal}
+                                    </Button>
+                                    <p className="mt-1.5 text-xs text-theme-text-muted">
+                                        Includes a{" "}
+                                        {formatUsdCentsCompact(
+                                            selectedTopUpFeeCents,
+                                        )}{" "}
+                                        service fee. Tax is calculated at
+                                        checkout. You won&apos;t be charged
+                                        until you confirm there.
+                                    </p>
                                 </Alert>
                             </div>
                         )}

--- a/enter.pollinations.ai/frontend/src/components/pollen/pollen-pack-controls.tsx
+++ b/enter.pollinations.ai/frontend/src/components/pollen/pollen-pack-controls.tsx
@@ -24,6 +24,7 @@ type PollenPackSliderProps = {
     label?: string;
     selectedBadgeLabel?: string;
     selectedBadgeDetail?: string;
+    showSelectedBadge?: boolean;
     disabled?: boolean;
 };
 
@@ -34,6 +35,7 @@ export const PollenPackSlider: FC<PollenPackSliderProps> = ({
     label = "Select amount",
     selectedBadgeLabel,
     selectedBadgeDetail,
+    showSelectedBadge = true,
     disabled = false,
 }) => {
     const selectedIndex = Math.max(
@@ -110,7 +112,7 @@ export const PollenPackSlider: FC<PollenPackSliderProps> = ({
                                             </span>
                                         )}
                                     </span>
-                                    {isSelected && (
+                                    {isSelected && showSelectedBadge && (
                                         <span
                                             className={cn(
                                                 "absolute top-full mt-1 inline-flex flex-col whitespace-nowrap",

--- a/enter.pollinations.ai/src/routes/stripe.ts
+++ b/enter.pollinations.ai/src/routes/stripe.ts
@@ -26,6 +26,33 @@ import {
     stripeNewCardGateMetadata,
 } from "../utils/stripe-card-gate.ts";
 
+function getCheckoutReturnUrl(
+    baseUrl: string,
+    packKey: string,
+    returnTo?: string,
+): URL {
+    const fallbackUrl = new URL("/pollen", baseUrl);
+    fallbackUrl.searchParams.set("pack", packKey);
+
+    if (!returnTo?.startsWith("/") || returnTo.startsWith("//")) {
+        return fallbackUrl;
+    }
+
+    const requestedUrl = new URL(returnTo, baseUrl);
+    if (
+        requestedUrl.origin !== new URL(baseUrl).origin ||
+        requestedUrl.pathname !== "/authorize"
+    ) {
+        return fallbackUrl;
+    }
+
+    requestedUrl.hash = "";
+    requestedUrl.searchParams.delete("stripe_success");
+    requestedUrl.searchParams.delete("stripe_canceled");
+    requestedUrl.searchParams.delete("session_id");
+    return requestedUrl;
+}
+
 /**
  * Stripe pack configuration
  * Checkout keeps pack pricing USD-native and lets Stripe Adaptive Pricing
@@ -69,12 +96,20 @@ export const stripeRoutes = new Hono<Env>()
         // Create Stripe client
         const stripe = createStripeClient(c.env);
 
-        // Return checkout sessions to the Pollen page for this environment.
+        // Dashboard checkouts return to Pollen. The authorize screen can ask
+        // to resume its exact same-origin consent URL after Checkout.
         const baseUrl =
             c.env.STRIPE_SUCCESS_URL || PUBLIC_URLS.enter.production;
-        const pollenUrl = new URL("/pollen", baseUrl);
-        pollenUrl.searchParams.set("pack", pack.packKey);
-        const pollenReturnUrl = pollenUrl.toString();
+        const checkoutReturnUrl = getCheckoutReturnUrl(
+            baseUrl,
+            pack.packKey,
+            c.req.query("return_to"),
+        );
+        const successUrl = new URL(checkoutReturnUrl);
+        successUrl.searchParams.set("stripe_success", "true");
+        successUrl.searchParams.set("session_id", "{CHECKOUT_SESSION_ID}");
+        const cancelUrl = new URL(checkoutReturnUrl);
+        cancelUrl.searchParams.set("stripe_canceled", "true");
 
         // Resolve cohort from buyer IP for analytics. Checkout stays USD-native
         // and does not call FX at runtime.
@@ -171,8 +206,13 @@ export const stripeRoutes = new Hono<Env>()
                     },
                 },
                 metadata: packMetadata,
-                success_url: `${pollenReturnUrl}&stripe_success=true&session_id={CHECKOUT_SESSION_ID}`,
-                cancel_url: `${pollenReturnUrl}&stripe_canceled=true`,
+                success_url: successUrl
+                    .toString()
+                    .replace(
+                        "%7BCHECKOUT_SESSION_ID%7D",
+                        "{CHECKOUT_SESSION_ID}",
+                    ),
+                cancel_url: cancelUrl.toString(),
             });
 
             // Redirect to Stripe Checkout (will use checkout.pollinations.ai custom domain)

--- a/enter.pollinations.ai/test/integration/stripe.test.ts
+++ b/enter.pollinations.ai/test/integration/stripe.test.ts
@@ -315,6 +315,72 @@ test("GET /api/stripe/checkout/:packKey reuses the stable Stripe customer", asyn
     expect(checkoutRequest?.body["customer_update[address]"]).toBe("auto");
 });
 
+test("GET /api/stripe/checkout returns an authorize checkout to the consent flow", async ({
+    sessionToken,
+    mocks,
+}) => {
+    await mocks.enable("stripe", "tinybird");
+    const checkoutUrl = new URL(`${base}/checkout/p5`);
+    checkoutUrl.searchParams.set(
+        "return_to",
+        "/authorize?redirect_url=https%3A%2F%2Fexample.com%2Fcallback&client_id=test-app",
+    );
+
+    const response = await SELF.fetch(checkoutUrl, {
+        headers: { cookie: `better-auth.session_token=${sessionToken}` },
+        redirect: "manual",
+    });
+
+    expect(response.status).toBe(302);
+    const body = mocks.stripe.state.requests.find(
+        (request) => request.path === "/v1/checkout/sessions",
+    )?.body;
+    const successUrl = new URL(body?.success_url ?? "");
+    const cancelUrl = new URL(body?.cancel_url ?? "");
+
+    expect(successUrl.pathname).toBe("/authorize");
+    expect(successUrl.searchParams.get("redirect_url")).toBe(
+        "https://example.com/callback",
+    );
+    expect(successUrl.searchParams.get("client_id")).toBe("test-app");
+    expect(successUrl.searchParams.get("stripe_success")).toBe("true");
+    expect(successUrl.searchParams.get("session_id")).toBe(
+        "{CHECKOUT_SESSION_ID}",
+    );
+    expect(cancelUrl.pathname).toBe("/authorize");
+    expect(cancelUrl.searchParams.get("stripe_canceled")).toBe("true");
+});
+
+test.for([
+    "https://example.com/authorize",
+    "//example.com/authorize",
+    "/keys",
+])("GET /api/stripe/checkout rejects unsafe return path %s", async (returnTo, {
+    sessionToken,
+    mocks,
+}) => {
+    await mocks.enable("stripe", "tinybird");
+    const checkoutUrl = new URL(`${base}/checkout/p5`);
+    checkoutUrl.searchParams.set("return_to", returnTo);
+
+    const response = await SELF.fetch(checkoutUrl, {
+        headers: { cookie: `better-auth.session_token=${sessionToken}` },
+        redirect: "manual",
+    });
+
+    expect(response.status).toBe(302);
+    const body = mocks.stripe.state.requests.find(
+        (request) => request.path === "/v1/checkout/sessions",
+    )?.body;
+    const successUrl = new URL(body?.success_url ?? "");
+    const cancelUrl = new URL(body?.cancel_url ?? "");
+
+    expect(successUrl.pathname).toBe("/pollen");
+    expect(successUrl.searchParams.get("pack")).toBe("p5");
+    expect(cancelUrl.pathname).toBe("/pollen");
+    expect(cancelUrl.searchParams.get("pack")).toBe("p5");
+});
+
 test("GET /api/stripe/checkout/p10 sets pack identity in session metadata", async ({
     sessionToken,
     mocks,


### PR DESCRIPTION
- Adds the Pollen pack slider and direct Stripe Checkout button to the zero-balance consent notice
- Keeps the red wallet notice and opens Quests separately
- Returns successful or canceled consent checkouts to the same authorization URL
- Restricts custom checkout returns to the same-origin `/authorize` route
- Keeps dashboard checkouts returning to the Pollen page and tests unsafe return fallbacks