### PR TITLE
feat: add Sweden Azure fallback for Cohere embeddings

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -166,6 +166,16 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.00000009,
     },
   },
+  "cohere-embed-v4-azure-sweden": {
+    "cost": {
+      "promptImageTokens": 0.00000047,
+      "promptTextTokens": 0.00000012,
+    },
+    "price": {
+      "promptImageTokens": 0.0000003525,
+      "promptTextTokens": 0.00000009,
+    },
+  },
   "command-a-plus": {
     "cost": {
       "completionTextTokens": 0.0000032,

--- a/gen.pollinations.ai/src/embeddings/cohereAzure.ts
+++ b/gen.pollinations.ai/src/embeddings/cohereAzure.ts
@@ -2,12 +2,20 @@ import { ensureUpstreamOk } from "@shared/error.ts";
 import type { Usage } from "@shared/registry/registry.ts";
 import type { OpenAIEmbeddingResponse } from "./openai.ts";
 
-const COHERE_AZURE_ENDPOINT =
-    "https://myceli-prod-eastus.cognitiveservices.azure.com/openai/v1/embeddings";
+const COHERE_AZURE_ROUTES = {
+    "cohere-embed-v4": {
+        host: "https://myceli-prod-eastus.cognitiveservices.azure.com",
+        key: "AZURE_MYCELI_PROD_API_KEY",
+    },
+    "cohere-embed-v4-azure-sweden": {
+        host: "https://myceli-prod-swedencentral.cognitiveservices.azure.com",
+        key: "AZURE_MYCELI_PROD_SWEDEN_API_KEY",
+    },
+} as const;
 // This Cohere deployment exposes image embeddings only on this Azure preview
 // contract; the 2025-04-01 image route returns 404.
 const COHERE_AZURE_IMAGE_ENDPOINT =
-    "https://myceli-prod-eastus.cognitiveservices.azure.com/models/images/embeddings?api-version=2024-05-01-preview";
+    "/models/images/embeddings?api-version=2024-05-01-preview";
 
 type CohereAzureInputType = "document" | "query";
 
@@ -27,6 +35,7 @@ type CohereAzureImageEmbeddingRequest = {
 
 export async function callCohereAzureEmbed(
     env: CloudflareBindings,
+    routeId: string,
     modelId: string,
     input: string[],
     dimensions?: number,
@@ -39,11 +48,12 @@ export async function callCohereAzureEmbed(
         ...(dimensions ? { dimensions } : {}),
     };
 
-    return callCohereAzure(env, COHERE_AZURE_ENDPOINT, body);
+    return callCohereAzure(env, routeId, "/openai/v1/embeddings", body);
 }
 
 export async function callCohereAzureImageEmbed(
     env: CloudflareBindings,
+    routeId: string,
     modelId: string,
     input: CohereAzureImageEmbeddingRequest["input"],
     dimensions?: number,
@@ -56,17 +66,21 @@ export async function callCohereAzureImageEmbed(
         ...(dimensions ? { dimensions } : {}),
     };
 
-    return callCohereAzure(env, COHERE_AZURE_IMAGE_ENDPOINT, body);
+    return callCohereAzure(env, routeId, COHERE_AZURE_IMAGE_ENDPOINT, body);
 }
 
 async function callCohereAzure(
     env: CloudflareBindings,
-    endpoint: string,
+    routeId: string,
+    path: string,
     body: CohereAzureEmbeddingRequest | CohereAzureImageEmbeddingRequest,
 ): Promise<OpenAIEmbeddingResponse> {
-    const apiKey = env.AZURE_MYCELI_PROD_API_KEY;
+    const route =
+        COHERE_AZURE_ROUTES[routeId as keyof typeof COHERE_AZURE_ROUTES];
+    const endpoint = `${route.host}${path}`;
+    const apiKey = env[route.key];
     if (!apiKey) {
-        throw new Error("AZURE_MYCELI_PROD_API_KEY is not configured");
+        throw new Error(`${route.key} is not configured`);
     }
 
     const response = await fetch(endpoint, {

--- a/gen.pollinations.ai/src/embeddings/handler.ts
+++ b/gen.pollinations.ai/src/embeddings/handler.ts
@@ -36,6 +36,7 @@ const EMBEDDING_PROVIDER_MODEL_IDS: Record<EmbeddingServiceId, string> = {
     "openai-3-small": "text-embedding-3-small",
     "openai-3-large": "text-embedding-3-large",
     "cohere-embed-v4": "embed-v-4-0",
+    "cohere-embed-v4-azure-sweden": "embed-v-4-0",
     "qwen3-embedding-8b": "accounts/fireworks/models/qwen3-embedding-8b",
 };
 
@@ -58,6 +59,10 @@ const EMBEDDING_DIMENSIONS: Record<
     "openai-3-small": { max: 1536 },
     "openai-3-large": { max: 3072 },
     "cohere-embed-v4": { max: 1536, allowed: [256, 512, 1024, 1536] },
+    "cohere-embed-v4-azure-sweden": {
+        max: 1536,
+        allowed: [256, 512, 1024, 1536],
+    },
     "qwen3-embedding-8b": { max: 4096 },
 };
 
@@ -110,6 +115,7 @@ async function generateCohereAzureEmbeddings(
     if (imageInput) {
         const result = await callCohereAzureImageEmbed(
             env,
+            responseModel,
             request.model,
             [imageInput],
             request.dimensions,
@@ -131,6 +137,7 @@ async function generateCohereAzureEmbeddings(
 
     const result = await callCohereAzureEmbed(
         env,
+        responseModel,
         request.model,
         textInputs,
         request.dimensions,

--- a/gen.pollinations.ai/test/embeddings/embeddings.test.ts
+++ b/gen.pollinations.ai/test/embeddings/embeddings.test.ts
@@ -811,80 +811,81 @@ describe("POST /v1/embeddings", () => {
         });
     });
 
-    test.for(["text", "image"])(
-        "rescues Cohere %s embeddings through Sweden without changing the quote",
-        async (modality, { apiKey, mocks }) => {
-            await mocks.enable("tinybird", "tinybirdStats", "cohereAzure");
-            mocks.cohereAzure.state.failPrimary = true;
-            const input =
-                modality === "image"
-                    ? [
-                          {
-                              type: "image_url",
-                              image_url: {
-                                  url: "data:image/png;base64,aGVsbG8=",
-                              },
+    test.for([
+        "text",
+        "image",
+    ])("rescues Cohere %s embeddings through Sweden without changing the quote", async (modality, {
+        apiKey,
+        mocks,
+    }) => {
+        await mocks.enable("tinybird", "tinybirdStats", "cohereAzure");
+        mocks.cohereAzure.state.failPrimary = true;
+        const input =
+            modality === "image"
+                ? [
+                      {
+                          type: "image_url",
+                          image_url: {
+                              url: "data:image/png;base64,aGVsbG8=",
                           },
-                      ]
-                    : ["Hello", "World"];
-            const { response, wait } = await fetchWorker("/v1/embeddings", {
-                method: "POST",
-                headers: {
-                    "content-type": "application/json",
-                    authorization: `Bearer ${apiKey}`,
-                },
-                body: buildEmbeddingsBody({
-                    model: TEST_COHERE_MODEL,
-                    input,
-                    dimensions: 256,
-                    input_type: "query",
-                }),
-            });
-            expect(response.status).toBe(200);
-            expect(response.headers.get(FALLBACK_TARGET_HEADER)).toBe(
-                "config.targets[1]",
-            );
-            const body = (await response.json()) as {
-                model: string;
-                data: { embedding: number[] }[];
-            };
-            expect(body.data[0].embedding).toHaveLength(256);
-            expect(
-                mocks.cohereAzure.state.urls.map(
-                    (url) => new URL(url).hostname,
-                ),
-            ).toEqual([AZURE_HOST, AZURE_SWEDEN_HOST]);
-            expect(mocks.cohereAzure.state.apiKeys).toEqual([
-                "test-azure-api-key",
-                "test-azure-sweden-api-key",
-            ]);
-            expect(mocks.cohereAzure.state.requests).toEqual([
-                expect.objectContaining({
-                    model: TEST_COHERE_PROVIDER_MODEL,
-                    input_type: "query",
-                    dimensions: 256,
-                }),
-                expect.objectContaining({
-                    model: TEST_COHERE_PROVIDER_MODEL,
-                    input_type: "query",
-                    dimensions: 256,
-                }),
-            ]);
-            await wait();
-            const events = mocks.tinybird.state.events;
-            const billed = events.filter((event) => event.isBilledUsage);
-            expect(billed).toHaveLength(1);
-            expect(billed[0]).toMatchObject({
-                modelRequested: TEST_COHERE_MODEL,
-                modelUsed: "cohere-embed-v4-azure-sweden",
-                totalCost:
-                    modality === "image"
-                        ? (4 * 0.47) / 1_000_000
-                        : (8 * 0.12) / 1_000_000,
-                totalPrice: modality === "image" ? 0.00000141 : 0.00000072,
-            });
-        },
-    );
+                      },
+                  ]
+                : ["Hello", "World"];
+        const { response, wait } = await fetchWorker("/v1/embeddings", {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                authorization: `Bearer ${apiKey}`,
+            },
+            body: buildEmbeddingsBody({
+                model: TEST_COHERE_MODEL,
+                input,
+                dimensions: 256,
+                input_type: "query",
+            }),
+        });
+        expect(response.status).toBe(200);
+        expect(response.headers.get(FALLBACK_TARGET_HEADER)).toBe(
+            "config.targets[1]",
+        );
+        const body = (await response.json()) as {
+            model: string;
+            data: { embedding: number[] }[];
+        };
+        expect(body.data[0].embedding).toHaveLength(256);
+        expect(
+            mocks.cohereAzure.state.urls.map((url) => new URL(url).hostname),
+        ).toEqual([AZURE_HOST, AZURE_SWEDEN_HOST]);
+        expect(mocks.cohereAzure.state.apiKeys).toEqual([
+            "test-azure-api-key",
+            "test-azure-sweden-api-key",
+        ]);
+        expect(mocks.cohereAzure.state.requests).toEqual([
+            expect.objectContaining({
+                model: TEST_COHERE_PROVIDER_MODEL,
+                input_type: "query",
+                dimensions: 256,
+            }),
+            expect.objectContaining({
+                model: TEST_COHERE_PROVIDER_MODEL,
+                input_type: "query",
+                dimensions: 256,
+            }),
+        ]);
+        await wait();
+        const events = mocks.tinybird.state.events;
+        const billed = events.filter((event) => event.isBilledUsage);
+        expect(billed).toHaveLength(1);
+        expect(billed[0]).toMatchObject({
+            modelRequested: TEST_COHERE_MODEL,
+            modelUsed: "cohere-embed-v4-azure-sweden",
+            totalCost:
+                modality === "image"
+                    ? (4 * 0.47) / 1_000_000
+                    : (8 * 0.12) / 1_000_000,
+            totalPrice: modality === "image" ? 0.00000141 : 0.00000072,
+        });
+    });
 
     test("passes Cohere query input_type through Azure", async ({
         apiKey,

--- a/gen.pollinations.ai/test/embeddings/embeddings.test.ts
+++ b/gen.pollinations.ai/test/embeddings/embeddings.test.ts
@@ -33,6 +33,8 @@ const TEST_QWEN_PROVIDER_MODEL = "accounts/fireworks/models/qwen3-embedding-8b";
 const TEST_EMBEDDING_INPUT = "Hello world";
 const VERTEX_HOST = "aiplatform.us.rep.googleapis.com";
 const AZURE_HOST = "myceli-prod-eastus.cognitiveservices.azure.com";
+const AZURE_SWEDEN_HOST =
+    "myceli-prod-swedencentral.cognitiveservices.azure.com";
 const FIREWORKS_HOST = "api.fireworks.ai";
 const TINYBIRD_STATS_HOST = "api.europe-west2.gcp.tinybird.co";
 
@@ -69,6 +71,7 @@ function createEmbeddingMocks() {
     env.GOOGLE_PROJECT_ID = "test-project";
     env.OPENAI_API_KEY = "test-openai-api-key";
     env.AZURE_MYCELI_PROD_API_KEY = "test-azure-api-key";
+    env.AZURE_MYCELI_PROD_SWEDEN_API_KEY = "test-azure-sweden-api-key";
     env.FIREWORKS_NEO_API_KEY = "test-fireworks-neo-api-key";
     process.env.GOOGLE_PROJECT_ID = env.GOOGLE_PROJECT_ID;
 
@@ -219,50 +222,69 @@ function createAzureOpenAIMock(): MockAPI<{
 function createCohereAzureMock(): MockAPI<{
     requests: unknown[];
     urls: string[];
+    failPrimary?: boolean;
+    apiKeys: (string | null)[];
 }> {
-    const state: { requests: unknown[]; urls: string[] } = {
+    const state: {
+        requests: unknown[];
+        urls: string[];
+        failPrimary?: boolean;
+        apiKeys: (string | null)[];
+    } = {
         requests: [],
         urls: [],
+        apiKeys: [],
+    };
+    const handler = async (request: Request) => {
+        const body = (await request.json()) as {
+            input?: (string | { image: string; text?: string })[];
+            input_type?: string;
+            dimensions?: number;
+            model?: string;
+        };
+        state.urls.push(request.url);
+        state.requests.push(body);
+        state.apiKeys.push(request.headers.get("api-key"));
+        if (state.failPrimary && new URL(request.url).hostname === AZURE_HOST) {
+            return Response.json(
+                { error: { message: "Primary unavailable" } },
+                { status: 503 },
+            );
+        }
+
+        const inputs = body.input ?? [];
+        const dimensions = body.dimensions ?? 1536;
+
+        return Response.json({
+            object: "list",
+            data: inputs
+                .map((_, index) => ({
+                    object: "embedding",
+                    embedding: Array.from(
+                        { length: dimensions },
+                        (_, valueIndex) => index + valueIndex / 10,
+                    ),
+                    index,
+                }))
+                .reverse(),
+            model: body.model,
+            usage: {
+                prompt_tokens: inputs.length * 4,
+                total_tokens: inputs.length * 4,
+            },
+        });
     };
     return {
         state,
         handlerMap: {
-            [AZURE_HOST]: async (request) => {
-                const body = (await request.json()) as {
-                    input?: (string | { image: string; text?: string })[];
-                    input_type?: string;
-                    dimensions?: number;
-                    model?: string;
-                };
-                state.urls.push(request.url);
-                state.requests.push(body);
-
-                const inputs = body.input ?? [];
-                const dimensions = body.dimensions ?? 1536;
-
-                return Response.json({
-                    object: "list",
-                    data: inputs
-                        .map((_, index) => ({
-                            object: "embedding",
-                            embedding: Array.from(
-                                { length: dimensions },
-                                (_, valueIndex) => index + valueIndex / 10,
-                            ),
-                            index,
-                        }))
-                        .reverse(),
-                    model: body.model,
-                    usage: {
-                        prompt_tokens: inputs.length * 4,
-                        total_tokens: inputs.length * 4,
-                    },
-                });
-            },
+            [AZURE_HOST]: handler,
+            [AZURE_SWEDEN_HOST]: handler,
         },
         reset: () => {
             state.requests = [];
             state.urls = [];
+            state.apiKeys = [];
+            state.failPrimary = undefined;
         },
     };
 }
@@ -789,6 +811,81 @@ describe("POST /v1/embeddings", () => {
         });
     });
 
+    test.for(["text", "image"])(
+        "rescues Cohere %s embeddings through Sweden without changing the quote",
+        async (modality, { apiKey, mocks }) => {
+            await mocks.enable("tinybird", "tinybirdStats", "cohereAzure");
+            mocks.cohereAzure.state.failPrimary = true;
+            const input =
+                modality === "image"
+                    ? [
+                          {
+                              type: "image_url",
+                              image_url: {
+                                  url: "data:image/png;base64,aGVsbG8=",
+                              },
+                          },
+                      ]
+                    : ["Hello", "World"];
+            const { response, wait } = await fetchWorker("/v1/embeddings", {
+                method: "POST",
+                headers: {
+                    "content-type": "application/json",
+                    authorization: `Bearer ${apiKey}`,
+                },
+                body: buildEmbeddingsBody({
+                    model: TEST_COHERE_MODEL,
+                    input,
+                    dimensions: 256,
+                    input_type: "query",
+                }),
+            });
+            expect(response.status).toBe(200);
+            expect(response.headers.get(FALLBACK_TARGET_HEADER)).toBe(
+                "config.targets[1]",
+            );
+            const body = (await response.json()) as {
+                model: string;
+                data: { embedding: number[] }[];
+            };
+            expect(body.data[0].embedding).toHaveLength(256);
+            expect(
+                mocks.cohereAzure.state.urls.map(
+                    (url) => new URL(url).hostname,
+                ),
+            ).toEqual([AZURE_HOST, AZURE_SWEDEN_HOST]);
+            expect(mocks.cohereAzure.state.apiKeys).toEqual([
+                "test-azure-api-key",
+                "test-azure-sweden-api-key",
+            ]);
+            expect(mocks.cohereAzure.state.requests).toEqual([
+                expect.objectContaining({
+                    model: TEST_COHERE_PROVIDER_MODEL,
+                    input_type: "query",
+                    dimensions: 256,
+                }),
+                expect.objectContaining({
+                    model: TEST_COHERE_PROVIDER_MODEL,
+                    input_type: "query",
+                    dimensions: 256,
+                }),
+            ]);
+            await wait();
+            const events = mocks.tinybird.state.events;
+            const billed = events.filter((event) => event.isBilledUsage);
+            expect(billed).toHaveLength(1);
+            expect(billed[0]).toMatchObject({
+                modelRequested: TEST_COHERE_MODEL,
+                modelUsed: "cohere-embed-v4-azure-sweden",
+                totalCost:
+                    modality === "image"
+                        ? (4 * 0.47) / 1_000_000
+                        : (8 * 0.12) / 1_000_000,
+                totalPrice: modality === "image" ? 0.00000141 : 0.00000072,
+            });
+        },
+    );
+
     test("passes Cohere query input_type through Azure", async ({
         apiKey,
         mocks,
@@ -1228,6 +1325,9 @@ describe("embedding models", () => {
             output_modalities?: string[];
             context_length?: number;
         }[];
+        expect(data.map((model) => model.name)).not.toContain(
+            "cohere-embed-v4-azure-sweden",
+        );
         expect(data).toEqual(
             expect.arrayContaining([
                 expect.objectContaining({
@@ -1265,6 +1365,9 @@ describe("embedding models", () => {
             data: { id: string; supported_endpoints?: string[] }[];
         };
         expect(data.object).toBe("list");
+        expect(data.data.map((model) => model.id)).not.toContain(
+            "cohere-embed-v4-azure-sweden",
+        );
         expect(data.data).toEqual(
             expect.arrayContaining([
                 expect.objectContaining({

--- a/shared/registry/embeddings.ts
+++ b/shared/registry/embeddings.ts
@@ -1,3 +1,4 @@
+import { mergeFallbacks } from "./merge-fallbacks";
 import { perMillion } from "./price-helpers";
 import type { ModelDefinition } from "./registry";
 
@@ -5,7 +6,7 @@ export type EmbeddingServiceId = keyof typeof EMBEDDING_SERVICES;
 
 export const DEFAULT_EMBEDDING_MODEL: EmbeddingServiceId = "openai-3-small";
 
-export const EMBEDDING_SERVICES = {
+const EMBEDDING_BASE_SERVICES = {
     "gemini-2": {
         aliases: ["embedding", "google/gemini-embedding-2"],
         provider: "google",
@@ -99,3 +100,9 @@ export const EMBEDDING_SERVICES = {
         contextLength: 40960,
     },
 } as const satisfies Record<string, ModelDefinition>;
+
+export const EMBEDDING_SERVICES = mergeFallbacks(EMBEDDING_BASE_SERVICES, {
+    "cohere-embed-v4": {
+        "cohere-embed-v4-azure-sweden": { provider: "azure" },
+    },
+});


### PR DESCRIPTION
- Adds one internal fallback: East US `embed-v-4-0` → Sweden `embed-v-4-0`, identical Cohere version 1. Created approved GlobalStandard Sweden deployment at 500K TPM/500 RPM; reuses existing credentials.
- Approved contract unchanged: `cohere-embed-v4`; aliases `embed-v-4-0`, `cohere-embed-v-4-0`, `cohere/embed-v4.0`; Azure; multiplier 0.75; paid-only no; Pollinations GPU no. No public API changes.
- Both routes cost $0.12/M text tokens and $0.47/M image tokens, verified using Azure Retail Prices meters for both regions. [Azure pricing](https://azure.microsoft.com/en-gb/pricing/details/ai-foundry-models/cohere/). Customer prices unchanged.
- 38 focused tests, Gen typecheck and formatting pass. Live batches pass 256/512/1024/1536 dimensions. Actual adapter forced fallback passes text/image. 149 image tokens: cost $0.00007003, rounded price $0.00005252. Worker fixtures verify one billed event and correct attribution.
- Draft pending live authenticated Worker/wallet/Tinybird/cache E2E. Existing combined text+image requests return422 on BOTH regions; image-only works. No secret changes or Cloudflare deployment.