### PR TITLE
refactor: unify raw request URL logging

### DIFF
--- a/enter.pollinations.ai/src/middleware/logger.ts
+++ b/enter.pollinations.ai/src/middleware/logger.ts
@@ -1,5 +1,1 @@
-import { createRequestLogger } from "@shared/middleware/logger.ts";
-
-export type { LoggerVariables } from "@shared/middleware/logger.ts";
-
-export const logger = createRequestLogger((url) => url.toString());
+export { type LoggerVariables, logger } from "@shared/middleware/logger.ts";

--- a/gen.pollinations.ai/src/middleware/logger.ts
+++ b/gen.pollinations.ai/src/middleware/logger.ts
@@ -1,6 +1,1 @@
-import { createRequestLogger } from "@shared/middleware/logger.ts";
-import { redactCredentialQueryParams } from "@shared/observability/request-inputs.ts";
-
-export type { LoggerVariables } from "@shared/middleware/logger.ts";
-
-export const logger = createRequestLogger(redactCredentialQueryParams);
+export { type LoggerVariables, logger } from "@shared/middleware/logger.ts";

--- a/gen.pollinations.ai/test/logger.test.ts
+++ b/gen.pollinations.ai/test/logger.test.ts
@@ -37,24 +37,22 @@ afterAll(async () => {
     if (originalConfig) await configure({ ...originalConfig, reset: true });
 });
 
+it("uses the same middleware in both services", () => {
+    expect(genLogger).toBe(enterLogger);
+});
+
 describe.each([
-    [
-        "Gen",
-        genLogger,
-        "https://gen.pollinations.ai/log?key=%5Bredacted%5D&model=test",
-    ],
-    [
-        "Enter",
-        enterLogger,
-        "https://gen.pollinations.ai/log?key=test-value&model=test",
-    ],
-] as const)("%s request logger", (_name, logger, publicUrl) => {
+    ["Gen", genLogger],
+    ["Enter", enterLogger],
+] as const)("%s request logger", (_name, logger) => {
     it.each([
         "local",
         "test",
         "staging",
         "production",
-    ])("preserves context and log ordering in %s", async (environment) => {
+    ])("preserves raw URLs, context and log ordering in %s", async (environment) => {
+        const publicUrl =
+            "https://gen.pollinations.ai/log?key=test-value&token=test-token&key=second&text=a%20b";
         const app = new Hono<{
             Variables: LoggerVariables & { requestId: string };
         }>();
@@ -69,7 +67,7 @@ describe.each([
             return c.text("ok", 201);
         });
         const response = await app.request(
-            "https://internal.example/log?key=test-value&model=test",
+            "https://internal.example/log?key=test-value&token=test-token&key=second&text=a%20b",
             {
                 headers: {
                     "x-forwarded-host": "gen.pollinations.ai",

--- a/shared/middleware/logger.ts
+++ b/shared/middleware/logger.ts
@@ -23,48 +23,46 @@ type Env = {
     Variables: LoggerVariables & { requestId?: string };
 };
 
-export function createRequestLogger(formatUrl: (url: URL) => string) {
-    return createMiddleware<Env>(async (c, next) => {
-        await ensureConfigured({
-            level: c.env.LOG_LEVEL || "debug",
-            format: c.env.LOG_FORMAT || "text",
-        });
-        const log = getLogger(["hono"]);
-        c.set("log", log);
-
-        const startTime = Date.now();
-        c.set("requestStartedAt", startTime);
-        const shouldEmitRequestLogs =
-            c.env.ENVIRONMENT === "local" || c.env.ENVIRONMENT === "test";
-
-        const publicUrl = formatUrl(getPublicUrl(c));
-
-        await withContext(
-            {
-                requestId: c.var.requestId,
-                method: c.req.method,
-                routePath: publicUrl,
-                userAgent: c.req.header("user-agent"),
-                ipAddress: getRealClientIp(c),
-            },
-            async () => {
-                if (shouldEmitRequestLogs) {
-                    log.info("{method} {url}", {
-                        method: c.req.method,
-                        url: publicUrl,
-                    });
-                }
-
-                await next();
-
-                const duration = Date.now() - startTime;
-                if (shouldEmitRequestLogs) {
-                    log.info("RESPONSE {status} {duration}ms", {
-                        status: c.res.status,
-                        duration,
-                    });
-                }
-            },
-        );
+export const logger = createMiddleware<Env>(async (c, next) => {
+    await ensureConfigured({
+        level: c.env.LOG_LEVEL || "debug",
+        format: c.env.LOG_FORMAT || "text",
     });
-}
+    const log = getLogger(["hono"]);
+    c.set("log", log);
+
+    const startTime = Date.now();
+    c.set("requestStartedAt", startTime);
+    const shouldEmitRequestLogs =
+        c.env.ENVIRONMENT === "local" || c.env.ENVIRONMENT === "test";
+
+    const publicUrl = getPublicUrl(c).toString();
+
+    await withContext(
+        {
+            requestId: c.var.requestId,
+            method: c.req.method,
+            routePath: publicUrl,
+            userAgent: c.req.header("user-agent"),
+            ipAddress: getRealClientIp(c),
+        },
+        async () => {
+            if (shouldEmitRequestLogs) {
+                log.info("{method} {url}", {
+                    method: c.req.method,
+                    url: publicUrl,
+                });
+            }
+
+            await next();
+
+            const duration = Date.now() - startTime;
+            if (shouldEmitRequestLogs) {
+                log.info("RESPONSE {status} {duration}ms", {
+                    status: c.res.status,
+                    duration,
+                });
+            }
+        },
+    );
+});


### PR DESCRIPTION
- Replaces the configurable request-logger factory with one shared middleware and identical Gen/Enter re-exports.
- Intentionally keeps raw public URLs in Gen’s log context, including credential query parameters, matching Enter’s policy as requested. Request/response log emission remains local/test-only.
- Leaves structured error-input and realtime referrer telemetry redaction unchanged.
- Verifies singleton reuse, query order/encoding/duplicates, context, environment behavior, and adjacent tracking: 116 distinct targeted tests passed, plus both service typechecks, Biome 2.3.10, and whitespace checks.
- Follow-up to #14489; includes latest main. No deployment.