### PR TITLE
fix: accept provisional usage in managed-agent streams

### DIFF
--- a/gen.pollinations.ai/src/text/agents/runtime.ts
+++ b/gen.pollinations.ai/src/text/agents/runtime.ts
@@ -200,7 +200,7 @@ async function createAgent(
                 };
             },
             createStreamExtractor() {
-                let usage: CompletionUsage | undefined;
+                let usage: unknown;
                 return {
                     processChunk(chunk) {
                         if (
@@ -209,12 +209,18 @@ async function createAgent(
                             "usage" in chunk &&
                             chunk.usage != null
                         ) {
-                            usage = completionUsage(chunk.usage);
+                            // Providers may send provisional counts before final usage.
+                            usage = chunk.usage;
                         }
                     },
                     buildMetadata() {
                         return {
-                            pollinations: { completionUsage: usage ?? null },
+                            pollinations: {
+                                completionUsage:
+                                    usage == null
+                                        ? null
+                                        : completionUsage(usage),
+                            },
                         };
                     },
                 };

--- a/gen.pollinations.ai/test/text/agents/runtime.test.ts
+++ b/gen.pollinations.ai/test/text/agents/runtime.test.ts
@@ -910,6 +910,71 @@ describe("prompt-agent runtime", () => {
         expect(completed.usage.input_tokens).toBe(6);
     });
 
+    it.each([
+        "complete",
+        "partial",
+        "missing",
+    ])("validates %s final usage after provisional streamed usage", async (finalUsage) => {
+        const events = [
+            {
+                choices: [{ index: 0, delta: { content: "Hello" } }],
+                usage: {
+                    prompt_tokens: 6,
+                    ...(finalUsage === "partial"
+                        ? { completion_tokens: 0, total_tokens: 6 }
+                        : {}),
+                },
+            },
+            ...(finalUsage === "missing"
+                ? []
+                : [
+                      {
+                          choices: [
+                              { index: 0, delta: {}, finish_reason: "stop" },
+                          ],
+                          usage:
+                              finalUsage === "partial"
+                                  ? { prompt_tokens: 6 }
+                                  : {
+                                        prompt_tokens: 6,
+                                        completion_tokens: 4,
+                                        total_tokens: 10,
+                                    },
+                      },
+                  ]),
+        ];
+        const response = await runAgent(
+            { messages: [{ role: "user", content: "hi" }], stream: true },
+            {
+                ...BASE_RUNTIME,
+                fetcher: async () =>
+                    new Response(
+                        `${events
+                            .map(
+                                (event) => `data: ${JSON.stringify(event)}\n\n`,
+                            )
+                            .join("")}data: [DONE]\n\n`,
+                        { headers: { "content-type": "text/event-stream" } },
+                    ),
+            },
+        );
+        const output = responseStreamEvents(await response.text());
+        if (finalUsage !== "complete") {
+            expect(output.at(-1)).toMatchObject({ type: "response.failed" });
+            expect(
+                output.some((event) => event.type === "response.completed"),
+            ).toBe(false);
+            return;
+        }
+        expect(output.at(-1)).toMatchObject({
+            type: "response.completed",
+            response: {
+                usage: { input_tokens: 6, output_tokens: 4, total_tokens: 10 },
+            },
+        });
+        expect(output.some((event) => event.type === "error")).toBe(false);
+    });
+
     it("streams base-model errors as terminal errors", async () => {
         vi.stubGlobal(
             "fetch",


### PR DESCRIPTION
- Fixes managed agents rejecting an otherwise successful stream when the provider sends partial token counts before complete final usage.
- Moves the existing usage check to the end of each streamed model step; no new helpers, retries, pricing rules, or secret changes.
- Keeps missing or invalid final usage as a failure, including valid early counts followed by invalid final counts.
- Reproduced the failure before fixing it. Full Gen: 1,808 passed / 6 skipped with an isolated snapshot server and a 15-second local timeout; typechecking and Biome pass. Default-timeout focused run hit the existing Perplexity fixture timeout. Addresses #14500 and #14360.