### PR TITLE
fix: omit the implicit simple-text seed

### DIFF
--- a/gen.pollinations.ai/src/schemas/text.ts
+++ b/gen.pollinations.ai/src/schemas/text.ts
@@ -27,9 +27,9 @@ export const GenerateTextRequestQueryParamsSchema = z.object({
         description:
             "Text model to use. See /v1/models or /text/models for the full list of available models.",
     }),
-    seed: z.coerce.number().int().min(-1).optional().default(0).meta({
+    seed: z.coerce.number().int().min(-1).optional().meta({
         description:
-            "Seed for reproducible results. -1 maps to the stable compatibility seed.",
+            "Optional seed for reproducible results on models that support it. Omitted by default. -1 maps to the stable compatibility seed.",
     }),
     system: z.string().optional().meta({
         description:

--- a/gen.pollinations.ai/test/text/requestUtils.test.ts
+++ b/gen.pollinations.ai/test/text/requestUtils.test.ts
@@ -5,6 +5,7 @@ import {
     getChatRequestData,
     getSimpleTextRequestData,
 } from "../../src/text/requestUtils.js";
+import { chatToResponsesRequest } from "../../src/text/responses/chatRequest.js";
 import { SENTINEL_SEED } from "../../src/util.js";
 
 afterEach(() => vi.restoreAllMocks());
@@ -118,16 +119,38 @@ describe("getSimpleTextRequestData", () => {
         });
     });
 
-    it("keeps the established simple-text defaults", () => {
+    it("does not introduce a seed when the caller omits it", () => {
         const query = GenerateTextRequestQueryParamsSchema.parse({});
         expect(
             getSimpleTextRequestData("hello", "resolved-model", query),
         ).toEqual({
             model: "resolved-model",
             messages: [{ role: "user", content: "hello" }],
-            seed: 0,
             stream: false,
         });
+    });
+
+    it.each([0, 12, -1])("preserves an explicit seed %s", (seed) => {
+        const query = GenerateTextRequestQueryParamsSchema.parse({ seed });
+        expect(getSimpleTextRequestData("hello", "openai", query).seed).toBe(
+            seed === -1 ? SENTINEL_SEED : seed,
+        );
+    });
+
+    it("allows an ordinary simple-text request through the Responses adapter", () => {
+        const query = GenerateTextRequestQueryParamsSchema.parse({
+            model: "gpt-5.6-terra",
+        });
+        const request = getSimpleTextRequestData("hello", query.model, query);
+        expect(chatToResponsesRequest(request.messages, request)).toMatchObject(
+            {
+                model: "gpt-5.6-terra",
+                stream: false,
+            },
+        );
+        expect(() =>
+            chatToResponsesRequest(request.messages, { ...request, seed: 0 }),
+        ).toThrow("seed is not supported");
     });
 
     it("leaves numeric normalization to the provider pipeline", () => {


### PR DESCRIPTION
- Remove the default seed from simple-text requests so Responses-backed models no longer reject an otherwise ordinary request.
- Preserve explicit seeds, including zero and the -1 compatibility mapping. Explicit unsupported seeds still return 400.
- Leave image seeds and request-based cache keys unchanged; document the optional text seed in the source schema.
- Tests: 49 request, Responses-adapter, and text-cache tests; gen typecheck passes.