### PR TITLE
refactor: share CLI harness lifecycle helpers

### DIFF
--- a/packages/polli-cli/src/harnesses/dsh.ts
+++ b/packages/polli-cli/src/harnesses/dsh.ts
@@ -1,4 +1,4 @@
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 import { parseEnv } from "node:util";
 import { isMap, isSeq, parseDocument, Scalar } from "yaml";
 import polliSkill from "../../SKILL.md?raw";
@@ -7,15 +7,12 @@ import {
     commandExists,
     readTextIfExists,
     removeIfExists,
+    resolveHomePath,
     writeTextAtomic,
 } from "./fs.js";
 import { resolveHarnessKey } from "./keys.js";
 import { fetchHarnessModels } from "./models.js";
-import {
-    applyWithSnapshot,
-    clearSnapshot,
-    restoreSnapshot,
-} from "./snapshot.js";
+import { applyWithSnapshot, restoreOrStrip } from "./snapshot.js";
 import type {
     HarnessAdapter,
     HarnessContext,
@@ -42,13 +39,7 @@ const JS_TAG = {
 export const dshHome = (ctx: HarnessContext) => {
     const configured = ctx.env.DSH_HOME;
     if (!configured?.trim()) return join(ctx.home, ".dsh");
-    const expanded =
-        configured === "~"
-            ? ctx.home
-            : configured.startsWith("~/") || configured.startsWith("~\\")
-              ? join(ctx.home, configured.slice(2))
-              : configured;
-    return resolve(expanded);
+    return resolveHomePath(ctx.home, configured);
 };
 const settingsPath = (ctx: HarnessContext) =>
     join(dshHome(ctx), "settings.yaml");
@@ -277,12 +268,7 @@ export const configureDsh = (
 };
 
 export const disableDsh = (ctx: HarnessContext): HarnessResult => {
-    const managedFiles = files(ctx);
-    let outcome: HarnessResult["outcome"] = "restored";
-    if (restoreSnapshot(ctx, ID, managedFiles) !== "restored") {
-        outcome = stripConfig(ctx) ? "stripped" : "unchanged";
-        clearSnapshot(ctx, ID, managedFiles);
-    }
+    const outcome = restoreOrStrip(ctx, ID, files(ctx), () => stripConfig(ctx));
     return { ...result(ctx), configured: false, outcome };
 };
 
@@ -300,12 +286,7 @@ export const dsh: HarnessAdapter = {
             );
         }
         const model = options.model ?? DEFAULT_MODEL;
-        const models = await fetchHarnessModels();
-        if (!models.some((candidate) => candidate.id === model)) {
-            throw new Error(
-                `Model "${model}" is not a tool-calling text model. Run: polli models`,
-            );
-        }
+        const models = await fetchHarnessModels(model);
 
         const apiKey = await resolveHarnessKey(
             { id: ID, label: LABEL, existingKey: readKey(ctx) },

--- a/packages/polli-cli/src/harnesses/fs.test.ts
+++ b/packages/polli-cli/src/harnesses/fs.test.ts
@@ -1,0 +1,23 @@
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveHomePath } from "./fs.js";
+
+describe("harness home paths", () => {
+    const home = resolve("test-home");
+
+    it.each([
+        ["~", home],
+        ["~/agent", join(home, "agent")],
+        ["~\\agent", join(home, "agent")],
+        ["~/agent/../config", join(home, "config")],
+        ["agent", resolve("agent")],
+        [home, home],
+        ["~other/agent", resolve("~other/agent")],
+        [" ~/agent ", resolve(" ~/agent ")],
+    ])(
+        "resolves %s without changing caller whitespace rules",
+        (path, expected) => {
+            expect(resolveHomePath(home, path)).toBe(expected);
+        },
+    );
+});

--- a/packages/polli-cli/src/harnesses/fs.test.ts
+++ b/packages/polli-cli/src/harnesses/fs.test.ts
@@ -14,10 +14,7 @@ describe("harness home paths", () => {
         [home, home],
         ["~other/agent", resolve("~other/agent")],
         [" ~/agent ", resolve(" ~/agent ")],
-    ])(
-        "resolves %s without changing caller whitespace rules",
-        (path, expected) => {
-            expect(resolveHomePath(home, path)).toBe(expected);
-        },
-    );
+    ])("resolves %s without changing caller whitespace rules", (path, expected) => {
+        expect(resolveHomePath(home, path)).toBe(expected);
+    });
 });

--- a/packages/polli-cli/src/harnesses/fs.ts
+++ b/packages/polli-cli/src/harnesses/fs.ts
@@ -9,7 +9,17 @@ import {
     unlinkSync,
     writeFileSync,
 } from "node:fs";
-import { basename, delimiter, dirname, join } from "node:path";
+import { basename, delimiter, dirname, join, resolve } from "node:path";
+
+/** Resolve a configured path, expanding only the current user's tilde. */
+export const resolveHomePath = (home: string, path: string) =>
+    resolve(
+        path === "~"
+            ? home
+            : path.startsWith("~/") || path.startsWith("~\\")
+              ? join(home, path.slice(2))
+              : path,
+    );
 
 const isExecutable = (path: string) => {
     try {

--- a/packages/polli-cli/src/harnesses/keys.test.ts
+++ b/packages/polli-cli/src/harnesses/keys.test.ts
@@ -93,7 +93,7 @@ describe("harness keys", () => {
 
 describe("harness models", () => {
     it("only includes models supporting chat completions", async () => {
-        await expect(fetchHarnessModels()).resolves.toEqual([
+        await expect(fetchHarnessModels("chat")).resolves.toEqual([
             { id: "chat", contextWindow: 100, input: ["text"] },
             {
                 id: "publisher/chat",
@@ -102,4 +102,13 @@ describe("harness models", () => {
             },
         ]);
     });
+
+    it.each(["missing", "realtime", "owner/community-chat"])(
+        "rejects an unavailable harness model: %s",
+        async (model) => {
+            await expect(fetchHarnessModels(model)).rejects.toThrow(
+                `Model "${model}" is not a tool-calling text model. Run: polli models`,
+            );
+        },
+    );
 });

--- a/packages/polli-cli/src/harnesses/keys.test.ts
+++ b/packages/polli-cli/src/harnesses/keys.test.ts
@@ -103,12 +103,13 @@ describe("harness models", () => {
         ]);
     });
 
-    it.each(["missing", "realtime", "owner/community-chat"])(
-        "rejects an unavailable harness model: %s",
-        async (model) => {
-            await expect(fetchHarnessModels(model)).rejects.toThrow(
-                `Model "${model}" is not a tool-calling text model. Run: polli models`,
-            );
-        },
-    );
+    it.each([
+        "missing",
+        "realtime",
+        "owner/community-chat",
+    ])("rejects an unavailable harness model: %s", async (model) => {
+        await expect(fetchHarnessModels(model)).rejects.toThrow(
+            `Model "${model}" is not a tool-calling text model. Run: polli models`,
+        );
+    });
 });

--- a/packages/polli-cli/src/harnesses/models.ts
+++ b/packages/polli-cli/src/harnesses/models.ts
@@ -17,9 +17,11 @@ interface CatalogModel {
  * drive. Community models and published agents are left out:
  * they come and go, and they would triple the list.
  */
-export const fetchHarnessModels = async (): Promise<HarnessModel[]> => {
+export const fetchHarnessModels = async (
+    selectedModel: string,
+): Promise<HarnessModel[]> => {
     const { data } = await gen<{ data: CatalogModel[] }>("/v1/models");
-    return data
+    const models = data
         .filter(
             (m) =>
                 m.tools === true &&
@@ -36,4 +38,10 @@ export const fetchHarnessModels = async (): Promise<HarnessModel[]> => {
                 (modality) => modality === "text" || modality === "image",
             ),
         }));
+    if (!models.some((model) => model.id === selectedModel)) {
+        throw new Error(
+            `Model "${selectedModel}" is not a tool-calling text model. Run: polli models`,
+        );
+    }
+    return models;
 };

--- a/packages/polli-cli/src/harnesses/openclaw.ts
+++ b/packages/polli-cli/src/harnesses/openclaw.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 import JSON5 from "json5";
 import polliSkill from "../../SKILL.md?raw";
 import { BASE_URL } from "../lib/config.js";
@@ -7,15 +7,12 @@ import {
     commandExists,
     readTextIfExists,
     removeIfExists,
+    resolveHomePath,
     writeTextAtomic,
 } from "./fs.js";
 import { resolveHarnessKey } from "./keys.js";
 import { fetchHarnessModels } from "./models.js";
-import {
-    applyWithSnapshot,
-    clearSnapshot,
-    restoreSnapshot,
-} from "./snapshot.js";
+import { applyWithSnapshot, restoreOrStrip } from "./snapshot.js";
 import type {
     HarnessAdapter,
     HarnessContext,
@@ -31,26 +28,19 @@ const DEFAULT_MODEL = "kimi";
 // matching OpenClaw's own config-level variable substitution.
 const KEY_ENV = "POLLI_OPENCLAW_API_KEY";
 
-const expandTilde = (ctx: HarnessContext, value: string) =>
-    value === "~"
-        ? ctx.home
-        : value.startsWith("~/") || value.startsWith("~\\")
-          ? join(ctx.home, value.slice(2))
-          : value;
-
 /** OPENCLAW_STATE_DIR wins; otherwise OPENCLAW_HOME relocates the home. */
 export const openclawStateDir = (ctx: HarnessContext) => {
     const stateDir = ctx.env.OPENCLAW_STATE_DIR?.trim();
-    if (stateDir) return resolve(expandTilde(ctx, stateDir));
+    if (stateDir) return resolveHomePath(ctx.home, stateDir);
     const home = ctx.env.OPENCLAW_HOME?.trim();
-    return join(home ? resolve(expandTilde(ctx, home)) : ctx.home, ".openclaw");
+    return join(home ? resolveHomePath(ctx.home, home) : ctx.home, ".openclaw");
 };
 
 // The active config path: OPENCLAW_CONFIG_PATH wins, else $STATE_DIR/openclaw.json.
 const configPath = (ctx: HarnessContext) => {
     const override = ctx.env.OPENCLAW_CONFIG_PATH?.trim();
     return override
-        ? resolve(expandTilde(ctx, override))
+        ? resolveHomePath(ctx.home, override)
         : join(openclawStateDir(ctx), "openclaw.json");
 };
 
@@ -214,12 +204,7 @@ export const configureOpenClaw = (
 };
 
 export const disableOpenClaw = (ctx: HarnessContext): HarnessResult => {
-    const managedFiles = files(ctx);
-    let outcome: HarnessResult["outcome"] = "restored";
-    if (restoreSnapshot(ctx, ID, managedFiles) !== "restored") {
-        outcome = stripConfig(ctx) ? "stripped" : "unchanged";
-        clearSnapshot(ctx, ID, managedFiles);
-    }
+    const outcome = restoreOrStrip(ctx, ID, files(ctx), () => stripConfig(ctx));
     return { ...result(ctx), configured: false, outcome };
 };
 
@@ -252,12 +237,7 @@ export const openclaw: HarnessAdapter = {
             );
         }
         const model = options.model ?? DEFAULT_MODEL;
-        const models = await fetchHarnessModels();
-        if (!models.some((candidate) => candidate.id === model)) {
-            throw new Error(
-                `Model "${model}" is not a tool-calling text model. Run: polli models`,
-            );
-        }
+        const models = await fetchHarnessModels(model);
         initializeOpenClaw(ctx);
 
         const apiKey = await resolveHarnessKey(

--- a/packages/polli-cli/src/harnesses/opencode.ts
+++ b/packages/polli-cli/src/harnesses/opencode.ts
@@ -1,17 +1,14 @@
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 import {
     commandExists,
     readTextIfExists,
     removeIfExists,
+    resolveHomePath,
     writeTextAtomic,
 } from "./fs.js";
 import { resolveHarnessKey } from "./keys.js";
 import { fetchHarnessModels } from "./models.js";
-import {
-    applyWithSnapshot,
-    clearSnapshot,
-    restoreSnapshot,
-} from "./snapshot.js";
+import { applyWithSnapshot, restoreOrStrip } from "./snapshot.js";
 import type { HarnessAdapter, HarnessContext, HarnessResult } from "./types.js";
 
 const ID = "opencode";
@@ -35,24 +32,17 @@ const pollinationsConfigDir = (ctx: HarnessContext) => {
     }
     const xdg = ctx.env.XDG_CONFIG_HOME?.trim();
     return join(
-        xdg ? resolve(expandTilde(ctx, xdg)) : join(ctx.home, ".config"),
+        xdg ? resolveHomePath(ctx.home, xdg) : join(ctx.home, ".config"),
         "pollinations",
     );
 };
 
-const expandTilde = (ctx: HarnessContext, path: string) =>
-    path === "~"
-        ? ctx.home
-        : path.startsWith("~/") || path.startsWith("~\\")
-          ? join(ctx.home, path.slice(2))
-          : path;
-
 const opencodeConfigFile = (ctx: HarnessContext) => {
     if (ctx.env.OPENCODE_CONFIG?.trim()) {
-        return resolve(expandTilde(ctx, ctx.env.OPENCODE_CONFIG));
+        return resolveHomePath(ctx.home, ctx.env.OPENCODE_CONFIG);
     }
     const dir = ctx.env.OPENCODE_CONFIG_DIR?.trim()
-        ? resolve(expandTilde(ctx, ctx.env.OPENCODE_CONFIG_DIR))
+        ? resolveHomePath(ctx.home, ctx.env.OPENCODE_CONFIG_DIR)
         : join(ctx.home, ".config", "opencode");
     return join(dir, "opencode.json");
 };
@@ -76,7 +66,7 @@ const readJson = (path: string): Record<string, unknown> | null => {
     }
 };
 
-const writeJson = (ctx: HarnessContext, path: string, data: unknown) =>
+const writeJson = (path: string, data: unknown) =>
     writeTextAtomic(path, `${JSON.stringify(data, null, 2)}\n`, 0o600);
 
 const isPluginEntry = (entry: unknown) =>
@@ -100,14 +90,14 @@ const hasPluginEntry = (config: Record<string, unknown>) => {
 };
 
 const readApiKey = (ctx: HarnessContext): string | null => {
-    const key = (readJson(pluginConfigFile(ctx)) ?? {}).apiKey;
+    const key = readJson(pluginConfigFile(ctx))?.apiKey;
     return typeof key === "string" && key.length > 5 ? key : null;
 };
 
 const writeApiKey = (ctx: HarnessContext, apiKey: string) => {
     const config = readJson(pluginConfigFile(ctx)) ?? {};
     config.apiKey = apiKey;
-    writeJson(ctx, pluginConfigFile(ctx), config);
+    writeJson(pluginConfigFile(ctx), config);
 };
 
 const deleteApiKey = (ctx: HarnessContext) => {
@@ -116,7 +106,7 @@ const deleteApiKey = (ctx: HarnessContext) => {
     if (config === null || config.apiKey === undefined) return false;
     delete config.apiKey;
     if (Object.keys(config).length === 0) removeIfExists(path);
-    else writeJson(ctx, path, config);
+    else writeJson(path, config);
     return true;
 };
 
@@ -141,7 +131,7 @@ const writeOpenCodeConfig = (ctx: HarnessContext, model: string) => {
         config[key] = [...entries, PLUGIN_SPEC];
     }
     config.model = defaultModelRef(model);
-    writeJson(ctx, opencodeConfigFile(ctx), config);
+    writeJson(opencodeConfigFile(ctx), config);
 };
 
 const stripOpenCodeConfig = (ctx: HarnessContext) => {
@@ -164,7 +154,7 @@ const stripOpenCodeConfig = (ctx: HarnessContext) => {
         changed = true;
     }
 
-    if (changed) writeJson(ctx, path, config);
+    if (changed) writeJson(path, config);
     return changed;
 };
 
@@ -210,12 +200,7 @@ export const configureOpenCode = (
 };
 
 export const disableOpenCode = (ctx: HarnessContext): HarnessResult => {
-    const managedFiles = files(ctx);
-    let outcome: HarnessResult["outcome"] = "restored";
-    if (restoreSnapshot(ctx, ID, managedFiles) !== "restored") {
-        outcome = stripConfig(ctx) ? "stripped" : "unchanged";
-        clearSnapshot(ctx, ID, managedFiles);
-    }
+    const outcome = restoreOrStrip(ctx, ID, files(ctx), () => stripConfig(ctx));
     return { ...result(ctx), configured: false, outcome };
 };
 
@@ -238,12 +223,7 @@ export const opencode: HarnessAdapter = {
             );
         }
         const model = options.model ?? DEFAULT_MODEL;
-        const models = await fetchHarnessModels();
-        if (!models.some((candidate) => candidate.id === model)) {
-            throw new Error(
-                `Model "${model}" is not a tool-calling text model. Run: polli models`,
-            );
-        }
+        await fetchHarnessModels(model);
         const apiKey = await resolveHarnessKey(
             {
                 id: ID,

--- a/packages/polli-cli/src/harnesses/pi.test.ts
+++ b/packages/polli-cli/src/harnesses/pi.test.ts
@@ -237,6 +237,38 @@ describe("pi harness", () => {
         expect(pi.status(ctx).configured).toBe(true);
     });
 
+    it("keeps the snapshot when stripping edited config fails", () => {
+        configurePi(ctx, settings);
+        writeFileSync(modelsFile(), "{");
+
+        expect(() => disablePi(ctx)).toThrow();
+        expect(snapshotFiles()).toHaveLength(1);
+        expect(read(modelsFile())).toBe("{");
+        expect(existsSync(authFile())).toBe(true);
+    });
+
+    it("restores an incomplete setup snapshot without checking hashes", () => {
+        mkdirSync(agentDir(), { recursive: true });
+        const original = '{"providers":{}}\n';
+        writeFileSync(modelsFile(), original);
+        configurePi(ctx, settings);
+        const path = join(
+            home,
+            ".pollinations",
+            "harnesses",
+            snapshotFiles()[0],
+        );
+        const snapshot = readJson(path);
+        snapshot.complete = false;
+        writeFileSync(path, JSON.stringify(snapshot));
+        writeFileSync(modelsFile(), "partially written config");
+
+        expect(disablePi(ctx).outcome).toBe("restored");
+        expect(read(modelsFile())).toBe(original);
+        expect(existsSync(authFile())).toBe(false);
+        expect(snapshotFiles()).toHaveLength(0);
+    });
+
     it("keeps one backup per harness home", () => {
         configurePi(ctx, settings);
         const moved = {

--- a/packages/polli-cli/src/harnesses/pi.ts
+++ b/packages/polli-cli/src/harnesses/pi.ts
@@ -1,19 +1,16 @@
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 import polliSkill from "../../SKILL.md?raw";
 import { BASE_URL } from "../lib/config.js";
 import {
     commandExists,
     readTextIfExists,
     removeIfExists,
+    resolveHomePath,
     writeTextAtomic,
 } from "./fs.js";
 import { resolveHarnessKey } from "./keys.js";
 import { fetchHarnessModels } from "./models.js";
-import {
-    applyWithSnapshot,
-    clearSnapshot,
-    restoreSnapshot,
-} from "./snapshot.js";
+import { applyWithSnapshot, restoreOrStrip } from "./snapshot.js";
 import type {
     HarnessAdapter,
     HarnessContext,
@@ -29,13 +26,7 @@ const DEFAULT_MODEL = "deepseek";
 export const piAgentDir = (ctx: HarnessContext): string => {
     const configured = ctx.env.PI_CODING_AGENT_DIR;
     if (!configured?.trim()) return join(ctx.home, ".pi", "agent");
-    const expanded =
-        configured === "~"
-            ? ctx.home
-            : configured.startsWith("~/") || configured.startsWith("~\\")
-              ? join(ctx.home, configured.slice(2))
-              : configured;
-    return resolve(expanded);
+    return resolveHomePath(ctx.home, configured);
 };
 
 const modelsPath = (ctx: HarnessContext) =>
@@ -220,12 +211,7 @@ export const configurePi = (
 };
 
 export const disablePi = (ctx: HarnessContext): HarnessResult => {
-    const managedFiles = files(ctx);
-    let outcome: HarnessResult["outcome"] = "restored";
-    if (restoreSnapshot(ctx, ID, managedFiles) !== "restored") {
-        outcome = stripConfig(ctx) ? "stripped" : "unchanged";
-        clearSnapshot(ctx, ID, managedFiles);
-    }
+    const outcome = restoreOrStrip(ctx, ID, files(ctx), () => stripConfig(ctx));
     return { ...result(ctx), configured: false, outcome };
 };
 
@@ -242,12 +228,7 @@ export const pi: HarnessAdapter = {
             );
         }
         const model = options.model ?? DEFAULT_MODEL;
-        const models = await fetchHarnessModels();
-        if (!models.some((candidate) => candidate.id === model)) {
-            throw new Error(
-                `Model "${model}" is not a tool-calling text model. Run: polli models`,
-            );
-        }
+        const models = await fetchHarnessModels(model);
 
         const apiKey = await resolveHarnessKey(
             { id: ID, label: LABEL, existingKey: readKey(ctx) },

--- a/packages/polli-cli/src/harnesses/prime.ts
+++ b/packages/polli-cli/src/harnesses/prime.ts
@@ -1,19 +1,16 @@
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 import polliSkill from "../../SKILL.md?raw";
 import { BASE_URL } from "../lib/config.js";
 import {
     commandExists,
     readTextIfExists,
     removeIfExists,
+    resolveHomePath,
     writeTextAtomic,
 } from "./fs.js";
 import { resolveHarnessKey } from "./keys.js";
 import { fetchHarnessModels } from "./models.js";
-import {
-    applyWithSnapshot,
-    clearSnapshot,
-    restoreSnapshot,
-} from "./snapshot.js";
+import { applyWithSnapshot, restoreOrStrip } from "./snapshot.js";
 import type {
     HarnessAdapter,
     HarnessContext,
@@ -30,13 +27,7 @@ const DEFAULT_MODEL = "deepseek";
 export const primeAgentDir = (ctx: HarnessContext) => {
     const configured = ctx.env.PRIME_AGENT_CODING_AGENT_DIR;
     if (!configured?.trim()) return join(ctx.home, ".prime", "agent");
-    const expanded =
-        configured === "~"
-            ? ctx.home
-            : configured.startsWith("~/") || configured.startsWith("~\\")
-              ? join(ctx.home, configured.slice(2))
-              : configured;
-    return resolve(expanded);
+    return resolveHomePath(ctx.home, configured);
 };
 const modelsPath = (ctx: HarnessContext) =>
     join(primeAgentDir(ctx), "models.json");
@@ -210,12 +201,7 @@ export const configurePrime = (
 };
 
 export const disablePrime = (ctx: HarnessContext): HarnessResult => {
-    const managedFiles = files(ctx);
-    let outcome: HarnessResult["outcome"] = "restored";
-    if (restoreSnapshot(ctx, ID, managedFiles) !== "restored") {
-        outcome = stripConfig(ctx) ? "stripped" : "unchanged";
-        clearSnapshot(ctx, ID, managedFiles);
-    }
+    const outcome = restoreOrStrip(ctx, ID, files(ctx), () => stripConfig(ctx));
     return { ...result(ctx), configured: false, outcome };
 };
 
@@ -233,12 +219,7 @@ export const prime: HarnessAdapter = {
             );
         }
         const model = options.model ?? DEFAULT_MODEL;
-        const models = await fetchHarnessModels();
-        if (!models.some((candidate) => candidate.id === model)) {
-            throw new Error(
-                `Model "${model}" is not a tool-calling text model. Run: polli models`,
-            );
-        }
+        const models = await fetchHarnessModels(model);
 
         const apiKey = await resolveHarnessKey(
             { id: ID, label: LABEL, existingKey: readKey(ctx) },

--- a/packages/polli-cli/src/harnesses/snapshot.ts
+++ b/packages/polli-cli/src/harnesses/snapshot.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { join } from "node:path";
 import { readTextIfExists, removeIfExists, writeTextAtomic } from "./fs.js";
-import type { HarnessContext } from "./types.js";
+import type { HarnessContext, OffOutcome } from "./types.js";
 
 interface FileSnapshot {
     /** Content before the first `on`; null when the file did not exist. */
@@ -14,8 +14,6 @@ interface Snapshot {
     complete: boolean;
     files: Record<string, FileSnapshot>;
 }
-
-type RestoreOutcome = "restored" | "modified" | "missing";
 
 const sha256 = (content: string) =>
     createHash("sha256").update(content).digest("hex");
@@ -108,37 +106,31 @@ export const applyWithSnapshot = (
     writeSnapshot(ctx, id, paths, snapshot);
 };
 
-/** Put the files back byte-for-byte, unless something else edited them since `on`. */
-export const restoreSnapshot = (
+/** Restore untouched files byte-for-byte; otherwise strip only our config. */
+export const restoreOrStrip = (
     ctx: HarnessContext,
     id: string,
     paths: string[],
-): RestoreOutcome => {
+    strip: () => boolean,
+): OffOutcome => {
     const snapshot = loadSnapshot(ctx, id, paths);
-    if (!snapshot) return "missing";
-
-    if (!snapshot.complete) {
+    if (
+        snapshot &&
+        (!snapshot.complete ||
+            Object.entries(snapshot.files).every(
+                ([path, file]) =>
+                    contentHash(readTextIfExists(path)) === file.afterHash,
+            ))
+    ) {
         restoreFiles(snapshot.files);
-        removeIfExists(snapshotPath(ctx, id, paths));
+        clearSnapshot(ctx, id, paths);
         return "restored";
     }
 
-    const entries = Object.entries(snapshot.files);
-    if (
-        entries.some(
-            ([path, file]) =>
-                contentHash(readTextIfExists(path)) !== file.afterHash,
-        )
-    ) {
-        return "modified";
-    }
-    restoreFiles(snapshot.files);
-    removeIfExists(snapshotPath(ctx, id, paths));
-    return "restored";
+    const outcome = strip() ? "stripped" : "unchanged";
+    clearSnapshot(ctx, id, paths);
+    return outcome;
 };
 
-export const clearSnapshot = (
-    ctx: HarnessContext,
-    id: string,
-    paths: string[],
-) => removeIfExists(snapshotPath(ctx, id, paths));
+const clearSnapshot = (ctx: HarnessContext, id: string, paths: string[]) =>
+    removeIfExists(snapshotPath(ctx, id, paths));


### PR DESCRIPTION
- Shares model validation, home-path resolution, and restore-or-strip behavior across all five CLI harnesses.
- Preserves adapter-specific configuration, credentials, setup order, and protection for user-edited files; removes an unused OpenCode writer parameter.
- Adds 13 regression cases; all 98 CLI tests, package build, CLI help smoke test, Biome, and diff checks pass.
- Standalone TypeScript checking has the same 27 existing diagnostics as untouched main; no new diagnostics.