### PR TITLE
feat: add Replicate fallback for Veo

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -2716,6 +2716,21 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "completionVideoSeconds": 0.08,
     },
   },
+  "veo-replicate": {
+    "cost": {
+      "completionAudioSeconds": 0.05,
+      "completionVideoSeconds": 0.1,
+    },
+    "costVariants": {
+      "1080p": {
+        "completionVideoSeconds": 0.1,
+      },
+    },
+    "price": {
+      "completionAudioSeconds": 0.05,
+      "completionVideoSeconds": 0.1,
+    },
+  },
   "wan": {
     "cost": {
       "completionVideoSeconds": 0.1,

--- a/gen.pollinations.ai/src/image/createAndReturnVideos.ts
+++ b/gen.pollinations.ai/src/image/createAndReturnVideos.ts
@@ -24,6 +24,7 @@ import { callSeedanceProAPI } from "./models/seedanceReplicateVideoModel.ts";
 import { callSeedanceV2API } from "./models/seedanceV2VideoModel.ts";
 import {
     callVeoAPI,
+    callVeoReplicateAPI,
     type VideoGenerationResult,
 } from "./models/veoVideoModel.ts";
 import { callWan3FalAPI } from "./models/wan3FalVideoModel.ts";
@@ -73,6 +74,9 @@ export async function createAndReturnVideo(
             break;
         case "veo":
             result = await callVeoAPI(prompt, safeParams);
+            break;
+        case "veo-replicate":
+            result = await callVeoReplicateAPI(prompt, safeParams);
             break;
         case "seedance-pro":
             result = await callSeedanceProAPI(prompt, safeParams);

--- a/gen.pollinations.ai/src/image/models/veoVideoModel.ts
+++ b/gen.pollinations.ai/src/image/models/veoVideoModel.ts
@@ -6,7 +6,11 @@ import { getImageEnv } from "../env.ts";
 import type { ImageParams } from "../params.ts";
 import { sleep } from "../util.ts";
 import { fetchUpstream } from "../utils/fetchUpstream.ts";
-import { downloadUserImage } from "../utils/imageDownload.ts";
+import { downloadUserImage, toDataUri } from "../utils/imageDownload.ts";
+import {
+    runReplicatePrediction,
+    toReplicateUpstreamError,
+} from "../utils/replicateClient.ts";
 import { calculateVideoResolution } from "../utils/videoResolution.ts";
 
 // Logger
@@ -237,6 +241,54 @@ export const callVeoAPI = (
         prompt,
         safeParams,
     );
+
+/** Same Veo family through Replicate, using its shared prediction client. */
+export async function callVeoReplicateAPI(
+    prompt: string,
+    params: ImageParams,
+): Promise<VideoGenerationResult> {
+    const generateAudio = params.audio === true;
+    try {
+        const { output, videoOutputDurationSeconds } =
+            await runReplicatePrediction<Record<string, unknown>, string>({
+                model: "google/veo-3.1-fast",
+                input: {
+                    prompt,
+                    duration: params.duration ?? 4,
+                    resolution: params.resolution ?? "720p",
+                    aspect_ratio: calculateVideoResolution(params).aspectRatio,
+                    generate_audio: generateAudio,
+                    ...(params.image[0]
+                        ? { image: await toDataUri(params.image[0]) }
+                        : {}),
+                    ...(params.image[1]
+                        ? { last_frame: await toDataUri(params.image[1]) }
+                        : {}),
+                },
+            });
+        const response = await fetchUpstream(output, {
+            errorLabel: "Failed to download Veo video",
+        });
+        const durationSeconds =
+            videoOutputDurationSeconds ?? params.duration ?? 4;
+        return {
+            buffer: Buffer.from(await response.arrayBuffer()),
+            mimeType: "video/mp4",
+            durationSeconds,
+            trackingData: {
+                actualModel: params.model,
+                usage: {
+                    completionVideoSeconds: durationSeconds,
+                    ...(generateAudio
+                        ? { completionAudioSeconds: durationSeconds }
+                        : {}),
+                },
+            },
+        };
+    } catch (error) {
+        throw toReplicateUpstreamError(error, "Veo generation failed");
+    }
+}
 
 /**
  * Poll Veo operation until completion using fetchPredictOperation

--- a/gen.pollinations.ai/test/image/veoVideoModel.test.ts
+++ b/gen.pollinations.ai/test/image/veoVideoModel.test.ts
@@ -1,4 +1,11 @@
+import { IMAGE_SERVICES } from "@shared/registry/image.ts";
+import {
+    calculateUsageBilling,
+    getVisibleImageModels,
+} from "@shared/registry/registry.ts";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { type FallbackAttempt, withModelFallback } from "../../src/fallback.ts";
+import { createAndReturnVideo } from "../../src/image/createAndReturnVideos.ts";
 import { syncImageEnv } from "../../src/image/env.ts";
 import { callVeoAPI } from "../../src/image/models/veoVideoModel.ts";
 import type { ImageParams } from "../../src/image/params.ts";
@@ -148,5 +155,139 @@ describe("veoVideoModel resolution selection", () => {
                 },
             ],
         });
+    });
+});
+
+describe("Veo Replicate fallback", () => {
+    it("stays internal and preserves the public contract", () => {
+        expect(IMAGE_SERVICES.veo.fallbacks).toEqual(["veo-replicate"]);
+        expect(IMAGE_SERVICES["veo-replicate"]).toMatchObject({
+            provider: "replicate",
+            aliases: [],
+            hidden: true,
+            fallbackOnly: true,
+            paidOnly: true,
+            priceMultiplier: 1,
+            videoCapabilities: IMAGE_SERVICES.veo.videoCapabilities,
+            allowedDurations: [4, 6, 8],
+            maxReferenceImages: 2,
+        });
+        expect(getVisibleImageModels()).not.toContain("veo-replicate");
+    });
+
+    it.each([
+        [undefined, undefined, 0, 0.4, 0.32],
+        ["720p", true, 1, 0.6, 0.4],
+        ["1080p", false, 0, 0.4, 0.4],
+        ["1080p", true, 2, 0.6, 0.48],
+    ] as const)("routes and bills resolution %s / audio %s / %s frames", async (resolution, audio, frames, cost, price) => {
+        syncImageEnv(
+            {
+                REPLICATE_API_TOKEN: "replicate-test-key",
+                GOOGLE_PROJECT_ID: "test-project",
+            } as CloudflareBindings,
+            ["REPLICATE_API_TOKEN", "GOOGLE_PROJECT_ID"],
+        );
+        vi.spyOn(googleCloudAuth, "getAccessToken").mockResolvedValue(
+            "test-token",
+        );
+        const inputs: Record<string, unknown>[] = [];
+        vi.spyOn(globalThis, "fetch").mockImplementation(async (url, init) => {
+            const href = String(url);
+            if (href.endsWith(":predictLongRunning")) {
+                return Response.json(
+                    { error: { message: "Forced primary outage" } },
+                    { status: 503 },
+                );
+            }
+            if (href === FIRST_FRAME_URL || href === LAST_FRAME_URL) {
+                return new Response(PNG_BYTES, {
+                    headers: { "Content-Type": "image/png" },
+                });
+            }
+            if (
+                href ===
+                "https://api.replicate.com/v1/models/google/veo-3.1-fast/predictions"
+            ) {
+                inputs.push(JSON.parse(init?.body as string).input);
+                return Response.json({
+                    id: "veo-fallback-test",
+                    status: "succeeded",
+                    output: "https://video.example.com/veo.mp4",
+                    metrics: { video_output_duration_seconds: 4 },
+                });
+            }
+            return new Response("video", {
+                headers: { "Content-Type": "video/mp4" },
+            });
+        });
+        const params = {
+            ...baseParams,
+            model: "veo-replicate" as const,
+            resolution,
+            audio: audio ?? false,
+            duration: undefined,
+            image: [FIRST_FRAME_URL, LAST_FRAME_URL].slice(0, frames),
+        };
+        const attempts: FallbackAttempt[] = [];
+        const { result, index } = await withModelFallback(
+            ["veo", ...IMAGE_SERVICES.veo.fallbacks].map((id) => ({
+                id,
+                definition: IMAGE_SERVICES[id as keyof typeof IMAGE_SERVICES],
+            })),
+            ({ id }) =>
+                createAndReturnVideo(
+                    "a paper boat",
+                    { ...params, model: id as "veo" | "veo-replicate" },
+                    "veo-test",
+                ),
+            attempts,
+        );
+        expect(index).toBe(1);
+        expect(
+            attempts.map(({ candidate, settled }) => [candidate.id, settled]),
+        ).toEqual([
+            ["veo", false],
+            ["veo-replicate", true],
+        ]);
+        expect(inputs).toEqual([
+            {
+                prompt: "a paper boat",
+                duration: 4,
+                resolution: resolution ?? "720p",
+                aspect_ratio: "16:9",
+                generate_audio: audio === true,
+                ...(frames >= 1
+                    ? {
+                          image: expect.stringMatching(
+                              /^data:image\/png;base64,/,
+                          ),
+                      }
+                    : {}),
+                ...(frames === 2
+                    ? {
+                          last_frame: expect.stringMatching(
+                              /^data:image\/png;base64,/,
+                          ),
+                      }
+                    : {}),
+            },
+        ]);
+        expect(result.trackingData).toEqual({
+            actualModel: "veo-replicate",
+            usage: {
+                completionVideoSeconds: 4,
+                ...(audio ? { completionAudioSeconds: 4 } : {}),
+            },
+        });
+        const billing = calculateUsageBilling({
+            model: "veo",
+            usage: result.trackingData.usage,
+            servedBy: IMAGE_SERVICES["veo-replicate"],
+            quotedBy: IMAGE_SERVICES.veo,
+            input: { resolution },
+        });
+        expect(billing.cost.totalCost).toBeCloseTo(cost);
+        expect(billing.price.totalPrice).toBeCloseTo(price);
     });
 });

--- a/gen.pollinations.ai/test/image/videoFrameValidation.test.ts
+++ b/gen.pollinations.ai/test/image/videoFrameValidation.test.ts
@@ -14,6 +14,7 @@ import type { ImageParams } from "../../src/image/params.ts";
 const VIDEO_FRAME_LIMITS = [
     ["google/gemini-omni-1.1-flash", 2],
     ["veo", 2],
+    ["veo-replicate", 2],
     ["seedance-pro", 1],
     ["seedance-pro-fal", 1],
     ["seedance-2.0", 2],

--- a/shared/registry/image-fallbacks.ts
+++ b/shared/registry/image-fallbacks.ts
@@ -8,6 +8,18 @@ import type { FallbackMap } from "./merge-fallbacks";
  * `FallbackDefinition`.
  */
 export const IMAGE_FALLBACKS = {
+    veo: {
+        "veo-replicate": {
+            provider: "replicate",
+            // https://replicate.com/google/veo-3.1-fast: $0.10/s silent,
+            // $0.15/s with audio at either resolution. Keep the caller's
+            // Google quote; absorb the approved $0–$0.05/s fallback difference.
+            cost: {
+                completionVideoSeconds: 0.1,
+                completionAudioSeconds: 0.05,
+            },
+        },
+    },
     gptimage: {
         "gptimage-openai": {
             provider: "openai",


### PR DESCRIPTION
- Adds one internal fallback: Vertex `veo-3.1-fast-generate-001` → Replicate `google/veo-3.1-fast`, reusing the existing prediction client. One 48-line adapter, no extra retry layer.
- Approved contract unchanged: `veo`; aliases `veo-3.1-fast`, `veo-720p`, `video`, `veo-1080p`, `veo-3.1-fast-1080p`, `veo-1080`, `google/veo-3.1-fast`; Google; multiplier 1; paid-only yes; Pollinations GPU no.
- [Replicate](https://replicate.com/google/veo-3.1-fast) costs $0.10/s silent, $0.15/s audio at both resolutions. Customers retain [Google](https://cloud.google.com/vertex-ai/generative-ai/pricing) quote: 720p $0.08/$0.10, 1080p $0.10/$0.12. Approved premium absorbed.
- 160 tests, Gen typecheck and formatting pass. Live 720/1080p, 4/6/8s, audio, portrait, start/end frames pass with inspected media. Actual adapter forced fallback succeeds in 37.7s: cost $0.40, customer $0.32.
- Draft: burst of 3 produced two Replicate 429s; sequential probes pass. Full authenticated Worker/wallet/Tinybird/disconnect-rejoin/cache E2E outstanding. Google primary polling unchanged. Provider-hidden checkpoint/person-policy equivalence unverified. No secret or deployment changes.