### PR TITLE
fix: validate text streams before splitting for billing

### DIFF
--- a/gen.pollinations.ai/src/text/chat/usage.ts
+++ b/gen.pollinations.ai/src/text/chat/usage.ts
@@ -20,20 +20,23 @@ export class ChatUsageError extends Error {
 
 export function createChatStreamUsageValidator() {
     const decoder = new TextDecoder();
-    let usageSeen = false;
+    let lastUsage: unknown;
     let doneSeen = false;
     let errorSeen = false;
-    let validationError: ChatUsageError | undefined;
 
     const parser = createParser({
         onEvent(message) {
+            if (doneSeen) return;
             if (message.data.trim() === "[DONE]") {
-                doneSeen = true;
-                if (!usageSeen && !errorSeen) {
-                    validationError = new ChatUsageError(
-                        "Chat Completions provider omitted terminal usage",
+                if (
+                    !errorSeen &&
+                    !CompletionUsageSchema.safeParse(lastUsage).success
+                ) {
+                    throw new ChatUsageError(
+                        "Chat Completions provider returned invalid or omitted terminal usage",
                     );
                 }
+                doneSeen = true;
                 return;
             }
 
@@ -43,33 +46,20 @@ export function createChatStreamUsageValidator() {
             } catch {
                 return;
             }
-            if (!event || typeof event !== "object" || !("usage" in event)) {
-                const error =
-                    event && typeof event === "object"
-                        ? (event as { error?: unknown }).error
-                        : undefined;
-                if (error && typeof error === "object") {
-                    errorSeen = true;
-                }
-                return;
-            }
-
-            const usage = (event as { usage?: unknown }).usage;
-            if (usage === null || usage === undefined) return;
-            if (CompletionUsageSchema.safeParse(usage).success) {
-                usageSeen = true;
-            } else {
-                validationError = new ChatUsageError(
-                    "Chat Completions provider returned invalid terminal usage",
-                );
-            }
+            if (!event || typeof event !== "object") return;
+            const { usage, error } = event as {
+                usage?: unknown;
+                error?: unknown;
+            };
+            if (error && typeof error === "object") errorSeen = true;
+            // Providers may send provisional counts; only the last update is final.
+            if (usage !== null && usage !== undefined) lastUsage = usage;
         },
     });
 
     return {
         feed(chunk: Uint8Array) {
             parser.feed(decoder.decode(chunk, { stream: true }));
-            if (validationError) throw validationError;
         },
         finish() {
             // Some compatible providers close after one newline instead of an
@@ -77,8 +67,7 @@ export function createChatStreamUsageValidator() {
             // the client still receives the exact upstream bytes.
             parser.feed(`${decoder.decode()}\n\n`);
             parser.reset({ consume: true });
-            if (validationError) throw validationError;
-            if (!errorSeen && (!doneSeen || !usageSeen)) {
+            if (!errorSeen && !doneSeen) {
                 throw new ChatUsageError(
                     "Chat Completions provider ended without terminal usage",
                 );

--- a/gen.pollinations.ai/src/text/handler.ts
+++ b/gen.pollinations.ai/src/text/handler.ts
@@ -381,8 +381,11 @@ async function generateTextResponse(
             if (!completion.responseStream) {
                 return sendTextStreamResponse(completion, servedModelId);
             }
-            const [clientBody, trackingBody] = completion.responseStream.tee();
-            completion.responseStream = requireChatStreamUsage(clientBody);
+            // Client and billing must see the same validation errors.
+            const [clientBody, trackingBody] = requireChatStreamUsage(
+                completion.responseStream,
+            ).tee();
+            completion.responseStream = clientBody;
             const response = sendTextStreamResponse(completion, servedModelId);
             c.var.track?.overrideResponseTracking(
                 new Response(trackingBody, { headers: response.headers }),

--- a/gen.pollinations.ai/src/text/responses/handler.ts
+++ b/gen.pollinations.ai/src/text/responses/handler.ts
@@ -233,8 +233,10 @@ async function handleDirectResponse(
         let responseBody = result.response.body;
         let trackingResponse: Response | undefined;
         if (request.stream && responseBody) {
-            const [clientBody, trackingBody] = responseBody.tee();
-            responseBody = requireResponsesStreamUsage(clientBody);
+            // Client and billing must see the same validation errors.
+            const [clientBody, trackingBody] =
+                requireResponsesStreamUsage(responseBody).tee();
+            responseBody = clientBody;
             trackingResponse = new Response(trackingBody, { headers });
         }
         const response = new Response(responseBody, { headers });

--- a/gen.pollinations.ai/test/generation-vcr.test.ts
+++ b/gen.pollinations.ai/test/generation-vcr.test.ts
@@ -138,11 +138,21 @@ function createGenerationMocks() {
                     : { type: "response.completed" }),
                 response,
             };
+            const invalidUsageChunk =
+                body.input === "vcr invalid usage after valid usage"
+                    ? `event: response.completed\ndata: ${JSON.stringify({
+                          type: "response.completed",
+                          response: {
+                              ...response,
+                              usage: { input_tokens: 12 },
+                          },
+                      })}\n\n`
+                    : "";
             return new Response(
                 `event: response.output_text.delta\ndata: ${JSON.stringify({
                     type: "response.output_text.delta",
                     delta: "direct response",
-                })}\n\nevent: response.completed\ndata: ${JSON.stringify(terminalEvent)}\n\n`,
+                })}\n\nevent: response.completed\ndata: ${JSON.stringify(terminalEvent)}\n\n${invalidUsageChunk}`,
                 { headers: { "content-type": "text/event-stream" } },
             );
         }
@@ -414,8 +424,13 @@ async function fakePortkeyResponse(request: Request) {
         const usageChunk = prompt.includes("vcr missing chat stream usage")
             ? ""
             : `data: ${JSON.stringify(usageEvent)}\n\n`;
+        const invalidUsageChunk = prompt.includes(
+            "vcr invalid usage after valid usage",
+        )
+            ? `data: ${JSON.stringify({ ...usageEvent, usage: { prompt_tokens: 7 } })}\n\n`
+            : "";
         return new Response(
-            `data: ${JSON.stringify(streamEvent)}\n\n${usageChunk}data: [DONE]\n\n`,
+            `data: ${JSON.stringify(streamEvent)}\n\n${usageChunk}${invalidUsageChunk}data: [DONE]\n\n`,
             {
                 headers: {
                     "content-type": "text/event-stream; charset=utf-8",
@@ -771,6 +786,61 @@ test("chat streaming without usage fails closed and remains unbilled", async ({
         upstream_status: 200,
         error_code: "usage_missing",
         upstream_body: expect.any(String),
+    });
+    expect(await getUserBalance(db, caller.userId)).toEqual(balanceBefore);
+});
+
+test.for([
+    "/v1/chat/completions",
+    "/v1/responses",
+])("%s does not bill valid usage followed by a stream validation error", async (path, {
+    mocks,
+}) => {
+    await mocks.enable("tinybird", "portkeyDirect", "responsesDirect");
+    const caller = await createTestApiKey({
+        name: "invalid-usage-after-valid-usage",
+        user: { packBalance: 100 },
+    });
+    const db = drizzle(env.DB);
+    const balanceBefore = await getUserBalance(db, caller.userId);
+    const prompt = "vcr invalid usage after valid usage";
+    const { response, wait } = await fetchWorker(path, {
+        method: "POST",
+        headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${caller.key}`,
+        },
+        body: JSON.stringify({
+            stream: true,
+            ...(path === "/v1/responses"
+                ? { model: "qwen-large", input: prompt }
+                : {
+                      model: "openai-fast",
+                      messages: [{ role: "user", content: prompt }],
+                  }),
+        }),
+    });
+
+    expect(response.status).toBe(200);
+    const stream = await response.text();
+    expect(stream).toContain('"total_tokens":');
+    expect(stream).toContain('"code":"usage_missing"');
+    expect(stream).not.toContain("[DONE]");
+    await wait();
+
+    expect(mocks.tinybird.state.events).toHaveLength(1);
+    expect(mocks.tinybird.state.events[0]).toMatchObject({
+        responseStatus: 502,
+        isBilledUsage: false,
+        totalPrice: 0,
+        errorResponseCode: "usage_missing",
+    });
+    expect(mocks.tinybird.state.events[0].totalCost).toBeGreaterThan(0);
+    expect(mocks.tinybird.state.errorEvents).toHaveLength(1);
+    expect(mocks.tinybird.state.errorEvents[0]).toMatchObject({
+        status: 502,
+        upstream_status: 200,
+        error_code: "usage_missing",
     });
     expect(await getUserBalance(db, caller.userId)).toEqual(balanceBefore);
 });

--- a/gen.pollinations.ai/test/generation-vcr.test.ts
+++ b/gen.pollinations.ai/test/generation-vcr.test.ts
@@ -429,8 +429,20 @@ async function fakePortkeyResponse(request: Request) {
         )
             ? `data: ${JSON.stringify({ ...usageEvent, usage: { prompt_tokens: 7 } })}\n\n`
             : "";
+        const earlyUsageChunk = prompt.includes("vcr early usage")
+            ? `data: ${JSON.stringify({
+                  ...streamEvent,
+                  usage: prompt.includes("partial")
+                      ? { prompt_tokens: 7 }
+                      : {
+                            prompt_tokens: 7,
+                            completion_tokens: 0,
+                            total_tokens: 7,
+                        },
+              })}\n\n`
+            : "";
         return new Response(
-            `data: ${JSON.stringify(streamEvent)}\n\n${usageChunk}${invalidUsageChunk}data: [DONE]\n\n`,
+            `${earlyUsageChunk}data: ${JSON.stringify(streamEvent)}\n\n${usageChunk}${invalidUsageChunk}data: [DONE]\n\n`,
             {
                 headers: {
                     "content-type": "text/event-stream; charset=utf-8",
@@ -843,6 +855,49 @@ test.for([
         error_code: "usage_missing",
     });
     expect(await getUserBalance(db, caller.userId)).toEqual(balanceBefore);
+});
+
+test.for([
+    "partial",
+    "valid",
+])("chat bills final usage after %s early usage", async (kind, { mocks }) => {
+    await mocks.enable("tinybird", "portkeyDirect");
+    const caller = await createTestApiKey({ user: { packBalance: 100 } });
+    const db = drizzle(env.DB);
+    const balanceBefore = await getUserBalance(db, caller.userId);
+    const { response, wait } = await fetchWorker("/v1/chat/completions", {
+        method: "POST",
+        headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${caller.key}`,
+        },
+        body: JSON.stringify({
+            model: "openai-fast",
+            stream: true,
+            messages: [{ role: "user", content: `vcr early usage ${kind}` }],
+        }),
+    });
+
+    expect(response.status).toBe(200);
+    const stream = await response.text();
+    expect(stream).toContain("[DONE]");
+    expect(stream).not.toContain("usage_missing");
+    await wait();
+    expect(mocks.tinybird.state.events).toHaveLength(1);
+    const event = mocks.tinybird.state.events[0];
+    expect(event).toMatchObject({
+        responseStatus: 200,
+        isBilledUsage: true,
+        tokenCountPromptText: 7,
+        tokenCountCompletionText: 3,
+    });
+    expect(event.totalPrice).toBeGreaterThan(0);
+    expect(mocks.tinybird.state.errorEvents).toHaveLength(0);
+    const balanceAfter = await getUserBalance(db, caller.userId);
+    expect(balanceBefore.packBalance - balanceAfter.packBalance).toBeCloseTo(
+        event.totalPrice,
+        12,
+    );
 });
 
 test("Chat uses a native Responses target and preserves billing usage", async ({

--- a/gen.pollinations.ai/test/text/genericOpenAIClient.test.ts
+++ b/gen.pollinations.ai/test/text/genericOpenAIClient.test.ts
@@ -869,6 +869,26 @@ describe("Chat Completions stream usage", () => {
         ).toThrow(/omitted terminal usage/);
     });
 
+    it("keeps early valid usage when later chunks omit it or use null", () => {
+        const validator = createChatStreamUsageValidator();
+        validator.feed(
+            encoder.encode(
+                'data: {"usage":{"prompt_tokens":2,"completion_tokens":1,"total_tokens":3}}\n\ndata: {"choices":[]}\n\ndata: {"usage":null}\n\ndata: [DONE]\n\n',
+            ),
+        );
+        expect(() => validator.finish()).not.toThrow();
+    });
+
+    it("passes through explicit errors even alongside partial usage", () => {
+        const validator = createChatStreamUsageValidator();
+        validator.feed(
+            encoder.encode(
+                'data: {"usage":{"prompt_tokens":2},"error":{"message":"provider failed"}}\n\ndata: [DONE]\n\n',
+            ),
+        );
+        expect(() => validator.finish()).not.toThrow();
+    });
+
     it("rejects a stream that ends before terminal usage", () => {
         const validator = createChatStreamUsageValidator();
         validator.feed(

--- a/gen.pollinations.ai/test/text/streamUsageFraming.test.ts
+++ b/gen.pollinations.ai/test/text/streamUsageFraming.test.ts
@@ -61,10 +61,11 @@ describe.each([
                 .split(/\r\n|\r|\n/)
                 .filter((line) => line.startsWith("data:"))
                 .map((line) => JSON.parse(line.slice(5)));
-            expect(events).toHaveLength(2);
-            expect(events[1].error?.code ?? events[1].code).toBe(
-                "usage_missing",
-            );
+            // Chat forwards provisional usage and validates it at DONE;
+            // Responses validates its terminal event before forwarding it.
+            expect(events).toHaveLength(_name === "Chat" ? 3 : 2);
+            const error = events.at(-1);
+            expect(error.error?.code ?? error.code).toBe("usage_missing");
             expect(output).not.toContain("[DONE]");
         }
     });


### PR DESCRIPTION
- Fixes the #14494 gap by validating before the existing client/billing stream split.
- Simplifies Chat validation: retain the latest non-null usage and validate at DONE, allowing provisional early counts. Removes 11 runtime lines; no new abstractions.
- Keeps explicit-error detection, failed-stream no-charge behavior, and Responses terminal validation.
- Covers successful final-usage wallet charges, invalid-final-usage no-charge behavior, provider costs, null usage, and SSE framing. 213 focused tests passed with an isolated snapshot server; a default-setup rerun hit an existing non-stream Perplexity timeout. Type-checking and Biome pass.