### PR TITLE
feat: add Sweden Azure fallback for Grok 4.6

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -989,6 +989,20 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.0000015,
     },
   },
+  "grok-4.6-azure-sweden": {
+    "cost": {
+      "completionTextTokens": 0.000006,
+      "promptCachedTokens": 0.0000005,
+      "promptImageTokens": 0.000002,
+      "promptTextTokens": 0.000002,
+    },
+    "price": {
+      "completionTextTokens": 0.0000045,
+      "promptCachedTokens": 0.000000375,
+      "promptImageTokens": 0.0000015,
+      "promptTextTokens": 0.0000015,
+    },
+  },
   "grok-imagine": {
     "cost": {
       "completionImageTokens": 0.02,

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -317,6 +317,10 @@ const models: ModelDefinition[] = [
         config: portkeyConfig["grok-4.6"],
     },
     {
+        name: "grok-4.6-azure-sweden",
+        config: portkeyConfig["grok-4.6-azure-sweden"],
+    },
+    {
         name: "openai-audio",
         config: portkeyConfig["gpt-audio-mini-2025-12-15"],
         // Audio models don't support reasoning_effort.

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -169,6 +169,15 @@ export const portkeyConfig: PortkeyConfigMap = {
         responsesAuthHeader: "api-key",
     }),
 
+    "grok-4.6-azure-sweden": () => ({
+        ...portkeyConfig["grok-4.6"](),
+        directEndpoint:
+            "https://myceli-prod-swedencentral.cognitiveservices.azure.com/openai/deployments/grok-4.6/chat/completions?api-version=2024-12-01-preview",
+        authKey: textEnvironmentValue("AZURE_MYCELI_PROD_SWEDEN_API_KEY"),
+        responsesEndpoint:
+            "https://myceli-prod-swedencentral.openai.azure.com/openai/v1/responses",
+    }),
+
     // -- Azure (Myceli Prod — eastus, Cohere) --------------------------------
     "Cohere-command-a-plus-05-2026": () =>
         createAzureResponsesModelConfig(

--- a/gen.pollinations.ai/test/static-provider-fallbacks.test.ts
+++ b/gen.pollinations.ai/test/static-provider-fallbacks.test.ts
@@ -178,6 +178,12 @@ describe("static provider fallbacks", () => {
     });
 
     it("keeps provider-specific fallback costs", () => {
+        expect(TEXT_SERVICES["grok-4.6"].fallbacks).toEqual([
+            "grok-4.6-azure-sweden",
+        ]);
+        expect(TEXT_SERVICES["grok-4.6-azure-sweden"].cost).toEqual(
+            TEXT_SERVICES["grok-4.6"].cost,
+        );
         expect(TEXT_SERVICES["deepseek-deepinfra"].cost).toMatchObject({
             promptTextTokens: 0.08 / 1_000_000,
             completionTextTokens: 0.18 / 1_000_000,
@@ -265,6 +271,18 @@ describe("static provider fallbacks", () => {
     });
 
     it("binds fallback-only text ids to their exact provider routes", () => {
+        expect(
+            findModelByName("grok-4.6-azure-sweden")?.config(),
+        ).toMatchObject({
+            provider: "openai",
+            model: "grok-4.6",
+            directAuthHeader: "api-key",
+            directEndpoint:
+                "https://myceli-prod-swedencentral.cognitiveservices.azure.com/openai/deployments/grok-4.6/chat/completions?api-version=2024-12-01-preview",
+            responsesEndpoint:
+                "https://myceli-prod-swedencentral.openai.azure.com/openai/v1/responses",
+            responsesAuthHeader: "api-key",
+        });
         expect(findModelByName("deepseek-deepinfra")?.config()).toMatchObject({
             "custom-host": "https://api.deepinfra.com/v1/openai",
             model: "deepseek-ai/DeepSeek-V4-Flash-0731",

--- a/gen.pollinations.ai/test/text/generateTextPortkey.test.ts
+++ b/gen.pollinations.ai/test/text/generateTextPortkey.test.ts
@@ -1,4 +1,8 @@
+import { calculateUsageBilling } from "@shared/registry/registry.ts";
+import { TEXT_SERVICES } from "@shared/registry/text.ts";
+import { openaiUsageToUsage } from "@shared/registry/usage-headers.ts";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { withModelFallback } from "../../src/fallback.ts";
 import { generateTextPortkey } from "../../src/text/generateTextPortkey.js";
 
 const azureModelConfig = {
@@ -17,6 +21,81 @@ afterEach(() => {
 });
 
 describe("generateTextPortkey", () => {
+    it("falls back from East US to Sweden Grok and bills image and reasoning usage", async () => {
+        const hosts: string[] = [];
+        vi.spyOn(globalThis, "fetch").mockImplementation(
+            async (input, init) => {
+                const url = new URL(String(input));
+                hosts.push(url.hostname);
+                expect(JSON.parse(String(init?.body)).model).toBe("grok-4.6");
+                expect(new Headers(init?.headers).has("api-key")).toBe(true);
+                if (
+                    url.hostname ===
+                    "myceli-prod-eastus.cognitiveservices.azure.com"
+                ) {
+                    return Response.json(
+                        { error: { message: "Capacity exhausted" } },
+                        { status: 429 },
+                    );
+                }
+                return Response.json({
+                    model: "grok-4.6",
+                    choices: [
+                        {
+                            index: 0,
+                            message: { role: "assistant", content: "Example" },
+                            finish_reason: "stop",
+                        },
+                    ],
+                    // Observed Sweden usage: reasoning is additive to completion_tokens.
+                    usage: {
+                        prompt_tokens: 91,
+                        completion_tokens: 22,
+                        total_tokens: 353,
+                        prompt_tokens_details: {
+                            text_tokens: 15,
+                            image_tokens: 76,
+                        },
+                        completion_tokens_details: { reasoning_tokens: 240 },
+                    },
+                });
+            },
+        );
+        const { result, index } = await withModelFallback(
+            ["grok-4.6", ...TEXT_SERVICES["grok-4.6"].fallbacks].map((id) => ({
+                id,
+                definition: TEXT_SERVICES[id as keyof typeof TEXT_SERVICES],
+            })),
+            ({ id }) =>
+                generateTextPortkey(
+                    [{ role: "user", content: "Read the image." }],
+                    { model: id },
+                ),
+        );
+        expect(index).toBe(1);
+        expect(hosts).toEqual([
+            "myceli-prod-eastus.cognitiveservices.azure.com",
+            "myceli-prod-swedencentral.cognitiveservices.azure.com",
+        ]);
+        const usage = openaiUsageToUsage(
+            result.usage as Parameters<typeof openaiUsageToUsage>[0],
+        );
+        expect(usage).toMatchObject({
+            promptTextTokens: 15,
+            promptImageTokens: 76,
+            completionTextTokens: 22,
+            completionReasoningTokens: 240,
+        });
+        const billing = calculateUsageBilling({
+            model: "grok-4.6",
+            usage,
+            servedBy: TEXT_SERVICES["grok-4.6-azure-sweden"],
+            quotedBy: TEXT_SERVICES["grok-4.6"],
+        });
+        expect(billing.cost.totalCost).toBeCloseTo(0.001754, 12);
+        expect(billing.price.totalPrice).toBe(0.0013155);
+    });
+
     it("calls OpenRouter directly and preserves its request and response fields", async () => {
         const fetchSpy = vi
             .spyOn(globalThis, "fetch")

--- a/shared/registry/text-fallbacks.ts
+++ b/shared/registry/text-fallbacks.ts
@@ -9,6 +9,12 @@ import { perMillion } from "./price-helpers";
 
 /** Exact-checkpoint provider routes used when a text model's primary fails. */
 export const TEXT_FALLBACKS = {
+    "grok-4.6": {
+        "grok-4.6-azure-sweden": {
+            provider: "azure",
+            addedDate: new Date("2026-09-06").getTime(),
+        },
+    },
     deepseek: {
         "deepseek-deepinfra": {
             provider: "deepinfra",

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -997,7 +997,7 @@ const TEXT_BASE_SERVICES = {
         addedDate: new Date("2026-07-18").getTime(),
         paidOnly: false,
         priceMultiplier: 0.75,
-        // Provisional Azure sheet pending an exact public or account meter.
+        // Microsoft Foundry Global Standard rates, published August 26, 2026.
         // The direct route reports image tokens separately from text tokens.
         cost: {
             promptTextTokens: perMillion(2),


### PR DESCRIPTION
- Adds one internal fallback: East US `grok-4.6` → Sweden `grok-4.6`, xAI version 1 GlobalStandard. Created approved Sweden deployment: 1M TPM/1000 RPM. Separate resource/quota allocation, not independence from Azure global infrastructure.
- Approved contract unchanged: public `grok-4.6`; aliases `grok-4.5`, `grok-4-5`, `x-ai/grok-4.6`; Azure; multiplier 0.75; paid-only no; Pollinations GPU no. 200K context, images/tools/reasoning preserved.
- Both routes: input/image $2/M, cached input $0.50/M, output/reasoning $6/M; customer quote unchanged. [Microsoft rates](https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/grok-4-6-comes-to-microsoft-foundry-models-built-for-long-horizon-reasoning-and-/4547578).
- 107 focused tests, Gen typecheck and formatting pass. Live five-request burst passes text/JSON/tools/stream/small token limit; Responses passes. Actual adapter forced fallback reads two images and bills all 353 tokens: cost $0.001754, price $0.0013155. Repeated prefix reports 13366 cached tokens.
- Draft pending full authenticated Worker/wallet/Tinybird/cache E2E. Existing Sweden key reused; no secret changes or Cloudflare deployment.