### PR TITLE
fix: return structured MCP call errors

### DIFF
--- a/gen.pollinations.ai/src/text/agents/mcp.ts
+++ b/gen.pollinations.ai/src/text/agents/mcp.ts
@@ -2,12 +2,7 @@ import { z } from "zod";
 
 const McpCallErrorSchema = z.discriminatedUnion("type", [
     z.object({
-        type: z.literal("mcp_protocol_error"),
-        code: z.number().int(),
-        message: z.string(),
-    }),
-    z.object({
-        type: z.literal("http_error"),
+        type: z.enum(["mcp_protocol_error", "http_error"]),
         code: z.number().int(),
         message: z.string(),
     }),
@@ -54,7 +49,7 @@ export function mcpCallError(error: unknown): McpCallError {
     }
     return {
         type: "mcp_tool_execution_error",
-        content: { content: [{ type: "text", text: message }], isError: true },
+        content: message,
     };
 }
 

--- a/gen.pollinations.ai/src/text/agents/mcp.ts
+++ b/gen.pollinations.ai/src/text/agents/mcp.ts
@@ -1,5 +1,22 @@
 import { z } from "zod";
 
+const McpCallErrorSchema = z.discriminatedUnion("type", [
+    z.object({
+        type: z.literal("mcp_protocol_error"),
+        code: z.number().int(),
+        message: z.string(),
+    }),
+    z.object({
+        type: z.literal("http_error"),
+        code: z.number().int(),
+        message: z.string(),
+    }),
+    z.object({
+        type: z.literal("mcp_tool_execution_error"),
+        content: z.json(),
+    }),
+]);
+
 export const McpCallSchema = z.object({
     type: z.literal("mcp_call"),
     id: z.string().min(1),
@@ -10,10 +27,54 @@ export const McpCallSchema = z.object({
         .enum(["in_progress", "completed", "incomplete", "calling", "failed"])
         .default("completed"),
     output: z.string().nullable().default(null),
-    error: z.string().nullable().default(null),
+    error: McpCallErrorSchema.nullable().default(null),
 });
 
 export type McpCall = z.infer<typeof McpCallSchema>;
+type McpCallError = z.infer<typeof McpCallErrorSchema>;
+
+export function mcpCallError(error: unknown): McpCallError {
+    const message = error instanceof Error ? error.message : String(error);
+    if (error && typeof error === "object") {
+        // The MCP SDK exposes HTTP and JSON-RPC codes on its transport errors.
+        if ("statusCode" in error && Number.isSafeInteger(error.statusCode)) {
+            return {
+                type: "http_error",
+                code: error.statusCode as number,
+                message,
+            };
+        }
+        if ("code" in error && Number.isSafeInteger(error.code)) {
+            return {
+                type: "mcp_protocol_error",
+                code: error.code as number,
+                message,
+            };
+        }
+    }
+    return {
+        type: "mcp_tool_execution_error",
+        content: { content: [{ type: "text", text: message }], isError: true },
+    };
+}
+
+/** Keep Chat rendering and model-visible replay consistent with structured errors. */
+export function mcpErrorText(error: McpCallError): string {
+    if (error.type !== "mcp_tool_execution_error") return error.message;
+    const content = error.content;
+    if (
+        content &&
+        typeof content === "object" &&
+        "content" in content &&
+        Array.isArray(content.content)
+    ) {
+        const output = safeMcpModelOutput({ output: content });
+        return output.type === "text"
+            ? output.value
+            : output.value.map((part) => part.text).join("\n");
+    }
+    return typeof content === "string" ? content : JSON.stringify(content);
+}
 
 const SafeMcpPartSchema = z.union([
     z.object({ type: z.literal("text"), text: z.string() }),
@@ -109,14 +170,15 @@ function escapeHtml(value: string): string {
 /** Chat clients display server-executed tools as details, not function calls. */
 export function formatMcpCall(item: McpCall, seenUrls: Set<string>): string {
     let output: unknown;
-    let text = item.error ?? item.output ?? "";
+    const errorText = item.error === null ? null : mcpErrorText(item.error);
+    let text = errorText ?? item.output ?? "";
     if (item.output) {
         try {
             output = JSON.parse(item.output);
             if (output && typeof output === "object" && "content" in output) {
                 const modelOutput = safeMcpModelOutput({ output });
                 text =
-                    item.error ??
+                    errorText ??
                     (modelOutput.type === "text"
                         ? modelOutput.value
                         : modelOutput.value

--- a/gen.pollinations.ai/src/text/agents/output.ts
+++ b/gen.pollinations.ai/src/text/agents/output.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { McpCallSchema, safeMcpModelOutput, safeMcpOutput } from "./mcp.ts";
+import { McpCallSchema, mcpCallError, safeMcpOutput } from "./mcp.ts";
 import type { AgentPart } from "./runtime.ts";
 
 const MessageSchema = z.object({
@@ -138,19 +138,15 @@ export function collectOutput(
                 throw new Error("Agent tool result has no matching call");
             }
             if (part.type === "tool-error") {
-                item.error =
-                    part.error instanceof Error
-                        ? part.error.message
-                        : String(part.error);
+                item.error = mcpCallError(part.error);
             } else {
                 const result = safeMcpOutput(part.output);
                 item.output = JSON.stringify(result);
                 if (result.isError) {
-                    const output = safeMcpModelOutput({ output: result });
-                    item.error =
-                        output.type === "text"
-                            ? output.value
-                            : output.value.map((part) => part.text).join("\n");
+                    item.error = {
+                        type: "mcp_tool_execution_error",
+                        content: result,
+                    };
                 }
             }
             item.status = item.error === null ? "completed" : "failed";

--- a/gen.pollinations.ai/src/text/agents/responses.ts
+++ b/gen.pollinations.ai/src/text/agents/responses.ts
@@ -7,7 +7,7 @@ import {
 } from "@shared/schemas/openai.ts";
 import { APICallError, type ModelMessage, type ToolResultPart } from "ai";
 import { z } from "zod";
-import { McpCallSchema, safeMcpModelOutput } from "./mcp.ts";
+import { McpCallSchema, mcpErrorText, safeMcpModelOutput } from "./mcp.ts";
 import { type AgentOutputItem, collectOutput } from "./output.ts";
 import {
     type AgentOutput,
@@ -212,7 +212,10 @@ function inputMessages(request: CreateResponseRequest): ModelMessage[] {
                     call.error !== null || call.status === "failed"
                         ? "error-text"
                         : "text",
-                value: call.error ?? call.output ?? "",
+                value:
+                    call.error === null
+                        ? (call.output ?? "")
+                        : mcpErrorText(call.error),
             };
             if (call.error === null && call.output !== null) {
                 try {

--- a/gen.pollinations.ai/test/text/agents/responses.test.ts
+++ b/gen.pollinations.ai/test/text/agents/responses.test.ts
@@ -1,5 +1,6 @@
 import OpenAI from "openai";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mcpCallError } from "../../../src/text/agents/mcp.ts";
 import {
     handlePromptAgentResponsesRequest,
     PromptAgentResponsesRequestSchema,
@@ -39,6 +40,27 @@ function streamEvents(body: string): Record<string, unknown>[] {
 
 describe("managed agent Responses runtime", () => {
     beforeEach(() => vi.unstubAllGlobals());
+
+    it.each([
+        1.5,
+        Number.MAX_SAFE_INTEGER + 1,
+        NaN,
+        Infinity,
+    ])("does not expose an invalid MCP error code %s", (code) => {
+        for (const field of ["code", "statusCode"]) {
+            expect(
+                mcpCallError(
+                    Object.assign(new Error("Failed"), { [field]: code }),
+                ),
+            ).toEqual({
+                type: "mcp_tool_execution_error",
+                content: {
+                    content: [{ type: "text", text: "Failed" }],
+                    isError: true,
+                },
+            });
+        }
+    });
 
     it("returns a native stateless Response with required usage", async () => {
         const fetchMock = vi.fn(
@@ -502,9 +524,19 @@ describe("managed agent Responses runtime", () => {
     });
 
     it.each([
-        "completed",
-        "failed",
-    ] as const)("replays %s MCP calls as history without executing them", async (status) => {
+        null,
+        { type: "http_error", code: 503, message: "Saved failure" },
+        { type: "mcp_protocol_error", code: -32603, message: "Saved failure" },
+        { type: "mcp_tool_execution_error", content: "Saved failure" },
+        {
+            type: "mcp_tool_execution_error",
+            content: {
+                content: [{ type: "text", text: "Saved failure" }],
+                isError: true,
+            },
+        },
+    ])("replays MCP calls with error %j without executing them", async (error) => {
+        const status = error === null ? "completed" : "failed";
         const history = {
             type: "mcp_call",
             id: "prior-call",
@@ -518,7 +550,7 @@ describe("managed agent Responses runtime", () => {
                           content: [{ type: "text", text: "Saved answer" }],
                       })
                     : null,
-            error: status === "failed" ? "Saved failure" : null,
+            error,
         };
         const fetchMock = vi.fn(
             async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -545,11 +577,14 @@ describe("managed agent Responses runtime", () => {
                         {
                             role: "tool",
                             tool_call_id: "prior-call",
-                            content:
-                                history.error ??
-                                JSON.stringify([
-                                    { type: "text", text: "Saved answer" },
-                                ]),
+                            content: error
+                                ? "Saved failure"
+                                : JSON.stringify([
+                                      {
+                                          type: "text",
+                                          text: "Saved answer",
+                                      },
+                                  ]),
                         },
                         expect.objectContaining({
                             role: "user",
@@ -593,6 +628,24 @@ describe("managed agent Responses runtime", () => {
             [history, history],
             [{ ...history, status: "in_progress" }],
             [{ ...history, arguments: "invalid JSON" }],
+            [{ ...history, error: "legacy string error" }],
+            [
+                {
+                    ...history,
+                    error: { type: "http_error", message: "Missing code" },
+                },
+            ],
+            [
+                {
+                    ...history,
+                    error: {
+                        type: "mcp_protocol_error",
+                        code: -1.5,
+                        message: "Invalid code",
+                    },
+                },
+            ],
+            [{ ...history, error: { type: "mcp_tool_execution_error" } }],
         ]) {
             const invalid = await handlePromptAgentResponsesRequest(
                 request({ input }),

--- a/gen.pollinations.ai/test/text/agents/responses.test.ts
+++ b/gen.pollinations.ai/test/text/agents/responses.test.ts
@@ -1,6 +1,5 @@
 import OpenAI from "openai";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { mcpCallError } from "../../../src/text/agents/mcp.ts";
 import {
     handlePromptAgentResponsesRequest,
     PromptAgentResponsesRequestSchema,
@@ -40,27 +39,6 @@ function streamEvents(body: string): Record<string, unknown>[] {
 
 describe("managed agent Responses runtime", () => {
     beforeEach(() => vi.unstubAllGlobals());
-
-    it.each([
-        1.5,
-        Number.MAX_SAFE_INTEGER + 1,
-        NaN,
-        Infinity,
-    ])("does not expose an invalid MCP error code %s", (code) => {
-        for (const field of ["code", "statusCode"]) {
-            expect(
-                mcpCallError(
-                    Object.assign(new Error("Failed"), { [field]: code }),
-                ),
-            ).toEqual({
-                type: "mcp_tool_execution_error",
-                content: {
-                    content: [{ type: "text", text: "Failed" }],
-                    isError: true,
-                },
-            });
-        }
-    });
 
     it("returns a native stateless Response with required usage", async () => {
         const fetchMock = vi.fn(

--- a/gen.pollinations.ai/test/text/agents/runtime.test.ts
+++ b/gen.pollinations.ai/test/text/agents/runtime.test.ts
@@ -1406,8 +1406,17 @@ describe("prompt-agent runtime", () => {
         expect(toolCalls).toBe(0);
     });
 
-    it("feeds a failing tool's error back to the model instead of 502", async () => {
+    it.each(
+        ["http", "protocol", "execution", "network"].flatMap((kind) =>
+            [false, true].map((stream) => ({ kind, stream })),
+        ),
+    )("returns structured $kind tool errors with stream=$stream", async ({
+        kind,
+        stream,
+    }) => {
         let modelCalls = 0;
+        const failureMessage = "upstream boom <failed>";
+        const binaryData = "UFJJVkFURV9CSU5BUlk=";
         const fetchMock = vi.fn(
             async (input: RequestInfo | URL, init?: RequestInit) => {
                 const request = new Request(input, init);
@@ -1453,54 +1462,100 @@ describe("prompt-agent runtime", () => {
                             },
                         });
                     }
-                    // tools/call fails upstream.
-                    return new Response("upstream boom", { status: 500 });
+                    if (kind === "http") {
+                        return new Response(failureMessage, {
+                            status: 500,
+                        });
+                    }
+                    if (kind === "network") throw new Error(failureMessage);
+                    return Response.json({
+                        jsonrpc: "2.0",
+                        id: body.id,
+                        ...(kind === "protocol"
+                            ? {
+                                  error: {
+                                      code: -32603,
+                                      message: failureMessage,
+                                  },
+                              }
+                            : {
+                                  result: {
+                                      isError: true,
+                                      content: [
+                                          {
+                                              type: "text",
+                                              text: failureMessage,
+                                          },
+                                          {
+                                              type: "image",
+                                              data: binaryData,
+                                              mimeType: "image/png",
+                                          },
+                                      ],
+                                  },
+                              }),
+                    });
                 }
 
                 modelCalls++;
-                // First turn: ask for the MCP tool.
-                if (modelCalls === 1) {
+                if (modelCalls === 2) {
+                    const body = await request.json();
+                    expect(JSON.stringify(body)).toContain(failureMessage);
+                    expect(JSON.stringify(body)).not.toContain(binaryData);
+                }
+                const message =
+                    modelCalls === 1
+                        ? {
+                              role: "assistant",
+                              content: "",
+                              tool_calls: [
+                                  {
+                                      index: 0,
+                                      id: "c1",
+                                      type: "function",
+                                      function: {
+                                          name: "mcp__pollinations__listModels",
+                                          arguments: "{}",
+                                      },
+                                  },
+                              ],
+                          }
+                        : {
+                              role: "assistant",
+                              content: "sorry, lookup failed",
+                          };
+                const finish_reason = modelCalls === 1 ? "tool_calls" : "stop";
+                const usage = {
+                    prompt_tokens: 2,
+                    completion_tokens: 2,
+                    total_tokens: 4,
+                };
+                if (!stream) {
                     return Response.json({
-                        choices: [
-                            {
-                                message: {
-                                    role: "assistant",
-                                    content: "",
-                                    tool_calls: [
-                                        {
-                                            id: "c1",
-                                            function: {
-                                                name: "mcp__pollinations__listModels",
-                                                arguments: "{}",
-                                            },
-                                        },
-                                    ],
-                                },
-                            },
-                        ],
-                        usage: {
-                            prompt_tokens: 3,
-                            completion_tokens: 1,
-                            total_tokens: 4,
-                        },
+                        choices: [{ message, finish_reason }],
+                        usage,
                     });
                 }
-                // Next model turn recovers and answers.
-                return Response.json({
-                    choices: [
+                return new Response(
+                    `${[
                         {
-                            message: {
-                                role: "assistant",
-                                content: "sorry, lookup failed",
-                            },
+                            choices: [
+                                {
+                                    index: 0,
+                                    delta: message,
+                                    finish_reason: null,
+                                },
+                            ],
                         },
-                    ],
-                    usage: {
-                        prompt_tokens: 2,
-                        completion_tokens: 2,
-                        total_tokens: 4,
-                    },
-                });
+                        {
+                            choices: [{ index: 0, delta: {}, finish_reason }],
+                            usage,
+                        },
+                    ]
+                        .map((event) => `data: ${JSON.stringify(event)}\n\n`)
+                        .join("")}data: [DONE]\n\n`,
+                    { headers: { "content-type": "text/event-stream" } },
+                );
             },
         );
         vi.stubGlobal("fetch", fetchMock);
@@ -1508,6 +1563,7 @@ describe("prompt-agent runtime", () => {
         const res = await runAgent(
             {
                 messages: [{ role: "user", content: "look up cats" }],
+                stream,
             },
             {
                 ...BASE_RUNTIME,
@@ -1518,28 +1574,96 @@ describe("prompt-agent runtime", () => {
             },
         );
         // A tool failure does not fail the request.
+        expect(res.status).toBe(200);
+        const chatSource = res.clone().body;
+        if (!chatSource) throw new Error("Missing response body");
         const responseText = await res.text();
-        expect(res.status, responseText).toBe(200);
-        const json = JSON.parse(responseText) as {
-            output: { content: { text: string }[] }[];
-            usage: { tool_call_counts: Record<string, number> };
-        };
+        const events = stream ? responseStreamEvents(responseText) : [];
+        const json = stream
+            ? events.at(-1)?.response
+            : JSON.parse(responseText);
         expect(responseOutputText(json)).toBe("sorry, lookup failed");
-        expect(json.output[0]).toMatchObject({
+        const error =
+            kind === "http" || kind === "protocol"
+                ? {
+                      type:
+                          kind === "http" ? "http_error" : "mcp_protocol_error",
+                      code: kind === "http" ? 500 : -32603,
+                      message: expect.stringContaining(failureMessage),
+                  }
+                : {
+                      type: "mcp_tool_execution_error",
+                      content: {
+                          isError: true,
+                          content: expect.arrayContaining([
+                              {
+                                  type: "text",
+                                  text: expect.stringContaining(failureMessage),
+                              },
+                          ]),
+                      },
+                  };
+        const failedCall = {
             type: "mcp_call",
             id: "c1",
             status: "failed",
-            error: expect.stringContaining("MCP HTTP Transport Error"),
-            output: null,
+            error,
+        };
+        expect(json).toMatchObject({
+            status: "completed",
+            output: [
+                expect.objectContaining(failedCall),
+                expect.objectContaining({ type: "message" }),
+            ],
+            usage: {
+                input_tokens: 4,
+                output_tokens: 4,
+                total_tokens: 8,
+                tool_call_counts: { mcp_call: 1 },
+            },
         });
-        const content = chatOutputText(json);
+        expect(JSON.stringify(json)).not.toContain(binaryData);
+        if (stream) {
+            expect(events.map((event) => event.sequence_number)).toEqual(
+                events.map((_, index) => index),
+            );
+            expect(
+                events.filter(
+                    (event) => event.type === "response.mcp_call.failed",
+                ),
+            ).toHaveLength(1);
+            expect(
+                events.find(
+                    (event) => event.type === "response.output_item.done",
+                ),
+            ).toMatchObject({ item: failedCall });
+            expect(events.at(-1)?.type).toBe("response.completed");
+        }
+        const content = stream
+            ? responseStreamEvents(
+                  await new Response(
+                      responsesToChatStream(chatSource, "test-agent"),
+                  ).text(),
+              )
+                  .map(
+                      (chunk) =>
+                          (
+                              chunk.choices as {
+                                  delta: { content?: string };
+                              }[]
+                          )?.[0]?.delta.content ?? "",
+                  )
+                  .join("")
+            : chatOutputText(json);
         expect(content).toContain(
             '<details type="tool_calls" done="true" id="c1" name="listModels" arguments="{}">',
         );
         expect(content).toContain("<summary>Tool Failed</summary>");
-        expect(content).toContain("MCP HTTP Transport Error");
+        expect(content).toContain("upstream boom &lt;failed&gt;");
+        expect(content).not.toContain("[object Object]");
+        expect(content).not.toContain(binaryData);
         expect(content.endsWith("sorry, lookup failed")).toBe(true);
-        // The (failed) tool call is still counted — the owner's tool ran.
-        expect(json.usage.tool_call_counts).toEqual({ mcp_call: 1 });
+        // The model recovers on the next turn after the failed tool.
+        expect(modelCalls).toBe(2);
     });
 });

--- a/gen.pollinations.ai/test/text/agents/runtime.test.ts
+++ b/gen.pollinations.ai/test/text/agents/runtime.test.ts
@@ -1593,15 +1593,20 @@ describe("prompt-agent runtime", () => {
                   }
                 : {
                       type: "mcp_tool_execution_error",
-                      content: {
-                          isError: true,
-                          content: expect.arrayContaining([
-                              {
-                                  type: "text",
-                                  text: expect.stringContaining(failureMessage),
-                              },
-                          ]),
-                      },
+                      content:
+                          kind === "network"
+                              ? expect.stringContaining(failureMessage)
+                              : {
+                                    isError: true,
+                                    content: expect.arrayContaining([
+                                        {
+                                            type: "text",
+                                            text: expect.stringContaining(
+                                                failureMessage,
+                                            ),
+                                        },
+                                    ]),
+                                },
                   };
         const failedCall = {
             type: "mcp_call",


### PR DESCRIPTION
Follow-up to #14510.

- Replace managed Responses MCP error strings with HTTP, protocol, and execution error objects defined by the [current OpenAI SDK](https://github.com/openai/openai-python/blob/v3.8.0/src/openai/types/responses/mcp_tool_call_error.py).
- Validate errors with Zod, retain sanitized tool results, and preserve readable Chat rendering and stateless replay. Previously returned string errors are no longer accepted in replay.
- Keep recovery, usage accounting, and top-level request failures unchanged. Network errors carry a simple message, without a synthetic MCP result. No legacy-error compatibility or cause-chain fallbacks.
- Adversarially reviewed against the actual SDK; removed tests for unreachable SDK error codes. All 164 targeted tests, Gen typecheck, and Biome pass after simplification. Updated with main; net production change is 58 lines across three modules.