### PR TITLE
fix: unblock dashboard loading from billing and earnings

### DIFF
--- a/enter.pollinations.ai/frontend/src/routes/_dashboard.pollen.tsx
+++ b/enter.pollinations.ai/frontend/src/routes/_dashboard.pollen.tsx
@@ -36,9 +36,9 @@ export const Route = createFileRoute("/_dashboard/pollen")({
     loader: () =>
         apiClient.stripe.billing.$get().then((r) => (r.ok ? r.json() : null)),
     pendingComponent: () => (
-        <p role="status" className="text-theme-text-muted">
+        <output className="text-theme-text-muted">
             Loading billing details…
-        </p>
+        </output>
     ),
     component: PollenPage,
 });

--- a/enter.pollinations.ai/frontend/src/routes/_dashboard.pollen.tsx
+++ b/enter.pollinations.ai/frontend/src/routes/_dashboard.pollen.tsx
@@ -35,13 +35,20 @@ export const Route = createFileRoute("/_dashboard/pollen")({
     },
     loader: () =>
         apiClient.stripe.billing.$get().then((r) => (r.ok ? r.json() : null)),
+    pendingComponent: () => (
+        <p role="status" className="text-theme-text-muted">
+            Loading billing details…
+        </p>
+    ),
     component: PollenPage,
 });
 
 function PollenPage() {
     const { pack } = Route.useSearch();
     const navigate = useNavigate({ from: "/pollen" });
-    const wallet = DashboardRoute.useLoaderData();
+    const { tierBalance, packBalance, earnings } =
+        DashboardRoute.useLoaderData();
+    const balances = { tierBalance, packBalance };
     const billingState = Route.useLoaderData();
     const selectedPack = getPollenPackByKey(pack ?? "p5") ?? POLLEN_PACKS[0];
 
@@ -54,10 +61,12 @@ function PollenPage() {
         <div className="flex flex-col gap-6">
             <Section title="Wallet" framed>
                 <Await
-                    promise={wallet.earnings}
-                    fallback={<PollenBalance {...wallet} />}
+                    promise={earnings}
+                    fallback={<PollenBalance {...balances} />}
                 >
-                    {(earnings) => <PollenBalance {...wallet} {...earnings} />}
+                    {(earnings) => (
+                        <PollenBalance {...balances} {...earnings} />
+                    )}
                 </Await>
             </Section>
             <Section title="Top-up" framed id="buy-pollen">

--- a/enter.pollinations.ai/frontend/src/routes/_dashboard.pollen.tsx
+++ b/enter.pollinations.ai/frontend/src/routes/_dashboard.pollen.tsx
@@ -6,7 +6,13 @@ import {
     POLLEN_PACKS,
     type PollenPackKey,
 } from "@shared/pollen-packs.ts";
-import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
+import {
+    Await,
+    createFileRoute,
+    redirect,
+    useNavigate,
+} from "@tanstack/react-router";
+import { apiClient } from "../api.ts";
 import { BuyPollenPanel, PollenBalance } from "../components/pollen";
 import { Route as DashboardRoute } from "./_dashboard.tsx";
 
@@ -27,14 +33,16 @@ export const Route = createFileRoute("/_dashboard/pollen")({
             });
         }
     },
+    loader: () =>
+        apiClient.stripe.billing.$get().then((r) => (r.ok ? r.json() : null)),
     component: PollenPage,
 });
 
 function PollenPage() {
     const { pack } = Route.useSearch();
     const navigate = useNavigate({ from: "/pollen" });
-    const { tierBalance, packBalance, paidWeek, tierWeek, billingState } =
-        DashboardRoute.useLoaderData();
+    const wallet = DashboardRoute.useLoaderData();
+    const billingState = Route.useLoaderData();
     const selectedPack = getPollenPackByKey(pack ?? "p5") ?? POLLEN_PACKS[0];
 
     function selectPack(amount: number): void {
@@ -45,12 +53,12 @@ function PollenPage() {
     return (
         <div className="flex flex-col gap-6">
             <Section title="Wallet" framed>
-                <PollenBalance
-                    tierBalance={tierBalance}
-                    packBalance={packBalance}
-                    paidWeek={paidWeek}
-                    tierWeek={tierWeek}
-                />
+                <Await
+                    promise={wallet.earnings}
+                    fallback={<PollenBalance {...wallet} />}
+                >
+                    {(earnings) => <PollenBalance {...wallet} {...earnings} />}
+                </Await>
             </Section>
             <Section title="Top-up" framed id="buy-pollen">
                 <BuyPollenPanel

--- a/enter.pollinations.ai/frontend/src/routes/_dashboard.tsx
+++ b/enter.pollinations.ai/frontend/src/routes/_dashboard.tsx
@@ -92,6 +92,10 @@ export const Route = createFileRoute("/_dashboard")({
 
 function DashboardLayout() {
     const data = Route.useLoaderData();
+    const balances = {
+        tierBalance: data.tierBalance,
+        packBalance: data.packBalance,
+    };
     const [isSigningOut, setIsSigningOut] = useState(false);
 
     async function handleSignOut(): Promise<void> {
@@ -118,10 +122,10 @@ function DashboardLayout() {
                 data.user ? (
                     <Await
                         promise={data.earnings}
-                        fallback={<SidebarWallet {...data} />}
+                        fallback={<SidebarWallet {...balances} />}
                     >
                         {(earnings) => (
-                            <SidebarWallet {...data} {...earnings} />
+                            <SidebarWallet {...balances} {...earnings} />
                         )}
                     </Await>
                 ) : undefined

--- a/enter.pollinations.ai/frontend/src/routes/_dashboard.tsx
+++ b/enter.pollinations.ai/frontend/src/routes/_dashboard.tsx
@@ -1,5 +1,5 @@
 import { Button, GitHubIcon, InlineLink } from "@pollinations/ui";
-import { createFileRoute, Outlet } from "@tanstack/react-router";
+import { Await, createFileRoute, Outlet } from "@tanstack/react-router";
 import { useState } from "react";
 import { apiClient } from "../api.ts";
 import { authClient } from "../auth.ts";
@@ -46,35 +46,28 @@ export const Route = createFileRoute("/_dashboard")({
                 packBalance: 0,
                 communityEndpointsAllowed: false,
                 discordAvailable: false,
-                billingState: null,
-                paidWeek: 0,
-                tierWeek: 0,
+                earnings: Promise.resolve(null),
             };
         }
 
-        const [
-            apiKeysResult,
-            d1BalanceResult,
-            profileResult,
-            billingState,
-            earningsTodayResult,
-        ] = await Promise.all([
-            apiClient["api-keys"]
-                .$get()
-                .then((r) => (r.ok ? r.json() : { data: [] })),
-            apiClient.customer.balance
-                .$get()
-                .then((r) => (r.ok ? r.json() : null)),
-            apiClient.account.profile
-                .$get()
-                .then((r) => (r.ok ? r.json() : null)),
-            apiClient.stripe.billing
-                .$get()
-                .then((r) => (r.ok ? r.json() : null)),
-            apiClient.customer.balance.today
-                .$get()
-                .then((r) => (r.ok ? r.json() : null)),
-        ]);
+        // Weekly earnings are optional display data, not a prerequisite for
+        // opening any dashboard page. Keep slow analytics off the loader path.
+        const earnings = apiClient.customer.balance.today
+            .$get()
+            .then((r) => (r.ok ? r.json() : null))
+            .catch(() => null);
+        const [apiKeysResult, d1BalanceResult, profileResult] =
+            await Promise.all([
+                apiClient["api-keys"]
+                    .$get()
+                    .then((r) => (r.ok ? r.json() : { data: [] })),
+                apiClient.customer.balance
+                    .$get()
+                    .then((r) => (r.ok ? r.json() : null)),
+                apiClient.account.profile
+                    .$get()
+                    .then((r) => (r.ok ? r.json() : null)),
+            ]);
         const sessionUser = context.user as typeof context.user & {
             githubUsername?: string | null;
         };
@@ -91,9 +84,7 @@ export const Route = createFileRoute("/_dashboard")({
             communityEndpointsAllowed:
                 profileResult?.communityEndpointsAllowed ?? false,
             discordAvailable: profileResult?.discordAvailable ?? false,
-            billingState,
-            paidWeek: earningsTodayResult?.paidWeek ?? 0,
-            tierWeek: earningsTodayResult?.tierWeek ?? 0,
+            earnings,
         };
     },
     component: DashboardLayout,
@@ -125,12 +116,14 @@ function DashboardLayout() {
             showFooterLinks={Boolean(data.user)}
             walletArea={
                 data.user ? (
-                    <SidebarWallet
-                        tierBalance={data.tierBalance}
-                        packBalance={data.packBalance}
-                        paidWeek={data.paidWeek}
-                        tierWeek={data.tierWeek}
-                    />
+                    <Await
+                        promise={data.earnings}
+                        fallback={<SidebarWallet {...data} />}
+                    >
+                        {(earnings) => (
+                            <SidebarWallet {...data} {...earnings} />
+                        )}
+                    </Await>
                 ) : undefined
             }
         >


### PR DESCRIPTION
- Removes Stripe billing from the shared dashboard loader; only the Pollen page fetches it. Previously every signed-in dashboard page waited for Stripe before rendering.
- Lets weekly earnings load after the dashboard renders using the router's existing `Await`. Wallet balances remain visible while earnings are pending or unavailable.
- Shows a loading message while Pollen waits for billing. Keeps the change to two route files, with no new dependencies or caching logic.
- Addresses #14000; related to #14421, which changes catalog fetching. This PR removes dashboard blockers before Models renders; it does not replace #14421. The reported long delay was not reproduced.
- Validation: production frontend build, TypeScript, and Biome pass. Actual loader, router, and rendering checks cover deferred/failed earnings, signed-out loading, Pollen-only billing and its pending state, and pack navigation preserving billing data.
