### PR TITLE
fix: ignore caller tools on managed agents instead of rejecting

### DIFF
--- a/enter.pollinations.ai/src/services/prompt-agent-responses.ts
+++ b/enter.pollinations.ai/src/services/prompt-agent-responses.ts
@@ -243,12 +243,9 @@ function requestSettings(
     ) {
         invalidRequest("Invalid reasoning effort", "reasoning.effort");
     }
-    if (request.tools?.length) {
-        invalidRequest(
-            "Caller-provided tools are not supported by managed agents",
-            "tools",
-        );
-    }
+    // Caller tools are ignored, not rejected: an agent runs its own tools, and
+    // clients attach theirs unprompted. Open WebUI injects builtin tool specs
+    // into every chat sent from its UI, so rejecting made agents unusable there.
     if (request.tool_choice !== undefined) {
         invalidRequest(
             "Caller-provided tool choice is not supported by managed agents",

--- a/enter.pollinations.ai/test/prompt-agent-responses.test.ts
+++ b/enter.pollinations.ai/test/prompt-agent-responses.test.ts
@@ -483,7 +483,7 @@ describe("managed agent Responses runtime", () => {
         ).toBe(false);
     });
 
-    it("rejects state and caller-supplied tools", async () => {
+    it("rejects state and unsupported parameters", async () => {
         expect(
             PromptAgentResponsesRequestSchema.safeParse({
                 model: crypto.randomUUID(),
@@ -492,17 +492,17 @@ describe("managed agent Responses runtime", () => {
             }).success,
         ).toBe(false);
 
-        const response = await handlePromptAgentResponsesRequest(
+        // Caller tools are ignored, not rejected: Open WebUI attaches builtin
+        // tool specs to every chat sent from its UI, which used to 400 every
+        // managed-agent call.
+        const withTools = await handlePromptAgentResponsesRequest(
             request({
                 tools: [{ type: "function", name: "external", parameters: {} }],
             }),
             new AbortController().signal,
             RUNTIME,
         );
-        expect(response.status).toBe(400);
-        await expect(response.json()).resolves.toMatchObject({
-            error: { code: "unsupported_parameter", param: "tools" },
-        });
+        expect(withTools.status).not.toBe(400);
 
         for (const [field, value] of [
             ["max_tool_calls", { max_tool_calls: 2 }],


### PR DESCRIPTION
- Managed agents 400'd on any request carrying `tools`. Open WebUI injects builtin tool specs into **every** chat sent from its UI (`use_builtin_tools` defaults on for any session; connection-fetched models have no `meta.capabilities` to disable it), so 100% of agent calls from Open WebUI failed with `Caller-provided tools are not supported by managed agents`.
- Observed on 3 agents / 3 users in the first day of openwebui.pollinations.ai. No user configuration involved — the tools are Open WebUI's own builtins, not the Pollinations MCP tool server.
- An agent runs its own tools, so caller tools were never going to be used. Dropping them is no more lossy than erroring, and non-fatal.
- `tool_choice` and `parallel_tool_calls` keep rejecting — Open WebUI sends neither.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mNrP6DkRQmm3YStNjfFv3