### PR TITLE
feat: add GPT-6 Astra

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -1925,6 +1925,28 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.00000375,
     },
   },
+  "openai/gpt-6-astra": {
+    "cost": {
+      "completionTextTokens": 0.00005,
+      "promptCacheWriteTokens": 0.0000125,
+      "promptCachedTokens": 0.000001,
+      "promptTextTokens": 0.00001,
+    },
+    "costVariants": {
+      "long_context": {
+        "completionTextTokens": 0.000075,
+        "promptCacheWriteTokens": 0.000025,
+        "promptCachedTokens": 0.000002,
+        "promptTextTokens": 0.00002,
+      },
+    },
+    "price": {
+      "completionTextTokens": 0.0000375,
+      "promptCacheWriteTokens": 0.000009375,
+      "promptCachedTokens": 0.00000075,
+      "promptTextTokens": 0.0000075,
+    },
+  },
   "p-image": {
     "cost": {
       "completionImageTokens": 0.005,

--- a/enter.pollinations.ai/test/cost-variants.test.ts
+++ b/enter.pollinations.ai/test/cost-variants.test.ts
@@ -49,6 +49,7 @@ describe("long-context cost variants", () => {
         ["gpt-5.6-sol", 272_000],
         ["gpt-5.6-terra", 272_000],
         ["gpt-5.6-luna", 272_000],
+        ["openai/gpt-6-astra", 272_000],
     ] satisfies [
         ModelName,
         number,
@@ -254,6 +255,7 @@ describe("long-context cost variants", () => {
         ["gpt-5.6-sol", 10, 1, 12.5, 45, 1 / 3],
         ["gpt-5.6-terra", 4, 0.4, 5, 18, 0.75],
         ["gpt-5.6-luna", 0.4, 0.04, 0.5, 1.8, 0.75],
+        ["openai/gpt-6-astra", 20, 2, 25, 75, 0.75],
     ] satisfies [
         ModelName,
         number,

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -103,6 +103,11 @@ const models: ModelDefinition[] = [
         useResponsesApi: true,
     },
     {
+        name: "openai/gpt-6-astra",
+        config: portkeyConfig["gpt-6-astra"],
+        useResponsesApi: true,
+    },
+    {
         name: "mercury",
         config: portkeyConfig["mercury-2"],
         transform: stripReasoning,

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -122,6 +122,11 @@ export const portkeyConfig: PortkeyConfigMap = {
             textEnvironmentValue("AZURE_MYCELI_PROD_API_KEY"),
             "https://myceli-prod-eastus.openai.azure.com/openai/deployments/gpt-5.6-luna/chat/completions?api-version=2025-04-01-preview",
         ),
+    "gpt-6-astra": () =>
+        createAzureResponsesModelConfig(
+            textEnvironmentValue("AZURE_MYCELI_PROD_API_KEY"),
+            "https://myceli-prod-eastus.openai.azure.com/openai/deployments/gpt-6-astra/chat/completions?api-version=2025-04-01-preview",
+        ),
 
     // -- Azure (Myceli Prod — swedencentral, audio mini) ------------------------
     "gpt-audio-mini-2025-12-15": () =>

--- a/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
+++ b/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
@@ -46,6 +46,22 @@ describe("resolveModelConfig", () => {
         expect(result.options.model).toBe("global.anthropic.claude-opus-5");
     });
 
+    it.each([
+        "openai/gpt-6-astra",
+        "gpt-6-astra",
+    ])("routes %s to the direct Azure Responses deployment", (model) => {
+        const result = resolveModelConfig(messages, { model });
+
+        expect(result.options.model).toBe("gpt-6-astra");
+        expect(result.options.modelConfig).toMatchObject({
+            provider: "azure-openai",
+            "azure-deployment-id": "gpt-6-astra",
+            responsesEndpoint:
+                "https://myceli-prod-eastus.openai.azure.com/openai/v1/responses",
+        });
+        expect(result.options.provider).toBeUndefined();
+    });
+
     it("routes Claude Fable 5.1 to its global profile", () => {
         expect(
             resolveModelConfig(messages, {

--- a/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
+++ b/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
@@ -46,11 +46,10 @@ describe("resolveModelConfig", () => {
         expect(result.options.model).toBe("global.anthropic.claude-opus-5");
     });
 
-    it.each([
-        "openai/gpt-6-astra",
-        "gpt-6-astra",
-    ])("routes %s to the direct Azure Responses deployment", (model) => {
-        const result = resolveModelConfig(messages, { model });
+    it("routes openai/gpt-6-astra to the direct Azure Responses deployment", () => {
+        const result = resolveModelConfig(messages, {
+            model: "openai/gpt-6-astra",
+        });
 
         expect(result.options.model).toBe("gpt-6-astra");
         expect(result.options.modelConfig).toMatchObject({
@@ -60,6 +59,12 @@ describe("resolveModelConfig", () => {
                 "https://myceli-prod-eastus.openai.azure.com/openai/v1/responses",
         });
         expect(result.options.provider).toBeUndefined();
+    });
+
+    it("does not expose gpt-6-astra as an alias", () => {
+        expect(() =>
+            resolveModelConfig(messages, { model: "gpt-6-astra" }),
+        ).toThrow("Model configuration not found for: gpt-6-astra");
     });
 
     it("routes Claude Fable 5.1 to its global profile", () => {

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -354,6 +354,49 @@ const TEXT_BASE_SERVICES = {
         contextLength: 1050000,
         isSpecialized: false,
     },
+    "openai/gpt-6-astra": {
+        aliases: ["gpt-6-astra"],
+        provider: "azure",
+        brand: "OpenAI",
+        category: "text",
+        addedDate: new Date("2026-09-04").getTime(),
+        priceMultiplier: 0.75,
+        cost: {
+            promptTextTokens: perMillion(10.0),
+            promptCachedTokens: perMillion(1.0),
+            promptCacheWriteTokens: perMillion(12.5),
+            completionTextTokens: perMillion(50.0),
+        },
+        ...defineCostVariants(
+            {
+                long_context: {
+                    promptTextTokens: perMillion(20.0),
+                    promptCachedTokens: perMillion(2.0),
+                    promptCacheWriteTokens: perMillion(25.0),
+                    completionTextTokens: perMillion(75.0),
+                },
+            },
+            longContextAbove(272_000),
+            {
+                long_context: {
+                    label: "Long context (>272K)",
+                    description:
+                        "More than 272,000 prompt tokens; the higher rates apply to the full request.",
+                },
+            },
+            "≤272K context",
+        ),
+        title: "GPT-6 Astra",
+        description:
+            "Frontier reasoning for complex agentic, coding, and multimodal work",
+        inputModalities: ["text", "image"],
+        outputModalities: ["text"],
+        maxReferenceImages: 10,
+        tools: true,
+        reasoning: true,
+        contextLength: 1050000,
+        isSpecialized: false,
+    },
     "mercury": {
         aliases: [
             "mercury-2",

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -355,7 +355,7 @@ const TEXT_BASE_SERVICES = {
         isSpecialized: false,
     },
     "openai/gpt-6-astra": {
-        aliases: ["gpt-6-astra"],
+        aliases: [],
         provider: "azure",
         brand: "OpenAI",
         category: "text",


### PR DESCRIPTION
- Adds the approved contract: canonical `openai/gpt-6-astra`, no aliases, multiplier `0.75`, Quest-Pollen access, and no fallback. The internal Azure deployment remains `gpt-6-astra`.
- Routes to Azure Global model version `2026-09-03` with 15M TPM. The same-version `gpt-6-astra-datazone` deployment is the best fallback candidate (5M TPM), but remains reserved and unconfigured under the approved single-route decision.
- Uses [Microsoft’s published Global pricing](https://azure.microsoft.com/en-us/blog/gpt-6-astra-frontier-intelligence-for-work-now-available-in-microsoft-foundry/): $10/$1/$12.50/$50 per million tokens, then $20/$2/$25/$75 above 272K. Azure Retail Prices API meters are not published yet; recheck Cost Management after first billed usage.
- Live adapter checks passed text, tools, structured output, vision, streaming, unsupported-parameter errors, and a 30-request burst with zero failures. Prompt caching reported `cache_write_tokens: 3208`, then `cached_tokens: 3208`.
- Adds canonical-only routing, alias rejection, strict-boundary, and effective-price snapshot coverage. Latest focused tests pass: Enter 537, Gen 55; Gen typecheck and Biome are clean. Full wallet/output-cache/Tinybird E2E awaits an existing local test token.