### PR TITLE
chore: sync main into production

### DIFF
--- a/.github/workflows/news-generate-summary.yml
+++ b/.github/workflows/news-generate-summary.yml
@@ -9,14 +9,19 @@ on:
         description: 'Date to summarize (YYYY-MM-DD). For daily: yesterday. For weekly: week start (Sunday).'
         required: false
         type: string
+      target_month:
+        description: 'Month to summarize (YYYY-MM). Defaults to the previous completed month.'
+        required: false
+        type: string
       mode:
-        description: 'Force daily or weekly mode (auto-detects by day-of-week if empty)'
+        description: 'Choose one generator, or auto-run the calendar schedule'
         required: false
         type: choice
         options:
           - auto
           - daily
           - weekly
+          - monthly
 
 jobs:
   generate-summary:
@@ -49,24 +54,48 @@ jobs:
       - name: Overlay news branch data
         run: git fetch origin news && git checkout origin/news -- operations/social/news/ || echo "No news branch data yet"
 
-      - name: Determine mode (daily vs weekly)
+      - name: Determine generators
         id: mode
         run: |
           MODE="${{ github.event.inputs.mode || 'auto' }}"
+          RUN_DAILY=false
+          RUN_DAILY_BUFFER=false
+          RUN_WEEKLY=false
+          RUN_MONTHLY=false
+          MONTHLY_TARGET="${{ github.event.inputs.target_month || '' }}"
           if [ "$MODE" = "auto" ]; then
             DOW=$(date -u +%u)  # 1=Monday, 7=Sunday
+            DOM=$(date -u +%d)
+            RUN_DAILY=true
             if [ "$DOW" = "7" ]; then
-              MODE="weekly"
+              RUN_WEEKLY=true
             else
-              MODE="daily"
+              RUN_DAILY_BUFFER=true
             fi
+            if [ "$DOM" = "01" ]; then
+              RUN_MONTHLY=true
+            elif [ "$DOW" = "7" ]; then
+              RUN_MONTHLY=true
+              MONTHLY_TARGET=$(date -u +%Y-%m)
+            fi
+          elif [ "$MODE" = "daily" ]; then
+            RUN_DAILY=true
+            RUN_DAILY_BUFFER=true
+          elif [ "$MODE" = "weekly" ]; then
+            RUN_WEEKLY=true
+          elif [ "$MODE" = "monthly" ]; then
+            RUN_MONTHLY=true
           fi
-          echo "mode=$MODE" >> "$GITHUB_OUTPUT"
-          echo "Mode: $MODE"
+          echo "daily=$RUN_DAILY" >> "$GITHUB_OUTPUT"
+          echo "daily_buffer=$RUN_DAILY_BUFFER" >> "$GITHUB_OUTPUT"
+          echo "weekly=$RUN_WEEKLY" >> "$GITHUB_OUTPUT"
+          echo "monthly=$RUN_MONTHLY" >> "$GITHUB_OUTPUT"
+          echo "monthly_target=$MONTHLY_TARGET" >> "$GITHUB_OUTPUT"
+          echo "Daily: $RUN_DAILY · Daily Buffer: $RUN_DAILY_BUFFER · Weekly: $RUN_WEEKLY · Monthly: $RUN_MONTHLY"
 
       # ── Daily: generate + stage to Buffer ──────────────────────────
       - name: Generate daily summary
-        if: steps.mode.outputs.mode == 'daily'
+        if: steps.mode.outputs.daily == 'true'
         env:
           GITHUB_TOKEN: ${{ steps.pollinations-ai.outputs.token }}
           POLLINATIONS_TOKEN: ${{ secrets.PLN_GITHUB_NEWS_KEY }}
@@ -76,7 +105,7 @@ jobs:
         run: python operations/social/scripts/generate_daily.py
 
       - name: Stage daily posts to Buffer
-        if: steps.mode.outputs.mode == 'daily'
+        if: steps.mode.outputs.daily_buffer == 'true'
         env:
           GITHUB_TOKEN: ${{ steps.pollinations-ai.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -87,7 +116,7 @@ jobs:
 
       # ── Weekly: generate + stage to Buffer ─────────────────────────
       - name: Generate weekly digest
-        if: steps.mode.outputs.mode == 'weekly'
+        if: steps.mode.outputs.weekly == 'true'
         env:
           GITHUB_TOKEN: ${{ steps.pollinations-ai.outputs.token }}
           POLLINATIONS_TOKEN: ${{ secrets.PLN_GITHUB_NEWS_KEY }}
@@ -96,7 +125,7 @@ jobs:
         run: python operations/social/scripts/generate_weekly.py
 
       - name: Stage weekly posts to Buffer
-        if: steps.mode.outputs.mode == 'weekly'
+        if: steps.mode.outputs.weekly == 'true'
         env:
           GITHUB_TOKEN: ${{ steps.pollinations-ai.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -104,3 +133,17 @@ jobs:
           PUBLISH_MODE: buffer
           WEEK_START_DATE: ${{ github.event.inputs.target_date || '' }}
         run: python operations/social/scripts/publish_weekly.py
+
+      # ── Monthly: website archive only ──────────────────────────────
+      - name: Refresh news branch for monthly digest
+        if: steps.mode.outputs.monthly == 'true'
+        run: git fetch origin news && git checkout origin/news -- operations/social/news/
+
+      - name: Generate monthly build diary
+        if: steps.mode.outputs.monthly == 'true'
+        env:
+          GITHUB_TOKEN: ${{ steps.pollinations-ai.outputs.token }}
+          POLLINATIONS_TOKEN: ${{ secrets.PLN_GITHUB_NEWS_KEY }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          TARGET_MONTH: ${{ steps.mode.outputs.monthly_target }}
+        run: python operations/social/scripts/generate_monthly.py

--- a/enter.pollinations.ai/frontend/src/components/auth/authorize.tsx
+++ b/enter.pollinations.ai/frontend/src/components/auth/authorize.tsx
@@ -8,6 +8,7 @@ import {
     MailIcon,
     ScrollArea,
     useScrollLock,
+    WalletIcon,
 } from "@pollinations/ui";
 import {
     AuthInfoCard,
@@ -619,10 +620,16 @@ export function Authorize() {
                 ) : (
                     <div>
                         {totalBalance !== null && totalBalance <= 0 && (
-                            <div className="px-4 py-4">
+                            <div className="py-4">
                                 <Alert
                                     intent="info"
-                                    title="You’re out of Pollen"
+                                    className="!bg-intent-danger-bg-light"
+                                    title={
+                                        <span className="inline-flex items-center gap-1.5 leading-none">
+                                            <WalletIcon className="h-4 w-4 shrink-0" />
+                                            You’re out of Pollen
+                                        </span>
+                                    }
                                 >
                                     Complete a free{" "}
                                     <InlineLink

--- a/enter.pollinations.ai/src/services/prompt-agent-responses.ts
+++ b/enter.pollinations.ai/src/services/prompt-agent-responses.ts
@@ -243,12 +243,9 @@ function requestSettings(
     ) {
         invalidRequest("Invalid reasoning effort", "reasoning.effort");
     }
-    if (request.tools?.length) {
-        invalidRequest(
-            "Caller-provided tools are not supported by managed agents",
-            "tools",
-        );
-    }
+    // Caller tools are ignored, not rejected: an agent runs its own tools, and
+    // clients attach theirs unprompted. Open WebUI injects builtin tool specs
+    // into every chat sent from its UI, so rejecting made agents unusable there.
     if (request.tool_choice !== undefined) {
         invalidRequest(
             "Caller-provided tool choice is not supported by managed agents",

--- a/enter.pollinations.ai/test/prompt-agent-responses.test.ts
+++ b/enter.pollinations.ai/test/prompt-agent-responses.test.ts
@@ -483,7 +483,7 @@ describe("managed agent Responses runtime", () => {
         ).toBe(false);
     });
 
-    it("rejects state and caller-supplied tools", async () => {
+    it("rejects state and unsupported parameters", async () => {
         expect(
             PromptAgentResponsesRequestSchema.safeParse({
                 model: crypto.randomUUID(),
@@ -492,17 +492,17 @@ describe("managed agent Responses runtime", () => {
             }).success,
         ).toBe(false);
 
-        const response = await handlePromptAgentResponsesRequest(
+        // Caller tools are ignored, not rejected: Open WebUI attaches builtin
+        // tool specs to every chat sent from its UI, which used to 400 every
+        // managed-agent call.
+        const withTools = await handlePromptAgentResponsesRequest(
             request({
                 tools: [{ type: "function", name: "external", parameters: {} }],
             }),
             new AbortController().signal,
             RUNTIME,
         );
-        expect(response.status).toBe(400);
-        await expect(response.json()).resolves.toMatchObject({
-            error: { code: "unsupported_parameter", param: "tools" },
-        });
+        expect(withTools.status).not.toBe(400);
 
         for (const [field, value] of [
             ["max_tool_calls", { max_tool_calls: 2 }],

--- a/operations/social/prompts/monthly.md
+++ b/operations/social/prompts/monthly.md
@@ -1,0 +1,55 @@
+# Monthly Build Diary — System Prompt
+
+You synthesize a month of daily Pollinations build summaries into one concise monthly narrative for the website build diary.
+
+{about}
+
+## Your Task
+
+Given the canonical daily summaries for one calendar month, identify the few themes that best explain what changed across the month. The result is a quiet retrospective, not a social post or a changelog.
+
+## Rules
+
+- **Synthesize, don't concatenate.** Find the month's through-lines instead of listing days.
+- **Lead with user-visible progress.** Infrastructure and maintenance belong in supporting themes.
+- **Be concrete.** Name important products, capabilities, models, or systems when they matter.
+- **Keep it compact.** The website displays one title and one short summary.
+- **Positive framing only.** Skip pricing changes, feature removals, and business negatives.
+- **Use only the supplied daily summaries.** Do not invent releases, metrics, or outcomes.
+
+## Output Format (JSON only)
+
+```json
+{
+  "month": "2026-08",
+  "pr_count": 123,
+  "mood": "productive",
+  "theme": "One sentence capturing the month's overall direction.",
+  "arcs": [
+    {
+      "headline": "A short title for one important theme",
+      "summary": "A concise explanation of what changed and why it matters.",
+      "days": ["2026-08-03", "2026-08-14"],
+      "importance": "major"
+    }
+  ],
+  "pr_summary": "MONTHLY UPDATES (123 merged PRs):\n- Theme one\n- Theme two"
+}
+```
+
+- `arcs`: 3-5 thematic groups spanning the month.
+- `mood`: Match the actual work. Prefer restrained descriptions such as "productive", "tending the garden", "building foundations", or "shipping month".
+- `theme`: One sentence that frames the month as a whole.
+- `pr_summary`: A compact theme list for the image-prompt generator.
+
+Return ONLY the JSON object. No markdown fences, no explanation.
+
+## Monthly Image Identity
+
+This image is the visual cover for one month in the website build diary.
+
+- Create one calm, cohesive pixel-art scene representing the month's main themes.
+- Use the shared Pollinations visual identity and characters.
+- Prefer one readable focal point over a crowded collage.
+- Avoid dates, statistics, logos, headlines, dashboards, and small text in the image.
+- Keep enough quiet space that the image sits comfortably beside editorial text.

--- a/operations/social/scripts/common.py
+++ b/operations/social/scripts/common.py
@@ -34,10 +34,11 @@ LINKEDIN_MAX_CHARS = 1248
 OWNER = "pollinations"
 REPO = "pollinations"
 GISTS_BRANCH = "news"  # Unprotected branch for gist data (avoids main branch protection)
+NEWS_REL_DIR = "operations/social/news"
 
 
 # Models-weekly staging
-MODELS_NEWS_DIR = "operations/social/news/models"
+MODELS_NEWS_DIR = f"{NEWS_REL_DIR}/models"
 
 
 def models_news_staging_dir(date_str: str) -> str:
@@ -511,7 +512,7 @@ def get_file_sha(github_token: str, owner: str, repo: str, file_path: str, branc
 # ── Gist I/O helpers ─────────────────────────────────────────────────
 
 # Directory where gist JSONs live, relative to repo root
-GISTS_REL_DIR = "operations/social/news/gists"
+GISTS_REL_DIR = f"{NEWS_REL_DIR}/gists"
 
 # Required top-level keys for a valid gist
 _GIST_REQUIRED_KEYS = {"pr_number", "title", "author", "url", "merged_at"}

--- a/operations/social/scripts/common.py
+++ b/operations/social/scripts/common.py
@@ -306,21 +306,18 @@ def call_pollinations_api(
     last_error = None
 
     for attempt in range(MAX_RETRIES):
-        seed = random.randint(0, MAX_SEED)
-
         payload = {
             "model": MODEL,
             "messages": [
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": user_prompt}
             ],
-            "temperature": temperature,
-            "seed": seed
+            "temperature": temperature
         }
 
         if attempt > 0:
             backoff_delay = INITIAL_RETRY_DELAY * (2 ** attempt)
-            print(f"  Retry {attempt}/{MAX_RETRIES - 1} with new seed: {seed} (waiting {backoff_delay}s)")
+            print(f"  Retry {attempt}/{MAX_RETRIES - 1} (waiting {backoff_delay}s)")
             time.sleep(backoff_delay)
 
         try:

--- a/operations/social/scripts/generate_daily.py
+++ b/operations/social/scripts/generate_daily.py
@@ -42,14 +42,15 @@ from common import (
     GITHUB_API_BASE,
     GISTS_BRANCH,
     IMAGE_SIZE,
+    NEWS_REL_DIR,
     OWNER,
     REPO,
 )
 
 # ── Constants ────────────────────────────────────────────────────────
 
-DAILY_REL_DIR = "operations/social/news/daily"
-HIGHLIGHTS_PATH = "operations/social/news/highlights.md"
+DAILY_REL_DIR = f"{NEWS_REL_DIR}/daily"
+HIGHLIGHTS_PATH = f"{NEWS_REL_DIR}/highlights.md"
 
 
 # ── Highlights ────────────────────────────────────────────────────────

--- a/operations/social/scripts/generate_monthly.py
+++ b/operations/social/scripts/generate_monthly.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Generate one canonical monthly build-diary summary and cover image.
+
+The monthly archive is website-only. It reads canonical daily summaries and
+writes exactly two artifacts to the news branch; it does not create or publish
+social posts.
+"""
+
+import calendar
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from common import (
+    GISTS_BRANCH,
+    IMAGE_SIZE,
+    build_canonical_summary,
+    call_pollinations_api,
+    commit_files_to_branch,
+    commit_image_to_branch,
+    generate_image,
+    generate_platform_post,
+    get_env,
+    get_repo_root,
+    join_summary_parts,
+    load_prompt,
+    NEWS_REL_DIR,
+    parse_json_response,
+)
+
+DAILY_REL_DIR = f"{NEWS_REL_DIR}/daily"
+MONTHLY_REL_DIR = f"{NEWS_REL_DIR}/monthly"
+
+
+def get_target_month(override: Optional[str] = None) -> str:
+    """Return YYYY-MM, defaulting to the last completed UTC month."""
+    if override:
+        datetime.strptime(override, "%Y-%m")
+        return override
+    today = datetime.now(timezone.utc).date()
+    previous_month_end = today.replace(day=1) - timedelta(days=1)
+    return previous_month_end.strftime("%Y-%m")
+
+
+def month_dates(month: str) -> tuple[str, str]:
+    year, month_number = (int(part) for part in month.split("-"))
+    final_day = calendar.monthrange(year, month_number)[1]
+    return f"{month}-01", f"{month}-{final_day:02d}"
+
+
+def read_daily_summaries(month: str, repo_root: Optional[str] = None) -> List[Dict]:
+    """Read valid canonical daily summaries for a calendar month."""
+    root = Path(repo_root or get_repo_root())
+    daily_root = root / DAILY_REL_DIR
+    summaries = []
+    for path in sorted(daily_root.glob(f"{month}-*/summary.json")):
+        try:
+            summary = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as error:
+            print(f"  Warning: skipping malformed daily summary {path}: {error}")
+            continue
+        if str(summary.get("date") or "").startswith(month):
+            summaries.append(summary)
+    return summaries
+
+
+def generate_digest(
+    daily_summaries: List[Dict], month: str, token: str
+) -> Optional[Dict]:
+    """Synthesize canonical daily summaries into one monthly digest."""
+    system_prompt = load_prompt("monthly")
+    context = [
+        {
+            "date": summary.get("date"),
+            "title": summary.get("title"),
+            "summary": summary.get("summary"),
+            "pr_count": summary.get("pr_count", 0),
+        }
+        for summary in daily_summaries
+    ]
+    pr_count = sum(int(summary.get("pr_count") or 0) for summary in daily_summaries)
+    user_prompt = (
+        f"Month: {month}\n"
+        f"Merged PRs: {pr_count}\n"
+        f"Active days: {len(daily_summaries)}\n\n"
+        f"Canonical daily summaries:\n{json.dumps(context, indent=2, ensure_ascii=False)}"
+    )
+    response = call_pollinations_api(
+        system_prompt, user_prompt, token, temperature=0.3
+    )
+    return parse_json_response(response) if response else None
+
+
+def build_monthly_summary_artifact(
+    digest: Dict,
+    daily_summaries: List[Dict],
+    month: str,
+    generated_at: str,
+) -> Dict:
+    """Build the canonical summary stored in the monthly news archive."""
+    period_start, period_end = month_dates(month)
+    arcs = digest.get("arcs") or []
+    theme = str(digest.get("theme") or "").strip()
+    headline = next(
+        (
+            str(arc.get("headline") or "").strip()
+            for arc in arcs
+            if str(arc.get("headline") or "").strip()
+        ),
+        "",
+    )
+    title = headline or theme or datetime.strptime(month, "%Y-%m").strftime("%B %Y")
+    arc_summaries = [
+        str(arc.get("summary") or "").strip()
+        for arc in arcs[:4]
+        if str(arc.get("summary") or "").strip()
+    ]
+    summary_text = join_summary_parts(
+        ([theme] if theme and theme != title else []) + arc_summaries
+    )
+
+    prs = []
+    for daily in daily_summaries:
+        prs.extend(daily.get("prs") or [])
+
+    return build_canonical_summary(
+        date=period_end,
+        period_start=period_start,
+        period_end=period_end,
+        title=title,
+        summary=summary_text or theme or title,
+        prs=prs,
+        generated_at=generated_at,
+    )
+
+
+def monthly_image_context() -> str:
+    prompt = load_prompt("monthly")
+    marker = "## Monthly Image Identity"
+    index = prompt.find(marker)
+    return f"\n\n{prompt[index:]}" if index != -1 else ""
+
+
+def generate_monthly_artifacts(
+    month: str, daily_summaries: List[Dict], token: str
+) -> tuple[Dict, bytes]:
+    """Generate the canonical summary and one cover image for a month."""
+    digest = generate_digest(daily_summaries, month, token)
+    if not digest:
+        raise RuntimeError(f"monthly summary generation failed for {month}")
+
+    cover_plan = generate_platform_post(
+        "twitter",
+        digest,
+        token,
+        "Create the visual concept for this monthly website build-diary cover. The post text is not published; focus on image_prompt.",
+        temperature=0.7,
+        extra_context=monthly_image_context(),
+    )
+    image_prompt = str((cover_plan or {}).get("image_prompt") or "").strip()
+    if not image_prompt:
+        raise RuntimeError(f"monthly image prompt generation failed for {month}")
+
+    image_bytes, _ = generate_image(image_prompt, token, IMAGE_SIZE, IMAGE_SIZE)
+    if not image_bytes:
+        raise RuntimeError(f"monthly cover generation failed for {month}")
+
+    generated_at = datetime.now(timezone.utc).isoformat()
+    summary = build_monthly_summary_artifact(
+        digest, daily_summaries, month, generated_at
+    )
+    return summary, image_bytes
+
+
+def main() -> None:
+    print("=== Monthly Build Diary Generator ===")
+    github_token = get_env("GITHUB_TOKEN")
+    pollinations_token = get_env("POLLINATIONS_TOKEN")
+    owner, repo = get_env("GITHUB_REPOSITORY").split("/")
+    month = get_target_month(get_env("TARGET_MONTH", required=False))
+    print(f"  Month: {month}")
+
+    daily_summaries = read_daily_summaries(month)
+    if not daily_summaries:
+        print(f"  No daily summaries found for {month}. Skipping.")
+        return
+    print(f"  Found {len(daily_summaries)} active days")
+
+    summary, image_bytes = generate_monthly_artifacts(
+        month, daily_summaries, pollinations_token
+    )
+    base_path = f"{MONTHLY_REL_DIR}/{month}"
+    image_url = commit_image_to_branch(
+        image_bytes,
+        f"{base_path}/images/cover.jpg",
+        GISTS_BRANCH,
+        github_token,
+        owner,
+        repo,
+    )
+    if not image_url:
+        print("  FATAL: monthly cover commit failed")
+        sys.exit(1)
+
+    commit_files_to_branch(
+        [(f"{base_path}/summary.json", summary)],
+        GISTS_BRANCH,
+        github_token,
+        owner,
+        repo,
+        label=f"for monthly build diary {month}",
+    )
+    print(f"  Committed monthly build diary for {month} to {GISTS_BRANCH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/operations/social/scripts/generate_weekly.py
+++ b/operations/social/scripts/generate_weekly.py
@@ -42,11 +42,12 @@ from common import (
     commit_files_to_branch,
     GISTS_BRANCH,
     IMAGE_SIZE,
+    NEWS_REL_DIR,
 )
 
 # ── Constants ────────────────────────────────────────────────────────
 
-WEEKLY_REL_DIR = "operations/social/news/weekly"
+WEEKLY_REL_DIR = f"{NEWS_REL_DIR}/weekly"
 
 def _weekly_image_context() -> str:
     """Load weekly image identity from weekly.md (everything after '## Weekly Image Identity')."""

--- a/operations/social/scripts/publish_daily.py
+++ b/operations/social/scripts/publish_daily.py
@@ -18,6 +18,7 @@ from datetime import datetime, timezone, timedelta
 from common import (
     deploy_reddit_news_post,
     get_env,
+    NEWS_REL_DIR,
 )
 from buffer_publish import publish_twitter_post, stage_buffer_posts
 
@@ -43,7 +44,7 @@ def main():
 
     owner, repo = repo_full.split("/")
     date_str = get_target_date()
-    daily_dir = os.path.join("social", "news", "daily", date_str)
+    daily_dir = os.path.join(NEWS_REL_DIR, "daily", date_str)
 
     print(f"  Date: {date_str}")
     print(f"  Mode: {publish_mode}")

--- a/operations/social/scripts/publish_weekly.py
+++ b/operations/social/scripts/publish_weekly.py
@@ -28,6 +28,7 @@ from common import (
     deploy_reddit_news_post,
     get_env,
     get_post_image_urls,
+    NEWS_REL_DIR,
     read_news_file,
 )
 
@@ -165,7 +166,7 @@ def main():
     print(f"  Weekly publish date: {weekly_date}")
     print(f"  Mode: {publish_mode}")
 
-    weekly_dir = os.path.join("social", "news", "weekly", weekly_date)
+    weekly_dir = os.path.join(NEWS_REL_DIR, "weekly", weekly_date)
     results = {}
 
     # ── Buffer staging (Twitter + LinkedIn + Instagram) ───────────

--- a/packages/ui/src/compositions/Alert.tsx
+++ b/packages/ui/src/compositions/Alert.tsx
@@ -10,7 +10,7 @@ const intentClasses: Record<AlertIntent, string> = {
     danger: "polli:bg-intent-danger-bg-light polli:text-intent-danger-text",
 };
 
-export type AlertProps = ComponentPropsWithoutRef<"div"> & {
+export type AlertProps = Omit<ComponentPropsWithoutRef<"div">, "title"> & {
     intent?: AlertIntent;
     title?: ReactNode;
 };

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -55,6 +55,10 @@ export {
     periodBucketKeyToDate,
 } from "./lib/period.ts";
 export { useScrollLock } from "./lib/use-scroll-lock.ts";
+export {
+    AccountMenu,
+    type AccountMenuProps,
+} from "./modules/account-menu/AccountMenu.tsx";
 export { Button, type ButtonProps } from "./primitives/Button.tsx";
 export {
     ButtonGroup,

--- a/packages/ui/src/modules/account-menu/AccountMenu.tsx
+++ b/packages/ui/src/modules/account-menu/AccountMenu.tsx
@@ -1,0 +1,89 @@
+import { cn } from "../../lib/cn.ts";
+import { ChevronIcon } from "../../primitives/ChevronIcon.tsx";
+import { Dropdown } from "../../primitives/Dropdown.tsx";
+import { DropdownItem } from "../../primitives/DropdownItem.tsx";
+import { SignOutIcon } from "../../primitives/icons/index.tsx";
+
+export type AccountMenuProps = {
+    name: string;
+    avatarUrl?: string | null;
+    onSignOut: () => void;
+    className?: string;
+    side?: "top" | "bottom";
+    menuLabel?: string;
+    signOutLabel?: string;
+};
+
+function initials(name: string) {
+    const parts = name.trim().split(/\s+/).filter(Boolean);
+    if (parts.length === 0) return "?";
+    if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+    return `${parts[0][0] ?? ""}${parts.at(-1)?.[0] ?? ""}`.toUpperCase();
+}
+
+export function AccountMenu({
+    name,
+    avatarUrl,
+    onSignOut,
+    className,
+    side = "bottom",
+    menuLabel = "Account menu",
+    signOutLabel = "Sign Out",
+}: AccountMenuProps) {
+    return (
+        <Dropdown
+            align="end"
+            side={side}
+            className="polli:w-[var(--reference-width)] polli:min-w-48 polli:p-1"
+            trigger={(open) => (
+                <button
+                    type="button"
+                    data-theme="accent"
+                    aria-label={menuLabel}
+                    className={cn(
+                        "polli-control polli:flex polli:min-w-0 polli:items-center polli:gap-2 polli:rounded-full polli:bg-theme-bg-active polli:p-1 polli:pr-3 polli:text-theme-text-strong polli:transition-colors polli:hover:bg-theme-bg-hover",
+                        className,
+                    )}
+                >
+                    {avatarUrl ? (
+                        <img
+                            src={avatarUrl}
+                            alt=""
+                            className="polli:h-8 polli:w-8 polli:shrink-0 polli:rounded-full polli:object-cover"
+                        />
+                    ) : (
+                        <span
+                            role="img"
+                            aria-label={`${name} avatar`}
+                            className="polli:flex polli:h-8 polli:w-8 polli:shrink-0 polli:items-center polli:justify-center polli:rounded-full polli:bg-theme-bg-pale polli:text-xs polli:font-semibold polli:text-theme-text-strong"
+                        >
+                            {initials(name)}
+                        </span>
+                    )}
+                    <span className="polli:min-w-0 polli:flex-1 polli:truncate polli:text-left polli:text-sm polli:font-medium">
+                        {name}
+                    </span>
+                    <ChevronIcon
+                        expanded={open}
+                        className="polli:ml-auto polli:h-4 polli:w-4 polli:text-theme-text-strong"
+                    />
+                </button>
+            )}
+        >
+            {(close) => (
+                <DropdownItem
+                    onClick={() => {
+                        close();
+                        onSignOut();
+                    }}
+                >
+                    <SignOutIcon
+                        className="polli:h-4 polli:w-4 polli:shrink-0"
+                        aria-hidden="true"
+                    />
+                    {signOutLabel}
+                </DropdownItem>
+            )}
+        </Dropdown>
+    );
+}

--- a/packages/ui/src/primitives/Dropdown.tsx
+++ b/packages/ui/src/primitives/Dropdown.tsx
@@ -13,6 +13,7 @@ export type DropdownProps = {
     children: ReactNode | ((close: () => void) => ReactNode);
     /** Panel placement relative to the trigger. */
     align?: "start" | "end";
+    side?: "top" | "bottom";
     /** Controlled open state. Omit to let the Dropdown manage its own. */
     open?: boolean;
     onOpenChange?: (open: boolean) => void;
@@ -24,6 +25,7 @@ export const Dropdown: FC<DropdownProps> = ({
     trigger,
     children,
     align = "start",
+    side = "bottom",
     open: openProp,
     onOpenChange,
     className,
@@ -42,7 +44,7 @@ export const Dropdown: FC<DropdownProps> = ({
             open={open}
             onOpenChange={(details) => setOpen(details.open)}
             positioning={{
-                placement: align === "end" ? "bottom-end" : "bottom-start",
+                placement: `${side}-${align}`,
             }}
         >
             <Popover.Trigger asChild>{trigger(open)}</Popover.Trigger>


### PR DESCRIPTION
- Promotes the five reviewed commits currently on `main`.
- Fixes managed-agent compatibility with caller tool metadata and unsupported social text seeds.
- Adds the shared account menu and refines the zero-Pollen authorization notice.
- Restores weekly news publishing and adds monthly news generation.
- All source PR checks passed; no Tinybird definitions changed.