### PR TITLE
fix(sdk): extract streaming fixes and missing request options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19832,6 +19832,9 @@
         "react": {
           "optional": true
         }
+      },
+      "dependencies": {
+        "eventsource-parser": "3.0.6"
       }
     },
     "packages/sdk/node_modules/@esbuild/aix-ppc64": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19806,7 +19806,7 @@
     },
     "packages/sdk": {
       "name": "@pollinations/sdk",
-      "version": "5.1.0-alpha.6",
+      "version": "5.1.0-alpha.7",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.10.0",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -16,7 +16,8 @@ All notable changes to `@pollinations/sdk` will be documented in this file.
   API tokens out of callback URLs without changing its public API.
 - Chat streaming uses `eventsource-parser` for standard SSE event boundaries,
   multiline data, and comments. Events need a terminating blank line; incomplete
-  events at EOF are discarded. Cancellation and streamed error handling are preserved.
+  events at EOF are discarded. Stops at `[DONE]` and releases the connection;
+  cancellation and streamed error handling are preserved.
 
 ## [5.1.0-alpha.6] - 2026-08-23
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -14,9 +14,9 @@ All notable changes to `@pollinations/sdk` will be documented in this file.
 ### Changed
 - `PolliProvider` now uses OAuth authorization-code + PKCE, keeping delegated
   API tokens out of callback URLs without changing its public API.
-- Chat streaming decodes SSE by event boundary (CRLF, multi-line data,
-  comments), rejects data after `[DONE]` as malformed, tolerates a repeated
-  `[DONE]`, and cancels the response body when iteration stops early.
+- Chat streaming uses `eventsource-parser` for standard SSE event boundaries,
+  multiline data, and comments. Events need a terminating blank line; incomplete
+  events at EOF are discarded. Cancellation and streamed error handling are preserved.
 
 ## [5.1.0-alpha.6] - 2026-08-23
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -4,9 +4,19 @@ All notable changes to `@pollinations/sdk` will be documented in this file.
 
 ## [Unreleased]
 
+## [5.1.0-alpha.7] - 2026-09-05
+
+### Added
+- `ChatOptions.routing` for per-capability model overrides on router models,
+  with the `CHAT_ROUTING_CAPABILITIES` constant and `ChatRouting` types.
+- `resolution` on image and video generation options and `ModelInfo.resolutions`.
+
 ### Changed
 - `PolliProvider` now uses OAuth authorization-code + PKCE, keeping delegated
   API tokens out of callback URLs without changing its public API.
+- Chat streaming decodes SSE by event boundary (CRLF, multi-line data,
+  comments), rejects data after `[DONE]` as malformed, tolerates a repeated
+  `[DONE]`, and cancels the response body when iteration stops early.
 
 ## [5.1.0-alpha.6] - 2026-08-23
 

--- a/packages/sdk/package-lock.json
+++ b/packages/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pollinations/sdk",
-  "version": "5.1.0-alpha.6",
+  "version": "5.1.0-alpha.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pollinations/sdk",
-      "version": "5.1.0-alpha.6",
+      "version": "5.1.0-alpha.7",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.10.0",

--- a/packages/sdk/package-lock.json
+++ b/packages/sdk/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@pollinations/sdk",
       "version": "5.1.0-alpha.7",
       "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "3.0.6"
+      },
       "devDependencies": {
         "@types/node": "^20.10.0",
         "@types/react": "^19.2.15",
@@ -1205,6 +1208,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/expect-type": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollinations/sdk",
-  "version": "5.1.0-alpha.6",
+  "version": "5.1.0-alpha.7",
   "description": "Official SDK for pollinations.ai - Generate images, videos, audio, and text with ease",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -95,6 +95,9 @@
     "type": "github",
     "url": "https://github.com/sponsors/pollinations"
   },
+  "dependencies": {
+    "eventsource-parser": "3.0.6"
+  },
   "devDependencies": {
     "@types/node": "^20.10.0",
     "@types/react": "^19.2.15",

--- a/packages/sdk/src/client.test.ts
+++ b/packages/sdk/src/client.test.ts
@@ -520,6 +520,56 @@ describe("Pollinations chat routing", () => {
 });
 
 describe("Pollinations chat streaming", () => {
+    it("passes request values and provider payloads through unchanged", async () => {
+        const messages = [
+            { role: "user" as const, content: "  keep this text  " },
+        ];
+        const routing = { text: "publisher/custom-model" };
+        const payload = {
+            model: "provider-reported-id",
+            choices: [
+                {
+                    index: 0,
+                    delta: {
+                        content: "  answer  ",
+                        reasoning: "provider detail",
+                    },
+                    finish_reason: "provider_finish",
+                },
+            ],
+            usage: {
+                prompt_tokens: 1,
+                completion_tokens: 2,
+                total_tokens: 3,
+                provider_cost: 0.123,
+            },
+            provider_metadata: { region: "example", nested: [0, false, null] },
+        };
+        fetchMock.mockResolvedValue(
+            new Response(
+                `data: ${JSON.stringify(payload)}\n\ndata: [DONE]\n\n`,
+            ),
+        );
+        const chunks = [];
+        for await (const chunk of newClient().chatStream(messages, {
+            model: "requested-alias",
+            routing,
+            seed: 0,
+            temperature: 0,
+        })) {
+            chunks.push(chunk);
+        }
+        expect(chunks).toEqual([payload]);
+        expect(bodyOf(fetchMock.mock.calls[0])).toEqual({
+            messages,
+            model: "requested-alias",
+            routing,
+            seed: 0,
+            temperature: 0,
+            stream: true,
+        });
+    });
+
     it.each([
         "\n",
         "\r",
@@ -1016,36 +1066,29 @@ describe("Pollinations simple text facade", () => {
             status: 502,
         });
     });
-
-    it("reports malformed provider data appended after DONE", async () => {
-        fetchMock.mockResolvedValue(
-            makeResponse(
-                [
-                    'data: {"choices":[]}',
-                    "data: [DONE]",
-                    'data: {"provider_metadata":{"private":true}}',
-                    "",
-                ].join("\n\n"),
-                {
-                    kind: "stream",
-                    contentType: "text/event-stream",
-                },
-            ),
-        );
-
-        const consume = async () => {
-            for await (const _chunk of newClient().chatStream([
-                { role: "user", content: "hello" },
-            ])) {
-                // Consume the stream.
-            }
-        };
-
-        await expect(consume()).rejects.toMatchObject({
-            name: "PollinationsError",
-            code: "MALFORMED_STREAM",
-            status: 502,
+    it("stops at DONE without waiting for EOF or inspecting trailing data", async () => {
+        const cancel = vi.fn();
+        const body = new ReadableStream<Uint8Array>({
+            start(controller) {
+                controller.enqueue(
+                    new TextEncoder().encode(
+                        'data: {"choices":[]}\n\ndata: [DONE]\n\ndata: [not-json]\n\n',
+                    ),
+                );
+                // Deliberately leave the connection open.
+            },
+            cancel,
         });
+        fetchMock.mockResolvedValue(new Response(body));
+        const chunks = [];
+        for await (const chunk of newClient().chatStream([
+            { role: "user", content: "hello" },
+        ])) {
+            chunks.push(chunk);
+        }
+        expect(chunks).toEqual([{ choices: [] }]);
+        expect(cancel).toHaveBeenCalledOnce();
+        expect(body.locked).toBe(false);
     });
 });
 

--- a/packages/sdk/src/client.test.ts
+++ b/packages/sdk/src/client.test.ts
@@ -295,7 +295,7 @@ describe("Pollinations server-owned defaults", () => {
                 },
             ],
         };
-        const stream = 'data: {"choices":[{"delta":{"content":"x"}}]}\n';
+        const stream = 'data: {"choices":[{"delta":{"content":"x"}}]}\n\n';
         fetchMock
             .mockResolvedValueOnce(
                 makeResponse({ data: [{ b64_json: "AAAA" }] }),
@@ -387,7 +387,7 @@ describe("Pollinations seed handling", () => {
 
     it("passes seed through text and chat requests consistently", async () => {
         const client = newClient();
-        const stream = 'data: {"choices":[{"delta":{"content":"x"}}]}\n';
+        const stream = 'data: {"choices":[{"delta":{"content":"x"}}]}\n\n';
         fetchMock
             .mockResolvedValueOnce(
                 makeResponse({ choices: [{ message: { content: "ok" } }] }),
@@ -480,7 +480,7 @@ describe("Pollinations chat routing", () => {
         const client = newClient();
         fetchMock.mockResolvedValue(
             makeResponse(
-                'data: {"choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null}]}\n',
+                'data: {"choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null}]}\n\n',
                 {
                     kind: "stream",
                     contentType: "text/event-stream",
@@ -591,7 +591,7 @@ describe("Pollinations chat streaming", () => {
         expect(body.locked).toBe(false);
     });
 
-    it("reads a final event without a trailing newline", async () => {
+    it("discards an incomplete SSE event at EOF", async () => {
         const event = { choices: [{ delta: { content: "last" } }] };
         fetchMock.mockResolvedValue(
             new Response(`data: ${JSON.stringify(event)}`),
@@ -604,7 +604,19 @@ describe("Pollinations chat streaming", () => {
             chunks.push(chunk);
         }
 
-        expect(chunks).toEqual([event]);
+        expect(chunks).toEqual([]);
+    });
+
+    it("does not guess event boundaries between complete JSON data lines", async () => {
+        fetchMock.mockResolvedValue(
+            new Response('data: {"choices":[]}\ndata: {"choices":[]}\n\n'),
+        );
+
+        await expect(
+            newClient()
+                .chatStream([{ role: "user", content: "hello" }])
+                .next(),
+        ).rejects.toMatchObject({ code: "MALFORMED_STREAM" });
     });
 
     it("cancels and releases the body when decoding fails", async () => {
@@ -829,7 +841,7 @@ describe("Pollinations simple text facade", () => {
             'data: {"choices":[{"delta":{"content":""}}]}',
             "data: [DONE]",
             "",
-        ].join("\n");
+        ].join("\n\n");
         fetchMock.mockResolvedValue(
             makeResponse(stream, {
                 kind: "stream",
@@ -862,7 +874,7 @@ describe("Pollinations simple text facade", () => {
                     'data: {"error":{"message":"Upstream model unavailable"}}',
                     "data: [DONE]",
                     "",
-                ].join("\n"),
+                ].join("\n\n"),
                 {
                     kind: "stream",
                     contentType: "text/event-stream",
@@ -959,7 +971,7 @@ describe("Pollinations simple text facade", () => {
                     'data: {"provider_metadata":{"status":"ok"}}',
                     "data: [DONE]",
                     "",
-                ].join("\n"),
+                ].join("\n\n"),
                 {
                     kind: "stream",
                     contentType: "text/event-stream",
@@ -1013,7 +1025,7 @@ describe("Pollinations simple text facade", () => {
                     "data: [DONE]",
                     'data: {"provider_metadata":{"private":true}}',
                     "",
-                ].join("\n"),
+                ].join("\n\n"),
                 {
                     kind: "stream",
                     contentType: "text/event-stream",

--- a/packages/sdk/src/client.test.ts
+++ b/packages/sdk/src/client.test.ts
@@ -50,7 +50,11 @@ function makeResponse(
 
     if (kind === "stream") {
         const encoder = new TextEncoder();
-        const chunks = typeof body === "string" ? [encoder.encode(body)] : [];
+        const chunks = Array.isArray(body)
+            ? body.map((chunk) => encoder.encode(String(chunk)))
+            : typeof body === "string"
+              ? [encoder.encode(body)]
+              : [];
         let i = 0;
         resp.body = {
             getReader: () => ({
@@ -59,6 +63,7 @@ function makeResponse(
                         ? { done: false, value: chunks[i++] }
                         : { done: true, value: undefined },
                 releaseLock: () => {},
+                cancel: async () => {},
             }),
         };
     }
@@ -363,18 +368,21 @@ describe("Pollinations seed handling", () => {
             }),
         );
 
-        await client.image("a cat", { seed: -1 });
+        await client.image("a cat", { seed: -1, resolution: "2k" });
         await client.video("a long scene", {
             model: "nova-reel",
             duration: 120,
+            resolution: "1080p",
             seed: -1,
         });
 
-        const imageUrl = fetchMock.mock.calls[0][0] as string;
+        const imageUrl = new URL(fetchMock.mock.calls[0][0] as string);
         const videoUrl = new URL(fetchMock.mock.calls[1][0] as string);
-        expect(seedFromUrl(imageUrl)).toBe("-1");
+        expect(seedFromUrl(imageUrl.toString())).toBe("-1");
+        expect(imageUrl.searchParams.get("resolution")).toBe("2k");
         expect(videoUrl.searchParams.get("seed")).toBe("-1");
         expect(videoUrl.searchParams.get("duration")).toBe("120");
+        expect(videoUrl.searchParams.get("resolution")).toBe("1080p");
     });
 
     it("passes seed through text and chat requests consistently", async () => {
@@ -432,6 +440,345 @@ describe("Pollinations seed handling", () => {
         expect(body.reasoning_effort).toBe("medium");
         expect("thinking" in body).toBe(false);
         expect("thinking_budget" in body).toBe(false);
+    });
+});
+
+describe("Pollinations chat routing", () => {
+    it("serializes per-capability routing for chat requests", async () => {
+        const client = newClient();
+        fetchMock.mockResolvedValue(
+            makeResponse({ choices: [{ message: { content: "ok" } }] }),
+        );
+
+        await client.chat([{ role: "user", content: "hello" }], {
+            model: "floret",
+            routing: {
+                text: "openai",
+                web_search: "perplexity-fast",
+                image_generation: "flux",
+                image_editing: "nanobanana",
+                video: "veo",
+                audio: "elevenlabs",
+            },
+        });
+
+        expect(bodyOf(fetchMock.mock.calls[0])).toMatchObject({
+            model: "floret",
+            stream: false,
+            routing: {
+                text: "openai",
+                web_search: "perplexity-fast",
+                image_generation: "flux",
+                image_editing: "nanobanana",
+                video: "veo",
+                audio: "elevenlabs",
+            },
+        });
+    });
+
+    it("serializes partial routing for streaming chat requests", async () => {
+        const client = newClient();
+        fetchMock.mockResolvedValue(
+            makeResponse(
+                'data: {"choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null}]}\n',
+                {
+                    kind: "stream",
+                    contentType: "text/event-stream",
+                },
+            ),
+        );
+
+        for await (const _chunk of client.chatStream(
+            [{ role: "user", content: "hello" }],
+            {
+                model: "floret",
+                routing: { video: "veo" },
+            },
+        )) {
+            // Consume the stream.
+        }
+
+        expect(bodyOf(fetchMock.mock.calls[0])).toMatchObject({
+            model: "floret",
+            stream: true,
+            routing: { video: "veo" },
+        });
+    });
+
+    it("omits routing when no override is provided", async () => {
+        const client = newClient();
+        fetchMock.mockResolvedValue(
+            makeResponse({ choices: [{ message: { content: "ok" } }] }),
+        );
+
+        await client.chat([{ role: "user", content: "hello" }], {
+            model: "floret",
+        });
+
+        expect(bodyOf(fetchMock.mock.calls[0]).routing).toBeUndefined();
+    });
+});
+
+describe("Pollinations chat streaming", () => {
+    it.each([
+        "\n",
+        "\r",
+        "\r\n",
+    ])("preserves UTF-8 and tool/usage events split at every byte (%j)", async (newline) => {
+        const events = [
+            {
+                choices: [
+                    {
+                        index: 0,
+                        delta: { content: "🌸 café" },
+                        finish_reason: null,
+                    },
+                ],
+            },
+            {
+                choices: [
+                    {
+                        index: 0,
+                        delta: {
+                            tool_calls: [
+                                {
+                                    index: 0,
+                                    id: "call_1",
+                                    type: "function",
+                                    function: {
+                                        name: "search",
+                                        arguments: "{}",
+                                    },
+                                },
+                            ],
+                        },
+                        finish_reason: "tool_calls",
+                    },
+                ],
+            },
+            {
+                choices: [],
+                usage: {
+                    prompt_tokens: 2,
+                    completion_tokens: 3,
+                    total_tokens: 5,
+                },
+            },
+        ];
+        const sse = events
+            .map((event) => `data:${JSON.stringify(event)}${newline}${newline}`)
+            .join("");
+        const bytes = new TextEncoder().encode(
+            `${sse}data: [DONE]${newline}${newline}`,
+        );
+        const body = new ReadableStream<Uint8Array>({
+            start(controller) {
+                for (const byte of bytes)
+                    controller.enqueue(Uint8Array.of(byte));
+                controller.close();
+            },
+        });
+        fetchMock.mockResolvedValue(new Response(body));
+
+        const chunks = [];
+        for await (const chunk of newClient().chatStream([
+            { role: "user", content: "hello" },
+        ])) {
+            chunks.push(chunk);
+        }
+
+        expect(chunks).toEqual(events);
+        expect(body.locked).toBe(false);
+    });
+
+    it("reads a final event without a trailing newline", async () => {
+        const event = { choices: [{ delta: { content: "last" } }] };
+        fetchMock.mockResolvedValue(
+            new Response(`data: ${JSON.stringify(event)}`),
+        );
+
+        const chunks = [];
+        for await (const chunk of newClient().chatStream([
+            { role: "user", content: "hello" },
+        ])) {
+            chunks.push(chunk);
+        }
+
+        expect(chunks).toEqual([event]);
+    });
+
+    it("cancels and releases the body when decoding fails", async () => {
+        const cancel = vi.fn();
+        const body = new ReadableStream<Uint8Array>({
+            start(controller) {
+                controller.enqueue(
+                    new TextEncoder().encode("data: [invalid-json]\n\n"),
+                );
+            },
+            cancel,
+        });
+        fetchMock.mockResolvedValue(new Response(body));
+
+        await expect(
+            newClient()
+                .chatStream([{ role: "user", content: "hello" }])
+                .next(),
+        ).rejects.toMatchObject({ code: "MALFORMED_STREAM" });
+        expect(cancel).toHaveBeenCalledOnce();
+        expect(body.locked).toBe(false);
+    });
+
+    it("decodes SSE across chunk boundaries and ignores comment lines", async () => {
+        const client = newClient();
+        const chunk = {
+            id: "chatcmpl-test",
+            object: "chat.completion.chunk",
+            created: 1,
+            model: "floret",
+            choices: [
+                {
+                    index: 0,
+                    delta: { content: "ready" },
+                    finish_reason: null,
+                },
+            ],
+        };
+        const json = JSON.stringify(chunk);
+        const split = json.indexOf(',"choices"') + 1;
+        fetchMock.mockResolvedValue(
+            makeResponse(
+                [
+                    ": keep-alive\r",
+                    `\n: ping\r\n\r\ndata: ${json.slice(0, split)}\r\ndata:${json.slice(split)}\r\n\r\ndata:[DONE]\r\n\r\n`,
+                ],
+                {
+                    kind: "stream",
+                    contentType: "text/event-stream",
+                },
+            ),
+        );
+
+        const chunks = [];
+        for await (const chunk of client.chatStream([
+            { role: "user", content: "transcribe this" },
+        ])) {
+            chunks.push(chunk);
+        }
+
+        expect(chunks).toEqual([chunk]);
+    });
+
+    it("ignores a repeated [DONE] instead of failing a complete response", async () => {
+        const client = newClient();
+        fetchMock.mockResolvedValue(
+            makeResponse(
+                'data: {"choices":[{"index":0,"delta":{"content":"done"},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\ndata: [DONE]\n\n',
+                { kind: "stream", contentType: "text/event-stream" },
+            ),
+        );
+
+        const chunks = [];
+        for await (const chunk of client.chatStream([
+            { role: "user", content: "hello" },
+        ])) {
+            chunks.push(chunk);
+        }
+
+        expect(chunks).toHaveLength(1);
+    });
+
+    it("cancels the response body when the consumer stops early", async () => {
+        const client = newClient();
+        let cancelled = false;
+        const body = new ReadableStream<Uint8Array>({
+            start(controller) {
+                controller.enqueue(
+                    new TextEncoder().encode(
+                        'data: {"choices":[{"index":0,"delta":{"content":"a"},"finish_reason":null}]}\n\n',
+                    ),
+                );
+            },
+            cancel() {
+                cancelled = true;
+            },
+        });
+        fetchMock.mockResolvedValue(
+            new Response(body, {
+                status: 200,
+                headers: { "content-type": "text/event-stream" },
+            }),
+        );
+
+        for await (const _chunk of client.chatStream([
+            { role: "user", content: "hello" },
+        ])) {
+            break;
+        }
+
+        expect(cancelled).toBe(true);
+    });
+
+    it("surfaces stream errors instead of silently completing", async () => {
+        const client = newClient();
+        fetchMock.mockResolvedValue(
+            makeResponse(
+                'data: {"error":{"message":"Agent failed"}}\n\ndata: [DONE]\n\n',
+                {
+                    kind: "stream",
+                    contentType: "text/event-stream",
+                },
+            ),
+        );
+
+        const consume = async () => {
+            for await (const _chunk of client.chatStream([
+                { role: "user", content: "hello" },
+            ])) {
+                // Consume the stream.
+            }
+        };
+
+        await expect(consume()).rejects.toMatchObject({
+            code: "STREAM_ERROR",
+            message: "Agent failed",
+        });
+    });
+
+    it("cancels an active response body when the caller aborts", async () => {
+        const client = newClient();
+        const encoder = new TextEncoder();
+        let cancelled = false;
+        const body = new ReadableStream<Uint8Array>({
+            start(controller) {
+                controller.enqueue(
+                    encoder.encode(
+                        'data: {"choices":[{"index":0,"delta":{"content":"started"},"finish_reason":null}]}\n\n',
+                    ),
+                );
+            },
+            cancel() {
+                cancelled = true;
+            },
+        });
+        fetchMock.mockResolvedValue(
+            new Response(body, {
+                status: 200,
+                headers: { "content-type": "text/event-stream" },
+            }),
+        );
+        const controller = new AbortController();
+        const stream = client.chatStream([{ role: "user", content: "hello" }], {
+            signal: controller.signal,
+        });
+
+        await expect(stream.next()).resolves.toMatchObject({
+            value: { choices: [{ delta: { content: "started" } }] },
+        });
+        const pending = stream.next();
+        controller.abort();
+
+        await expect(pending).rejects.toMatchObject({ code: "CANCELLED" });
+        expect(cancelled).toBe(true);
     });
 });
 

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1,3 +1,4 @@
+import { createParser } from "eventsource-parser";
 import { pollinationsErrorFromResponse } from "./error-response.js";
 import type {
     AccountBalance,
@@ -133,96 +134,6 @@ function stripKeyFromUrl(url: string): string {
     const urlObj = new URL(url);
     urlObj.searchParams.delete("key");
     return urlObj.toString();
-}
-
-interface SSEMessage {
-    data: string;
-}
-
-/** Incremental SSE decoder following event boundaries rather than network lines. */
-class SSEDecoder {
-    private buffer = "";
-    private data: string[] = [];
-
-    push(chunk: string, flush = false): SSEMessage[] {
-        this.buffer += chunk;
-        const messages: SSEMessage[] = [];
-
-        while (this.buffer.length > 0) {
-            const ending = this.nextLineEnding(flush);
-            if (!ending) break;
-            const line = this.buffer.slice(0, ending.index);
-            this.buffer = this.buffer.slice(ending.index + ending.length);
-            const message = this.processLine(line);
-            if (message) messages.push(message);
-        }
-
-        if (flush) {
-            if (this.buffer.length > 0) {
-                const message = this.processLine(this.buffer);
-                this.buffer = "";
-                if (message) messages.push(message);
-            }
-            const pending = this.dispatch();
-            if (pending) messages.push(pending);
-        }
-
-        return messages;
-    }
-
-    private nextLineEnding(
-        flush: boolean,
-    ): { index: number; length: number } | null {
-        for (let index = 0; index < this.buffer.length; index += 1) {
-            const character = this.buffer[index];
-            if (character === "\n") return { index, length: 1 };
-            if (character !== "\r") continue;
-            if (index + 1 === this.buffer.length && !flush) return null;
-            return {
-                index,
-                length: this.buffer[index + 1] === "\n" ? 2 : 1,
-            };
-        }
-        return null;
-    }
-
-    private processLine(line: string): SSEMessage | null {
-        if (line === "") return this.dispatch();
-        if (line.startsWith(":")) return null;
-
-        const separator = line.indexOf(":");
-        const field = separator < 0 ? line : line.slice(0, separator);
-        const rawValue = separator < 0 ? "" : line.slice(separator + 1);
-        const value = rawValue.startsWith(" ") ? rawValue.slice(1) : rawValue;
-        if (field === "data") {
-            // OpenAI-compatible streams commonly emit one JSON payload per
-            // data line without the blank SSE separator. Preserve legitimate
-            // multiline data until the accumulated JSON is complete.
-            const pending = this.hasCompleteData() ? this.dispatch() : null;
-            this.data.push(value);
-            return pending;
-        }
-        return null;
-    }
-
-    private hasCompleteData(): boolean {
-        if (this.data.length === 0) return false;
-        const data = this.data.join("\n").trim();
-        if (data === "[DONE]") return true;
-        try {
-            JSON.parse(data);
-            return true;
-        } catch {
-            return false;
-        }
-    }
-
-    private dispatch(): SSEMessage | null {
-        if (this.data.length === 0) return null;
-        const message = { data: this.data.join("\n") };
-        this.data = [];
-        return message;
-    }
 }
 
 function chatStreamError(chunk: unknown): PollinationsError | null {
@@ -1015,7 +926,10 @@ export class Pollinations {
         }
 
         const decoder = new TextDecoder();
-        const sseDecoder = new SSEDecoder();
+        let events: string[] = [];
+        const parser = createParser({
+            onEvent: ({ data }) => events.push(data),
+        });
         let finished = false;
         let completed = false;
         const cancelReader = () => {
@@ -1024,9 +938,9 @@ export class Pollinations {
         options.signal?.addEventListener("abort", cancelReader, { once: true });
 
         const chunksFrom = function* (
-            messages: SSEMessage[],
+            messages: string[],
         ): Generator<ChatStreamChunk> {
-            for (const message of messages) {
+            for (const data of messages) {
                 if (options.signal?.aborted) {
                     throw new PollinationsError(
                         "Request was cancelled",
@@ -1034,8 +948,8 @@ export class Pollinations {
                         499,
                     );
                 }
-                if (!message.data) continue;
-                if (message.data.trim() === "[DONE]") {
+                if (!data) continue;
+                if (data.trim() === "[DONE]") {
                     // Proxies may repeat [DONE]; the response is complete.
                     finished = true;
                     continue;
@@ -1047,7 +961,7 @@ export class Pollinations {
                         502,
                     );
                 }
-                yield parseChatStreamData(message.data);
+                yield parseChatStreamData(data);
             }
         };
 
@@ -1056,8 +970,9 @@ export class Pollinations {
             while (true) {
                 const { done, value } = await reader.read();
                 if (done) break;
-                const text = decoder.decode(value, { stream: true });
-                yield* chunksFrom(sseDecoder.push(text));
+                parser.feed(decoder.decode(value, { stream: true }));
+                yield* chunksFrom(events);
+                events = [];
             }
             if (options.signal?.aborted) {
                 throw new PollinationsError(
@@ -1066,7 +981,8 @@ export class Pollinations {
                     499,
                 );
             }
-            yield* chunksFrom(sseDecoder.push(decoder.decode(), true));
+            parser.feed(decoder.decode());
+            yield* chunksFrom(events);
             completed = true;
         } catch (error) {
             if (options.signal?.aborted) {

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -135,10 +135,94 @@ function stripKeyFromUrl(url: string): string {
     return urlObj.toString();
 }
 
-// SSE parsing result
-interface SSEParseResult<T> {
-    chunks: T[];
-    remainingBuffer: string;
+interface SSEMessage {
+    data: string;
+}
+
+/** Incremental SSE decoder following event boundaries rather than network lines. */
+class SSEDecoder {
+    private buffer = "";
+    private data: string[] = [];
+
+    push(chunk: string, flush = false): SSEMessage[] {
+        this.buffer += chunk;
+        const messages: SSEMessage[] = [];
+
+        while (this.buffer.length > 0) {
+            const ending = this.nextLineEnding(flush);
+            if (!ending) break;
+            const line = this.buffer.slice(0, ending.index);
+            this.buffer = this.buffer.slice(ending.index + ending.length);
+            const message = this.processLine(line);
+            if (message) messages.push(message);
+        }
+
+        if (flush) {
+            if (this.buffer.length > 0) {
+                const message = this.processLine(this.buffer);
+                this.buffer = "";
+                if (message) messages.push(message);
+            }
+            const pending = this.dispatch();
+            if (pending) messages.push(pending);
+        }
+
+        return messages;
+    }
+
+    private nextLineEnding(
+        flush: boolean,
+    ): { index: number; length: number } | null {
+        for (let index = 0; index < this.buffer.length; index += 1) {
+            const character = this.buffer[index];
+            if (character === "\n") return { index, length: 1 };
+            if (character !== "\r") continue;
+            if (index + 1 === this.buffer.length && !flush) return null;
+            return {
+                index,
+                length: this.buffer[index + 1] === "\n" ? 2 : 1,
+            };
+        }
+        return null;
+    }
+
+    private processLine(line: string): SSEMessage | null {
+        if (line === "") return this.dispatch();
+        if (line.startsWith(":")) return null;
+
+        const separator = line.indexOf(":");
+        const field = separator < 0 ? line : line.slice(0, separator);
+        const rawValue = separator < 0 ? "" : line.slice(separator + 1);
+        const value = rawValue.startsWith(" ") ? rawValue.slice(1) : rawValue;
+        if (field === "data") {
+            // OpenAI-compatible streams commonly emit one JSON payload per
+            // data line without the blank SSE separator. Preserve legitimate
+            // multiline data until the accumulated JSON is complete.
+            const pending = this.hasCompleteData() ? this.dispatch() : null;
+            this.data.push(value);
+            return pending;
+        }
+        return null;
+    }
+
+    private hasCompleteData(): boolean {
+        if (this.data.length === 0) return false;
+        const data = this.data.join("\n").trim();
+        if (data === "[DONE]") return true;
+        try {
+            JSON.parse(data);
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    private dispatch(): SSEMessage | null {
+        if (this.data.length === 0) return null;
+        const message = { data: this.data.join("\n") };
+        this.data = [];
+        return message;
+    }
 }
 
 function chatStreamError(chunk: unknown): PollinationsError | null {
@@ -182,26 +266,33 @@ function chatStreamError(chunk: unknown): PollinationsError | null {
     return new PollinationsError(message, code, status);
 }
 
-// Parse SSE lines from buffer and extract data
-function parseSSEBuffer<T>(
-    buffer: string,
-    parseChunk: (data: string) => T | null,
-): SSEParseResult<T> {
-    const lines = buffer.split("\n");
-    const remainingBuffer = lines.pop() || "";
-    const chunks: T[] = [];
-    for (const line of lines) {
-        const trimmed = line.trim();
-        if (!trimmed || trimmed === "data: [DONE]") continue;
-        if (trimmed.startsWith("data: ")) {
-            const parsed = parseChunk(trimmed.slice(6));
-            if (parsed !== null) {
-                chunks.push(parsed);
-            }
-        }
+function parseChatStreamData(data: string): ChatStreamChunk {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(data);
+    } catch {
+        throw new PollinationsError(
+            "Invalid JSON in chat completion stream",
+            "MALFORMED_STREAM",
+            502,
+        );
     }
+    const error = chatStreamError(parsed);
+    if (error) throw error;
 
-    return { chunks, remainingBuffer };
+    if (
+        !parsed ||
+        typeof parsed !== "object" ||
+        !("choices" in parsed) ||
+        !Array.isArray((parsed as { choices: unknown }).choices)
+    ) {
+        throw new PollinationsError(
+            "Invalid chat completion stream event",
+            "MALFORMED_STREAM",
+            502,
+        );
+    }
+    return parsed as ChatStreamChunk;
 }
 
 /**
@@ -334,6 +425,7 @@ export class Pollinations {
             model: options.model,
             width: options.width,
             height: options.height,
+            resolution: options.resolution,
             seed: options.seed,
             safe: options.safe,
             quality: options.quality,
@@ -625,6 +717,7 @@ export class Pollinations {
             model: options.model,
             duration: options.duration,
             aspectRatio: options.aspectRatio,
+            resolution: options.resolution,
             seed: options.seed,
             audio: options.audio,
             image: options.referenceImage,
@@ -805,6 +898,7 @@ export class Pollinations {
         return this.stripUndefined({
             messages,
             model: options.model,
+            routing: options.routing,
             temperature: options.temperature,
             top_p: options.topP,
             max_tokens: options.maxTokens,
@@ -921,46 +1015,73 @@ export class Pollinations {
         }
 
         const decoder = new TextDecoder();
-        let buffer = "";
+        const sseDecoder = new SSEDecoder();
+        let finished = false;
+        let completed = false;
+        const cancelReader = () => {
+            void reader.cancel().catch(() => undefined);
+        };
+        options.signal?.addEventListener("abort", cancelReader, { once: true });
+
+        const chunksFrom = function* (
+            messages: SSEMessage[],
+        ): Generator<ChatStreamChunk> {
+            for (const message of messages) {
+                if (options.signal?.aborted) {
+                    throw new PollinationsError(
+                        "Request was cancelled",
+                        "CANCELLED",
+                        499,
+                    );
+                }
+                if (!message.data) continue;
+                if (message.data.trim() === "[DONE]") {
+                    // Proxies may repeat [DONE]; the response is complete.
+                    finished = true;
+                    continue;
+                }
+                if (finished) {
+                    throw new PollinationsError(
+                        "Chat stream contained data after completion",
+                        "MALFORMED_STREAM",
+                        502,
+                    );
+                }
+                yield parseChatStreamData(message.data);
+            }
+        };
 
         try {
+            if (options.signal?.aborted) await reader.cancel();
             while (true) {
                 const { done, value } = await reader.read();
                 if (done) break;
-
-                buffer += decoder.decode(value, { stream: true });
-                const result = parseSSEBuffer<unknown>(buffer, (data) => {
-                    try {
-                        return JSON.parse(data) as unknown;
-                    } catch {
-                        throw new PollinationsError(
-                            "Invalid JSON in chat completion stream",
-                            "MALFORMED_STREAM",
-                            502,
-                        );
-                    }
-                });
-
-                buffer = result.remainingBuffer;
-                for (const chunk of result.chunks) {
-                    const error = chatStreamError(chunk);
-                    if (error) throw error;
-                    if (
-                        !chunk ||
-                        typeof chunk !== "object" ||
-                        !("choices" in chunk) ||
-                        !Array.isArray((chunk as { choices: unknown }).choices)
-                    ) {
-                        throw new PollinationsError(
-                            "Invalid chat completion stream event",
-                            "MALFORMED_STREAM",
-                            502,
-                        );
-                    }
-                    yield chunk as ChatStreamChunk;
-                }
+                const text = decoder.decode(value, { stream: true });
+                yield* chunksFrom(sseDecoder.push(text));
             }
+            if (options.signal?.aborted) {
+                throw new PollinationsError(
+                    "Request was cancelled",
+                    "CANCELLED",
+                    499,
+                );
+            }
+            yield* chunksFrom(sseDecoder.push(decoder.decode(), true));
+            completed = true;
+        } catch (error) {
+            if (options.signal?.aborted) {
+                throw new PollinationsError(
+                    "Request was cancelled",
+                    "CANCELLED",
+                    499,
+                );
+            }
+            throw error;
         } finally {
+            options.signal?.removeEventListener("abort", cancelReader);
+            // An early break or a decoder error leaves the body open; cancel
+            // it so the connection is released.
+            if (!completed) await reader.cancel().catch(() => undefined);
             reader.releaseLock();
         }
     }

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -930,60 +930,25 @@ export class Pollinations {
         const parser = createParser({
             onEvent: ({ data }) => events.push(data),
         });
-        let finished = false;
-        let completed = false;
         const cancelReader = () => {
             void reader.cancel().catch(() => undefined);
         };
         options.signal?.addEventListener("abort", cancelReader, { once: true });
 
-        const chunksFrom = function* (
-            messages: string[],
-        ): Generator<ChatStreamChunk> {
-            for (const data of messages) {
-                if (options.signal?.aborted) {
-                    throw new PollinationsError(
-                        "Request was cancelled",
-                        "CANCELLED",
-                        499,
-                    );
-                }
-                if (!data) continue;
-                if (data.trim() === "[DONE]") {
-                    // Proxies may repeat [DONE]; the response is complete.
-                    finished = true;
-                    continue;
-                }
-                if (finished) {
-                    throw new PollinationsError(
-                        "Chat stream contained data after completion",
-                        "MALFORMED_STREAM",
-                        502,
-                    );
-                }
-                yield parseChatStreamData(data);
-            }
-        };
-
         try {
-            if (options.signal?.aborted) await reader.cancel();
+            options.signal?.throwIfAborted();
             while (true) {
                 const { done, value } = await reader.read();
-                if (done) break;
-                parser.feed(decoder.decode(value, { stream: true }));
-                yield* chunksFrom(events);
+                options.signal?.throwIfAborted();
+                parser.feed(decoder.decode(value, { stream: !done }));
+                for (const data of events) {
+                    options.signal?.throwIfAborted();
+                    if (data.trim() === "[DONE]") return;
+                    if (data) yield parseChatStreamData(data);
+                }
                 events = [];
+                if (done) return;
             }
-            if (options.signal?.aborted) {
-                throw new PollinationsError(
-                    "Request was cancelled",
-                    "CANCELLED",
-                    499,
-                );
-            }
-            parser.feed(decoder.decode());
-            yield* chunksFrom(events);
-            completed = true;
         } catch (error) {
             if (options.signal?.aborted) {
                 throw new PollinationsError(
@@ -995,9 +960,8 @@ export class Pollinations {
             throw error;
         } finally {
             options.signal?.removeEventListener("abort", cancelReader);
-            // An early break or a decoder error leaves the body open; cancel
-            // it so the connection is released.
-            if (!completed) await reader.cancel().catch(() => undefined);
+            // Release the connection on [DONE], early exit, or error.
+            await reader.cancel().catch(() => undefined);
             reader.releaseLock();
         }
     }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -95,6 +95,8 @@ export type {
     ChatChoice,
     ChatOptions,
     ChatResponse,
+    ChatRouting,
+    ChatRoutingCapability,
     ChatStreamChunk,
     CompletionUsage,
     CreatedKey,
@@ -161,5 +163,5 @@ export type {
     VideoResponse,
 } from "./types.js";
 
-// Export the error class
-export { PollinationsError } from "./types.js";
+// Export runtime constants and the error class
+export { CHAT_ROUTING_CAPABILITIES, PollinationsError } from "./types.js";

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -43,6 +43,8 @@ export interface ImageGenerateOptions extends RequestOptions {
     width?: number;
     /** Image height in pixels (default: 1024) */
     height?: number;
+    /** Model-specific output resolution tier (for example, "1k" or "2k") */
+    resolution?: string;
     /** Seed for reproducible generation (default: random) */
     seed?: number;
     /** Enable safety content filters (default: false) */
@@ -93,6 +95,8 @@ export interface VideoGenerateOptions extends RequestOptions {
     duration?: number;
     /** Aspect ratio (e.g., '16:9', '9:16', '1:1') */
     aspectRatio?: string;
+    /** Model-specific output resolution tier (for example, "720p" or "1080p") */
+    resolution?: string;
     /** Seed for reproducible generation */
     seed?: number;
     /** Enable audio generation where supported by the selected video model */
@@ -254,10 +258,28 @@ export type BuiltInToolType =
     | "computer_use"
     | "file_search";
 
+/** Capabilities that router models can delegate to downstream models. */
+export const CHAT_ROUTING_CAPABILITIES = [
+    "text",
+    "web_search",
+    "image_generation",
+    "image_editing",
+    "video",
+    "audio",
+] as const;
+
+/** Capability names accepted by router-model routing preferences. */
+export type ChatRoutingCapability = (typeof CHAT_ROUTING_CAPABILITIES)[number];
+
+/** Optional downstream-model overrides for router models. */
+export type ChatRouting = Partial<Record<ChatRoutingCapability, string>>;
+
 /** Options for chat completions (POST endpoint) */
 export interface ChatOptions extends RequestOptions {
     /** Text model to use (server default: 'openai') */
     model?: TextModel;
+    /** Per-capability downstream model overrides for router models. */
+    routing?: ChatRouting;
     /** Temperature 0-2 (default: 1) */
     temperature?: number;
     /** Top P sampling 0-1 (default: 1) */
@@ -398,8 +420,14 @@ export interface ChatStreamChunk {
     choices: Array<{
         index: number;
         delta: {
-            role?: "assistant";
-            content?: string;
+            role?: Exclude<MessageRole, "function">;
+            content?: string | null;
+            /** Deprecated OpenAI function-call delta. */
+            function_call?: {
+                name?: string;
+                arguments?: string;
+            };
+            refusal?: string | null;
             tool_calls?: Array<{
                 index: number;
                 id?: string;
@@ -415,9 +443,13 @@ export interface ChatStreamChunk {
             | "length"
             | "tool_calls"
             | "content_filter"
+            | "function_call"
             | null;
+        logprobs?: ChatChoice["logprobs"];
     }>;
-    usage?: CompletionUsage;
+    usage?: CompletionUsage | null;
+    service_tier?: "auto" | "default" | "flex" | "scale" | "priority" | null;
+    system_fingerprint?: string;
 }
 
 // ============================================================================
@@ -899,6 +931,7 @@ export interface ModelInfo {
     input_modalities?: ModelInputModality[];
     output_modalities?: ModelOutputModality[];
     video_capabilities?: VideoCapability[];
+    resolutions?: string[];
     min_duration?: number;
     max_duration?: number;
     default_duration?: number;


### PR DESCRIPTION
- Extracts SDK changes from #14472 so they can ship without the website redesign. Addresses #14472; remaining website work stays there.
- Uses eventsource-parser instead of custom SSE parsing. Requires standard event boundaries, discards incomplete events at EOF, and stops at [DONE] without inspecting trailing data.
- Keeps request values and provider payloads unchanged, including extra fields. Retains existing malformed-response/API-error checks and cancellation, including #14487. Adds routing, resolution options, response types, and alpha.7.
- All 51 client tests, typecheck, builds, and Biome pass. Full suite: 72/73 pass; the unchanged PKCE callback test still intermittently fails, as noted during the original extraction.
- No website, shared UI, backend, deployment, or secret changes. Credits Elliot for the extracted work.