### PR TITLE
docs: record website local redirect registrations

### DIFF
--- a/pollinations.ai/src/api.config.ts
+++ b/pollinations.ai/src/api.config.ts
@@ -4,6 +4,8 @@
 // Direct calls to gen.pollinations.ai. Users must log in and use their own
 // API key (sk_ / pk_ issued via enter.pollinations.ai) to generate.
 
+// Local redirects registered for this key: http://localhost/play and
+// http://127.0.0.1/play. Each accepts any port; the hostname must match.
 export const APP_KEY = "pk_5F0qxjbCjlgBODHa"; // BYOP app key for authorization flow
 export const API_BASE = "https://gen.pollinations.ai";
 


### PR DESCRIPTION
- Documents the website key's registered `localhost` and `127.0.0.1` redirects and existing any-port behavior.
- Fixes #14361: added `http://127.0.0.1/play` to the live website registration, preserving every existing entry. The repository change is only this two-line comment.
- Uses registration instead of the broader hostname matching proposed in #14455; shared authentication behavior stays unchanged.
- Validation: live app lookup accepts both local hosts on different ports and existing production/staging URLs, and rejects unregistered hosts and paths. Biome and diff checks pass.
