### PR TITLE
fix: use Fal first for Grok video

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -1145,7 +1145,7 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptImageTokens": 0.002,
     },
   },
-  "grok-video-pro-fal": {
+  "grok-video-pro-openrouter": {
     "cost": {
       "completionVideoSeconds": 0.07,
       "promptImageTokens": 0.002,

--- a/gen.pollinations.ai/src/image/createAndReturnVideos.ts
+++ b/gen.pollinations.ai/src/image/createAndReturnVideos.ts
@@ -80,7 +80,7 @@ export async function createAndReturnVideo(
         case "seedance-pro-fal":
         case "wan-fal":
         case "wan-fast-fal":
-        case "grok-video-pro-fal":
+        case "grok-video-pro":
         case "grok-imagine-video-1.5-fal":
             result = await callFalFallbackVideo(prompt, safeParams);
             break;
@@ -107,7 +107,7 @@ export async function createAndReturnVideo(
         case "nova-reel":
             result = await callNovaReelAPI(prompt, safeParams, requestId);
             break;
-        case "grok-video-pro":
+        case "grok-video-pro-openrouter":
         case "grok-imagine-video-1.5":
             result = await callOpenRouterGrokVideoAPI(prompt, safeParams);
             break;

--- a/gen.pollinations.ai/src/image/models/falFallbackMediaModel.ts
+++ b/gen.pollinations.ai/src/image/models/falFallbackMediaModel.ts
@@ -5,6 +5,10 @@ import { getImageEnv } from "../env.ts";
 import type { ImageParams } from "../params.ts";
 import { closestRatioLogSpace } from "../utils/aspectRatio.ts";
 import { fetchUpstream } from "../utils/fetchUpstream.ts";
+import {
+    resolveGrokAspectRatio,
+    resolveGrokDuration,
+} from "./openRouterVideoModel.ts";
 import type { VideoGenerationResult } from "./veoVideoModel.ts";
 
 const RATIOS = ["1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3"] as const;
@@ -146,15 +150,14 @@ type FalVideoConfig = {
 };
 
 const VIDEO_CONFIGS: Record<string, FalVideoConfig> = {
-    "grok-video-pro-fal": {
+    "grok-video-pro": {
         textEndpoint: "xai/grok-imagine-video/text-to-video",
         imageEndpoint: "xai/grok-imagine-video/image-to-video",
-        duration: (params) =>
-            Math.min(15, Math.max(1, Math.floor(params.duration ?? 5))),
+        duration: (params) => resolveGrokDuration(params.duration),
         input: (params, duration) => ({
             duration,
             resolution: "720p",
-            aspect_ratio: aspectRatio(params),
+            aspect_ratio: resolveGrokAspectRatio(params),
         }),
     },
     "grok-imagine-video-1.5-fal": {

--- a/gen.pollinations.ai/src/image/models/openRouterVideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/openRouterVideoModel.ts
@@ -21,7 +21,7 @@ const GROK_VIDEO_15_MODEL = "x-ai/grok-imagine-video-1.5";
 const POLL_INTERVAL_MS = 3000;
 const MAX_POLL_DELAY_MS = 30000;
 const HAPPYHORSE_POLL_TIMEOUT_MS = 5 * 60 * 1000;
-const GROK_POLL_TIMEOUT_MS = 3 * 60 * 1000;
+const GROK_15_POLL_TIMEOUT_MS = 3 * 60 * 1000;
 const HAPPYHORSE_ASPECT_RATIOS = [
     "16:9",
     "9:16",
@@ -173,7 +173,8 @@ export async function callOpenRouterGrokVideoAPI(
 
     const { buffer, providerCost } = await generateOpenRouterVideo(
         requestBody,
-        GROK_POLL_TIMEOUT_MS,
+        // Base Grok's 15-second clips can complete after the old 3-minute cutoff.
+        isVersion15 ? GROK_15_POLL_TIMEOUT_MS : 5 * 60 * 1000,
     );
 
     logOps("Grok Video Pro generation complete", {

--- a/gen.pollinations.ai/src/image/models/openRouterVideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/openRouterVideoModel.ts
@@ -120,7 +120,7 @@ export async function callHappyHorseAPI(
     };
 }
 
-function resolveGrokDuration(duration?: number): number {
+export function resolveGrokDuration(duration?: number): number {
     const requested = duration || 5;
     if (!Number.isInteger(requested)) {
         throw UpstreamError.fromProvider(400, {
@@ -131,7 +131,9 @@ function resolveGrokDuration(duration?: number): number {
     return Math.min(Math.max(requested, 1), 15);
 }
 
-function resolveGrokAspectRatio(safeParams: ImageParams): string | undefined {
+export function resolveGrokAspectRatio(
+    safeParams: ImageParams,
+): string | undefined {
     if (
         !safeParams.dimensionsExplicit &&
         safeParams.aspectRatio &&

--- a/gen.pollinations.ai/test/image/falFallbackMediaModel.test.ts
+++ b/gen.pollinations.ai/test/image/falFallbackMediaModel.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createAndReturnVideo } from "../../src/image/createAndReturnVideos.ts";
 import { syncImageEnv } from "../../src/image/env.ts";
 import {
     callFalFallbackImage,
@@ -67,6 +68,67 @@ afterEach(() => {
 });
 
 describe("Fal fallback media models", () => {
+    it.each([
+        [undefined, "16:9", false, 1024, 1024, 5, "16:9"],
+        [0, "9:16", true, 1080, 720, 5, "3:2"],
+        [99, "9:16", false, 1024, 1024, 15, "9:16"],
+        [-1, undefined, true, 1024, 1024, 1, "1:1"],
+    ] as const)("routes Grok duration %s through Fal with unchanged parameters", async (duration, aspectRatio, dimensionsExplicit, width, height, expectedDuration, expectedRatio) => {
+        const requests = mockFal({ video: { url: MEDIA_URL } });
+        const resultPromise = createAndReturnVideo(
+            "move",
+            {
+                ...baseParams,
+                model: "grok-video-pro",
+                duration,
+                aspectRatio,
+                dimensionsExplicit,
+                width,
+                height,
+                image: ["https://example.com/start.png"],
+            },
+            "grok-test",
+        );
+        await vi.advanceTimersByTimeAsync(5_000);
+        const result = await resultPromise;
+        expect(requests[0]).toEqual({
+            url: "https://queue.fal.run/xai/grok-imagine-video/image-to-video",
+            body: {
+                prompt: "move",
+                duration: expectedDuration,
+                resolution: "720p",
+                aspect_ratio: expectedRatio,
+                image_url: "https://example.com/start.png",
+                seed: 42,
+            },
+        });
+        expect(result.trackingData).toEqual({
+            actualModel: "grok-video-pro",
+            usage: {
+                promptImageTokens: 1,
+                completionVideoSeconds: expectedDuration,
+            },
+        });
+    });
+
+    it.each([
+        0.5, 4.5, 15.5,
+    ])("rejects fractional Grok duration %s before Fal submission", async (duration) => {
+        const fetchSpy = vi.spyOn(globalThis, "fetch");
+        await expect(
+            createAndReturnVideo(
+                "move",
+                {
+                    ...baseParams,
+                    model: "grok-video-pro",
+                    duration,
+                },
+                "grok-test",
+            ),
+        ).rejects.toMatchObject({ status: 400 });
+        expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
     it("sends Seedream 5 through the exact Fal endpoint", async () => {
         const requests = mockFal({
             images: [{ url: MEDIA_URL, content_type: "image/jpeg" }],
@@ -92,7 +154,7 @@ describe("Fal fallback media models", () => {
 
     it.each([
         [
-            "grok-video-pro-fal",
+            "grok-video-pro",
             "xai/grok-imagine-video/text-to-video",
             { duration: 1, resolution: "720p", aspect_ratio: "1:1" },
         ],

--- a/gen.pollinations.ai/test/image/openRouterVideoModel.test.ts
+++ b/gen.pollinations.ai/test/image/openRouterVideoModel.test.ts
@@ -1,5 +1,5 @@
 import { IMAGE_SERVICES } from "@shared/registry/image.ts";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, assert, describe, expect, it, vi } from "vitest";
 import { type FallbackAttempt, withModelFallback } from "../../src/fallback.ts";
 import { createAndReturnVideo } from "../../src/image/createAndReturnVideos.ts";
 import { syncImageEnv } from "../../src/image/env.ts";
@@ -444,7 +444,47 @@ describe("OpenRouter Grok Video Pro", () => {
         expect(result.durationSeconds).toBe(15);
     });
 
-    it("enforces a three-minute timeout", async () => {
+    it("accepts a base Grok fallback that completes after three minutes", async () => {
+        vi.useFakeTimers();
+        setOpenRouterEnv();
+        const startedAt = Date.now();
+        const requests: Record<string, unknown>[] = [];
+        const fetchMock = mockGrokFetch(requests);
+        const completedFetch = fetchMock.getMockImplementation();
+        assert(completedFetch);
+        fetchMock.mockImplementation(async (url, init) => {
+            if (
+                url.toString() === GROK_POLL_URL &&
+                Date.now() - startedAt < 195_000
+            ) {
+                return Response.json({ status: "pending" });
+            }
+            return completedFetch(url, init);
+        });
+
+        const resultPromise = createAndReturnVideo(
+            "animate this frame",
+            {
+                ...baseParams,
+                model: "grok-video-pro-openrouter",
+                duration: 15,
+                image: ["https://example.com/start.png"],
+            },
+            "grok-late-completion",
+        );
+        await vi.advanceTimersByTimeAsync(195_000);
+        const result = await resultPromise;
+        expect(result.trackingData).toEqual({
+            actualModel: "grok-video-pro-openrouter",
+            usage: { promptImageTokens: 1, completionVideoSeconds: 15 },
+        });
+        expect(requests).toHaveLength(1);
+    });
+
+    it.each([
+        ["grok-video-pro-openrouter", 5],
+        ["grok-imagine-video-1.5", 3],
+    ] as const)("enforces a %s timeout of %i minutes", async (model, minutes) => {
         vi.useFakeTimers();
         setOpenRouterEnv();
 
@@ -476,15 +516,15 @@ describe("OpenRouter Grok Video Pro", () => {
 
         const resultPromise = callOpenRouterGrokVideoAPI(
             "a calm ocean at sunrise",
-            { ...baseParams, model: "grok-video-pro" },
+            { ...baseParams, model },
         );
         const rejection = expect(resultPromise).rejects.toMatchObject({
             status: 504,
         });
 
-        await vi.advanceTimersByTimeAsync(3 * 60 * 1000);
+        await vi.advanceTimersByTimeAsync(minutes * 60 * 1000);
         await rejection;
-        expect(pollAttempts).toBe(6);
+        expect(pollAttempts).toBe(minutes * 2);
     });
 
     it.each([

--- a/gen.pollinations.ai/test/image/openRouterVideoModel.test.ts
+++ b/gen.pollinations.ai/test/image/openRouterVideoModel.test.ts
@@ -1,4 +1,7 @@
+import { IMAGE_SERVICES } from "@shared/registry/image.ts";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { type FallbackAttempt, withModelFallback } from "../../src/fallback.ts";
+import { createAndReturnVideo } from "../../src/image/createAndReturnVideos.ts";
 import { syncImageEnv } from "../../src/image/env.ts";
 import {
     callHappyHorseAPI,
@@ -267,21 +270,73 @@ function mockGrokFetch(requests: Record<string, unknown>[]) {
 }
 
 describe("OpenRouter Grok Video Pro", () => {
+    it("falls back from a Fal 503 to the same model on OpenRouter", async () => {
+        syncImageEnv(
+            {
+                FAL_KEY: "test-fal-key",
+                OPENROUTER_API_KEY: "openrouter-test-key",
+            } as CloudflareBindings,
+            ["FAL_KEY", "OPENROUTER_API_KEY"],
+        );
+        const requests: Record<string, unknown>[] = [];
+        mockGrokFetch(requests).mockImplementationOnce(async (url) => {
+            expect(url).toBe(
+                "https://queue.fal.run/xai/grok-imagine-video/image-to-video",
+            );
+            return Response.json(
+                { error: "temporarily unavailable" },
+                { status: 503 },
+            );
+        });
+        const candidates = [
+            "grok-video-pro",
+            ...IMAGE_SERVICES["grok-video-pro"].fallbacks,
+        ].map((id) => ({
+            id: id as ImageParams["model"],
+            definition: IMAGE_SERVICES[id as keyof typeof IMAGE_SERVICES],
+        }));
+        const attempts: FallbackAttempt[] = [];
+        const { result, index, candidate } = await withModelFallback(
+            candidates,
+            ({ id }) =>
+                createAndReturnVideo(
+                    "move",
+                    {
+                        ...baseParams,
+                        model: id,
+                        duration: 15,
+                        image: ["https://example.com/start.png"],
+                    },
+                    "grok-fallback-test",
+                ),
+            attempts,
+        );
+        expect(index).toBe(1);
+        expect(candidate.definition.provider).toBe("openrouter");
+        expect(attempts.map(({ settled }) => settled)).toEqual([false, true]);
+        expect(result.trackingData).toEqual({
+            actualModel: "grok-video-pro-openrouter",
+            usage: { promptImageTokens: 1, completionVideoSeconds: 15 },
+        });
+        expect(requests[0].model).toBe("x-ai/grok-imagine-video");
+    });
+
     it("submits the exact 720p route and honors an explicit aspect ratio", async () => {
         setOpenRouterEnv();
         const requests: Record<string, unknown>[] = [];
         mockGrokFetch(requests);
 
-        const result = await callOpenRouterGrokVideoAPI(
+        const result = await createAndReturnVideo(
             "a calm ocean at sunrise",
             {
                 ...baseParams,
-                model: "grok-video-pro",
+                model: "grok-video-pro-openrouter",
                 dimensionsExplicit: false,
                 width: 1024,
                 height: 1024,
                 aspectRatio: "16:9",
             },
+            "grok-fallback-test",
         );
 
         expect(requests).toEqual([
@@ -298,7 +353,7 @@ describe("OpenRouter Grok Video Pro", () => {
             mimeType: "video/mp4",
             durationSeconds: 5,
             trackingData: {
-                actualModel: "grok-video-pro",
+                actualModel: "grok-video-pro-openrouter",
                 usage: { completionVideoSeconds: 5 },
             },
         });

--- a/gen.pollinations.ai/test/image/videoFrameValidation.test.ts
+++ b/gen.pollinations.ai/test/image/videoFrameValidation.test.ts
@@ -26,7 +26,7 @@ const VIDEO_FRAME_LIMITS = [
     ["wan-fast-fal", 2],
     ["wan-pro", 2],
     ["grok-video-pro", 1],
-    ["grok-video-pro-fal", 1],
+    ["grok-video-pro-openrouter", 1],
     ["grok-imagine-video-1.5", 1],
     ["grok-imagine-video-1.5-fal", 1],
     ["seedance-2.5", 2],

--- a/gen.pollinations.ai/test/static-provider-fallbacks.test.ts
+++ b/gen.pollinations.ai/test/static-provider-fallbacks.test.ts
@@ -126,6 +126,26 @@ function expectInheritedRoute(
 }
 
 describe("static provider fallbacks", () => {
+    it("uses Fal first for Grok Video Pro without changing prices or access", () => {
+        const primary = IMAGE_SERVICES["grok-video-pro"];
+        const fallback = IMAGE_SERVICES["grok-video-pro-openrouter"];
+        expect(primary).toMatchObject({
+            provider: "fal",
+            paidOnly: true,
+            priceMultiplier: 1,
+            aliases: ["grok-imagine-video", "x-ai/grok-imagine-video"],
+            fallbacks: ["grok-video-pro-openrouter"],
+            cost: { promptImageTokens: 0.002, completionVideoSeconds: 0.07 },
+        });
+        expect(fallback.provider).toBe("openrouter");
+        expect(fallback.cost).toEqual(primary.cost);
+        expect(IMAGE_SERVICES).not.toHaveProperty("grok-video-pro-fal");
+        expect(IMAGE_SERVICES["grok-imagine-video-1.5"]).toMatchObject({
+            provider: "openrouter",
+            fallbacks: ["grok-imagine-video-1.5-fal"],
+        });
+    });
+
     it("registers exact text routes as fallback-only inherited models", () => {
         for (const [parent, routes] of Object.entries(
             fallbackRoutes(TEXT_FALLBACKS),

--- a/shared/registry/image-fallbacks.ts
+++ b/shared/registry/image-fallbacks.ts
@@ -111,8 +111,8 @@ export const IMAGE_FALLBACKS = {
         },
     },
     "grok-video-pro": {
-        "grok-video-pro-fal": {
-            provider: "fal",
+        "grok-video-pro-openrouter": {
+            provider: "openrouter",
             addedDate: new Date("2026-09-01").getTime(),
         },
     },

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -1119,7 +1119,7 @@ const IMAGE_BASE_SERVICES = {
     },
     "grok-video-pro": {
         aliases: ["grok-imagine-video", "x-ai/grok-imagine-video"],
-        provider: "openrouter",
+        provider: "fal",
         brand: "xAI",
         category: "video",
         addedDate: new Date("2026-03-23").getTime(),


### PR DESCRIPTION
- Switches `grok-video-pro` to Fal `xai/grok-imagine-video/{text-to-video,image-to-video}`, with one OpenRouter `x-ai/grok-imagine-video` fallback. Preserves aliases `grok-imagine-video`, `x-ai/grok-imagine-video`; multiplier 1; paid-only yes; Pollinations GPU no.
- Preserves 720p, 1–15s/default 5s, aspect ratios and start-image behavior. Leaves Grok 1.5 unchanged. Both routes charge $0.07/s plus $0.002/start-image; audio bundled. [Fal](https://fal.ai/models/xai/grok-imagine-video/image-to-video), [OpenRouter](https://openrouter.ai/x-ai/grok-imagine-video).
- Real 15s image-video jobs completed on Fal in 195s and OpenRouter in 201s; latter reported $1.052. Old 180s cutoff falsely timed out valid billable work. Base Grok fallback now allows 300s, matching Fal; Grok 1.5 remains 180s.
- 238 tests pass; 33 affected tests rerun after timeout fix; Gen typecheck/formatting pass. Tests exercise Fal 503→OpenRouter with billing/attribution and completion after 195s.
- Draft pending full live authenticated Worker/wallet/Tinybird/reconnect/cache E2E. Fal policy rejections can incur provider charges; abandoned provider jobs can still complete/bill. Existing cost-observability gaps remain documented. No secret or deployment changes.