### PR TITLE
Tag issue author in automated pre-review comments

### DIFF
--- a/operations/app-management/ingestion/review-agent.py
+++ b/operations/app-management/ingestion/review-agent.py
@@ -270,6 +270,17 @@ def sanitize_ai_lines(value, max_lines=4, max_line_length=240):
     return lines
 
 
+def get_issue_author():
+    try:
+        data = json.loads(VALIDATION_RESULT)
+    except (TypeError, ValueError):
+        return ""
+    username = (data.get("metadata") or {}).get("githubUsername", "")
+    if not re.fullmatch(r"[A-Za-z0-9-]+", username or ""):
+        return ""
+    return username
+
+
 def github_api_all(path):
     items = []
     page = 1
@@ -329,11 +340,14 @@ def main():
     if validation.get("system_error"):
         raise RuntimeError(validation["system_error"])
 
+    issue_author = get_issue_author()
+    mention = f"@{issue_author} " if issue_author else ""
+
     if not validation.get("valid"):
         errors = validation.get("errors") or ["The submission form is incomplete."]
         bullets = "\n".join(f"- {error}" for error in errors)
         replace_review_comment(
-            f"{COMMENT_MARKER}\n## App pre-review: more information needed\n\n{bullets}\n\nEdit the issue with the missing information; the pre-review will run again."
+            f"{COMMENT_MARKER}\n## App pre-review: more information needed\n\n{mention}{bullets}\n\nEdit the issue with the missing information; the pre-review will run again."
         )
         set_status_label("APP-NEEDS-INFO")
         return
@@ -365,7 +379,7 @@ def main():
     questions = questions[:4]
     if review["status"] == "ready":
         body = (
-            f"{COMMENT_MARKER}\n## App pre-review: ready for human review\n\n{summary}\n\n"
+            f"{COMMENT_MARKER}\n## App pre-review: ready for human review\n\n{mention}{summary}\n\n"
             "A maintainer can verify the app and add `APP-APPROVED` to publish it."
         )
         label = "APP-REVIEW"
@@ -376,7 +390,7 @@ def main():
             ]
         question_text = "\n".join(f"- {question}" for question in questions)
         body = (
-            f"{COMMENT_MARKER}\n## App pre-review: more information needed\n\n{summary}\n\n"
+            f"{COMMENT_MARKER}\n## App pre-review: more information needed\n\n{mention}{summary}\n\n"
             f"{question_text}\n\nEdit the issue with the requested information; the pre-review will run again."
         )
         label = "APP-NEEDS-INFO"
@@ -390,8 +404,10 @@ if __name__ == "__main__":
     except Exception as error:
         print(f"App pre-review failed: {error}", file=sys.stderr)
         try:
+            failure_mention = get_issue_author()
+            failure_mention = f"@{failure_mention} " if failure_mention else ""
             replace_review_comment(
-                f"{COMMENT_MARKER}\n## App pre-review unavailable\n\nThe automated check could not finish. A maintainer can rerun the workflow; no submitter action is required yet."
+                f"{COMMENT_MARKER}\n## App pre-review unavailable\n\n{failure_mention}The automated check could not finish. A maintainer can rerun the workflow; no submitter action is required yet."
             )
         except Exception as comment_error:
             print(f"Could not post failure status: {comment_error}", file=sys.stderr)


### PR DESCRIPTION
Prepends an @mention of the issue author (from the already-validated metadata.githubUsername) to the automated pre-review comments, so submitters get notified when the bot comments on their issue.