### PR TITLE
fix: add curated request bodies for responses and integrations docs examples

### DIFF
--- a/gen.pollinations.ai/scripts/generate-apidocs.ts
+++ b/gen.pollinations.ai/scripts/generate-apidocs.ts
@@ -948,6 +948,10 @@ const CURATED_BODIES: Record<string, Json> = {
         model: "openai",
         messages: [{ role: "user", content: "Hello!" }],
     },
+    postV1Responses: {
+        model: "openai",
+        input: "Hello!",
+    },
     postV1ImagesGenerations: {
         prompt: "a serene mountain landscape at sunset",
         model: "flux",
@@ -1008,6 +1012,9 @@ const CURATED_BODIES: Record<string, Json> = {
         systemPrompt: "You are a concise assistant.",
         baseModel: "openai",
         mcpServers: ["pollinations"],
+    },
+    postAccountIntegrations: {
+        toolkit: "github",
     },
     post3dByPrompt: {
         model: "hyper3d-rodin",


### PR DESCRIPTION
The Docs / Regenerate API reference workflow has failed since #14449 and the Connect App route went live (https://github.com/pollinations/pollinations/actions/runs/33920656829). Validation rejects the regenerated file because two POST examples have no body, so no docs PR is created.

- Adds `postV1Responses` and `postAccountIntegrations` to `CURATED_BODIES` in `gen.pollinations.ai/scripts/generate-apidocs.ts`
- `pickExample` cannot synthesize plain `string` fields, and both schemas' only required field is one (`input` string|array, `toolkit` string); compact mode also skips the optional `model` default
- Values mirror existing usage: `openai` advertises `/v1/responses`; `github` is the toolkit slug the integrations tests use
- Verified locally: `docs:generate` then `docs:validate` passes; `APIDOCS.md` is intentionally not included, the workflow regenerates it after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)