### PR TITLE
fix: restore Polli generation and visual tools

### DIFF
--- a/apps/polli/src/ai/client.py
+++ b/apps/polli/src/ai/client.py
@@ -84,7 +84,6 @@ from .prompts import get_tool_system_prompt
 from .tool_filters import (
     filter_admin_actions_from_tools,
     filter_api_tools,
-    filter_tools_by_intent,
     get_tools_with_embeddings,
 )
 from .tools import GITHUB_TOOLS
@@ -362,17 +361,10 @@ class PollinationsClient:
             tool for tool in client_tools if tool.get("function", {}).get("name") not in internal_tool_names
         ]
         client_tool_names = {tool.get("function", {}).get("name") for tool in client_tools}
-        tools = (
-            filter_tools_by_intent(user_message, all_tools, is_admin or is_collaborator) if user_message else all_tools
-        )
-        tools.extend(client_tools)
+        tools = [*all_tools, *client_tools]
 
-        # Log available tools for debugging
-        all_tool_names = [t["function"]["name"] for t in all_tools]
-        filtered_tool_names = [t["function"]["name"] for t in tools]
-        logger.info(f"Available tools (is_admin={is_admin}): {', '.join(all_tool_names)}")
-        if len(tools) < len(all_tools):
-            logger.info(f"Filtered tools to: {', '.join(filtered_tool_names)}")
+        tool_names = [tool["function"]["name"] for tool in tools]
+        logger.info("Available tools (is_admin=%s): %s", is_admin, ", ".join(tool_names))
 
         all_content_blocks = []
         total_usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}

--- a/apps/polli/src/ai/client.py
+++ b/apps/polli/src/ai/client.py
@@ -725,10 +725,12 @@ class PollinationsClient:
         payload = {
             "model": config.ai.model,
             "messages": messages,
-            "seed": (api_params or {}).get("seed", 42),
             "stream": True,
             "stream_options": {"include_usage": True},
         }
+        explicit_seed = (api_params or {}).get("seed")
+        if explicit_seed is not None:
+            payload["seed"] = explicit_seed
         for key, value in (api_params or {}).items():
             if key not in {"seed", "stream", "stream_options"} and value is not None:
                 payload[key] = value
@@ -832,9 +834,7 @@ class PollinationsClient:
         """Make API call to Pollinations with tool definitions.
 
         Includes:
-        - Random seed parameter (0 to int32 max) for each request
         - 3 retry attempts with 5s delay between retries
-        - New random seed for each retry attempt
         - Pass-through of OpenAI generation params (temperature, max_tokens, etc.)
         """
         # API mode: MUST use the user's passed-through key, never the bot's internal token.
@@ -859,20 +859,15 @@ class PollinationsClient:
 
         current_model = config.ai.model
         for attempt in range(MAX_RETRIES):
-            # Use caller's seed if provided (default 42), otherwise random per attempt
-            caller_seed = (api_params or {}).get("seed") if api_params else None
-            seed = caller_seed if caller_seed is not None else 42
-
             payload = {
                 "model": current_model,
                 "messages": messages,
-                "seed": seed,
             }
 
             # Merge caller-provided OpenAI params (temperature, max_tokens, etc.)
             if api_params:
                 for k, v in api_params.items():
-                    if k != "seed" and v is not None:
+                    if v is not None:
                         payload[k] = v
 
             if tools:
@@ -881,7 +876,7 @@ class PollinationsClient:
 
             try:
                 session = await self.get_session()
-                logger.debug(f"API attempt {attempt + 1}/{MAX_RETRIES} with seed {seed}")
+                logger.debug(f"API attempt {attempt + 1}/{MAX_RETRIES}")
 
                 async with session.post(
                     url,

--- a/apps/polli/src/ai/tool_filters.py
+++ b/apps/polli/src/ai/tool_filters.py
@@ -263,6 +263,7 @@ DEFAULT_TOOLS = {
     "web_search",
     "web_scrape",
     "discord_search",
+    "render_visual",
     "github_overview",
     "github_issue",
 }
@@ -305,7 +306,7 @@ def filter_tools_by_intent(user_message: str, all_tools: list[dict], is_admin: b
             matched_tools.add("github_pr")
 
     # Always include these tools - AI decides when to use them
-    AI_CONTROLLED_TOOLS = {"web_search", "code_search", "discord_search"}
+    AI_CONTROLLED_TOOLS = {"web_search", "code_search", "discord_search", "render_visual"}
 
     # Filter tools list
     filtered = [

--- a/apps/polli/tests/test_judgment_and_discord_tool.py
+++ b/apps/polli/tests/test_judgment_and_discord_tool.py
@@ -2,6 +2,7 @@ import inspect
 import unittest
 
 from src.ai.prompts import BASE_SYSTEM_PROMPT, DISCORD_PROMPT_ADDON
+from src.ai.tool_filters import filter_tools_by_intent
 from src.ai.tools import DISCORD_SEARCH_TOOL, RENDER_VISUAL_TOOL
 from src.bot import format_discord_identity
 from src.discord.search import tool_discord_search
@@ -47,6 +48,11 @@ class DiscordToolContractTests(unittest.TestCase):
 
         self.assertIn("Discord does not render Mermaid fences", description)
         self.assertNotIn("rendered inline automatically", description)
+
+    def test_render_capability_question_keeps_visual_tool(self):
+        filtered = filter_tools_by_intent("what all can you render?", [RENDER_VISUAL_TOOL])
+
+        self.assertEqual(filtered, [RENDER_VISUAL_TOOL])
 
 
 if __name__ == "__main__":

--- a/apps/polli/tests/test_openai_api.py
+++ b/apps/polli/tests/test_openai_api.py
@@ -273,7 +273,6 @@ class StreamingClientTests(unittest.IsolatedAsyncioTestCase):
                 return_value=[{"type": "function", "function": {"name": "internal"}}],
             ),
             patch("src.ai.client.filter_api_tools", side_effect=lambda tools: tools),
-            patch("src.ai.client.filter_tools_by_intent", side_effect=lambda _message, tools, _admin: tools),
         ):
             events = [
                 event
@@ -311,7 +310,6 @@ class StreamingClientTests(unittest.IsolatedAsyncioTestCase):
             patch.object(client, "_call_api_with_tools", upstream),
             patch("src.ai.client.get_tools_with_embeddings", return_value=[]),
             patch("src.ai.client.filter_api_tools", side_effect=lambda tools: tools),
-            patch("src.ai.client.filter_tools_by_intent", side_effect=lambda _message, tools, _admin: tools),
         ):
             result = await client.process_with_tools(
                 user_message="weather",

--- a/apps/polli/tests/test_openai_api.py
+++ b/apps/polli/tests/test_openai_api.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import unittest
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi.testclient import TestClient
 
@@ -202,7 +202,45 @@ class OpenAIAPITests(unittest.TestCase):
         self.assertEqual(added["item"]["id"], completed["response"]["output"][0]["id"])
 
 
+class FakeHTTPResponse:
+    status = 200
+
+    def __init__(self, payload):
+        self.payload = payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return None
+
+    async def json(self):
+        return self.payload
+
+
 class StreamingClientTests(unittest.IsolatedAsyncioTestCase):
+    async def test_buffered_request_omits_seed_by_default(self):
+        client = PollinationsClient()
+        response = FakeHTTPResponse({"choices": [{"message": {"content": "ok", "tool_calls": []}}], "usage": {}})
+        session = SimpleNamespace(post=MagicMock(return_value=response))
+        client.get_session = AsyncMock(return_value=session)
+
+        await client._call_api_with_tools([{"role": "user", "content": "hi"}])
+
+        payload = session.post.call_args.kwargs["json"]
+        self.assertNotIn("seed", payload)
+
+    async def test_buffered_request_preserves_explicit_seed(self):
+        client = PollinationsClient()
+        response = FakeHTTPResponse({"choices": [{"message": {"content": "ok", "tool_calls": []}}], "usage": {}})
+        session = SimpleNamespace(post=MagicMock(return_value=response))
+        client.get_session = AsyncMock(return_value=session)
+
+        await client._call_api_with_tools([{"role": "user", "content": "hi"}], api_params={"seed": 7})
+
+        payload = session.post.call_args.kwargs["json"]
+        self.assertEqual(payload["seed"], 7)
+
     async def test_internal_tool_round_content_is_not_streamed(self):
         client = PollinationsClient()
         client.register_tool_handler("internal", AsyncMock(return_value={"ok": True}))


### PR DESCRIPTION
- Stops injecting a default `seed` into Polli requests while preserving explicitly requested seeds.
- Exposes every role-permitted tool on Discord and every API-safe tool through the public API.
- Keeps role and API safety filtering intact while removing fragile keyword-based tool selection.
- Adds regression coverage for model payloads and visual-tool availability.