### PR TITLE
fix: harden Polli scraping, data controls, and request handling

### DIFF
--- a/apps/polli/Dockerfile
+++ b/apps/polli/Dockerfile
@@ -1,3 +1,9 @@
+FROM node:22-slim AS node
+
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
 FROM python:3.11-slim
 
 ENV PYTHONUNBUFFERED=1 \
@@ -42,11 +48,14 @@ ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 
 WORKDIR /app
 
+COPY --from=node /usr/local /usr/local
+COPY --from=node /app/node_modules ./node_modules
+ENV PATH=/usr/local/bin:$PATH
+
 COPY requirements.txt .
 
 RUN pip install --upgrade pip setuptools wheel && \
-    pip install -r requirements.txt && \
-    pip install playwright
+    pip install -r requirements.txt
 
 RUN playwright install chromium
 RUN playwright install-deps

--- a/apps/polli/README.md
+++ b/apps/polli/README.md
@@ -1,290 +1,235 @@
 <p align="center">
-  <img src="https://image.pollinations.ai/prompt/A%20cute%20parrot%20mascot%20named%20Polli%20with%20GitHub%20and%20Discord%20logos%2C%20digital%20art%2C%20friendly%2C%20colorful?width=200&height=200&nologo=true" alt="Polli" width="150" height="150">
-</p>
-
-<h1 align="center">🦜 Polli</h1>
-
-<p align="center">
-  <strong>Bidirectional GitHub ↔ Discord Assistant</strong>
+  <img src="../../packages/ui/src/brand/polli/polli.png" alt="Polli pixel-art bee mascot wearing headphones" width="152">
 </p>
 
 <p align="center">
-  <a href="#features">Features</a> •
-  <a href="#how-it-works">How It Works</a> •
-  <a href="#setup">Setup</a> •
-  <a href="#tools">Tools</a> •
-  <a href="#architecture">Architecture</a>
+  <img src="assets/readme/hero.svg" alt="Polli connects Discord, GitHub, and an OpenAI-compatible API to permission-aware engineering tools" width="100%">
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/python-3.10+-blue?style=flat-square&logo=python&logoColor=white" alt="Python">
-  <img src="https://img.shields.io/badge/discord.py-2.0+-5865F2?style=flat-square&logo=discord&logoColor=white" alt="Discord.py">
-  <img src="https://img.shields.io/badge/GitHub%20API-GraphQL%20%2B%20REST-181717?style=flat-square&logo=github&logoColor=white" alt="GitHub API">
-  <img src="https://img.shields.io/badge/AI-Pollinations-green?style=flat-square" alt="Pollinations AI">
+  <a href="#what-polli-does">What Polli does</a> ·
+  <a href="#interfaces">Interfaces</a> ·
+  <a href="#tools-and-access">Tools and access</a> ·
+  <a href="#local-setup">Local setup</a> ·
+  <a href="#privacy-and-data">Privacy and data</a>
 </p>
 
----
+# Polli
 
-## ✨ Features
+Polli is the Pollinations.ai engineering assistant for Discord and GitHub. It brings repository, issue, pull-request, web, and community context into a tool-calling conversation while applying access rules at each entry point.
 
-### 🔄 Bidirectional Communication
-| Platform    | Trigger                         | Response          |
-| ----------- | ------------------------------- | ----------------- |
-| **Discord** | @mention Polli                  | Replies in thread |
-| **GitHub**  | @mention in issues/PRs/comments | Replies on GitHub |
+The service also exposes a local OpenAI-compatible HTTP interface for authorized agent clients. That interface is distinct from the Discord bot: it accepts only pre-issued, short-lived `ag_` bearer tokens and deliberately exposes a narrower tool set.
 
-### 🎯 Full GitHub Integration
+## What Polli does
 
-<table>
-<tr>
-<td width="50%">
+- Starts a focused Discord thread from an `@Polli` mention, a reply, or the **Apps → Assist** context action.
+- Answers repository questions with exact file reads, text search, an optional semantic index, and optional symbol-graph traversal.
+- Reads and manages GitHub issues, pull requests, and Projects V2 according to the caller's role and the configured repository allowlist.
+- Searches caller-visible Discord context, searches or reads the web, and renders tables, charts, diagrams, code, and mathematical notation for Discord.
+- Tracks opt-in GitHub issue notifications and sends updates by DM when possible.
+- Can respond to authorized GitHub mentions through an optional, signature-verified webhook.
+- Provides `/v1/chat/completions` and `/v1/responses`, including streaming responses and client-defined tool calls.
 
-**📋 Issues**
-- Search, create, comment
-- Close, reopen, edit (admin)
-- Labels, assignees, milestones
-- Sub-issues & linking
-- Subscriptions & notifications
+Polli is an assistant, not an authority: tool results can be incomplete, generated answers can be wrong, and consequential changes still require human judgment.
 
-</td>
-<td width="50%">
+## Interfaces
 
-**🔀 Pull Requests**
-- List, review, approve, merge
-- Inline comments & suggestions
-- Request reviewers
-- AI-powered code review
-- Auto-merge support
+| Interface | Trigger and scope | Notes |
+| --- | --- | --- |
+| Discord | Mention Polli in a server channel, reply to it in a thread, or use **Assist** | Opens or continues a thread; available tools depend on Discord roles and channel visibility. |
+| Direct message | Subscription commands and privacy help | `subscribe #123`, `unsubscribe #123`, `unsubscribe all`, `list subscriptions`, or `privacy`. |
+| GitHub webhook | Mention the configured bot account in an issue or pull-request event | Disabled by default. Requests must have a valid webhook signature, come from an allowlisted repository, and currently come from a configured GitHub admin account. |
+| HTTP API | OpenAI-compatible request to the embedded server | Binds to `127.0.0.1:55288` by default. Requires `Authorization: Bearer ag_…`; persistent `sk_` and `pk_` keys are rejected. |
 
-</td>
-</tr>
-<tr>
-<td>
+### HTTP example
 
-**📊 Projects V2**
-- View project boards
-- Add/remove items
-- Update status & fields
-- Track progress
-
-</td>
-<td>
-
-**🤖 Code Agent**
-- Autonomous coding tasks
-- Create branches & PRs
-- Edit files directly
-- Run tests & fix issues
-
-</td>
-</tr>
-</table>
-
-### 🔍 Smart Search
-- **`code_search`** - Semantic search across codebase (OpenAI embeddings + ChromaDB)
-- **`doc_search`** - Semantic search across documentation (OpenAPI schema, etc.)
-- **`web_search`** - Real-time web search via Pollinations API
-
-### 🧠 AI-Powered
-- Native tool calling (Kimi k2.5 / GLM-5 / Gemini 3 Pro)
-- Parallel tool execution
-- Context-aware responses
-- Multi-language support
-
----
-
-## 🚀 How It Works
-
-### Discord → GitHub
-```
-User: @Polli find 502 errors
-
-   [Thread Created: "Issue: 502 errors"]
-
-Polli: Found 3 open issues:
-       • #156 - 502 errors on Flux model
-       • #142 - Intermittent 502 on image gen
-       • #98 - API returning 502 under load
-
-User: review PR #200
-
-Polli: 🔍 Reviewing PR #200...
-
-       ✅ Overall: LGTM with minor suggestions
-
-       📝 src/api.py:42 - Consider adding error handling
-       📝 src/utils.py:15 - This could be simplified
-```
-
-### GitHub → Discord
-```markdown
-<!-- In a GitHub issue comment -->
-@pollinations-ci can you explain what this error means?
-
-<!-- Polli replies directly on GitHub -->
-This error occurs when... [detailed explanation]
-```
-
----
-
-## 📦 Setup
-
-### Prerequisites
-- Python 3.10+
-- Discord Bot Token
-- GitHub App (recommended) or PAT
-
-### 1️⃣ Clone & Install
+The API is for clients that have already received a short-lived agent token from the surrounding trusted system. Polli does not mint these tokens, and this README intentionally does not describe an issuance flow.
 
 ```bash
-cd apps/polli
-python -m venv venv
-source venv/bin/activate  # or `venv\Scripts\activate` on Windows
-pip install -r requirements.txt
+curl http://127.0.0.1:55288/v1/chat/completions \
+  -H "Authorization: Bearer $POLLI_AGENT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "polli",
+    "messages": [{"role": "user", "content": "Summarize the open image API issues"}]
+  }'
 ```
 
-### 2️⃣ Configure Environment
+`model: "polli"` is an alias for the service's configured default upstream model and may use its configured fallback. A non-empty explicit upstream model name is forwarded as requested and does not use that fallback. `/v1/models` advertises only the stable `polli` alias; an explicit upstream model therefore need not appear in that list.
+
+The embedded API is not a universal pass into Polli. It uses non-admin context, removes mutation and subscription operations, excludes custom GitHub requests and visual rendering, blocks Discord member/role lookup, and restricts Discord results to public HTTP scope.
+
+## Architecture
+
+<p align="center">
+  <img src="assets/readme/architecture.svg" alt="Polli runtime architecture: Discord, signed GitHub webhooks, and the local API enter permission filtering and context assembly before Pollinations inference and permission-dependent tools" width="100%">
+</p>
+
+The Discord bot, embedded API server, and optional webhook server run in one Python process. Conversation sessions are held in memory and refreshed from Discord thread history. Tool handlers then call GitHub, Discord, Pollinations, web, local repository, Vectorize, and rendering services as configured.
+
+## Tools and access
+
+Tool availability is both **configuration-dependent** and **caller-dependent**. The model sees a filtered schema, and handlers receive request-specific identity and role context.
+
+| Capability | Discord member | Discord collaborator | Discord admin | HTTP API |
+| --- | --- | --- | --- | --- |
+| GitHub overview and reads | Available | Available | Available | Read subset |
+| Issue creation and comments | Available | Available | Available | Not available |
+| Close/reopen, labels, assignees | Not available | Available | Available | Not available |
+| Other issue, PR, and Project mutations | Not available | Not available | Available | Not available |
+| Read-only custom GitHub API request | Available | Available | Available | Not available |
+| Code search and repository exploration | When a backend is enabled | When a backend is enabled | When a backend is enabled | When a backend is enabled |
+| Discord search | Caller-visible channels | Caller-visible channels | Caller-visible channels | Public scope; no member/role lookup or private threads |
+| Web search and scraping | Available | Available | Available | Available |
+| Visual rendering | Available | Available | Available | Not available |
+| Issue subscriptions | Available | Available | Available | Not available |
+
+High-impact actions may require confirmation even when the caller has access. GitHub permissions and installation scope can further limit an operation.
+
+### Code intelligence
+
+`code_search` combines whichever backends are configured:
+
+- **Local clone:** exact grep, file reads, file lists, and directory trees.
+- **Cloudflare Vectorize:** semantic search using the configured embedding index and model.
+- **Symbol graph:** symbol discovery, callers, callees, and impact traversal through the locally pinned CodeGraph package when its index is available. Use returned stable symbol IDs for traversal; ambiguous names are rejected.
+
+No ChromaDB or OpenAI embeddings service is used by the current implementation.
+
+## Local setup
+
+### Requirements
+
+- Python **3.11** (the container image and `version.cfg` use 3.11)
+- Git
+- Node.js **22** and npm for the pinned symbol-graph runtime
+- A Discord application with **Message Content** and **Server Members** privileged intents enabled
+- GitHub authentication: a GitHub App installation, or a personal access token
+- A Pollinations API token for the bot's own upstream requests
+- Chromium installed through Playwright for browser-backed scraping
+
+Optional features need their own configuration: a GitHub Project token for Projects V2, a webhook secret for GitHub ingress, and Cloudflare credentials for Vectorize. Graph traversal uses the local npm dependency rather than a global `codegraph` installation.
+
+### Install
+
+```bash
+git clone https://github.com/pollinations/pollinations.git
+cd pollinations/apps/polli
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+npm ci --workspaces=false
+playwright install chromium
+```
+
+On Windows, activate with `.venv\Scripts\activate`.
+
+### Configure
+
+Copy the environment template and keep the resulting file private:
 
 ```bash
 cp .env.example .env
 ```
 
-Edit `.env` with your credentials:
+Required runtime secrets are:
 
-```env
-# Required
-DISCORD_TOKEN=your_discord_bot_token
-GITHUB_APP_ID=your_app_id
-GITHUB_PRIVATE_KEY=./polli.pem  # file path or inline key
-GITHUB_INSTALLATION_ID=your_installation_id
+```dotenv
+DISCORD_TOKEN=...
+POLLINATIONS_TOKEN=...
 
-# Optional
-OPENAI_EMBEDDINGS_API=your_openai_key  # for code/doc embeddings
-POLLINATIONS_TOKEN=your_pollinations_token
+# Choose GitHub App authentication…
+GITHUB_APP_ID=...
+GITHUB_INSTALLATION_ID=...
+GITHUB_PRIVATE_KEY=./polly.pem
+
+# …or a personal access token.
+POLLI_PAT=...
 ```
 
-### 3️⃣ Run
+`GITHUB_PROJECT_PAT`, `GITHUB_WEBHOOK_SECRET`, `CLOUDFLARE_ACCOUNT_ID`, and `VECTORIZE_API_TOKEN` are optional and only enable their corresponding features. Non-secret behavior—repository scope, role IDs, ports, models, limits, and feature switches—lives in [`config.json`](config.json). Never commit `.env`, private keys, or tokens.
+
+The Discord bot's `POLLINATIONS_TOKEN` is a service credential configured by the operator. It is not the same credential contract as the embedded HTTP API's request-scoped `ag_` token.
+
+### Run
 
 ```bash
 python main.py
 ```
 
-### 4️⃣ Media Handlers (Tables, Charts, LaTeX, Code)
+The default configuration starts the Discord bot and local HTTP API, keeps the GitHub webhook disabled, and follows `pollinations/pollinations` on `main` for local code search.
 
-Enabled by default — all deps ship in `requirements.txt`, fonts vendored in `assets/fonts/`:
+### Container
 
-- 📊 **Markdown Tables** → Rendered as PNG images with markdown-aware cells (bold/italic/code spans)
-- 📈 **Charts** → bar, line, pie, scatter, heatmap, histogram, etc. via the `render_visual` tool
-- ∑ **LaTeX Expressions** → Rendered as PNG images (inline `$...$` and display `$$...$$`)
-- 💻 **Code Blocks** → Smart splitting without breaking lines
-
-See [MEDIA_HANDLERS.md](docs/MEDIA_HANDLERS.md) for details.
-
----
-
-## 🛠️ Tools
-
-| Tool              | Description                                               | Access                       |
-| ----------------- | --------------------------------------------------------- | ---------------------------- |
-| `github_overview` | Quick repo summary (issues, labels, milestones, projects) | Everyone                     |
-| `github_issue`    | All issue operations                                      | Read: Everyone, Write: Admin |
-| `github_pr`       | All PR operations                                         | Read: Everyone, Write: Admin |
-| `github_project`  | Project board operations                                  | Read: Everyone, Write: Admin |
-| `github_code`     | Code agent (branches, edits, PRs)                         | Admin only                   |
-| `code_search`     | Semantic code search                                      | Everyone                     |
-| `doc_search`      | Semantic doc search (OpenAPI schema)                      | Everyone                     |
-| `web_search`      | Real-time web search                                      | Everyone                     |
-| `discord_search`  | Search Discord messages, members, channels                | Everyone                     |
-
----
-
-## 🏗️ Architecture
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                         ENTRY POINTS                            │
-├────────────────────────────┬────────────────────────────────────┤
-│     Discord (@mention)     │     GitHub Webhook (port 8002)     │
-│     └─ Thread-based        │     └─ Issues, PRs, Comments       │
-└────────────────────────────┴────────────────────────────────────┘
-                                    │
-                                    ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                    POLLINATIONS AI ENGINE                       │
-│  ┌─────────────┐  ┌─────────────┐  ┌─────────────────────────┐  │
-│  │  Kimi k2.5  │  │    GLM-5    │  │    Gemini 3 Pro         │  │
-│  └─────────────┘  └─────────────┘  └─────────────────────────┘  │
-│                    Native Tool Calling                          │
-└─────────────────────────────────────────────────────────────────┘
-                                    │
-                    ┌───────────────┼───────────────┐
-                    ▼               ▼               ▼
-            ┌─────────────┐ ┌─────────────┐ ┌─────────────┐
-            │   GitHub    │ │    Code     │ │  Embeddings │
-            │    APIs     │ │   Agent     │ │  (OpenAI)   │
-            │ GraphQL+REST│ │  Sandbox    │ │  ChromaDB   │
-            └─────────────┘ └─────────────┘ └─────────────┘
+```bash
+docker build -t polli .
+docker run --rm --env-file .env polli
 ```
 
----
+The checked-in [`deploy.json`](deploy.json) identifies the repository's deployment target, but deployment credentials and production procedures are intentionally outside this README.
 
-## 📁 Project Structure
+## Testing
 
-```
-Polli/
-├── 📄 main.py                    # Entry point
-├── 📄 requirements.txt           # Dependencies
-├── 📄 .env.example               # Environment template
-├── 📁 src/
-│   ├── 📄 bot.py                 # Discord bot + webhook server
-│   ├── 📄 config.py              # Configuration
-│   ├── 📄 constants.py           # Tools, prompts, schemas
-│   ├── 📁 context/               # Session management + repo_info.txt
-│   ├── 📁 api/                   # OpenAI-compatible REST API
-│   └── 📁 services/
-│       ├── 📄 github.py          # GitHub REST API
-│       ├── 📄 github_graphql.py  # GitHub GraphQL API
-│       ├── 📄 github_pr.py       # PR operations
-│       ├── 📄 pollinations.py    # AI client
-│       ├── 📄 embeddings.py      # Code embeddings (OpenAI + ChromaDB)
-│       ├── 📄 doc_embeddings.py  # Doc embeddings (crawl + embed)
-│       ├── 📄 discord_search.py  # Discord guild search
-│       ├── 📄 web_scraper.py     # Crawl4AI web scraper
-│       └── 📄 webhook_server.py  # GitHub webhooks
-└── 📄 deploy.json                # Production deployment manifest
+Tests use Python's standard `unittest` runner:
+
+```bash
+python -m unittest discover -s tests -p "test_*.py"
 ```
 
----
+Run one module while iterating:
 
-## ⚡ Performance
+```bash
+python -m unittest tests.test_openai_api
+```
 
-| Optimization            | Benefit                     |
-| ----------------------- | --------------------------- |
-| GraphQL batching        | 40-90% fewer API calls      |
-| Parallel tool execution | Multiple ops simultaneously |
-| Connection pooling      | Reused HTTP connections     |
-| Local embeddings        | Instant code search         |
-| Stateless design        | No database overhead        |
+Some integration paths depend on external credentials, network access, local binaries, or a live Discord guild. A passing isolated module does not certify those external systems.
 
----
+## Configuration map
 
-## 🔐 Permissions
+```text
+apps/polli/
+├── main.py                       process entry point
+├── config.json                   non-secret runtime configuration
+├── .env.example                  secret-variable template
+├── Dockerfile                    Python 3.11 container
+├── src/
+│   ├── ai/                       model client, prompts, schemas, tool filters
+│   ├── api/                      OpenAI-compatible HTTP routes
+│   ├── context/                  in-memory conversation sessions
+│   ├── core/                     configuration, auth context, logging
+│   ├── discord/                  Discord search and media handling
+│   ├── integrations/             GitHub, web, subscriptions, visuals, webhook
+│   └── search/                   local, semantic, and graph code search
+├── polli-core/                   optional native helpers
+└── tests/                        unittest suites
+```
 
-| Role         | Capabilities                                     |
-| ------------ | ------------------------------------------------ |
-| **Everyone** | Search, read issues/PRs, code search, web search |
-| **Admin**    | + Close, edit, label, assign, merge, code agent  |
+## Privacy and data
 
-Admin = Users with configured Discord role(s)
+Polli processes content supplied through Discord, GitHub webhooks, HTTP requests, linked pages, and attachments. Relevant prompts, context, and tool results can be sent to configured external services such as Pollinations, GitHub, Discord, and web-content providers. Do not send passwords, API keys, private keys, or other secrets to the bot.
 
----
+Current storage behavior:
 
-## 🤝 Contributing
+- Conversation sessions are in process memory, capped at 500 sessions, and expire after 300 seconds of inactivity by default. Discord messages and GitHub content remain governed by those platforms and are not deleted when an in-memory session expires.
+- Issue subscriptions persist in `data/subscriptions.db` with Discord user/channel identifiers, issue number, delivery state, and timestamps. They remain until unsubscribed or otherwise removed; no automatic retention deadline is implemented.
+- Code search may keep an operator-managed local repository clone and may query a configured external Vectorize index. The optional graph is derived from that clone.
+- Runtime logs go to standard output. Retention is controlled by the deployment environment; Polli does not define an application-level log retention period.
+- Provider-held request data follows each provider's own terms and retention controls.
 
-This is a private bot for Pollinations.AI. For issues or suggestions, reach out on Discord!
+DM `privacy` or `delete data` for the privacy link and instructions. DM `unsubscribe all` to remove issue subscriptions immediately. That command does **not** erase Discord messages, GitHub content, deployment logs, or provider-held data. For access, correction, deletion, privacy, or general support requests, email [hello@pollinations.ai](mailto:hello@pollinations.ai) with your Discord user ID and relevant message or issue links; never include credentials.
 
----
+See the [Pollinations.ai privacy policy](https://pollinations.ai/privacy).
 
-<p align="center">
-  Made with 💜 for <a href="https://pollinations.ai">Pollinations.AI</a>
-</p>
+## Creator and support
+
+**Creator**
+
+- GitHub: [Itachi-1824](https://github.com/Itachi-1824)
+- Discord: `_dr_misterio_`
+- Email: [Itachi@pollinations.ai](mailto:Itachi@pollinations.ai)
+
+Creator contact is separate from product support and privacy handling. Use [hello@pollinations.ai](mailto:hello@pollinations.ai) for Pollinations.ai support, legal, and privacy requests.
+
+## License and attribution
+
+Polli is part of the Pollinations.ai repository and is provided under the repository's [MIT License](../../LICENSE). Copyright © 2026 pollinations.ai. Pollinations.ai is the product brand; Myceli.AI OÜ remains the registered legal entity and data controller.

--- a/apps/polli/assets/readme/architecture.svg
+++ b/apps/polli/assets/readme/architecture.svg
@@ -1,0 +1,102 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="620" viewBox="0 0 1200 620" role="img" aria-labelledby="title desc">
+  <title id="title">Polli runtime architecture</title>
+  <desc id="desc">Discord mentions, optional signed GitHub webhooks, and a local HTTP API enter Polli. Polli applies identity and permission filters, builds conversational context, calls Pollinations text generation, and dispatches allowed tools to Discord, GitHub, web, code search, and visual rendering services.</desc>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0l10 5-10 5z" class="arrow"/>
+    </marker>
+  </defs>
+  <style>
+    .bg { fill: #f8fafc; }
+    .panel { fill: #ffffff; stroke: #cbd5e1; stroke-width: 2; }
+    .core { fill: #eef2ff; stroke: #6366f1; stroke-width: 2.5; }
+    .ink { fill: #172033; }
+    .muted { fill: #526077; }
+    .edge { fill: none; stroke: #64748b; stroke-width: 2.5; marker-end: url(#arrow); }
+    .arrow { fill: #64748b; }
+    .dash { stroke-dasharray: 7 7; }
+    .heading { font: 700 20px ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    .body { font: 500 15px ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    .small { font: 500 13px ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    @media (prefers-color-scheme: dark) {
+      .bg { fill: #0f172a; }
+      .panel { fill: #172033; stroke: #475569; }
+      .core { fill: #252852; stroke: #a5b4fc; }
+      .ink { fill: #f1f5f9; }
+      .muted { fill: #bdc7d8; }
+      .edge { stroke: #94a3b8; }
+      .arrow { fill: #94a3b8; }
+    }
+  </style>
+  <rect class="bg" width="1200" height="620" rx="24"/>
+
+  <text class="heading ink" x="70" y="54">Entry points</text>
+  <g transform="translate(70 78)">
+    <rect class="panel" width="250" height="82" rx="14"/>
+    <text class="heading ink" x="22" y="34">Discord</text>
+    <text class="body muted" x="22" y="60">mention, reply, or Assist</text>
+  </g>
+  <g transform="translate(70 190)">
+    <rect class="panel" width="250" height="94" rx="14"/>
+    <text class="heading ink" x="22" y="34">GitHub webhook</text>
+    <text class="body muted" x="22" y="60">signed + repo allowlisted</text>
+    <text class="small muted" x="22" y="80">disabled by default</text>
+  </g>
+  <g transform="translate(70 314)">
+    <rect class="panel" width="250" height="94" rx="14"/>
+    <text class="heading ink" x="22" y="34">HTTP API</text>
+    <text class="body muted" x="22" y="60">chat + responses</text>
+    <text class="small muted" x="22" y="80">short-lived ag_ bearer token</text>
+  </g>
+
+  <path class="edge" d="M320 119H416V170"/>
+  <path class="edge dash" d="M320 237H416V215"/>
+  <path class="edge" d="M320 361H416V260"/>
+
+  <g transform="translate(416 100)">
+    <rect class="core" width="368" height="242" rx="20"/>
+    <text class="heading ink" x="28" y="42">Polli orchestration</text>
+    <rect class="panel" x="28" y="66" width="312" height="46" rx="10"/>
+    <text class="body ink" x="47" y="95">identity + permission filters</text>
+    <rect class="panel" x="28" y="126" width="312" height="46" rx="10"/>
+    <text class="body ink" x="47" y="155">thread / request context</text>
+    <rect class="panel" x="28" y="186" width="312" height="34" rx="10"/>
+    <text class="body ink" x="47" y="209">tool loop + response formatting</text>
+  </g>
+
+  <path class="edge" d="M600 342v77"/>
+  <g transform="translate(416 419)">
+    <rect class="panel" width="368" height="96" rx="16"/>
+    <text class="heading ink" x="28" y="38">Pollinations text API</text>
+    <text class="body muted" x="28" y="66">configured model; optional fallback</text>
+  </g>
+
+  <path class="edge" d="M784 221h80"/>
+  <text class="heading ink" x="864" y="54">Permission-dependent tools</text>
+  <g transform="translate(864 78)">
+    <rect class="panel" width="266" height="82" rx="14"/>
+    <text class="heading ink" x="22" y="34">GitHub</text>
+    <text class="body muted" x="22" y="60">issues, PRs, projects, overview</text>
+  </g>
+  <g transform="translate(864 178)">
+    <rect class="panel" width="266" height="82" rx="14"/>
+    <text class="heading ink" x="22" y="34">Discord search</text>
+    <text class="body muted" x="22" y="60">caller-visible channel scope</text>
+  </g>
+  <g transform="translate(864 278)">
+    <rect class="panel" width="266" height="82" rx="14"/>
+    <text class="heading ink" x="22" y="34">Code intelligence</text>
+    <text class="body muted" x="22" y="60">local clone; optional Vectorize</text>
+  </g>
+  <g transform="translate(864 378)">
+    <rect class="panel" width="266" height="82" rx="14"/>
+    <text class="heading ink" x="22" y="34">Web + visuals</text>
+    <text class="body muted" x="22" y="60">search, scrape, render</text>
+  </g>
+
+  <path class="edge" d="M600 515v47h264"/>
+  <g transform="translate(70 536)">
+    <rect class="panel" width="714" height="50" rx="12"/>
+    <text class="body ink" x="22" y="31">State: short-lived in-memory sessions · persistent issue-subscription SQLite records</text>
+  </g>
+</svg>

--- a/apps/polli/assets/readme/hero.svg
+++ b/apps/polli/assets/readme/hero.svg
@@ -1,0 +1,73 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="360" viewBox="0 0 1200 360" role="img" aria-labelledby="title desc">
+  <title id="title">Polli, a Discord and GitHub engineering assistant</title>
+  <desc id="desc">A restrained banner showing Discord, GitHub, and API inputs flowing through Polli to research and engineering tools.</desc>
+  <style>
+    .bg { fill: #f8fafc; }
+    .panel { fill: #ffffff; stroke: #cbd5e1; }
+    .ink { fill: #172033; }
+    .muted { fill: #526077; }
+    .line { fill: none; stroke: #64748b; stroke-width: 3; stroke-linecap: round; }
+    .accent { fill: #4f46e5; }
+    .warm { fill: #f4b942; }
+    .label { font: 600 18px ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    .small { font: 500 15px ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    .wordmark { font: 750 64px ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing: -2px; }
+    .tagline { font: 500 24px ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    @media (prefers-color-scheme: dark) {
+      .bg { fill: #0f172a; }
+      .panel { fill: #172033; stroke: #475569; }
+      .ink { fill: #f1f5f9; }
+      .muted { fill: #b7c2d4; }
+      .line { stroke: #94a3b8; }
+      .accent { fill: #818cf8; }
+      .warm { fill: #f6c453; }
+    }
+  </style>
+  <rect class="bg" width="1200" height="360" rx="28"/>
+  <g opacity=".55">
+    <path class="line" d="M72 68h140M988 292h140M1090 68h38M72 292h38"/>
+    <circle class="accent" cx="72" cy="68" r="6"/>
+    <circle class="warm" cx="1128" cy="292" r="6"/>
+  </g>
+  <text class="wordmark ink" x="92" y="160">Polli</text>
+  <text class="tagline muted" x="94" y="204">Engineering context, where the conversation happens.</text>
+  <text class="small muted" x="94" y="247">Discord · GitHub · OpenAI-compatible API</text>
+
+  <path class="line" d="M695 94h82M695 180h82M695 266h82"/>
+  <circle class="accent" cx="777" cy="94" r="5"/>
+  <circle class="accent" cx="777" cy="180" r="5"/>
+  <circle class="accent" cx="777" cy="266" r="5"/>
+
+  <g transform="translate(592 61)">
+    <rect class="panel" width="150" height="66" rx="13"/>
+    <circle class="accent" cx="25" cy="33" r="10"/>
+    <text class="label ink" x="46" y="40">Discord</text>
+  </g>
+  <g transform="translate(592 147)">
+    <rect class="panel" width="150" height="66" rx="13"/>
+    <circle class="ink" cx="25" cy="33" r="10"/>
+    <text class="label ink" x="46" y="40">GitHub</text>
+  </g>
+  <g transform="translate(592 233)">
+    <rect class="panel" width="150" height="66" rx="13"/>
+    <path class="line" d="M17 33h16M25 25v16"/>
+    <text class="label ink" x="46" y="40">API</text>
+  </g>
+
+  <g transform="translate(777 76)">
+    <rect class="panel" width="174" height="208" rx="22"/>
+    <path class="warm" d="M87 28l31 18v36l-31 18-31-18V46z"/>
+    <circle class="ink" cx="87" cy="64" r="9"/>
+    <path class="line" d="M87 40v15M66 76l13-7M108 76l-13-7"/>
+    <text class="label ink" x="87" y="133" text-anchor="middle">Polli</text>
+    <text class="small muted" x="87" y="163" text-anchor="middle">context + tools</text>
+  </g>
+
+  <path class="line" d="M951 180h74"/>
+  <path class="accent" d="M1025 173l14 7-14 7z"/>
+  <g transform="translate(1039 126)">
+    <rect class="panel" width="93" height="108" rx="16"/>
+    <path class="line" d="M24 34h45M24 54h34M24 74h40"/>
+    <text class="small ink" x="46" y="99" text-anchor="middle">answer</text>
+  </g>
+</svg>

--- a/apps/polli/package-lock.json
+++ b/apps/polli/package-lock.json
@@ -1,0 +1,108 @@
+{
+  "name": "polli",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "polli",
+      "dependencies": {
+        "@colbymchenry/codegraph": "1.6.0"
+      }
+    },
+    "node_modules/@colbymchenry/codegraph": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colbymchenry/codegraph/-/codegraph-1.6.0.tgz",
+      "integrity": "sha512-nCN40MqmYxF7gH1QTKqlxJ1d2mzwhw3fzSdGV2wjnQKsymjM3JZnH/5rpGqhBkcUEom0qWq0WjDRvOZh2t8mFA==",
+      "license": "MIT",
+      "bin": {
+        "codegraph": "npm-shim.js"
+      },
+      "optionalDependencies": {
+        "@colbymchenry/codegraph-darwin-arm64": "1.6.0",
+        "@colbymchenry/codegraph-darwin-x64": "1.6.0",
+        "@colbymchenry/codegraph-linux-arm64": "1.6.0",
+        "@colbymchenry/codegraph-linux-x64": "1.6.0",
+        "@colbymchenry/codegraph-win32-arm64": "1.6.0",
+        "@colbymchenry/codegraph-win32-x64": "1.6.0"
+      }
+    },
+    "node_modules/@colbymchenry/codegraph-darwin-arm64": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colbymchenry/codegraph-darwin-arm64/-/codegraph-darwin-arm64-1.6.0.tgz",
+      "integrity": "sha512-usYVM30d7kH2Fm3ZPkiE84J8bWAicPsw/3Kh8LjbwvHkBkU3IlEYRQFkTDAf+HSRLLs8h5w/5WHkx/FvNKRZ/g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@colbymchenry/codegraph-darwin-x64": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colbymchenry/codegraph-darwin-x64/-/codegraph-darwin-x64-1.6.0.tgz",
+      "integrity": "sha512-MMYFseqAmytsj47ZsGZI+0OVDTYsEktHg6x42tB6y+8MWUjvH1ivz5Yk6RtX6iFAnNJeMSlV+SJepfP7pvbNbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@colbymchenry/codegraph-linux-arm64": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colbymchenry/codegraph-linux-arm64/-/codegraph-linux-arm64-1.6.0.tgz",
+      "integrity": "sha512-Uk2xKPh/DP/B0r4tg/uNZFwMsJDB+uKSbTN+Pcbf2F7PjolrqiFiR/9uqj8rndTjWmWDnxEK6IafJ1AOW4TpLA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@colbymchenry/codegraph-linux-x64": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colbymchenry/codegraph-linux-x64/-/codegraph-linux-x64-1.6.0.tgz",
+      "integrity": "sha512-zQMtxLdFBB5tNSuCIk5zLW281I/AMyfWqwjIcg1h7n521174Es54xlnWuEhmTPWKYSmMuOpInKeE6YpOPtERuQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@colbymchenry/codegraph-win32-arm64": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colbymchenry/codegraph-win32-arm64/-/codegraph-win32-arm64-1.6.0.tgz",
+      "integrity": "sha512-O5/xEp8RDiJh3cbto2Dg94uk02zO70UCq5OuvP1aJV9ZQmMKKFTnOWNyeZi+LSHMO5CQOv3kfskrORmGAB5+xw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@colbymchenry/codegraph-win32-x64": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colbymchenry/codegraph-win32-x64/-/codegraph-win32-x64-1.6.0.tgz",
+      "integrity": "sha512-zSjrLgkE2j2UYsPp6ThlVKL4xoZ1WnMkOfNH8i3XFGNXBS8p500WFA9bh0JJJ+IQx6vhtltTxTTdlVmVICGYsw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    }
+  }
+}

--- a/apps/polli/package.json
+++ b/apps/polli/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "polli",
+  "private": true,
+  "dependencies": {
+    "@colbymchenry/codegraph": "1.6.0"
+  }
+}

--- a/apps/polli/requirements.txt
+++ b/apps/polli/requirements.txt
@@ -6,7 +6,7 @@ aiohttp==3.13.3
 aiosignal==1.4.0
 aiosqlite==0.22.1
 annotated-types==0.7.0
-anyio==4.12.1
+anyio==4.15.1
 attrs==25.4.0
 backoff==2.2.1
 bcrypt==5.0.0
@@ -18,7 +18,10 @@ chardet==5.2.0
 charset-normalizer==3.4.4
 click==8.3.1
 coloredlogs==15.0.1
-crawl4ai==0.9.0
+crawl4ai[cosine]==0.9.3
+# Crawl4AI 0.9.3 uses Hugging Face loading arguments removed in Transformers 5.
+sentence-transformers==5.1.2
+transformers==4.57.1
 cryptography==46.0.4
 discord.py==2.6.4
 distro==1.9.0
@@ -37,7 +40,7 @@ httptools==0.7.1
 httpx==0.28.1
 humanfriendly==10.0
 humanize==4.15.0
-idna==3.11
+idna==3.19
 importlib_metadata==8.7.1
 Jinja2==3.1.6
 jiter==0.12.0
@@ -52,7 +55,7 @@ orjson>=3.10.0
 packaging==26.0
 pillow==12.1.0
 pilmoji>=2.0.0
-playwright==1.61.0
+playwright==1.62.0
 propcache==0.4.1
 protobuf==6.33.5
 pycparser==3.0
@@ -70,14 +73,14 @@ requests==2.32.5
 rich==14.3.1
 rnet==2.4.2
 rpds-py==0.30.0
-scrapling==0.4.9
+scrapling[fetchers,rag]==0.4.15
 seaborn>=0.13.0
 sniffio==1.3.1
 soupsieve==2.8.3
 starlette==0.50.0
 tenacity==9.1.2
 tqdm==4.67.2
-typing_extensions==4.15.0
+typing_extensions==4.16.0
 urllib3==2.6.3
 uuid-utils>=0.9.0
 uvloop==0.22.1

--- a/apps/polli/src/ai/client.py
+++ b/apps/polli/src/ai/client.py
@@ -2,7 +2,6 @@ import asyncio
 import codecs
 import json
 import logging
-import random
 import time
 from collections.abc import AsyncIterator, Awaitable, Callable
 
@@ -12,7 +11,6 @@ from ..utils.json import loads as _json_loads
 
 MAX_RETRIES = 3
 RETRY_DELAY = 5
-MAX_SEED = 2**31 - 1
 
 
 def _recent_queries(all_tool_calls: list[dict], tool_names: list[str], limit: int = 8) -> str:
@@ -139,7 +137,7 @@ class PollinationsClient:
 
         headers = {
             "Content-Type": "application/json",
-            "Authorization": authorization_or(config.ai.token),
+            "Authorization": _auth_override.get() or authorization_or(config.ai.token),
         }
 
         url = f"{config.ai.api_base}/v1/chat/completions"
@@ -150,7 +148,6 @@ class PollinationsClient:
             "messages": messages,
             "temperature": temperature,
             "max_tokens": max_tokens,
-            "seed": random.randint(0, MAX_SEED),
         }
 
         try:
@@ -163,19 +160,25 @@ class PollinationsClient:
             ) as response:
                 if response.status == 200:
                     data = await response.json()
-                    return data["choices"][0]["message"].get("content", "")
+                    choice = data["choices"][0]
+                    content = choice["message"].get("content", "")
+                    if not content:
+                        finish_reason = choice.get("finish_reason")
+                        if finish_reason not in {"stop", "length", "content_filter", "tool_calls"}:
+                            finish_reason = "unknown"
+                        logger.warning("generate_text returned empty content (finish_reason=%s)", finish_reason)
+                    return content
                 else:
-                    error_text = await response.text()
                     if response.status == 402:
                         logger.warning("generate_text: insufficient balance (402), bailing")
                         return None
-                    logger.error(f"generate_text error: HTTP {response.status}: {error_text[:200]}")
+                    logger.error("generate_text error: HTTP %s", response.status)
                     return None
-        except Exception as e:
-            logger.error(f"generate_text error: {e}")
+        except Exception as exc:
+            logger.error("generate_text failed (exception=%s)", type(exc).__name__)
             return None
 
-    def register_tool_handler(self, name: str, handler: callable):
+    def register_tool_handler(self, name: str, handler: Callable):
         self._tool_handlers[name] = handler
 
     async def process_with_tools(
@@ -205,9 +208,9 @@ class PollinationsClient:
         # API callers supply an OpenAI conversation verbatim. Polli adds only its
         # private system prompt; Discord keeps its richer thread framing below.
         if raw_messages is not None:
-            messages = [{"role": "system", "content": system_content}, *raw_messages]
+            api_messages = [{"role": "system", "content": system_content}, *raw_messages]
             return await self._call_with_tools(
-                messages,
+                api_messages,
                 discord_username,
                 is_admin=is_admin,
                 user_message=user_message,
@@ -218,7 +221,7 @@ class PollinationsClient:
             )
 
         # Build Discord messages
-        messages = [{"role": "system", "content": system_content}]
+        messages: list[dict[str, object]] = [{"role": "system", "content": system_content}]
         if mode == "discord":
             location_context = tool_context or {}
             source_channel_id = location_context.get("source_channel_id")
@@ -317,7 +320,7 @@ class PollinationsClient:
         file_notice = "\n\n" + "\n\n".join(notices) if notices else ""
 
         if image_urls:
-            content = [
+            content: list[dict[str, object]] = [
                 {
                     "type": "text",
                     "text": f"[{discord_username}]: {user_message}{file_notice}",
@@ -702,16 +705,16 @@ class PollinationsClient:
                 result = await handler(**args)
                 # Log result summary
                 if result.get("error"):
-                    logger.warning(f"Tool {func_name} returned error: {result.get('error')[:200]}")
+                    logger.warning("Tool %s returned an error", func_name)
                 else:
-                    logger.info(f"Tool {func_name} succeeded")
+                    logger.info("Tool %s succeeded", func_name)
                 # Cache successful read-only results
                 if cache_key and not result.get("error"):
                     self._cache.set(cache_key, result)
                 return result
-            except Exception as e:
-                logger.error(f"Tool {func_name} failed: {e}")
-                return {"error": str(e)}
+            except Exception as exc:
+                logger.error("Tool %s failed (exception=%s)", func_name, type(exc).__name__)
+                return {"error": str(exc)}
 
         # Run all tool calls in parallel
         tasks = [execute_single(tc) for tc in tool_calls]
@@ -733,10 +736,11 @@ class PollinationsClient:
             return None
         headers = {
             "Content-Type": "application/json",
-            "Authorization": authorization_or(config.ai.token),
+            "Authorization": override if mode == "api" else authorization_or(config.ai.token),
         }
+        model = (api_params or {}).get("model", config.ai.model)
         payload = {
-            "model": config.ai.model,
+            "model": model,
             "messages": messages,
             "stream": True,
             "stream_options": {"include_usage": True},
@@ -745,7 +749,7 @@ class PollinationsClient:
         if explicit_seed is not None:
             payload["seed"] = explicit_seed
         for key, value in (api_params or {}).items():
-            if key not in {"seed", "stream", "stream_options"} and value is not None:
+            if key not in {"model", "_explicit_model", "seed", "stream", "stream_options"} and value is not None:
                 payload[key] = value
         if tools:
             payload["tools"] = tools
@@ -761,7 +765,7 @@ class PollinationsClient:
             if response.status in (401, 403) and mode == "api":
                 raise UpstreamAuthError(response.status, await response.text())
             if response.status != 200:
-                logger.warning("Streaming API error: HTTP %s: %s", response.status, (await response.text())[:100])
+                logger.warning("Streaming API error: HTTP %s", response.status)
                 return None
             decoder = codecs.getincrementaldecoder("utf-8")()
             buffer = ""
@@ -870,7 +874,9 @@ class PollinationsClient:
         url = f"{config.ai.api_base}/v1/chat/completions"
         last_error = None
 
-        current_model = config.ai.model
+        requested_model = (api_params or {}).get("model", config.ai.model)
+        explicit_model = bool((api_params or {}).get("_explicit_model"))
+        current_model = requested_model
         for attempt in range(MAX_RETRIES):
             payload = {
                 "model": current_model,
@@ -880,7 +886,7 @@ class PollinationsClient:
             # Merge caller-provided OpenAI params (temperature, max_tokens, etc.)
             if api_params:
                 for k, v in api_params.items():
-                    if v is not None:
+                    if k not in {"model", "_explicit_model"} and v is not None:
                         payload[k] = v
 
             if tools:
@@ -915,29 +921,32 @@ class PollinationsClient:
                             "usage": data.get("usage"),
                         }
                     else:
-                        error_text = await response.text()
-                        last_error = f"HTTP {response.status}: {error_text[:100]}"
-                        logger.warning(f"Pollinations API error (attempt {attempt + 1}): {last_error}")
+                        last_error = f"HTTP {response.status}"
+                        logger.warning("Pollinations API error (attempt %s): HTTP %s", attempt + 1, response.status)
                         # 402 = global balance exhausted -- bail immediately, no retry
                         if response.status == 402:
                             break
                         # Other errors: switch to fallback model on next attempt
-                        if config.ai.fallback_model and current_model != config.ai.fallback_model:
+                        if (
+                            not explicit_model
+                            and config.ai.fallback_model
+                            and current_model != config.ai.fallback_model
+                        ):
                             logger.info(f"Switching to fallback model {config.ai.fallback_model!r} after error")
                             current_model = config.ai.fallback_model
                         # In API mode, propagate auth errors immediately — don't retry
                         if mode == "api" and response.status in (401, 403):
-                            raise UpstreamAuthError(response.status, error_text)
+                            raise UpstreamAuthError(response.status, "HTTP authentication error")
 
             except TimeoutError:
                 last_error = f"Timeout after {timeout}s"
                 logger.warning(f"API timeout (attempt {attempt + 1})")
-            except aiohttp.ClientError as e:
-                last_error = f"Network error: {e}"
-                logger.warning(f"Network error (attempt {attempt + 1}): {e}")
-            except Exception as e:
-                last_error = f"Error: {e}"
-                logger.warning(f"API error (attempt {attempt + 1}): {e}")
+            except aiohttp.ClientError as exc:
+                last_error = f"Network error ({type(exc).__name__})"
+                logger.warning("Network error (attempt %s, exception=%s)", attempt + 1, type(exc).__name__)
+            except Exception as exc:
+                last_error = f"Error ({type(exc).__name__})"
+                logger.warning("API error (attempt %s, exception=%s)", attempt + 1, type(exc).__name__)
 
             # Wait before retry (except on last attempt)
             if attempt < MAX_RETRIES - 1:
@@ -945,7 +954,7 @@ class PollinationsClient:
                 await asyncio.sleep(RETRY_DELAY)
 
         # All retries failed
-        logger.error(f"All {MAX_RETRIES} API attempts failed. Last error: {last_error}")
+        logger.error("All %s API attempts failed. Last error category: %s", MAX_RETRIES, last_error)
         return None
 
     def get_topic_summary_fast(self, message: str) -> str:
@@ -1022,8 +1031,8 @@ Output ONLY the formatted message, nothing else."""
             response = await self._call_api_with_tools(messages, tools=None, timeout=30)
             if response and response.get("content"):
                 return response["content"].strip()
-        except Exception as e:
-            logger.error(f"Failed to format notification with AI: {e}")
+        except Exception as exc:
+            logger.error("Failed to format notification with AI (exception=%s)", type(exc).__name__)
 
         # Fallback to simple format if AI fails
         return self._format_notification_fallback(issue, changes, issue_url)
@@ -1072,7 +1081,7 @@ pollinations_client = PollinationsClient()
 # =============================================================================
 
 
-async def web_search_handler(query: str, **kwargs) -> dict:
+async def web_search_handler(query: str, **_kwargs) -> dict:
     """
     Handle web_search tool calls via Perplexity (sonar-pro) through Pollinations.
 
@@ -1098,7 +1107,7 @@ async def web_search_handler(query: str, **kwargs) -> dict:
 
     headers = {
         "Content-Type": "application/json",
-        "Authorization": authorization_or(config.ai.token),
+        "Authorization": _auth_override.get() or authorization_or(config.ai.token),
     }
 
     payload = {
@@ -1115,16 +1124,39 @@ async def web_search_handler(query: str, **kwargs) -> dict:
         ) as response:
             if response.status == 200:
                 data = await response.json()
-                content = data["choices"][0]["message"].get("content", "")
-                return {"result": content, "model": model, "query": query}
+                message = data["choices"][0]["message"]
+                content = message.get("content", "")
+                sources = []
+                citations = data.get("citations") or message.get("citations") or []
+                for index, citation in enumerate(citations, start=1):
+                    source_url = (
+                        citation
+                        if isinstance(citation, str)
+                        else citation.get("url") if isinstance(citation, dict) else None
+                    )
+                    if isinstance(source_url, str) and source_url.startswith(("https://", "http://")):
+                        sources.append({"index": index, "url": source_url})
+                if not sources:
+                    for annotation in message.get("annotations") or []:
+                        citation = annotation.get("url_citation", {}) if isinstance(annotation, dict) else {}
+                        if not isinstance(citation, dict):
+                            continue
+                        source_url = citation.get("url")
+                        if isinstance(source_url, str) and source_url.startswith(("https://", "http://")):
+                            sources.append({"url": source_url, "title": citation.get("title", "")})
+                if sources:
+                    content += "\n\nSources:\n" + "\n".join(
+                        f"[{source['index']}] {source['url']}" if "index" in source else source["url"]
+                        for source in sources
+                    )
+                return {"result": content, "sources": sources, "model": model, "query": query}
             else:
-                error_text = await response.text()
-                logger.error(f"Web search API error: {response.status} - {error_text[:200]}")
+                logger.error("Web search API error: HTTP %s", response.status)
                 return {"error": f"Search failed: HTTP {response.status}"}
 
     except TimeoutError:
         logger.error("Web search timeout")
         return {"error": "Search timed out. Try a simpler query."}
-    except Exception as e:
-        logger.error(f"Web search error: {e}")
-        return {"error": f"Search failed: {str(e)}"}
+    except Exception as exc:
+        logger.error("Web search error (exception=%s)", type(exc).__name__)
+        return {"error": f"Search failed: {str(exc)}"}

--- a/apps/polli/src/ai/tools.py
+++ b/apps/polli/src/ai/tools.py
@@ -24,7 +24,7 @@ GITHUB_TOOLS = [
 Actions:
 - get: Get issue (issue_number, include_comments)
 - get_history: Get edit history - title changes and body edits (issue_number, edit_index=N for full diff of specific edit)
-- search: General issue search with filters (keywords, state, labels)
+- search: Search issues (keywords or native GitHub query; state, labels)
 - search_user: User's issues by discord username (discord_username, state)
 - find_similar: Find potential DUPLICATES before creating new issue (keywords, limit)
 - list_labels / list_milestones: List available
@@ -85,9 +85,22 @@ Actions:
                         "type": "integer",
                         "description": "Issue number (for get, close, comment, edit, label, assign, etc.)",
                     },
+                    "cursor": {
+                        "type": "string",
+                        "description": "Returned next_cursor for native-query search, labels, or milestones; keep the same filters.",
+                    },
+                    "edit_index": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "For get_history: fetched edit index, zero is most recent.",
+                    },
                     "keywords": {
                         "type": "string",
                         "description": "Search terms (for search, find_similar)",
+                    },
+                    "query": {
+                        "type": "string",
+                        "description": "For search: native GitHub qualifiers, e.g. is:closed label:bug. Repository-scoped; no implicit open filter.",
                     },
                     "state": {
                         "type": "string",
@@ -277,6 +290,16 @@ Read-only — mutations are blocked.""",
                         "type": "string",
                         "description": "Plain English fallback — describe what data you need",
                     },
+                    "author": {
+                        "type": "string",
+                        "description": "GitHub author login for issue/PR retrieval in request mode; use this field rather than only mentioning an author in request text.",
+                    },
+                    "page": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 10,
+                        "description": "REST page number (default 1); limit sets the page size.",
+                    },
                     "include_body": {
                         "type": "boolean",
                         "description": "Include full body text in results (for request mode)",
@@ -299,7 +322,7 @@ Read-only — mutations are blocked.""",
 Actions:
 - get: Get PR details (pr_number)
 - get_history: Get edit history - title changes and body edits (pr_number, edit_index=N for full diff of specific edit)
-- list: List PRs (state, limit, base)
+- list: List PRs (state, limit, base, author or native GitHub query)
 - get_files/get_diff/get_checks/get_commits: PR details (pr_number)
 - get_threads/get_review_comments: Review discussions (pr_number)
 - get_file_at_ref: Get file content at branch/commit (file_path, ref)
@@ -360,6 +383,23 @@ Actions:
                     "pr_number": {
                         "type": "integer",
                         "description": "PR number (for most actions)",
+                    },
+                    "author": {
+                        "type": "string",
+                        "description": "GitHub author login filter for list.",
+                    },
+                    "query": {
+                        "type": "string",
+                        "description": "For list: native GitHub qualifiers, e.g. is:merged author:login review:approved. Repository-scoped; no implicit open filter.",
+                    },
+                    "cursor": {
+                        "type": "string",
+                        "description": "Returned next_cursor for native-query list; keep the same query and filters.",
+                    },
+                    "edit_index": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "Get the full diff for a fetched history entry (0 is most recent).",
                     },
                     "state": {
                         "type": "string",

--- a/apps/polli/src/api/server.py
+++ b/apps/polli/src/api/server.py
@@ -28,7 +28,7 @@ class ChatRequest(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     messages: list[Message] = Field(min_length=1)
-    model: str = "polli"
+    model: str = Field(default="polli", min_length=1, max_length=128)
     stream: bool = False
     stream_options: dict[str, Any] | None = None
     user_name: str = "http_user"
@@ -38,19 +38,25 @@ class ChatRequest(BaseModel):
 
     @model_validator(mode="after")
     def validate_model(self):
-        if self.model != "polli":
-            raise ValueError(f"The model '{self.model}' does not exist")
+        if not self.model.strip():
+            raise ValueError("model must not be blank")
         return self
 
 
 class ResponsesRequest(BaseModel):
     model_config = ConfigDict(extra="allow")
 
-    model: str = "polli"
+    model: str = Field(default="polli", min_length=1, max_length=128)
     input: str | list[dict[str, Any]]
     instructions: str | None = None
     stream: bool = False
     user_name: str = "http_user"
+
+    @model_validator(mode="after")
+    def validate_model(self):
+        if not self.model.strip():
+            raise ValueError("model must not be blank")
+        return self
 
 
 _LOCAL_KEYS = {
@@ -81,10 +87,17 @@ def _error(message: str, status: int, code: str | None = None, param: str | None
 
 def _authorization(request: Request) -> str | None:
     value = request.headers.get("authorization", "")
-    return value if value.lower().startswith("bearer ") else None
+    if not value.lower().startswith("bearer "):
+        return None
+    token = value[7:].strip()
+    return value if token.startswith("ag_") else None
 
 
-def _request_args(request: ChatRequest) -> dict[str, Any]:
+def _model_name(model: str, config: Any) -> str:
+    return config.ai.model if model == "polli" else model
+
+
+def _request_args(request: ChatRequest, config: Any) -> dict[str, Any]:
     messages = [message.model_dump(exclude_none=True) for message in request.messages]
     last_user = next((message for message in reversed(messages) if message.get("role") == "user"), {})
     content = last_user.get("content", "")
@@ -95,6 +108,8 @@ def _request_args(request: ChatRequest) -> dict[str, Any]:
             if isinstance(part, dict) and part.get("type") in {"text", "input_text"}
         )
     params = request.model_dump(exclude_none=True, exclude=_LOCAL_KEYS)
+    params["model"] = _model_name(request.model, config)
+    params["_explicit_model"] = request.model != "polli"
     return {
         "user_message": content or "",
         "discord_username": request.user_name,
@@ -144,7 +159,7 @@ def _usage(usage: dict[str, int] | None) -> dict[str, int]:
     }
 
 
-def _chat_response(result: dict[str, Any], completion_id: str, created: int) -> dict[str, Any]:
+def _chat_response(result: dict[str, Any], completion_id: str, created: int, model: str) -> dict[str, Any]:
     message: dict[str, Any] = {"role": "assistant", "content": result.get("response", "")}
     if result.get("client_tool_calls"):
         message["tool_calls"] = result["client_tool_calls"]
@@ -152,7 +167,7 @@ def _chat_response(result: dict[str, Any], completion_id: str, created: int) -> 
         "id": completion_id,
         "object": "chat.completion",
         "created": created,
-        "model": "polli",
+        "model": model,
         "choices": [{"index": 0, "message": message, "finish_reason": result.get("finish_reason", "stop")}],
         "usage": _usage(result.get("usage")),
     }
@@ -162,7 +177,7 @@ def _sse(payload: dict[str, Any] | str) -> str:
     return f"data: {payload if isinstance(payload, str) else dumps(payload)}\n\n"
 
 
-async def _chat_stream(client, args: dict[str, Any], auth: str, include_usage: bool) -> AsyncIterator[str]:
+async def _chat_stream(client, args: dict[str, Any], auth: str, include_usage: bool, model: str) -> AsyncIterator[str]:
     completion_id = f"chatcmpl-{uuid4_hex()[:24]}"
     created = int(time.time())
     token = _auth_override.set(auth)
@@ -172,7 +187,7 @@ async def _chat_stream(client, args: dict[str, Any], auth: str, include_usage: b
                 "id": completion_id,
                 "object": "chat.completion.chunk",
                 "created": created,
-                "model": "polli",
+                "model": model,
                 "choices": [{"index": 0, "delta": {"role": "assistant", "content": ""}, "finish_reason": None}],
             }
         )
@@ -185,7 +200,7 @@ async def _chat_stream(client, args: dict[str, Any], auth: str, include_usage: b
                         "id": completion_id,
                         "object": "chat.completion.chunk",
                         "created": created,
-                        "model": "polli",
+                        "model": model,
                         "choices": [{"index": 0, "delta": {"content": event["delta"]}, "finish_reason": None}],
                     }
                 )
@@ -196,7 +211,7 @@ async def _chat_stream(client, args: dict[str, Any], auth: str, include_usage: b
                         "id": completion_id,
                         "object": "chat.completion.chunk",
                         "created": created,
-                        "model": "polli",
+                        "model": model,
                         "choices": [{"index": 0, "delta": {"tool_calls": [tool_call]}, "finish_reason": None}],
                     }
                 )
@@ -208,7 +223,7 @@ async def _chat_stream(client, args: dict[str, Any], auth: str, include_usage: b
                 "id": completion_id,
                 "object": "chat.completion.chunk",
                 "created": created,
-                "model": "polli",
+                "model": model,
                 "choices": [{"index": 0, "delta": {}, "finish_reason": finish_reason}],
             }
         )
@@ -218,7 +233,7 @@ async def _chat_stream(client, args: dict[str, Any], auth: str, include_usage: b
                     "id": completion_id,
                     "object": "chat.completion.chunk",
                     "created": created,
-                    "model": "polli",
+                    "model": model,
                     "choices": [],
                     "usage": usage or _usage(None),
                 }
@@ -233,6 +248,7 @@ def _response_object(
     created: int,
     text: str,
     usage: dict[str, int] | None,
+    model: str = "polli",
     message_id: str | None = None,
     tool_calls: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
@@ -265,7 +281,7 @@ def _response_object(
         "object": "response",
         "created_at": created,
         "status": "completed",
-        "model": "polli",
+        "model": model,
         "output": output,
         "output_text": text,
         "usage": {
@@ -278,11 +294,11 @@ def _response_object(
     }
 
 
-async def _responses_stream(client, args: dict[str, Any], auth: str) -> AsyncIterator[str]:
+async def _responses_stream(client, args: dict[str, Any], auth: str, model: str) -> AsyncIterator[str]:
     response_id = f"resp_{uuid4_hex()[:24]}"
     message_id = f"msg_{uuid4_hex()[:24]}"
     created = int(time.time())
-    base = _response_object(response_id, created, "", None)
+    base = _response_object(response_id, created, "", None, model)
     base.update({"status": "in_progress", "output": []})
     yield _sse({"type": "response.created", "sequence_number": 0, "response": base})
 
@@ -422,7 +438,7 @@ async def _responses_stream(client, args: dict[str, Any], auth: str) -> AsyncIte
         item = {"id": message_id, "type": "message", "status": "completed", "role": "assistant", "content": [done_part]}
         yield _sse({"type": "response.output_item.done", "sequence_number": sequence, "output_index": 0, "item": item})
         sequence += 1
-    response = _response_object(response_id, created, text, usage, message_id, tool_calls)
+    response = _response_object(response_id, created, text, usage, model, message_id, tool_calls)
     yield _sse({"type": "response.completed", "sequence_number": sequence, "response": response})
     yield _sse("[DONE]")
 
@@ -470,11 +486,11 @@ def create_api_app(pollinations_client, config, discord_bot=None):
         auth = _authorization(request)
         if not auth:
             return _error("Authorization header required", 401, "invalid_api_key")
-        args = add_discord_context(_request_args(body))
+        args = add_discord_context(_request_args(body, config))
         if body.stream:
             include_usage = bool((body.stream_options or {}).get("include_usage"))
             return StreamingResponse(
-                _chat_stream(pollinations_client, args, auth, include_usage),
+                _chat_stream(pollinations_client, args, auth, include_usage, body.model),
                 media_type="text/event-stream",
                 headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
             )
@@ -488,7 +504,7 @@ def create_api_app(pollinations_client, config, discord_bot=None):
             return _error("Internal server error", 500, "internal_error")
         finally:
             _auth_override.reset(token)
-        return JSONResponse(_chat_response(result, f"chatcmpl-{uuid4_hex()[:24]}", int(time.time())))
+        return JSONResponse(_chat_response(result, f"chatcmpl-{uuid4_hex()[:24]}", int(time.time()), body.model))
 
     @app.post("/v1/responses")
     async def responses(body: ResponsesRequest, request: Request):
@@ -496,10 +512,10 @@ def create_api_app(pollinations_client, config, discord_bot=None):
         if not auth:
             return _error("Authorization header required", 401, "invalid_api_key")
         chat = _responses_chat_request(body)
-        args = add_discord_context(_request_args(chat))
+        args = add_discord_context(_request_args(chat, config))
         if body.stream:
             return StreamingResponse(
-                _responses_stream(pollinations_client, args, auth),
+                _responses_stream(pollinations_client, args, auth, body.model),
                 media_type="text/event-stream",
                 headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
             )
@@ -519,6 +535,7 @@ def create_api_app(pollinations_client, config, discord_bot=None):
                 int(time.time()),
                 result.get("response", ""),
                 result.get("usage"),
+                body.model,
                 tool_calls=result.get("client_tool_calls"),
             )
         )

--- a/apps/polli/src/bot.py
+++ b/apps/polli/src/bot.py
@@ -613,6 +613,9 @@ class PolliBot(commands.Bot):
             from .search.code_search import close as close_embeddings
 
             await close_embeddings()
+        from .integrations.web_scraper import close_web_scraper
+
+        await close_web_scraper()
         await super().close()
 
     @tasks.loop(minutes=1)
@@ -915,6 +918,19 @@ async def handle_dm_message(message: discord.Message):
     text = message.content.strip().lower()
     user_id = message.author.id
 
+    if text in {"privacy", "privacy policy", "delete data", "delete my data"}:
+        await message.reply(
+            "**Privacy and data requests**\n"
+            "Privacy policy: https://pollinations.ai/privacy\n"
+            "For deletion or correction of your data, email hello@pollinations.ai "
+            "with your Discord user ID and the relevant message or issue links. "
+            "Do not send passwords or API keys.\n"
+            "To remove all issue-notification subscriptions now, DM `unsubscribe all`. "
+            "That command removes subscriptions only; it does not erase Discord messages, "
+            "GitHub content, operational logs or provider-held data."
+        )
+        return
+
     async with message.channel.typing():
         # Subscribe command
         subscribe_match = re.search(r"subscribe\s+(?:to\s+)?#?(\d+)", text)
@@ -955,7 +971,8 @@ async def handle_dm_message(message: discord.Message):
             "• `subscribe #123` - Subscribe to issue updates\n"
             "• `unsubscribe #123` - Unsubscribe from an issue\n"
             "• `unsubscribe all` - Unsubscribe from all issues\n"
-            "• `list subscriptions` - See your subscriptions\n\n"
+            "• `list subscriptions` - See your subscriptions\n"
+            "• `privacy` - Privacy policy and deletion/correction contact\n\n"
             "For other requests, please @mention me in a server channel!"
         )
         await message.reply(help_text)
@@ -1212,7 +1229,45 @@ async def handle_thread_message(
         )
 
 
+_active_conversations: set[int] = set()
+
+
 async def process_message(
+    channel: discord.Thread | discord.TextChannel,
+    user: discord.User | discord.Member,
+    text: str,
+    image_urls: list[str],
+    session: ConversationSession,
+    thread_history: list[dict] | None = None,
+    reply_to: discord.Message | None = None,
+    source_message: discord.Message | None = None,
+    video_urls: list[str] | None = None,
+    file_urls: list[str] | None = None,
+):
+    if channel.id in _active_conversations:
+        await channel.send(
+            "I'm still working on the previous request here. Please wait for that reply before retrying."
+        )
+        return
+    _active_conversations.add(channel.id)
+    try:
+        await _process_message(
+            channel,
+            user,
+            text,
+            image_urls,
+            session,
+            thread_history,
+            reply_to,
+            source_message,
+            video_urls,
+            file_urls,
+        )
+    finally:
+        _active_conversations.discard(channel.id)
+
+
+async def _process_message(
     channel: discord.Thread | discord.TextChannel,
     user: discord.User | discord.Member,
     text: str,
@@ -1355,6 +1410,8 @@ async def process_message(
                 tools=None,  # No tools, just respond
             )
             response_text = retry_result.get("content", "") if retry_result else ""
+            if not response_text and not image_files:
+                response_text = "I couldn't generate a response for this request. Please try again shortly."
 
         if response_text or image_files:
             await send_long_message(

--- a/apps/polli/src/context/manager.py
+++ b/apps/polli/src/context/manager.py
@@ -40,7 +40,7 @@ class SessionManager:
 
         self._sessions[thread_id] = session
 
-        logger.info(f"Created session for thread {thread_id} - topic: '{topic_summary}'")
+        logger.info(f"Created session for thread {thread_id}")
         return session
 
     def add_to_session(

--- a/apps/polli/src/core/logging.py
+++ b/apps/polli/src/core/logging.py
@@ -38,9 +38,9 @@ class CleanFormatter(logging.Formatter):
         module = module[:10].ljust(10)
         message = record.getMessage()
         if record.exc_info:
-            if not record.exc_text:
-                record.exc_text = self.formatException(record.exc_info)
-            message = f"{message}\n{record.exc_text}"
+            exception_class = record.exc_info[0]
+            exception_type = exception_class.__name__ if exception_class else "UnknownException"
+            message = f"{message} (exception={exception_type})"
         return f"{time_str} | {level} | {module} | {message}"
 
 

--- a/apps/polli/src/discord/search.py
+++ b/apps/polli/src/discord/search.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from collections.abc import Callable
 from typing import Any
 
 import aiohttp
@@ -100,7 +101,7 @@ class DiscordSearchClient:
         accessible_channel_ids: set | None = None,
     ) -> dict[str, Any]:
         session = await self.get_session()
-        params = {"content": query[:1024]}
+        params: dict[str, str] = {"content": query[:1024]}
         if channel_id:
             params["channel_id"] = str(channel_id)
         if author_id:
@@ -128,9 +129,9 @@ class DiscordSearchClient:
         if attachment_extension:
             params["attachment_extension"] = attachment_extension
         if limit:
-            params["limit"] = min(limit, 25)
+            params["limit"] = str(min(limit, 25))
         if offset:
-            params["offset"] = min(offset, 9975)
+            params["offset"] = str(min(offset, 9975))
         params["include_nsfw"] = "false"
         url = f"{config.discord.api_base}/guilds/{guild_id}/messages/search"
         for attempt in range(SEARCH_RETRIES):
@@ -191,8 +192,7 @@ class DiscordSearchClient:
                             return {"error": "Discord search is temporarily unavailable; retry shortly."}
                         if resp.status == 403:
                             return {"error": "Bot doesn't have permission to search messages in this guild"}
-                        text = await resp.text()
-                        logger.error("Message search failed: %s - %s", resp.status, text)
+                        logger.error("Message search failed: HTTP %s", resp.status)
                         return {"error": f"Search failed: {resp.status}"}
             except asyncio.CancelledError:
                 raise
@@ -307,9 +307,9 @@ class DiscordSearchClient:
                 "total": total,
                 "members": formatted,
             }
-        except Exception as e:
-            logger.error(f"Member search error: {e}")
-            return {"error": str(e)}
+        except Exception as error:
+            logger.error("Member search failed: %s", type(error).__name__)
+            return {"error": "Member search failed unexpectedly."}
 
     async def search_channels(
         self,
@@ -317,7 +317,7 @@ class DiscordSearchClient:
         query: str | None = None,
         channel_type: str | None = None,
         limit: int = 50,
-        can_view_channel: callable = None,
+        can_view_channel: Callable[[Any], bool] | None = None,
     ) -> dict[str, Any]:
         try:
             type_map = {
@@ -358,9 +358,9 @@ class DiscordSearchClient:
                 "count": len(formatted),
                 "channels": formatted,
             }
-        except Exception as e:
-            logger.error(f"Channel search error: {e}")
-            return {"error": str(e)}
+        except Exception as error:
+            logger.error("Channel search failed: %s", type(error).__name__)
+            return {"error": "Channel search failed unexpectedly."}
 
     async def search_threads(
         self,
@@ -368,7 +368,7 @@ class DiscordSearchClient:
         query: str | None = None,
         include_archived: bool = True,
         limit: int = 50,
-        can_view_channel: callable = None,
+        can_view_channel: Callable[[Any], bool] | None = None,
     ) -> dict[str, Any]:
         try:
             threads = []
@@ -406,7 +406,7 @@ class DiscordSearchClient:
                         "owner_id": str(t.owner_id) if t.owner_id else None,
                         "archived": t.archived,
                         "locked": t.locked,
-                        "message_count": t.message_count,
+                        "reported_message_count": t.message_count,
                         "member_count": t.member_count,
                         "created_at": (t.created_at.isoformat() if t.created_at else None),
                         "jump_url": t.jump_url,
@@ -417,9 +417,9 @@ class DiscordSearchClient:
                 "count": len(formatted),
                 "threads": formatted,
             }
-        except Exception as e:
-            logger.error(f"Thread search error: {e}")
-            return {"error": str(e)}
+        except Exception as error:
+            logger.error("Thread search failed: %s", type(error).__name__)
+            return {"error": "Thread search failed unexpectedly."}
 
     async def search_roles(
         self,
@@ -459,9 +459,9 @@ class DiscordSearchClient:
                 "total": total,
                 "roles": formatted,
             }
-        except Exception as e:
-            logger.error(f"Role search error: {e}")
-            return {"error": str(e)}
+        except Exception as error:
+            logger.error("Role search failed: %s", type(error).__name__)
+            return {"error": "Role search failed unexpectedly."}
 
     async def get_channel_history(
         self,
@@ -473,12 +473,9 @@ class DiscordSearchClient:
         try:
             limit = min(limit, 100)
             messages = []
-            kwargs = {"limit": limit}
-            if before:
-                kwargs["before"] = discord.Object(id=before)
-            if after:
-                kwargs["after"] = discord.Object(id=after)
-            async for msg in channel.history(**kwargs):
+            history_before = discord.Object(id=before) if before else None
+            history_after = discord.Object(id=after) if after else None
+            async for msg in channel.history(limit=limit, before=history_before, after=history_after):
                 messages.append(
                     {
                         "id": str(msg.id),
@@ -502,9 +499,9 @@ class DiscordSearchClient:
             }
         except discord.Forbidden:
             return {"error": f"No permission to read channel #{channel.name}"}
-        except Exception as e:
-            logger.error(f"Channel history error: {e}")
-            return {"error": str(e)}
+        except Exception as error:
+            logger.error("Channel history failed: %s", type(error).__name__)
+            return {"error": "Channel history failed unexpectedly."}
 
     async def get_message_context(
         self,
@@ -545,24 +542,23 @@ class DiscordSearchClient:
             }
         except discord.Forbidden:
             return {"error": f"No permission to read channel #{channel.name}"}
-        except Exception as e:
-            logger.error(f"Message context error: {e}")
-            return {"error": str(e)}
+        except Exception as error:
+            logger.error("Message context failed: %s", type(error).__name__)
+            return {"error": "Message context failed unexpectedly."}
 
     async def get_thread_history(
         self,
         thread: discord.Thread,
         limit: int = 50,
         before: int | None = None,
+        oldest_first: bool = False,
     ) -> dict[str, Any]:
         try:
             limit = min(limit, 100)
             messages = []
-            kwargs = {"limit": limit}
-            if before:
-                kwargs["before"] = discord.Object(id=before)
+            history_before = discord.Object(id=before) if before else None
             participants = {}
-            async for msg in thread.history(**kwargs):
+            async for msg in thread.history(limit=limit, before=history_before, oldest_first=oldest_first):
                 messages.append(
                     {
                         "id": str(msg.id),
@@ -585,24 +581,28 @@ class DiscordSearchClient:
                 "created_at": (thread.created_at.isoformat() if thread.created_at else None),
                 "archived": thread.archived,
                 "locked": thread.locked,
-                "total_messages": thread.message_count,
+                "reported_message_count": thread.message_count,
                 "participants": list(participants.values()),
                 "participant_count": len(participants),
-                "showing": len(messages),
+                "retrieved_message_count": len(messages),
                 "messages": messages,
-                "has_more": len(messages) == limit,
-                "oldest_id": messages[-1]["id"] if messages else None,
+                "has_more": len(messages) == limit if not oldest_first else None,
+                "oldest_id": messages[-1]["id"] if messages and not oldest_first else None,
                 "note": (
-                    f"Showing {len(messages)} of ~{thread.message_count} messages. Use before={messages[-1]['id']} to get older messages."
-                    if messages and thread.message_count and len(messages) < thread.message_count
-                    else None
+                    "Results are oldest first. This page establishes a lower bound; no older-page cursor is provided."
+                    if messages and oldest_first
+                    else (
+                        f"Retrieved {len(messages)} messages. Use before={messages[-1]['id']} to get older messages."
+                        if messages and len(messages) == limit
+                        else None
+                    )
                 ),
             }
         except discord.Forbidden:
             return {"error": f"No permission to read thread '{thread.name}'"}
-        except Exception as e:
-            logger.error(f"Thread history error: {e}")
-            return {"error": str(e)}
+        except Exception as error:
+            logger.error("Thread history failed: %s", type(error).__name__)
+            return {"error": "Thread history failed unexpectedly."}
 
 
 discord_search_client = DiscordSearchClient()
@@ -679,13 +679,19 @@ async def tool_discord_search(
             raise ValueError(f"{name} must be a Discord snowflake or supported mention")
         return parsed
 
+    normalized_channel_id: int | None
+    normalized_user_id: int | None
+    normalized_role_id: int | None
+    normalized_message_id: int | None
+    normalized_thread_id: int | None
+    normalized_mentions: int | None
     try:
-        channel_id = validated_id("channel_id", channel_id, r"<#(\d+)>")
-        user_id = validated_id("user_id", user_id, r"<@!?(\d+)>")
-        role_id = validated_id("role_id", role_id, r"<@&(\d+)>")
-        message_id = validated_id("message_id", message_id, r"(\d+)")
-        thread_id = validated_id("thread_id", thread_id, r"(\d+)")
-        mentions = validated_id("mentions", mentions, r"<@!?(\d+)>")
+        normalized_channel_id = validated_id("channel_id", channel_id, r"<#(\d+)>")
+        normalized_user_id = validated_id("user_id", user_id, r"<@!?(\d+)>")
+        normalized_role_id = validated_id("role_id", role_id, r"<@&(\d+)>")
+        normalized_message_id = validated_id("message_id", message_id, r"(\d+)")
+        normalized_thread_id = validated_id("thread_id", thread_id, r"(\d+)")
+        normalized_mentions = validated_id("mentions", mentions, r"<@!?(\d+)>")
         if not isinstance(top_n, int) or isinstance(top_n, bool) or not 1 <= top_n <= 25:
             raise ValueError("top_n must be an integer between 1 and 25")
         if not isinstance(offset, int) or isinstance(offset, bool) or not 0 <= offset <= 9975:
@@ -695,6 +701,10 @@ async def tool_discord_search(
                 raise ValueError(f"{name} must be a positive message snowflake")
     except ValueError as error:
         return {"error": str(error)}
+    resolved_channel_id = normalized_channel_id
+    resolved_user_id = normalized_user_id
+    resolved_role_id = normalized_role_id
+    resolved_mentions = normalized_mentions
     bot = _context.get("discord_bot")
     bot_member = guild.me if guild else None
     requesting_user_id = _context.get("user_id")
@@ -751,48 +761,53 @@ async def tool_discord_search(
         # Deliberately not `mentions`: that parameter is a single snowflake passed straight
         # to the search API, and overwriting it with this dict makes Discord reject the call.
         parsed = parse_discord_mentions(query)
-        if parsed["user_ids"] and not user_id:
-            user_id = parsed["user_ids"][0]
-        if parsed["channel_ids"] and not channel_id:
-            channel_id = parsed["channel_ids"][0]
-        if parsed["role_ids"] and not role_id:
-            role_id = parsed["role_ids"][0]
-    if channel_name and not channel_id:
+        if parsed["user_ids"] and not resolved_user_id:
+            resolved_user_id = parsed["user_ids"][0]
+        if parsed["channel_ids"] and not resolved_channel_id:
+            resolved_channel_id = parsed["channel_ids"][0]
+        if parsed["role_ids"] and not resolved_role_id:
+            resolved_role_id = parsed["role_ids"][0]
+    if channel_name and not resolved_channel_id:
         ch_mentions = parse_discord_mentions(channel_name)
         if ch_mentions["channel_ids"]:
-            channel_id = ch_mentions["channel_ids"][0]
-    if channel_name and not channel_id:
+            resolved_channel_id = ch_mentions["channel_ids"][0]
+    if channel_name and not resolved_channel_id:
         for ch in guild.channels:
             if channel_name.lower() in ch.name.lower() and can_view_channel(ch):
-                channel_id = ch.id
+                resolved_channel_id = ch.id
                 break
-        if not channel_id:
+        if not resolved_channel_id:
             return {"error": f"Channel '{channel_name}' was not found or is not accessible"}
-    if channel_id:
-        target_channel = guild.get_channel(channel_id)
+    target_channel = None
+    if resolved_channel_id:
+        target_channel = guild.get_channel(resolved_channel_id)
+        if target_channel is None and hasattr(guild, "get_thread"):
+            target_channel = guild.get_thread(resolved_channel_id)
         if not target_channel:
             try:
-                target_channel = await bot.fetch_channel(channel_id) if bot else None
+                target_channel = await bot.fetch_channel(resolved_channel_id) if bot else None
             except (discord.Forbidden, discord.NotFound, aiohttp.ClientError):
                 target_channel = None
         if not target_channel or getattr(target_channel, "guild", guild) not in (None, guild):
-            return {"error": f"Channel {channel_id} not found"}
+            return {"error": f"Channel {resolved_channel_id} not found"}
         if not can_view_channel(target_channel):
             return {"error": "You don't have permission to access that channel"}
         accessible_channel_ids.add(target_channel.id)
-    if role_name and not role_id:
+    if role_name and not resolved_role_id:
         for r in guild.roles:
             if role_name.lower() in r.name.lower():
-                role_id = r.id
+                resolved_role_id = r.id
                 break
+    if action == "roles" and role_name and not query:
+        query = role_name
     if action == "messages":
         if not query:
             return {"error": "Query is required for message search"}
         result = await discord_search_client.search_messages(
             guild_id=guild.id,
             query=query,
-            channel_id=channel_id,
-            author_id=user_id,
+            channel_id=resolved_channel_id,
+            author_id=resolved_user_id,
             author_type=author_type,
             has=has,
             pinned=pinned,
@@ -802,7 +817,7 @@ async def tool_discord_search(
             sort_order=sort_order,
             link_hostname=link_hostname,
             attachment_extension=attachment_extension,
-            mentions=mentions,
+            mentions=resolved_mentions,
             mention_everyone=mention_everyone,
             limit=result_count,
             offset=offset,
@@ -815,8 +830,8 @@ async def tool_discord_search(
         return await discord_search_client.search_members(
             guild=guild,
             query=query,
-            user_id=user_id,
-            role_id=role_id,
+            user_id=resolved_user_id,
+            role_id=resolved_role_id,
             limit=result_count,
         )
     elif action == "channels":
@@ -870,34 +885,34 @@ async def tool_discord_search(
             after=after_id,
         )
     elif action == "context":
-        if not message_id:
+        if not normalized_message_id:
             return {"error": "message_id required for context action"}
-        if not channel_id:
+        if not resolved_channel_id:
             return {"error": "channel_id or channel_name required for context action"}
-        channel = guild.get_channel(channel_id)
+        channel = target_channel
         if not channel:
-            return {"error": f"Channel {channel_id} not found"}
+            return {"error": f"Channel {resolved_channel_id} not found"}
         if not can_view_channel(channel):
             return {"error": "You don't have permission to view that channel"}
         return await discord_search_client.get_message_context(
             channel=channel,
-            message_id=message_id,
+            message_id=normalized_message_id,
             before_count=min(result_count // 2, 10),
             after_count=min(result_count // 2, 10),
         )
     elif action == "thread_history":
-        if not thread_id:
+        if not normalized_thread_id:
             return {"error": "thread_id required for thread_history action"}
-        thread = guild.get_thread(thread_id)
+        thread = guild.get_thread(normalized_thread_id)
         if not thread:
             try:
-                thread = await guild.fetch_channel(thread_id)
+                thread = await guild.fetch_channel(normalized_thread_id)
             except (discord.Forbidden, discord.NotFound, aiohttp.ClientError):
-                return {"error": f"Thread {thread_id} not found"}
+                return {"error": f"Thread {normalized_thread_id} not found"}
         if getattr(thread, "guild", guild) not in (None, guild):
-            return {"error": f"Thread {thread_id} not found"}
+            return {"error": f"Thread {normalized_thread_id} not found"}
         if not isinstance(thread, discord.Thread):
-            return {"error": f"Channel {thread_id} is not a thread"}
+            return {"error": f"Channel {normalized_thread_id} is not a thread"}
         thread_member = None if _context.get("is_http_api") else requesting_member
         if not bot_can_access(thread) or not _thread_is_accessible(thread, thread_member):
             return {"error": "You don't have permission to view that thread"}
@@ -906,6 +921,7 @@ async def tool_discord_search(
             thread=thread,
             limit=result_count,
             before=before_id,
+            oldest_first=sort_order == "asc",
         )
     else:
         return {

--- a/apps/polli/src/integrations/github/client.py
+++ b/apps/polli/src/integrations/github/client.py
@@ -90,25 +90,46 @@ class GitHubManager:
                 query_parts.append(f'label:"{label}"')
 
         query = " ".join(query_parts)
-        encoded_query = quote(query, safe="")
-        url = f"https://api.github.com/search/issues?q={encoded_query}&per_page={limit}&sort=updated&order=desc"
+        requested_limit = max(1, min(limit, 1000))
+        per_page = min(requested_limit, 100)
+        max_pages = min(10, (requested_limit + per_page - 1) // per_page)
+        collected: list[dict] = []
+        total_count = 0
+        truncated = False
 
         try:
             session = await self.get_session()
-            async with session.get(
-                url,
-                headers=await self._get_headers(),
-                timeout=aiohttp.ClientTimeout(total=15),
-            ) as response:
-                if response.status == 200:
+            for page in range(1, max_pages + 1):
+                url = (
+                    "https://api.github.com/search/issues?"
+                    f"q={quote(query, safe='')}&per_page={per_page}&page={page}&sort=updated&order=desc"
+                )
+                async with session.get(
+                    url,
+                    headers=await self._get_headers(),
+                    timeout=aiohttp.ClientTimeout(total=15),
+                ) as response:
+                    if response.status != 200:
+                        logger.warning("Search API returned HTTP %d", response.status)
+                        break
                     data = await response.json()
-                    return self._format_issue_list(data.get("items", []))
-                else:
-                    logger.warning(f"Search API error: {response.status}")
-        except Exception as e:
-            logger.warning(f"Issue search failed: {e}")
+                total_count = int(data.get("total_count", 0))
+                page_items = data.get("items", [])
+                collected.extend(page_items)
+                if len(collected) >= requested_limit:
+                    truncated = total_count > len(collected)
+                    break
+                if len(page_items) < per_page:
+                    break
+            else:
+                truncated = total_count > len(collected)
+        except Exception:
+            logger.exception("Issue search failed")
 
-        return []
+        formatted = self._format_issue_list(collected[:requested_limit])
+        if truncated:
+            logger.info("Issue search stopped at bounded result limit")
+        return formatted
 
     async def search_discord_issues(
         self,

--- a/apps/polli/src/integrations/github/graphql.py
+++ b/apps/polli/src/integrations/github/graphql.py
@@ -1,5 +1,7 @@
 import logging
+import re
 from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import aiohttp
 
@@ -14,6 +16,57 @@ logger = logging.getLogger(__name__)
 GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
 
 CACHE_TTL = 300
+GITHUB_LOGIN_RE = re.compile(r"^(?!.*--)[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$")
+GITHUB_QUALIFIER_RE = re.compile(
+    r'(?:^|(?<=[\s(]))(repo|is|state|author|base|label|milestone):("[^"]*"|[^\s()]+)', re.IGNORECASE
+)
+PR_INTENT_RE = re.compile(r"\bprs?\b|\bpull requests?\b|\bmerge(?:d)?\b", re.IGNORECASE)
+ISSUE_INTENT_RE = re.compile(r"\bissues?\b|\bspam\b|\bstale\b|\bbugs?\b|\breports?\b", re.IGNORECASE)
+
+
+def build_scoped_search_query(
+    native_query: str,
+    *,
+    repository: str,
+    kind: str,
+    state: str | None = None,
+    author: str | None = None,
+    base: str | None = None,
+) -> str | dict:
+    """Preserve native GitHub search syntax while pinning repository and item kind."""
+    qualifiers: dict[str, list[str]] = {}
+    for key, value in GITHUB_QUALIFIER_RE.findall(native_query):
+        qualifiers.setdefault(key.lower(), []).append(value.strip('"').lower())
+
+    repos = qualifiers.get("repo", [])
+    if repos and any(value != repository.lower() for value in repos):
+        return {"error": "query repo qualifier conflicts with the configured repository"}
+
+    kinds = set(qualifiers.get("is", []))
+    conflicting_kinds = {"issue"} if kind == "pr" else {"pr", "pull-request"}
+    if conflicting_kinds & kinds:
+        return {"error": f"query must target {kind}s, not the other item kind"}
+
+    state_values = {"open", "closed", "merged"} & (kinds | set(qualifiers.get("state", [])))
+    if state and state.lower() != "all" and state_values and state.lower() not in state_values:
+        return {"error": "query state qualifier conflicts with state filter"}
+    if author and qualifiers.get("author"):
+        return {"error": "query author qualifier conflicts with author filter"}
+    if base and qualifiers.get("base"):
+        return {"error": "query base qualifier conflicts with base filter"}
+
+    scoped_native_query = native_query.strip()
+    appended = [f"repo:{repository}", f"is:{kind}"]
+    if scoped_native_query:
+        appended.append(f"({scoped_native_query})")
+    if state and state.lower() != "all" and not state_values:
+        appended.append(f"is:{state.lower()}")
+    if author:
+        appended.append(f"author:{author}")
+    if base:
+        escaped_base = base.replace("\\", "\\\\").replace('"', '\\"')
+        appended.append(f'base:"{escaped_base}"')
+    return " ".join(part for part in appended if part)
 
 
 class GitHubGraphQL(ProjectsMixin, RepoOverviewMixin):
@@ -92,20 +145,22 @@ class GitHubGraphQL(ProjectsMixin, RepoOverviewMixin):
                 if response.status == 200:
                     data = await response.json()
                     if "errors" in data:
-                        error_msgs = [e.get("message", str(e)) for e in data["errors"]]
-                        logger.warning(f"GraphQL errors: {error_msgs}")
+                        error_msgs = [e.get("message", "GraphQL error") for e in data["errors"]]
+                        logger.warning("GraphQL response contained %d error(s)", len(error_msgs))
                         return {
                             "data": data.get("data"),
                             "error": "; ".join(error_msgs),
+                            "partial": data.get("data") is not None,
                         }
                     return {"data": data.get("data")}
-                else:
-                    error_text = await response.text()
-                    logger.error(f"GraphQL error {response.status}: {error_text[:200]}")
-                    return {"error": f"GitHub API error {response.status}: {error_text[:100]}"}
-        except Exception as e:
-            logger.error(f"GraphQL request failed: {e}")
-            return {"error": f"GitHub request failed: {str(e)}"}
+                logger.warning("GraphQL request returned HTTP %d", response.status)
+                return {"error": f"GitHub API error {response.status}"}
+        except aiohttp.ClientError:
+            logger.warning("GraphQL request failed due to an HTTP client error")
+            return {"error": "GitHub request failed"}
+        except Exception:
+            logger.exception("GraphQL request failed")
+            return {"error": "GitHub request failed"}
 
     async def get_issue_full(self, issue_number: int, comments_count: int = 5) -> dict | None:
         query = """
@@ -182,19 +237,35 @@ class GitHubGraphQL(ProjectsMixin, RepoOverviewMixin):
 
         return self._format_issue_full(issue)
 
-    async def search_issues_full(self, keywords: str, state: str = "open", limit: int = 10) -> list[dict]:
-        state_filter = ""
-        if state == "open":
-            state_filter = "is:open"
-        elif state == "closed":
-            state_filter = "is:closed"
+    async def search_issues_full(
+        self, keywords: str, state: str | None = None, limit: int = 10, query: str | None = None, cursor: str | None = None
+    ) -> dict:
+        if query is not None and not query.strip():
+            return {"error": "query must not be blank"}
+        if cursor and query is None:
+            return {"error": "cursor requires query search mode"}
+        if query is not None:
+            search_query = build_scoped_search_query(
+                query,
+                repository=config.bot.default_repo,
+                kind="issue",
+                state=state,
+            )
+            if isinstance(search_query, dict):
+                return search_query
+        else:
+            state_filter = ""
+            if state == "open":
+                state_filter = "is:open"
+            elif state == "closed":
+                state_filter = "is:closed"
+            search_query = f"repo:{config.bot.default_repo} is:issue {state_filter} {keywords}"
 
-        search_query = f"repo:{config.bot.default_repo} is:issue {state_filter} {keywords}"
-
-        query = """
-        query SearchIssuesFull($query: String!, $limit: Int!) {
-            search(query: $query, type: ISSUE, first: $limit) {
+        graphql_query = """
+        query SearchIssuesFull($query: String!, $limit: Int!, $after: String) {
+            search(query: $query, type: ISSUE, first: $limit, after: $after) {
                 issueCount
+                pageInfo { hasNextPage endCursor }
                 nodes {
                     ... on Issue {
                         number
@@ -217,21 +288,27 @@ class GitHubGraphQL(ProjectsMixin, RepoOverviewMixin):
         }
         """
 
-        result = await self._execute(query, {"query": search_query, "limit": limit})
+        result = await self._execute(
+            graphql_query, {"query": search_query, "limit": min(max(limit, 1), 100), "after": cursor}
+        )
 
         if result.get("error"):
-            return [{"error": result["error"]}]
+            return {"error": result["error"], "partial": result.get("partial", False)}
 
         data = result.get("data")
         if not data or not data.get("search"):
-            return []
+            return {"items": [], "count": 0, "matched_total": 0, "truncated": False, "next_cursor": None}
 
-        issues = []
-        for node in data["search"].get("nodes", []):
-            if node:
-                issues.append(self._format_issue_list(node))
-
-        return issues
+        connection = data["search"]
+        issues = [self._format_issue_list(node) for node in connection.get("nodes", []) if node]
+        page_info = connection.get("pageInfo", {})
+        return {
+            "items": issues,
+            "count": len(issues),
+            "matched_total": connection.get("issueCount", 0),
+            "truncated": bool(page_info.get("hasNextPage")),
+            "next_cursor": page_info.get("endCursor") if page_info.get("hasNextPage") else None,
+        }
 
     async def get_issues_batch(self, issue_numbers: list[int], include_comments: bool = False) -> dict:
         if not issue_numbers:
@@ -346,12 +423,58 @@ class GitHubGraphQL(ProjectsMixin, RepoOverviewMixin):
         return [self._format_issue_list(node) for node in data["search"].get("nodes", []) if node]
 
     async def search_user_issues(self, discord_username: str, state: str = "open", limit: int = 10) -> list[dict]:
+        """Find issues whose canonical submitted Author field exactly matches the user."""
+        requested_limit = max(1, min(limit, 100))
+        state_filter = ""
         if state == "open":
-            pass
+            state_filter = "is:open"
         elif state == "closed":
-            pass
+            state_filter = "is:closed"
 
-        return await self.search_issues_full(keywords=f'"**Author:**" "{discord_username}"', state=state, limit=limit)
+        escaped_username = discord_username.replace("\\", "\\\\").replace('"', '\\"')
+        search_query = f"repo:{self.owner}/{self.repo} is:issue {state_filter} " f'"**Author:**" "{escaped_username}"'
+        query = """
+        query SearchUserIssues($query: String!, $limit: Int!, $after: String) {
+            search(query: $query, type: ISSUE, first: $limit, after: $after) {
+                pageInfo { hasNextPage endCursor }
+                nodes {
+                    ... on Issue {
+                        number title body state url createdAt author { login }
+                        labels(first: 5) { nodes { name } }
+                        comments { totalCount }
+                    }
+                }
+            }
+        }
+        """
+
+        canonical_author = f"**Author:** {discord_username}".casefold()
+        matches: list[dict] = []
+        cursor: str | None = None
+        for _ in range(10):
+            result = await self._execute(
+                query,
+                {"query": search_query, "limit": 100, "after": cursor},
+            )
+            if result.get("error"):
+                return [{"error": result["error"]}]
+
+            connection = result.get("data", {}).get("search") or {}
+            for node in connection.get("nodes", []):
+                if not node:
+                    continue
+                issue = self._format_issue_list(node)
+                if any(line.strip().casefold() == canonical_author for line in issue["body"].splitlines()):
+                    matches.append(issue)
+                    if len(matches) >= requested_limit:
+                        return matches
+
+            page_info = connection.get("pageInfo") or {}
+            cursor = page_info.get("endCursor")
+            if not page_info.get("hasNextPage") or not cursor:
+                break
+
+        return matches
 
     async def get_latest_issue_number(self) -> int | None:
         query = """
@@ -462,60 +585,91 @@ class GitHubGraphQL(ProjectsMixin, RepoOverviewMixin):
                 if resp.status == 200:
                     data = await resp.json()
                     return {"data": data}
-                else:
-                    text = await resp.text()
-                    return {"error": f"GitHub API returned {resp.status}: {text[:200]}"}
-        except Exception as e:
-            return {"error": str(e)}
+                return {"error": f"GitHub API returned {resp.status}"}
+        except aiohttp.ClientError:
+            return {"error": "GitHub REST request failed"}
+        except Exception:
+            logger.exception("GitHub REST request failed")
+            return {"error": "GitHub REST request failed"}
 
     async def execute_custom_request(
         self,
         request: str,
         include_body: bool = False,
         limit: int = 50,
+        page: int = 1,
         graphql_query: str | None = None,
         rest_endpoint: str | None = None,
+        author: str | None = None,
         rest_url: str | None = None,
     ) -> dict:
-        if graphql_query:
-            # Block mutations — only allow queries
-            # Strip comments (# ...) before checking to prevent bypass
-            lines = [l for l in graphql_query.strip().splitlines() if not l.strip().startswith("#")]
-            stripped = "\n".join(lines).strip().lower()
-            if stripped.startswith("mutation") or not stripped:
-                return {"error": "Mutations not allowed. github_custom is read-only."}
+        if author and not GITHUB_LOGIN_RE.fullmatch(author):
+            return {"error": "author must be a valid GitHub login"}
 
+        if graphql_query:
+            lines = [line for line in graphql_query.strip().splitlines() if not line.strip().startswith("#")]
+            operation = "\n".join(lines).strip().lower()
+            if not operation or operation.startswith("mutation"):
+                return {"error": "Mutations not allowed. github_custom is read-only."}
             result = await self._execute(
                 graphql_query,
-                {"owner": self.owner, "repo": self.repo, "limit": min(limit, 100)},
+                {"owner": self.owner, "repo": self.repo, "limit": min(max(limit, 1), 100)},
             )
-            return {
+            response = {
                 "mode": "graphql",
-                "query": (graphql_query[:200] + "..." if len(graphql_query) > 200 else graphql_query),
-                "data": result.get("data", result),
+                "query": graphql_query[:200],
+                "data": result.get("data"),
             }
+            if result.get("error"):
+                response["error"] = result["error"]
+                response["partial"] = result.get("partial", False)
+            return response
+
+        if page < 1 or page > 10:
+            return {"error": "page must be between 1 and 10"}
 
         if rest_url:
-            # Full URL mode — must be api.github.com, GET only
+            # Full URL mode — must be api.github.com, GET only.
             if not rest_url.startswith("https://api.github.com/"):
                 return {"error": "rest_url must start with https://api.github.com/"}
-            result = await self._rest_get(rest_url)
-            return {"mode": "rest", "url": rest_url, **result}
+            parsed = urlsplit(rest_url)
+            url_params = dict(parse_qsl(parsed.query, keep_blank_values=True))
+            url_params.update({"per_page": str(min(max(limit, 1), 100)), "page": str(page)})
+            url = urlunsplit((parsed.scheme, parsed.netloc, parsed.path, urlencode(url_params), parsed.fragment))
+            result = await self._rest_get(url)
+            return {
+                "mode": "rest",
+                "url": rest_url,
+                "page": page,
+                "per_page": min(max(limit, 1), 100),
+                "truncated": page == 10,
+                **result,
+            }
 
         if rest_endpoint:
-            # Repo-relative endpoint — no whitelist, any GET path allowed
             endpoint = rest_endpoint.strip("/")
-            url = f"https://api.github.com/repos/{self.owner}/{self.repo}/{endpoint}"
+            endpoint_url = f"https://api.github.com/repos/{self.owner}/{self.repo}/{endpoint}"
+            parsed = urlsplit(endpoint_url)
+            url_params = dict(parse_qsl(parsed.query, keep_blank_values=True))
+            url_params.update({"per_page": str(min(max(limit, 1), 100)), "page": str(page)})
+            url = urlunsplit((parsed.scheme, parsed.netloc, parsed.path, urlencode(url_params), parsed.fragment))
             result = await self._rest_get(url)
-            return {"mode": "rest", "endpoint": endpoint, **result}
+            return {
+                "mode": "rest",
+                "endpoint": endpoint,
+                "page": page,
+                "per_page": min(max(limit, 1), 100),
+                "truncated": page == 10,
+                **result,
+            }
 
         request_lower = request.lower()
         limit = min(limit, 100)
 
         results = {}
 
-        needs_issues = any(word in request_lower for word in ["issue", "spam", "stale", "bug", "report"])
-        needs_prs = any(word in request_lower for word in ["pr", "pull request", "merge"])
+        needs_prs = bool(PR_INTENT_RE.search(request_lower))
+        needs_issues = bool(ISSUE_INTENT_RE.search(request_lower))
         needs_commits = any(word in request_lower for word in ["commit", "contributor", "active", "activity"])
         needs_stats = any(word in request_lower for word in ["stat", "health", "overview", "summary"])
         needs_releases = "release" in request_lower
@@ -536,11 +690,43 @@ class GitHubGraphQL(ProjectsMixin, RepoOverviewMixin):
             needs_issues = True
 
         if needs_issues:
-            issues_data = await self._fetch_all_issues(limit=limit, include_body=include_body)
+            if author:
+                search_query = f"repo:{self.owner}/{self.repo} is:issue author:{author}"
+                body_field = "body" if include_body else ""
+                query = f"""
+                query SearchIssuesByAuthor($query: String!, $limit: Int!) {{
+                    search(query: $query, type: ISSUE, first: $limit) {{
+                        issueCount
+                        pageInfo {{ hasNextPage }}
+                        nodes {{ ... on Issue {{ number title state url createdAt updatedAt author {{ login }} labels(first: 5) {{ nodes {{ name }} }} comments {{ totalCount }} {body_field} }} }}
+                    }}
+                }}
+                """
+                result = await self._execute(query, {"query": search_query, "limit": limit})
+                if result.get("error"):
+                    issues_data = {"error": result["error"], "partial": result.get("partial", False)}
+                else:
+                    connection = result.get("data", {}).get("search") or {}
+                    items = [self._format_issue_list(item) for item in connection.get("nodes", []) if item]
+                    if not include_body:
+                        for item in items:
+                            item.pop("body", None)
+                    issues_data = {
+                        "items": items,
+                        "matched_total": connection.get("issueCount", 0),
+                        "count": len(items),
+                        "truncated": bool(connection.get("pageInfo", {}).get("hasNextPage")),
+                        "author": author,
+                    }
+            else:
+                issues_data = await self._fetch_all_issues(limit=limit, include_body=include_body)
             results["issues"] = issues_data
 
         if needs_prs:
-            prs_data = await self._fetch_prs(limit=limit)
+            from .pull_requests import github_pr_manager
+
+            pr_state = "merged" if re.search(r"\bmerged\b", request_lower) else "closed" if re.search(r"\bclosed\b", request_lower) else "open" if re.search(r"\bopen\b", request_lower) else "all"
+            prs_data = await github_pr_manager.list_prs(limit=limit, state=pr_state, author=author)
             results["pull_requests"] = prs_data
 
         if needs_commits:
@@ -666,12 +852,15 @@ class GitHubGraphQL(ProjectsMixin, RepoOverviewMixin):
         }
 
         if include_projects:
-            projects_result = await self.list_projects(limit=10)
+            projects_result = await self.list_projects(limit=100)
             if not projects_result.get("error"):
                 overview["projects"] = [
                     {"number": p["number"], "title": p["title"], "url": p["url"]}
-                    for p in projects_result.get("projects", [])[:5]
+                    for p in projects_result.get("projects", [])
                 ]
+                overview["projects_truncated"] = projects_result.get("truncated", False)
+                if projects_result.get("next_cursor"):
+                    overview["projects_next_cursor"] = projects_result["next_cursor"]
 
         return overview
 
@@ -713,9 +902,12 @@ class GitHubGraphQL(ProjectsMixin, RepoOverviewMixin):
         }}
         """
 
+        if edit_index is not None and edit_index < 0:
+            return {"error": "edit_index must be zero or greater"}
+
         result = await self._execute(
             query,
-            {"owner": self.owner, "repo": self.repo, "number": number, "limit": limit},
+            {"owner": self.owner, "repo": self.repo, "number": number, "limit": min(limit, 100)},
         )
 
         if result.get("error"):
@@ -740,6 +932,9 @@ class GitHubGraphQL(ProjectsMixin, RepoOverviewMixin):
         body_edits = []
         edits_data = data.get("userContentEdits", {})
         nodes = edits_data.get("nodes", [])
+
+        if edit_index is not None and edit_index >= len(nodes):
+            return {"error": f"edit_index {edit_index} is outside the {len(nodes)} fetched edit(s)"}
 
         for i, edit in enumerate(nodes):
             if edit:

--- a/apps/polli/src/integrations/github/handlers.py
+++ b/apps/polli/src/integrations/github/handlers.py
@@ -17,7 +17,8 @@ async def tool_github_issue(
     action: str,
     issue_number: int = None,
     keywords: str = None,
-    state: str = "open",
+    state: str | None = None,
+    query: str | None = None,
     title: str = None,
     description: str = None,
     body: str = None,
@@ -35,6 +36,7 @@ async def tool_github_issue(
     limit: int = 10,
     child_issue_number: int = None,  # For sub-issue actions
     edit_index: int = None,  # For get_history - get full diff for specific edit (0=most recent)
+    cursor: str | None = None,  # Search and bounded list pagination cursor
     # Injected by bot.py for subscriptions (legacy params kept for compatibility)
     user_id: int = 0,
     channel_id: int = 0,
@@ -135,20 +137,33 @@ async def tool_github_issue(
         return history
 
     elif action == "search":
-        if not keywords:
-            return {"error": "keywords required for 'search' action"}
-        issues = await github_graphql.search_issues_full(keywords=keywords, state=state, limit=limit)
+        if not keywords and query is None:
+            return {"error": "keywords or query required for 'search' action"}
+        issues = await github_graphql.search_issues_full(
+            keywords=keywords,
+            state=state or ("all" if query is not None else "open"),
+            limit=limit,
+            query=query,
+            cursor=cursor,
+        )
+        if issues.get("error"):
+            return issues
         return {
-            "issues": issues,
-            "count": len(issues),
-            "query": keywords,
+            "issues": issues["items"],
+            "count": issues["count"],
+            "matched_total": issues["matched_total"],
+            "query": query or keywords,
             "state": state,
+            "truncated": issues["truncated"],
+            "next_cursor": issues["next_cursor"],
         }
 
     elif action == "search_user":
         if not discord_username:
             return {"error": "discord_username required for 'search_user' action"}
-        issues = await github_graphql.search_user_issues(discord_username=discord_username, state=state, limit=limit)
+        issues = await github_graphql.search_user_issues(
+            discord_username=discord_username, state=state or "open", limit=limit
+        )
         return {
             "issues": issues,
             "count": len(issues),
@@ -167,12 +182,10 @@ async def tool_github_issue(
         }
 
     elif action == "list_labels":
-        labels_list = await github_manager.list_labels()
-        return {"labels": labels_list, "count": len(labels_list)}
+        return await github_graphql._fetch_labels(limit=limit, after=cursor)
 
     elif action == "list_milestones":
-        milestones = await github_manager.list_milestones(state=state)
-        return {"milestones": milestones, "count": len(milestones), "state": state}
+        return await github_graphql._fetch_milestones(state=state or "open", limit=limit, after=cursor)
 
     # WRITE ACTIONS
     elif action == "create":
@@ -530,8 +543,10 @@ async def tool_github_custom(
     graphql_query: str = None,
     rest_endpoint: str = None,
     rest_url: str = None,
+    author: str | None = None,
     include_body: bool = False,
     limit: int = 50,
+    page: int = 1,
     _context: dict = None,
     **kwargs,
 ) -> dict:
@@ -548,9 +563,11 @@ async def tool_github_custom(
         request=request or "",
         include_body=include_body,
         limit=limit,
+        page=page,
         graphql_query=graphql_query,
         rest_endpoint=rest_endpoint,
         rest_url=rest_url,
+        author=author,
     )
 
 

--- a/apps/polli/src/integrations/github/pr_review.py
+++ b/apps/polli/src/integrations/github/pr_review.py
@@ -94,21 +94,29 @@ class PRReviewMixin:
 
         try:
             file_findings = await self._review_files_concurrently(files)
-        except Exception as e:
-            logger.error(f"Error generating PR review: {e}")
-            return {"error": f"Failed to generate review: {str(e)}"}
+        except Exception:
+            logger.exception("PR review generation failed")
+            return {"error": "Failed to generate review", "error_category": "review_execution_failed"}
 
-        reviewed = [f for f in file_findings if f["findings"] and not f.get("error")]
+        successful = [f for f in file_findings if not f.get("error")]
+        reviewed = [f for f in successful if f["findings"]]
         errored = [f for f in file_findings if f.get("error")]
 
-        if not reviewed and errored:
-            return {"error": f"Failed to review any files ({len(errored)} errors)"}
+        if not successful:
+            return {
+                "error": "No files were successfully reviewed",
+                "error_category": "all_file_reviews_failed",
+                "files_requested": len(files),
+                "files_successfully_reviewed": 0,
+                "successful_batches": 0,
+                "failed_batches": len(errored),
+            }
 
         try:
             review_text = await self._synthesize_review(pr, reviewed, errored)
-        except Exception as e:
-            logger.error(f"Error synthesizing PR review: {e}")
-            return {"error": f"Failed to synthesize review: {str(e)}"}
+        except Exception:
+            logger.exception("PR review synthesis failed")
+            return {"error": "Failed to synthesize review", "error_category": "synthesis_failed"}
 
         if not review_text:
             return {"error": "Failed to generate review"}
@@ -119,7 +127,11 @@ class PRReviewMixin:
             "pr_title": pr["title"],
             "pr_url": pr["url"],
             "review": review_text,
-            "files_reviewed": len(files),
+            "files_requested": len(files),
+            "files_successfully_reviewed": sum(len(f["filenames"]) for f in successful),
+            "successful_batches": len(successful),
+            "failed_batches": len(errored),
+            "file_review_errors": [f["error"] for f in errored],
             "posted_to_github": False,
         }
 
@@ -231,17 +243,30 @@ class PRReviewMixin:
                         user_prompt=combined_diff,
                         model=config.ai.model,
                         temperature=0.2,
-                        max_tokens=1024,
+                        max_tokens=4096,
                     )
-                except Exception as e:
-                    return {"filenames": filenames, "findings": "", "high_priority": high_priority, "error": str(e)}
+                except TimeoutError:
+                    return {
+                        "filenames": filenames,
+                        "findings": "",
+                        "high_priority": high_priority,
+                        "error": "review_timeout",
+                    }
+                except Exception:
+                    logger.exception("Per-file PR review failed")
+                    return {
+                        "filenames": filenames,
+                        "findings": "",
+                        "high_priority": high_priority,
+                        "error": "review_request_failed",
+                    }
 
             if not response:
                 return {
                     "filenames": filenames,
                     "findings": "",
                     "high_priority": high_priority,
-                    "error": "empty response",
+                    "error": "empty_review_response",
                 }
 
             findings = self._parse_review(response)
@@ -257,7 +282,7 @@ class PRReviewMixin:
         if not clean:
             summary = "**LGTM** - No major issues found across reviewed files."
             if errored:
-                summary += f"\n\n_Note: {len(errored)} file(s)/batch(es) could not be reviewed due to an error._"
+                summary += f"\n\n_Note: {len(errored)} review batch(es) did not complete._"
             return summary
 
         findings_blob = "\n\n".join(

--- a/apps/polli/src/integrations/github/projects.py
+++ b/apps/polli/src/integrations/github/projects.py
@@ -222,11 +222,14 @@ class ProjectsMixin:
             org = self.owner
 
         all_projects = []
+        org_has_next_page = False
+        repo_has_next_page = False
 
         org_query = """
         query ListOrgProjects($org: String!, $limit: Int!) {
             organization(login: $org) {
                 projectsV2(first: $limit, orderBy: {field: UPDATED_AT, direction: DESC}) {
+                    pageInfo { hasNextPage }
                     nodes {
                         id
                         number
@@ -244,7 +247,9 @@ class ProjectsMixin:
         if not result.get("error"):
             org_data = result.get("data", {}).get("organization")
             if org_data:
-                projects_data = org_data.get("projectsV2", {}).get("nodes", [])
+                projects_connection = org_data.get("projectsV2", {})
+                org_has_next_page = bool(projects_connection.get("pageInfo", {}).get("hasNextPage"))
+                projects_data = projects_connection.get("nodes", [])
                 for p in projects_data:
                     if p:
                         all_projects.append(
@@ -263,6 +268,7 @@ class ProjectsMixin:
         query ListRepoProjects($owner: String!, $repo: String!, $limit: Int!) {
             repository(owner: $owner, name: $repo) {
                 projectsV2(first: $limit, orderBy: {field: UPDATED_AT, direction: DESC}) {
+                    pageInfo { hasNextPage }
                     nodes {
                         id
                         number
@@ -284,7 +290,9 @@ class ProjectsMixin:
         if not result.get("error"):
             repo_data = result.get("data", {}).get("repository")
             if repo_data:
-                for p in repo_data.get("projectsV2", {}).get("nodes", []):
+                projects_connection = repo_data.get("projectsV2", {})
+                repo_has_next_page = bool(projects_connection.get("pageInfo", {}).get("hasNextPage"))
+                for p in projects_connection.get("nodes", []):
                     if p:
                         if not any(ep["number"] == p["number"] for ep in all_projects):
                             all_projects.append(
@@ -306,7 +314,13 @@ class ProjectsMixin:
                 "message": "No projects found. Either GITHUB_PROJECT_PAT is not set, or the organization has no ProjectV2 boards.",
             }
 
-        return {"projects": all_projects, "count": len(all_projects)}
+        return {
+            "projects": all_projects,
+            "count": len(all_projects),
+            "requested_per_scope": limit,
+            "truncated": org_has_next_page or repo_has_next_page,
+            "truncation_note": "Organization and repository project lists are each bounded by the requested limit.",
+        }
 
     async def get_project_view(self, project_number: int, org: str | None = None) -> dict:
         if org is None:

--- a/apps/polli/src/integrations/github/pull_requests.py
+++ b/apps/polli/src/integrations/github/pull_requests.py
@@ -1,5 +1,8 @@
 import logging
+import re
 from dataclasses import dataclass
+
+GITHUB_LOGIN_RE = re.compile(r"^(?!.*--)[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$")
 
 import aiohttp
 
@@ -179,14 +182,29 @@ class GitHubPRManager(PRReviewMixin):
                 "checks_state": rollup.get("state", "UNKNOWN"),
                 "node_id": pr["id"],
             }
-        except Exception as e:
-            logger.error(f"Error getting PR: {e}")
-            return {"error": str(e)}
+        except Exception:
+            logger.exception("Error getting PR")
+            return {"error": "GitHub request failed"}
 
-    async def list_prs(self, state: str = "open", limit: int = 10, base: str | None = None) -> dict:
+    async def list_prs(
+        self,
+        state: str | None = None,
+        limit: int = 10,
+        base: str | None = None,
+        author: str | None = None,
+        query: str | None = None,
+        cursor: str | None = None,
+    ) -> dict:
         """List pull requests using GraphQL."""
         if not has_github_auth():
             return {"error": "GitHub token not configured"}
+        if author and not GITHUB_LOGIN_RE.fullmatch(author):
+            return {"error": "author must be a valid GitHub login"}
+        if query is not None and not query.strip():
+            return {"error": "query must not be blank"}
+        if cursor and query is None:
+            return {"error": "cursor requires query search mode"}
+        state = state or ("all" if query is not None else "open")
 
         states_map = {
             "open": "OPEN",
@@ -196,10 +214,94 @@ class GitHubPRManager(PRReviewMixin):
         }
         gql_state = states_map.get(state.lower())
 
+        limit = max(1, min(limit, 100))
+        if author or base or query is not None:
+            from .graphql import build_scoped_search_query
+
+            native_query = build_scoped_search_query(
+                query or "",
+                repository=self.repo,
+                kind="pr",
+                state=state if query else None,
+                author=author,
+                base=base,
+            )
+            if isinstance(native_query, dict):
+                return native_query
+            if not query:
+                qualifiers = [f"repo:{self.repo}", "is:pr"]
+                if author:
+                    qualifiers.append(f"author:{author}")
+                if state != "all":
+                    qualifiers.append(f"is:{state}")
+                if base:
+                    escaped_base = base.replace("\\", "\\\\").replace('"', '\\"')
+                    qualifiers.append(f'base:"{escaped_base}"')
+                native_query = " ".join(qualifiers)
+
+            query = """
+            query SearchPullRequests($query: String!, $limit: Int!, $after: String) {
+                search(query: $query, type: ISSUE, first: $limit, after: $after) {
+                    issueCount
+                    pageInfo { hasNextPage endCursor }
+                    nodes {
+                        ... on PullRequest {
+                            number title state isDraft url author { login } headRefName baseRefName createdAt updatedAt
+                            labels(first: 5) { nodes { name } }
+                        }
+                    }
+                }
+            }
+            """
+            try:
+                result = await github_graphql._execute(
+                    query, {"query": native_query, "limit": limit, "after": cursor}
+                )
+                if result.get("error"):
+                    return {"error": result["error"], "partial": result.get("partial", False)}
+                connection = result.get("data", {}).get("search", {})
+                prs_data = connection.get("nodes", [])
+                prs = [
+                    {
+                        "number": pr["number"],
+                        "title": pr["title"],
+                        "state": pr["state"].lower(),
+                        "draft": pr["isDraft"],
+                        "url": pr["url"],
+                        "author": pr["author"]["login"] if pr.get("author") else "unknown",
+                        "head": pr["headRefName"],
+                        "base": pr["baseRefName"],
+                        "created_at": pr["createdAt"][:10],
+                        "updated_at": pr["updatedAt"][:10],
+                        "labels": [label["name"] for label in pr.get("labels", {}).get("nodes", [])],
+                    }
+                    for pr in prs_data
+                    if pr
+                ]
+                return {
+                    "prs": prs,
+                    "count": len(prs),
+                    "matched_total": connection.get("issueCount", 0),
+                    "fetched": len(prs_data),
+                    "source_total": connection.get("issueCount", 0),
+                    "truncated": bool(connection.get("pageInfo", {}).get("hasNextPage")),
+                    "next_cursor": connection.get("pageInfo", {}).get("endCursor")
+                    if connection.get("pageInfo", {}).get("hasNextPage")
+                    else None,
+                    "state": state,
+                    "base": base,
+                    "author": author,
+                }
+            except Exception:
+                logger.exception("Error listing pull requests by author")
+                return {"error": "Failed to list pull requests"}
+
         query = """
         query($owner: String!, $repo: String!, $limit: Int!, $states: [PullRequestState!]) {
             repository(owner: $owner, name: $repo) {
                 pullRequests(first: $limit, states: $states, orderBy: {field: UPDATED_AT, direction: DESC}) {
+                    totalCount
+                    pageInfo { hasNextPage }
                     nodes {
                         number
                         title
@@ -228,12 +330,11 @@ class GitHubPRManager(PRReviewMixin):
             if result.get("error"):
                 return {"error": result["error"]}
 
-            prs_data = result.get("data", {}).get("repository", {}).get("pullRequests", {}).get("nodes", [])
+            connection = result.get("data", {}).get("repository", {}).get("pullRequests", {})
+            prs_data = connection.get("nodes", [])
 
             prs = []
             for pr in prs_data:
-                if base and pr["baseRefName"] != base:
-                    continue
                 prs.append(
                     {
                         "number": pr["number"],
@@ -250,10 +351,20 @@ class GitHubPRManager(PRReviewMixin):
                     }
                 )
 
-            return {"prs": prs, "count": len(prs), "state": state}
-        except Exception as e:
-            logger.error(f"Error listing PRs: {e}")
-            return {"error": str(e)}
+            return {
+                "prs": prs,
+                "count": len(prs),
+                "matched_total": len(prs),
+                "fetched": len(prs_data),
+                "source_total": connection.get("totalCount", 0),
+                "truncated": bool(connection.get("pageInfo", {}).get("hasNextPage")),
+                "state": state,
+                "base": base,
+                "author": author,
+            }
+        except Exception:
+            logger.exception("Error listing PRs")
+            return {"error": "Failed to list pull requests"}
 
     async def get_pr_files(self, pr_number: int) -> dict:
         """Get files changed in a PR using REST API (GraphQL doesn't expose patches)."""
@@ -282,16 +393,16 @@ class GitHubPRManager(PRReviewMixin):
                         "pr_number": pr_number,
                         "files": files,
                         "count": len(files),
-                        "total_additions": sum(f["additions"] for f in files),
-                        "total_deletions": sum(f["deletions"] for f in files),
+                        "total_additions": sum(int(f.get("additions", 0)) for f in files),
+                        "total_deletions": sum(int(f.get("deletions", 0)) for f in files),
                     }
                 elif response.status == 404:
                     return {"error": f"PR #{pr_number} not found", "not_found": True}
                 else:
                     return {"error": f"GitHub API error: {response.status}"}
-        except Exception as e:
-            logger.error(f"Error getting PR files: {e}")
-            return {"error": str(e)}
+        except Exception:
+            logger.exception("Error getting PR files")
+            return {"error": "GitHub request failed"}
 
     async def get_pr_diff(self, pr_number: int) -> dict:
         """Get the unified diff for a PR."""
@@ -300,6 +411,8 @@ class GitHubPRManager(PRReviewMixin):
 
         url = f"https://api.github.com/repos/{self.repo}/pulls/{pr_number}"
         headers = await self._get_headers()
+        if not headers:
+            return {"error": "GitHub token not configured"}
         headers["Accept"] = "application/vnd.github.v3.diff"
 
         try:
@@ -312,9 +425,9 @@ class GitHubPRManager(PRReviewMixin):
                     return {"error": f"PR #{pr_number} not found", "not_found": True}
                 else:
                     return {"error": f"GitHub API error: {response.status}"}
-        except Exception as e:
-            logger.error(f"Error getting PR diff: {e}")
-            return {"error": str(e)}
+        except Exception:
+            logger.exception("Error getting PR diff")
+            return {"error": "GitHub request failed"}
 
     async def get_pr_checks(self, pr_number: int) -> dict:
         """Get CI/workflow status for a PR using GraphQL statusCheckRollup."""
@@ -416,9 +529,9 @@ class GitHubPRManager(PRReviewMixin):
                 "checks": checks,
                 "count": len(checks),
             }
-        except Exception as e:
-            logger.error(f"Error getting PR checks: {e}")
-            return {"error": str(e)}
+        except Exception:
+            logger.exception("Error getting PR checks")
+            return {"error": "GitHub request failed"}
 
     # ============================================================
     # PR WRITE OPERATIONS (GraphQL Mutations + REST)
@@ -463,9 +576,9 @@ class GitHubPRManager(PRReviewMixin):
                     return {"error": f"Cannot request reviewer: {error_data.get('message', 'validation failed')}"}
                 else:
                     return {"error": f"GitHub API error: {response.status}"}
-        except Exception as e:
-            logger.error(f"Error requesting reviewers: {e}")
-            return {"error": str(e)}
+        except Exception:
+            logger.exception("Error requesting reviewers")
+            return {"error": "GitHub request failed"}
 
     async def create_review(self, pr_number: int, event: str, body: str | None = None) -> dict:
         """Create a review on a PR (approve, request changes, or comment)."""
@@ -505,9 +618,9 @@ class GitHubPRManager(PRReviewMixin):
                     return {"error": f"Review failed: {error_data.get('message', 'validation failed')}"}
                 else:
                     return {"error": f"GitHub API error: {response.status}"}
-        except Exception as e:
-            logger.error(f"Error creating review: {e}")
-            return {"error": str(e)}
+        except Exception:
+            logger.exception("Error creating review")
+            return {"error": "GitHub request failed"}
 
     async def merge_pr(
         self,
@@ -554,9 +667,9 @@ class GitHubPRManager(PRReviewMixin):
                     return {"error": f"Merge conflict: {error_data.get('message', 'conflict')}"}
                 else:
                     return {"error": f"GitHub API error: {response.status}"}
-        except Exception as e:
-            logger.error(f"Error merging PR: {e}")
-            return {"error": str(e)}
+        except Exception:
+            logger.exception("Error merging PR")
+            return {"error": "GitHub request failed"}
 
     async def update_pr(
         self,
@@ -598,9 +711,9 @@ class GitHubPRManager(PRReviewMixin):
                     return {"error": f"PR #{pr_number} not found", "not_found": True}
                 else:
                     return {"error": f"GitHub API error: {response.status}"}
-        except Exception as e:
-            logger.error(f"Error updating PR: {e}")
-            return {"error": str(e)}
+        except Exception:
+            logger.exception("Error updating PR")
+            return {"error": "GitHub request failed"}
 
     async def create_pr(self, title: str, body: str, head: str, base: str = "main", draft: bool = False) -> dict:
         """Create a new pull request."""
@@ -632,9 +745,9 @@ class GitHubPRManager(PRReviewMixin):
                     return {"error": f"Cannot create PR: {error_data.get('message', 'validation failed')}"}
                 else:
                     return {"error": f"GitHub API error: {response.status}"}
-        except Exception as e:
-            logger.error(f"Error creating PR: {e}")
-            return {"error": str(e)}
+        except Exception:
+            logger.exception("Error creating PR")
+            return {"error": "GitHub request failed"}
 
     async def convert_to_draft(self, pr_number: int) -> dict:
         """Convert a PR to draft using GraphQL mutation."""
@@ -668,9 +781,9 @@ class GitHubPRManager(PRReviewMixin):
                 "is_draft": True,
                 "pr_url": f"https://github.com/{self.repo}/pull/{pr_number}",
             }
-        except Exception as e:
-            logger.error(f"Error converting to draft: {e}")
-            return {"error": str(e)}
+        except Exception:
+            logger.exception("Error converting to draft")
+            return {"error": "GitHub request failed"}
 
     async def mark_ready_for_review(self, pr_number: int) -> dict:
         """Mark a draft PR as ready for review using GraphQL mutation."""
@@ -704,9 +817,9 @@ class GitHubPRManager(PRReviewMixin):
                 "is_draft": False,
                 "pr_url": f"https://github.com/{self.repo}/pull/{pr_number}",
             }
-        except Exception as e:
-            logger.error(f"Error marking ready: {e}")
-            return {"error": str(e)}
+        except Exception:
+            logger.exception("Error marking ready")
+            return {"error": "GitHub request failed"}
 
     async def update_branch(self, pr_number: int) -> dict:
         """Update a PR branch with the latest from base branch."""
@@ -731,9 +844,9 @@ class GitHubPRManager(PRReviewMixin):
                     return {"error": "Branch cannot be updated (no updates available or conflict)"}
                 else:
                     return {"error": f"GitHub API error: {response.status}"}
-        except Exception as e:
-            logger.error(f"Error updating branch: {e}")
-            return {"error": str(e)}
+        except Exception:
+            logger.exception("Error updating branch")
+            return {"error": "GitHub request failed"}
 
     async def add_comment(self, pr_number: int, body: str, author: str = "Discord User") -> dict:
         """Add a comment to a PR."""
@@ -756,9 +869,9 @@ class GitHubPRManager(PRReviewMixin):
                     return {"error": f"PR #{pr_number} not found", "not_found": True}
                 else:
                     return {"error": f"GitHub API error: {response.status}"}
-        except Exception as e:
-            logger.error(f"Error adding comment: {e}")
-            return {"error": str(e)}
+        except Exception:
+            logger.exception("Error adding comment")
+            return {"error": "GitHub request failed"}
 
     # ============================================================
     # NEW: INLINE REVIEW COMMENTS
@@ -829,9 +942,9 @@ class GitHubPRManager(PRReviewMixin):
                     return {"error": f"Invalid comment position: {error_data.get('message', 'validation failed')}"}
                 else:
                     return {"error": f"GitHub API error: {response.status}"}
-        except Exception as e:
-            logger.error(f"Error adding inline comment: {e}")
-            return {"error": str(e)}
+        except Exception:
+            logger.exception("Error adding inline comment")
+            return {"error": "GitHub request failed"}
 
     async def add_code_suggestion(
         self,
@@ -926,9 +1039,9 @@ class GitHubPRManager(PRReviewMixin):
                     }
                 else:
                     return {"error": f"GitHub API error: {response.status}"}
-        except Exception as e:
-            logger.error(f"Error getting file at ref: {e}")
-            return {"error": str(e)}
+        except Exception:
+            logger.exception("Error getting file at ref")
+            return {"error": "GitHub request failed"}
 
     async def get_pr_commits(self, pr_number: int) -> dict:
         """Get all commits in a PR."""
@@ -962,9 +1075,9 @@ class GitHubPRManager(PRReviewMixin):
                     return {"error": f"PR #{pr_number} not found", "not_found": True}
                 else:
                     return {"error": f"GitHub API error: {response.status}"}
-        except Exception as e:
-            logger.error(f"Error getting PR commits: {e}")
-            return {"error": str(e)}
+        except Exception:
+            logger.exception("Error getting PR commits")
+            return {"error": "GitHub request failed"}
 
     # ============================================================
     # NEW: REVIEW THREADS (Resolve/Unresolve)
@@ -989,9 +1102,9 @@ class GitHubPRManager(PRReviewMixin):
                 return {"error": result["error"]}
 
             return {"success": True, "thread_id": thread_id, "resolved": True}
-        except Exception as e:
-            logger.error(f"Error resolving thread: {e}")
-            return {"error": str(e)}
+        except Exception:
+            logger.exception("Error resolving thread")
+            return {"error": "GitHub request failed"}
 
     async def unresolve_thread(self, thread_id: str) -> dict:
         """Unresolve a review thread using GraphQL."""
@@ -1012,9 +1125,9 @@ class GitHubPRManager(PRReviewMixin):
                 return {"error": result["error"]}
 
             return {"success": True, "thread_id": thread_id, "resolved": False}
-        except Exception as e:
-            logger.error(f"Error unresolving thread: {e}")
-            return {"error": str(e)}
+        except Exception:
+            logger.exception("Error unresolving thread")
+            return {"error": "GitHub request failed"}
 
     async def get_review_threads(self, pr_number: int) -> dict:
         """Get all review threads for a PR."""
@@ -1084,9 +1197,9 @@ class GitHubPRManager(PRReviewMixin):
                 "resolved": sum(1 for t in threads if t["resolved"]),
                 "unresolved": sum(1 for t in threads if not t["resolved"]),
             }
-        except Exception as e:
-            logger.error(f"Error getting review threads: {e}")
-            return {"error": str(e)}
+        except Exception:
+            logger.exception("Error getting review threads")
+            return {"error": "GitHub request failed"}
 
     # ============================================================
     # NEW: AUTO-MERGE
@@ -1123,9 +1236,9 @@ class GitHubPRManager(PRReviewMixin):
                 "merge_method": gql_method,
                 "pr_url": f"https://github.com/{self.repo}/pull/{pr_number}",
             }
-        except Exception as e:
-            logger.error(f"Error enabling auto-merge: {e}")
-            return {"error": str(e)}
+        except Exception:
+            logger.exception("Error enabling auto-merge")
+            return {"error": "GitHub request failed"}
 
     async def disable_auto_merge(self, pr_number: int) -> dict:
         """Disable auto-merge for a PR."""
@@ -1152,9 +1265,9 @@ class GitHubPRManager(PRReviewMixin):
                 "auto_merge": False,
                 "pr_url": f"https://github.com/{self.repo}/pull/{pr_number}",
             }
-        except Exception as e:
-            logger.error(f"Error disabling auto-merge: {e}")
-            return {"error": str(e)}
+        except Exception:
+            logger.exception("Error disabling auto-merge")
+            return {"error": "GitHub request failed"}
 
     # ============================================================
     # NEW: LIST REVIEW COMMENTS
@@ -1194,9 +1307,9 @@ class GitHubPRManager(PRReviewMixin):
                     return {"error": f"PR #{pr_number} not found", "not_found": True}
                 else:
                     return {"error": f"GitHub API error: {response.status}"}
-        except Exception as e:
-            logger.error(f"Error getting review comments: {e}")
-            return {"error": str(e)}
+        except Exception:
+            logger.exception("Error getting review comments")
+            return {"error": "GitHub request failed"}
 
     async def remove_reviewer(
         self,
@@ -1233,9 +1346,9 @@ class GitHubPRManager(PRReviewMixin):
                     return {"error": f"PR #{pr_number} not found", "not_found": True}
                 else:
                     return {"error": f"GitHub API error: {response.status}"}
-        except Exception as e:
-            logger.error(f"Error removing reviewers: {e}")
-            return {"error": str(e)}
+        except Exception:
+            logger.exception("Error removing reviewers")
+            return {"error": "GitHub request failed"}
 
 
 # Singleton instance
@@ -1249,44 +1362,47 @@ github_pr_manager = GitHubPRManager()
 
 async def tool_github_pr(
     action: str,
-    pr_number: int = None,
+    pr_number: int | None = None,
     # List filters
-    state: str = "open",
+    state: str | None = None,
     limit: int = 10,
-    base: str = None,
+    base: str | None = None,
+    author: str | None = None,
+    query: str | None = None,
+    cursor: str | None = None,
     # Create/Update fields
-    title: str = None,
-    body: str = None,
-    head: str = None,
+    title: str | None = None,
+    body: str | None = None,
+    head: str | None = None,
     draft: bool = False,
     # Reviewers
-    reviewers: list[str] = None,
-    team_reviewers: list[str] = None,
+    reviewers: list[str] | None = None,
+    team_reviewers: list[str] | None = None,
     # Review
-    event: str = None,
+    event: str | None = None,
     # Merge
-    commit_title: str = None,
-    commit_message: str = None,
+    commit_title: str | None = None,
+    commit_message: str | None = None,
     merge_method: str = "merge",
     # Comment
-    comment: str = None,
+    comment: str | None = None,
     # AI Review
     post_review_to_github: bool = False,
     # Inline comments
-    path: str = None,
-    line: int = None,
+    path: str | None = None,
+    line: int | None = None,
     side: str = "RIGHT",
-    suggestion: str = None,
+    suggestion: str | None = None,
     # Review threads
-    thread_id: str = None,
+    thread_id: str | None = None,
     # Get file at ref
-    file_path: str = None,
+    file_path: str | None = None,
     ref: str = "main",  # Default to main branch (pollinations/pollinations uses main, not master)
     # Edit history
-    edit_index: int = None,  # For get_history - get full diff for specific edit (0=most recent)
+    edit_index: int | None = None,  # For get_history - get full diff for specific edit (0=most recent)
     # Injected context
     reporter: str = "Discord User",
-    _context: dict = None,
+    _context: dict | None = None,
     **kwargs,  # Catch any extra args
 ) -> dict:
     """
@@ -1378,7 +1494,9 @@ async def tool_github_pr(
         return await github_pr_manager.get_pr(pr_number)
 
     elif action == "list":
-        return await github_pr_manager.list_prs(state=state, limit=limit, base=base)
+        return await github_pr_manager.list_prs(
+            state=state, limit=limit, base=base, author=author, query=query, cursor=cursor
+        )
 
     elif action == "get_history":
         if not pr_number:

--- a/apps/polli/src/integrations/github/repo_overview.py
+++ b/apps/polli/src/integrations/github/repo_overview.py
@@ -296,17 +296,19 @@ class RepoOverviewMixin:
             ],
         }
 
-    async def _fetch_labels(self) -> dict:
-        cache_key = f"labels:{self.owner}/{self.repo}"
+    async def _fetch_labels(self, limit: int = 50, after: str | None = None) -> dict:
+        limit = max(1, min(limit, 100))
+        cache_key = f"labels:{self.owner}/{self.repo}:{limit}:{after or ''}"
         cached = self._cache.get(cache_key)
         if cached is not None:
             logger.debug("Labels cache hit")
             return cached
 
         query = """
-        query Labels($owner: String!, $repo: String!) {
+        query Labels($owner: String!, $repo: String!, $limit: Int!, $after: String) {
             repository(owner: $owner, name: $repo) {
-                labels(first: 50) {
+                labels(first: $limit, after: $after) {
+                    pageInfo { hasNextPage endCursor }
                     nodes {
                         name
                         color
@@ -317,29 +319,35 @@ class RepoOverviewMixin:
         }
         """
 
-        result = await self._execute(query, {"owner": self.owner, "repo": self.repo})
+        result = await self._execute(query, {"owner": self.owner, "repo": self.repo, "limit": limit, "after": after})
 
         if result.get("error"):
             return {"error": result["error"]}
 
-        labels = result.get("data", {}).get("repository", {}).get("labels", {}).get("nodes", [])
+        connection = result.get("data", {}).get("repository", {}).get("labels", {})
+        labels = connection.get("nodes", [])
 
+        formatted_labels = [
+            {
+                "name": label["name"],
+                "color": label["color"],
+                "open_issues": label["issues"]["totalCount"],
+            }
+            for label in sorted(labels, key=lambda item: item["issues"]["totalCount"], reverse=True)
+        ]
         response = {
-            "items": [
-                {
-                    "name": l["name"],
-                    "color": l["color"],
-                    "open_issues": l["issues"]["totalCount"],
-                }
-                for l in sorted(labels, key=lambda x: x["issues"]["totalCount"], reverse=True)
-            ]
+            "labels": formatted_labels,
+            "count": len(formatted_labels),
+            "truncated": bool(connection.get("pageInfo", {}).get("hasNextPage")),
+            "next_cursor": connection.get("pageInfo", {}).get("endCursor"),
         }
 
         self._cache.set(cache_key, response)
         return response
 
-    async def _fetch_milestones(self, state: str = "OPEN") -> dict:
-        cache_key = f"milestones:{self.owner}/{self.repo}:{state.upper()}"
+    async def _fetch_milestones(self, state: str = "OPEN", limit: int = 100, after: str | None = None) -> dict:
+        limit = max(1, min(limit, 100))
+        cache_key = f"milestones:{self.owner}/{self.repo}:{state.upper()}:{limit}:{after or ''}"
         cached = self._cache.get(cache_key)
         if cached is not None:
             logger.debug("Milestones cache hit")
@@ -352,9 +360,10 @@ class RepoOverviewMixin:
             states_filter = [state.upper()]
 
         query = """
-        query Milestones($owner: String!, $repo: String!, $states: [MilestoneState!]) {
+        query Milestones($owner: String!, $repo: String!, $states: [MilestoneState!], $limit: Int!, $after: String) {
             repository(owner: $owner, name: $repo) {
-                milestones(first: 100, states: $states, orderBy: {field: DUE_DATE, direction: ASC}) {
+                milestones(first: $limit, after: $after, states: $states, orderBy: {field: DUE_DATE, direction: ASC}) {
+                    pageInfo { hasNextPage endCursor }
                     nodes {
                         title
                         description
@@ -370,27 +379,37 @@ class RepoOverviewMixin:
         }
         """
 
-        result = await self._execute(query, {"owner": self.owner, "repo": self.repo, "states": states_filter})
+        result = await self._execute(
+            query,
+            {"owner": self.owner, "repo": self.repo, "states": states_filter, "limit": limit, "after": after},
+        )
 
         if result.get("error"):
             return {"error": result["error"]}
 
-        milestones = result.get("data", {}).get("repository", {}).get("milestones", {}).get("nodes", [])
+        connection = result.get("data", {}).get("repository", {}).get("milestones", {})
+        milestones = connection.get("nodes", [])
 
+        formatted_milestones = [
+            {
+                "title": milestone["title"],
+                "description": milestone.get("description") or "",
+                "state": milestone["state"].lower(),
+                "number": milestone["number"],
+                "open_issues": milestone["issues"]["totalCount"],
+                "closed_issues": milestone["closedIssues"]["totalCount"],
+                "progress": milestone.get("progressPercentage", 0),
+                "due_on": milestone["dueOn"][:10] if milestone.get("dueOn") else None,
+            }
+            for milestone in milestones
+        ]
+        page_info = connection.get("pageInfo", {})
+        has_next_page = bool(page_info.get("hasNextPage"))
         response = {
-            "items": [
-                {
-                    "title": m["title"],
-                    "description": m.get("description") or "",
-                    "state": m["state"].lower(),
-                    "number": m["number"],
-                    "open_issues": m["issues"]["totalCount"],
-                    "closed_issues": m["closedIssues"]["totalCount"],
-                    "progress": m.get("progressPercentage", 0),
-                    "due_on": m["dueOn"][:10] if m.get("dueOn") else None,
-                }
-                for m in milestones
-            ]
+            "milestones": formatted_milestones,
+            "count": len(formatted_milestones),
+            "truncated": has_next_page,
+            "next_cursor": page_info.get("endCursor") if has_next_page else None,
         }
 
         self._cache.set(cache_key, response)

--- a/apps/polli/src/integrations/subscriptions.py
+++ b/apps/polli/src/integrations/subscriptions.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 from datetime import datetime
 from pathlib import Path
 
@@ -14,55 +15,97 @@ from ..utils.json import loads as _json_loads
 logger = logging.getLogger(__name__)
 
 # Database path
-DB_PATH = Path(__file__).parent.parent.parent / "data" / "subscriptions.db"
+DB_PATH = config.paths.data_dir / "subscriptions.db"
+_PRIVATE_MODE = 0o700
+_DATABASE_MODE = 0o600
+
+
+def _set_private_mode(path: Path, mode: int) -> None:
+    """Apply private POSIX permissions without traversing child paths."""
+    if os.name != "posix":
+        return
+    path.chmod(mode)
+
+
+def _protect_database_files(db_path: Path) -> None:
+    """Protect the database and SQLite sidecars when they exist."""
+    for path in (db_path, Path(f"{db_path}-wal"), Path(f"{db_path}-shm"), Path(f"{db_path}-journal")):
+        if path.exists():
+            _set_private_mode(path, _DATABASE_MODE)
 
 
 class SubscriptionManager:
     """Manages issue subscriptions with async SQLite storage."""
 
-    def __init__(self):
-        self._db_path = DB_PATH
+    def __init__(self, db_path: Path | None = None):
+        self._db_path = db_path or DB_PATH
         self._db: aiosqlite.Connection | None = None
         self._initialized = False
 
-    async def initialize(self):
+    async def initialize(self) -> None:
         """Initialize database connection and create tables."""
         if self._initialized:
             return
 
-        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            self._db_path.parent.mkdir(parents=True, exist_ok=True)
+            _set_private_mode(self._db_path.parent, _PRIVATE_MODE)
 
-        self._db = await aiosqlite.connect(self._db_path)
+            self._db = await aiosqlite.connect(self._db_path)
+            db = self._db
+            _protect_database_files(self._db_path)
 
-        # Enable WAL mode for faster concurrent reads/writes
-        await self._db.execute("PRAGMA journal_mode=WAL")
-        await self._db.execute("PRAGMA synchronous=NORMAL")
-        await self._db.execute("PRAGMA cache_size=10000")
+            # Enable WAL mode for faster concurrent reads/writes.
+            await db.execute("PRAGMA journal_mode=WAL")
+            _protect_database_files(self._db_path)
+            await db.execute("PRAGMA synchronous=NORMAL")
+            await db.execute("PRAGMA cache_size=10000")
+            await db.execute("PRAGMA secure_delete=ON")
 
-        await self._db.execute("""
-            CREATE TABLE IF NOT EXISTS subscriptions (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                user_id INTEGER NOT NULL,
-                issue_number INTEGER NOT NULL,
-                channel_id INTEGER NOT NULL,
-                guild_id INTEGER,
-                created_at TEXT DEFAULT CURRENT_TIMESTAMP,
-                last_notified_at TEXT,
-                last_state TEXT,
-                last_comment_count INTEGER DEFAULT 0,
-                last_labels TEXT,
-                UNIQUE(user_id, issue_number)
-            )
-        """)
-        await self._db.execute("""
-            CREATE INDEX IF NOT EXISTS idx_issue_number ON subscriptions(issue_number)
-        """)
-        await self._db.execute("""
-            CREATE INDEX IF NOT EXISTS idx_user_id ON subscriptions(user_id)
-        """)
-        await self._db.commit()
+            await db.execute("""
+                CREATE TABLE IF NOT EXISTS subscriptions (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    user_id INTEGER NOT NULL,
+                    issue_number INTEGER NOT NULL,
+                    channel_id INTEGER NOT NULL,
+                    guild_id INTEGER,
+                    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                    last_notified_at TEXT,
+                    last_state TEXT,
+                    last_comment_count INTEGER DEFAULT 0,
+                    last_labels TEXT,
+                    UNIQUE(user_id, issue_number)
+                )
+            """)
+            await db.execute("""
+                CREATE INDEX IF NOT EXISTS idx_issue_number ON subscriptions(issue_number)
+            """)
+            await db.execute("""
+                CREATE INDEX IF NOT EXISTS idx_user_id ON subscriptions(user_id)
+            """)
+            await db.commit()
+            _protect_database_files(self._db_path)
+        except BaseException:
+            if self._db is not None:
+                await self._db.close()
+                self._db = None
+            raise
+
         self._initialized = True
         logger.info("SubscriptionManager initialized with async SQLite")
+
+    async def _ensure_initialized(self) -> aiosqlite.Connection:
+        """Ensure database is initialized and return its connection."""
+        if not self._initialized:
+            await self.initialize()
+        if self._db is None:
+            raise RuntimeError("Subscription database connection is unavailable")
+        return self._db
+
+    async def _commit(self, db: aiosqlite.Connection) -> None:
+        """Commit changes and protect any SQLite sidecars that were created."""
+        await db.commit()
+        _protect_database_files(self._db_path)
 
     async def close(self):
         """Close database connection."""
@@ -70,11 +113,6 @@ class SubscriptionManager:
             await self._db.close()
             self._db = None
             self._initialized = False
-
-    async def _ensure_initialized(self):
-        """Ensure database is initialized."""
-        if not self._initialized:
-            await self.initialize()
 
     async def subscribe(
         self,
@@ -89,13 +127,13 @@ class SubscriptionManager:
 
         Returns True if new subscription, False if already subscribed.
         """
-        await self._ensure_initialized()
+        db = await self._ensure_initialized()
         try:
             state = initial_state.get("state", "open") if initial_state else "open"
             comment_count = initial_state.get("comments_count", 0) if initial_state else 0
             labels = _json_dumps(initial_state.get("labels", [])) if initial_state else "[]"
 
-            await self._db.execute(
+            await db.execute(
                 """
                 INSERT OR REPLACE INTO subscriptions
                 (user_id, issue_number, channel_id, guild_id, last_state, last_comment_count, last_labels)
@@ -103,10 +141,10 @@ class SubscriptionManager:
             """,
                 (user_id, issue_number, channel_id, guild_id, state, comment_count, labels),
             )
-            await self._db.commit()
+            await self._commit(db)
             return True
-        except Exception as e:
-            logger.error(f"Failed to subscribe: {e}")
+        except aiosqlite.Error:
+            logger.error("Failed to subscribe")
             return False
 
     async def unsubscribe(self, user_id: int, issue_number: int) -> bool:
@@ -115,18 +153,18 @@ class SubscriptionManager:
 
         Returns True if was subscribed, False if wasn't.
         """
-        await self._ensure_initialized()
+        db = await self._ensure_initialized()
         try:
-            cursor = await self._db.execute(
+            cursor = await db.execute(
                 """
                 DELETE FROM subscriptions WHERE user_id = ? AND issue_number = ?
             """,
                 (user_id, issue_number),
             )
-            await self._db.commit()
+            await self._commit(db)
             return cursor.rowcount > 0
-        except Exception as e:
-            logger.error(f"Failed to unsubscribe: {e}")
+        except aiosqlite.Error:
+            logger.error("Failed to unsubscribe")
             return False
 
     async def unsubscribe_all(self, user_id: int) -> int:
@@ -135,26 +173,26 @@ class SubscriptionManager:
 
         Returns number of subscriptions removed.
         """
-        await self._ensure_initialized()
+        db = await self._ensure_initialized()
         try:
-            cursor = await self._db.execute(
+            cursor = await db.execute(
                 """
                 DELETE FROM subscriptions WHERE user_id = ?
             """,
                 (user_id,),
             )
-            await self._db.commit()
+            await self._commit(db)
             return cursor.rowcount
-        except Exception as e:
-            logger.error(f"Failed to unsubscribe all: {e}")
+        except aiosqlite.Error:
+            logger.error("Failed to unsubscribe all")
             return 0
 
     async def get_user_subscriptions(self, user_id: int) -> list[dict]:
         """Get all subscriptions for a user."""
-        await self._ensure_initialized()
+        db = await self._ensure_initialized()
         try:
-            self._db.row_factory = aiosqlite.Row
-            cursor = await self._db.execute(
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute(
                 """
                 SELECT issue_number, channel_id, guild_id, created_at, last_state
                 FROM subscriptions WHERE user_id = ?
@@ -164,29 +202,29 @@ class SubscriptionManager:
             )
             rows = await cursor.fetchall()
             return [dict(row) for row in rows]
-        except Exception as e:
-            logger.error(f"Failed to get subscriptions: {e}")
+        except aiosqlite.Error:
+            logger.error("Failed to get subscriptions")
             return []
 
     async def get_all_subscribed_issues(self) -> list[int]:
         """Get all unique issue numbers with active subscriptions."""
-        await self._ensure_initialized()
+        db = await self._ensure_initialized()
         try:
-            cursor = await self._db.execute("""
+            cursor = await db.execute("""
                 SELECT DISTINCT issue_number FROM subscriptions
             """)
             rows = await cursor.fetchall()
             return [row[0] for row in rows]
-        except Exception as e:
-            logger.error(f"Failed to get subscribed issues: {e}")
+        except aiosqlite.Error:
+            logger.error("Failed to get subscribed issues")
             return []
 
     async def get_subscriptions_for_issue(self, issue_number: int) -> list[dict]:
         """Get all subscriptions for a specific issue."""
-        await self._ensure_initialized()
+        db = await self._ensure_initialized()
         try:
-            self._db.row_factory = aiosqlite.Row
-            cursor = await self._db.execute(
+            db.row_factory = aiosqlite.Row
+            cursor = await db.execute(
                 """
                 SELECT user_id, channel_id, guild_id, last_state, last_comment_count, last_labels
                 FROM subscriptions WHERE issue_number = ?
@@ -195,15 +233,15 @@ class SubscriptionManager:
             )
             rows = await cursor.fetchall()
             return [dict(row) for row in rows]
-        except Exception as e:
-            logger.error(f"Failed to get issue subscriptions: {e}")
+        except aiosqlite.Error:
+            logger.error("Failed to get issue subscriptions")
             return []
 
     async def update_issue_state(self, issue_number: int, state: str, comment_count: int, labels: list[str]):
         """Update the tracked state for all subscriptions of an issue."""
-        await self._ensure_initialized()
+        db = await self._ensure_initialized()
         try:
-            await self._db.execute(
+            await db.execute(
                 """
                 UPDATE subscriptions
                 SET last_state = ?, last_comment_count = ?, last_labels = ?, last_notified_at = ?
@@ -211,26 +249,26 @@ class SubscriptionManager:
             """,
                 (state, comment_count, _json_dumps(labels), datetime.utcnow().isoformat(), issue_number),
             )
-            await self._db.commit()
-        except Exception as e:
-            logger.error(f"Failed to update issue state: {e}")
+            await self._commit(db)
+        except aiosqlite.Error:
+            logger.error("Failed to update issue state")
 
     async def get_subscription_count(self) -> int:
         """Get total number of active subscriptions."""
-        await self._ensure_initialized()
+        db = await self._ensure_initialized()
         try:
-            cursor = await self._db.execute("SELECT COUNT(*) FROM subscriptions")
+            cursor = await db.execute("SELECT COUNT(*) FROM subscriptions")
             row = await cursor.fetchone()
             return row[0]
-        except Exception as e:
-            logger.error(f"Failed to get subscription count: {e}")
+        except aiosqlite.Error:
+            logger.error("Failed to get subscription count")
             return 0
 
     async def is_subscribed(self, user_id: int, issue_number: int) -> bool:
         """Check if a user is subscribed to an issue."""
-        await self._ensure_initialized()
+        db = await self._ensure_initialized()
         try:
-            cursor = await self._db.execute(
+            cursor = await db.execute(
                 """
                 SELECT 1 FROM subscriptions WHERE user_id = ? AND issue_number = ?
             """,
@@ -238,8 +276,8 @@ class SubscriptionManager:
             )
             row = await cursor.fetchone()
             return row is not None
-        except Exception as e:
-            logger.error(f"Failed to check subscription: {e}")
+        except aiosqlite.Error:
+            logger.error("Failed to check subscription")
             return False
 
 

--- a/apps/polli/src/integrations/web_scraper.py
+++ b/apps/polli/src/integrations/web_scraper.py
@@ -1,11 +1,214 @@
 import asyncio
+import json
 import logging
+import multiprocessing
+import os
+import queue
+import threading
+import time
+from html import unescape
 from typing import Any
 
 from ..utils.regex import re
 from ..utils.url import parse_url
 
 logger = logging.getLogger(__name__)
+
+# Crawl4AI owns Chromium and binds its Playwright objects to an event loop. A dedicated
+# thread makes one browser safe for both Discord and Granian's independent ASGI loop.
+_BROWSER_CONCURRENCY = 2
+_BROWSER_QUEUE_SIZE = 2
+_SEMANTIC_CONCURRENCY = 1
+_crawler_pool: "_SharedCrawlerPool | None" = None
+_crawler_pool_lock = threading.Lock()
+_semantic_slots = threading.BoundedSemaphore(_SEMANTIC_CONCURRENCY)
+
+
+class _SharedCrawlerPool:
+    def __init__(self, browser_config: Any):
+        self.browser_config = browser_config
+        self.loop = asyncio.new_event_loop()
+        self.ready = threading.Event()
+        self.tabs = threading.BoundedSemaphore(_BROWSER_CONCURRENCY + _BROWSER_QUEUE_SIZE)
+        self.active_tabs = asyncio.BoundedSemaphore(_BROWSER_CONCURRENCY)
+        self.start_lock: asyncio.Lock | None = None
+        self.closing = False
+        self.tasks: set[asyncio.Task[Any]] = set()
+        self.submission_lock = threading.Lock()
+        self.thread = threading.Thread(target=self._run_loop, daemon=True, name="polli-crawl4ai")
+        self.crawler: Any | None = None
+        self.start_error: BaseException | None = None
+        self.thread.start()
+        self.ready.wait()
+        if self.start_error:
+            raise self.start_error
+
+    def _run_loop(self) -> None:
+        asyncio.set_event_loop(self.loop)
+        self.ready.set()
+        self.loop.run_forever()
+        self.loop.close()
+
+    async def _get_crawler(self) -> Any:
+        if self.start_lock is None:
+            self.start_lock = asyncio.Lock()
+        async with self.start_lock:
+            if self.crawler is None:
+                from crawl4ai import AsyncWebCrawler
+
+                crawler = AsyncWebCrawler(config=self.browser_config)
+                try:
+                    await crawler.start()
+                except BaseException:
+                    await crawler.close()
+                    raise
+                self.crawler = crawler
+        return self.crawler
+
+    async def _run(self, url: str, crawl_config: Any, timeout: int) -> Any:
+        task = asyncio.current_task()
+        if task is not None:
+            self.tasks.add(task)
+        acquired_active_tab = False
+        try:
+            await asyncio.wait_for(self.active_tabs.acquire(), timeout=timeout)
+            acquired_active_tab = True
+            crawler = await asyncio.wait_for(self._get_crawler(), timeout=timeout)
+            return await asyncio.wait_for(crawler.arun(url=url, config=crawl_config), timeout=timeout)
+        finally:
+            if acquired_active_tab:
+                self.active_tabs.release()
+            if task is not None:
+                self.tasks.discard(task)
+            self.tabs.release()
+
+    async def submit(self, url: str, crawl_config: Any, timeout: int) -> Any:
+        with self.submission_lock:
+            if self.closing or not self.tabs.acquire(blocking=False):
+                raise RuntimeError("Browser scraper is busy; try again shortly.")
+            coroutine = self._run(url, crawl_config, timeout)
+            try:
+                future = asyncio.run_coroutine_threadsafe(coroutine, self.loop)
+            except BaseException:
+                coroutine.close()
+                self.tabs.release()
+                raise
+        try:
+            return await asyncio.wrap_future(future)
+        except asyncio.CancelledError:
+            future.cancel()
+            raise
+
+    async def close(self) -> None:
+        with self.submission_lock:
+            self.closing = True
+
+        async def close_crawler() -> None:
+            active = list(self.tasks)
+            for task in active:
+                task.cancel()
+            if active:
+                await asyncio.gather(*active, return_exceptions=True)
+            if self.crawler is not None:
+                await self.crawler.close()
+                self.crawler = None
+
+        future = asyncio.run_coroutine_threadsafe(close_crawler(), self.loop)
+        await asyncio.wrap_future(future)
+        self.loop.call_soon_threadsafe(self.loop.stop)
+        await asyncio.to_thread(self.thread.join)
+
+
+async def close_web_scraper() -> None:
+    """Close the shared Crawl4AI browser during application shutdown."""
+    global _crawler_pool
+    with _crawler_pool_lock:
+        pool, _crawler_pool = _crawler_pool, None
+    if pool is not None:
+        await pool.close()
+
+
+def _get_shared_crawler(browser_config: Any) -> _SharedCrawlerPool:
+    global _crawler_pool
+    with _crawler_pool_lock:
+        if _crawler_pool is None:
+            _crawler_pool = _SharedCrawlerPool(browser_config)
+        elif getattr(_crawler_pool.browser_config, "headless", None) != getattr(browser_config, "headless", None):
+            raise ValueError(
+                "The shared Crawl4AI browser configuration does not support changing headless mode per request."
+            )
+        return _crawler_pool
+
+
+def _semantic_worker(output: Any, url: str, markdown: str, semantic_filter: str | None) -> None:
+    """Run Crawl4AI's synchronous embedding stack outside the service process."""
+    try:
+        for variable in ("OMP_NUM_THREADS", "OPENBLAS_NUM_THREADS", "MKL_NUM_THREADS", "NUMEXPR_NUM_THREADS"):
+            os.environ[variable] = "1"
+        import torch
+
+        torch.set_num_threads(1)
+        from crawl4ai import CosineStrategy
+        from crawl4ai.chunking_strategy import RegexChunking
+
+        class SingleChunkCosineStrategy(CosineStrategy):
+            def hierarchical_clustering(self, sentences):
+                if len(sentences) == 1:
+                    return [0]
+                return super().hierarchical_clustering(sentences)
+
+        strategy = SingleChunkCosineStrategy(
+            semantic_filter=semantic_filter,
+            word_count_threshold=20,
+            max_dist=0.2,
+            top_k=5,
+            sim_threshold=0.3,
+            model_name="sentence-transformers/all-MiniLM-L6-v2",
+        )
+        output.put((True, strategy.run(url, RegexChunking().chunk(markdown))))
+    except BaseException as error:
+        output.put((False, str(error)))
+
+
+async def _semantic_extract(url: str, markdown: str, semantic_filter: str | None, timeout: int) -> str:
+    """Hard-stop an isolated semantic worker rather than blocking Polli's event loop."""
+    if not _semantic_slots.acquire(blocking=False):
+        raise RuntimeError("Semantic extractor is busy; try again shortly.")
+    output: Any | None = None
+    process: Any | None = None
+    started = False
+    try:
+        context = multiprocessing.get_context("spawn")
+        output = context.Queue(maxsize=1)
+        process = context.Process(target=_semantic_worker, args=(output, url, markdown, semantic_filter))
+        process.start()
+        started = True
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                success, value = output.get_nowait()
+                if success:
+                    return json.dumps(value, ensure_ascii=False)
+                raise RuntimeError(f"Semantic extraction failed: {value}")
+            except queue.Empty:
+                await asyncio.sleep(0.01)
+        raise TimeoutError
+    finally:
+        if started and process is not None:
+            if process.is_alive():
+                process.terminate()
+            cleanup_deadline = time.monotonic() + 1
+            while process.is_alive() and time.monotonic() < cleanup_deadline:
+                await asyncio.sleep(0.01)
+            if process.is_alive():
+                process.kill()
+                while process.is_alive():
+                    await asyncio.sleep(0.01)
+            process.join()
+        if output is not None:
+            output.close()
+        _semantic_slots.release()
+
 
 _BOT_MARKERS = [
     "cloudflare",
@@ -50,6 +253,21 @@ def _html_to_markdown(html: str) -> str:
         return soup.get_text(separator="\n", strip=True)
 
 
+def _regex_pattern_map(regex_strategy: Any) -> dict[str, Any]:
+    """Map public Crawl4AI 0.9 preset names to its exact IntFlag constants."""
+    return {
+        "email": regex_strategy.Email,
+        "phone": regex_strategy.PhoneIntl,
+        "url": regex_strategy.Url,
+        "date": regex_strategy.DateIso,
+        "currency": regex_strategy.Currency,
+        "ip": regex_strategy.IPv4,
+        "hashtag": regex_strategy.Hashtag,
+        "twitter": regex_strategy.TwitterHandle,
+        "all": regex_strategy.All,
+    }
+
+
 def _needs_browser(
     output_format: str,
     extraction_strategy: str | None,
@@ -91,7 +309,6 @@ async def _try_rnet(url: str, timeout: int) -> str | None:
         client = Client(
             timeout=timeout,
             impersonate=Impersonate.Chrome136,
-            redirect=10,
         )
         resp = await client.get(url)
         status = resp.status
@@ -112,15 +329,17 @@ async def _try_scrapling(url: str, timeout: int) -> str | None:
         from scrapling.fetchers import AsyncFetcher
 
         page = await asyncio.wait_for(
-            AsyncFetcher().get(url, follow_redirects=True),
+            AsyncFetcher.get(url, follow_redirects="safe"),
             timeout=timeout,
         )
         html = page.html_content if hasattr(page, "html_content") else ""
         if not html:
             html = page.body.decode(page.encoding or "utf-8", errors="replace") if hasattr(page, "body") else ""
-        if not html or _is_bot_blocked(html, 200):
+        if not html or _is_bot_blocked(html, page.status):
             return None
-        md = _html_to_markdown(html)
+        md = page.markdown(main_content_only=True)
+        if not md or not md.strip():
+            md = _html_to_markdown(html)
         return md if md and len(md) > 50 else None
     except Exception as e:
         logger.debug(f"scrapling failed for {url}: {e}")
@@ -422,11 +641,17 @@ async def _scrape_with_crawl4ai(
     headless: bool = True,
     session_id: str | None = None,
 ) -> dict:
+    if session_id:
+        return {
+            "success": False,
+            "url": url,
+            "error": "session_id is not supported by the shared browser scraper.",
+        }
     try:
-        from crawl4ai import AsyncWebCrawler, BrowserConfig, CacheMode, CrawlerRunConfig
+        from crawl4ai import BrowserConfig, CacheMode, CrawlerRunConfig
 
         ext_strategy = None
-        if extraction_strategy:
+        if extraction_strategy and extraction_strategy not in {"llm", "cosine"}:
             ext_strategy = _build_extraction_strategy(
                 strategy_type=extraction_strategy,
                 schema=schema,
@@ -444,6 +669,7 @@ async def _scrape_with_crawl4ai(
 
         browser_config = BrowserConfig(
             headless=headless,
+            create_isolated_context=True,
             verbose=False,
         )
 
@@ -458,7 +684,6 @@ async def _scrape_with_crawl4ai(
             wait_for=wait_for,
             screenshot=screenshot,
             pdf=pdf,
-            session_id=session_id,
             simulate_user=simulate_user or magic_mode,
             override_navigator=stealth_mode or magic_mode,
             magic=magic_mode,
@@ -466,9 +691,14 @@ async def _scrape_with_crawl4ai(
             process_iframes=process_iframes,
         )
 
-        async with AsyncWebCrawler(config=browser_config) as crawler:
-            result = await asyncio.wait_for(crawler.arun(url=url, config=crawl_config), timeout=timeout)
-
+        crawler_pool = _get_shared_crawler(browser_config)
+        try:
+            result = await crawler_pool.submit(url, crawl_config, timeout)
+        except RuntimeError as error:
+            if str(error) == "Browser scraper is busy; try again shortly.":
+                return {"success": False, "url": url, "error": str(error)}
+            raise
+        if True:
             if not result.success:
                 return {
                     "success": False,
@@ -503,13 +733,61 @@ async def _scrape_with_crawl4ai(
             if include_raw_html and result.html:
                 response["raw_html"] = result.html
 
-            if result.extracted_content:
-                try:
-                    from ..utils.json import loads as _json_loads
+            if extraction_strategy == "llm":
+                extracted_content = await _pollinations_extract(
+                    rendered,
+                    instruction or "Extract the main content and key information.",
+                    schema,
+                )
+            elif extraction_strategy == "cosine":
+                extracted_content = await _semantic_extract(url, rendered, semantic_filter, timeout)
+            elif extraction_strategy:
+                extracted_content = result.extracted_content
+            else:
+                extracted_content = None
 
-                    response["extracted"] = _json_loads(result.extracted_content)
+            if extraction_strategy:
+                if not extracted_content:
+                    return {
+                        "success": False,
+                        "url": url,
+                        "error": f"{extraction_strategy} extraction returned no result.",
+                    }
+                try:
+                    extracted_value = json.loads(extracted_content)
                 except ValueError:
-                    response["extracted"] = result.extracted_content
+                    if extraction_strategy == "css":
+                        return {
+                            "success": False,
+                            "url": url,
+                            "error": "CSS extraction returned invalid structured data.",
+                        }
+                    extracted_value = extracted_content
+                if isinstance(extracted_value, dict) and extracted_value.get("error"):
+                    return {
+                        "success": False,
+                        "url": url,
+                        "error": f"{extraction_strategy} extraction failed: {extracted_value['error']}",
+                    }
+                if isinstance(extracted_value, list):
+                    extraction_error = next(
+                        (item.get("error") for item in extracted_value if isinstance(item, dict) and item.get("error")),
+                        None,
+                    )
+                    if extraction_error:
+                        return {
+                            "success": False,
+                            "url": url,
+                            "error": f"{extraction_strategy} extraction failed: {extraction_error}",
+                        }
+                if extraction_strategy == "regex" and isinstance(extracted_value, list):
+                    for item in extracted_value:
+                        if isinstance(item, dict) and item.get("label") == "url" and isinstance(item.get("value"), str):
+                            item["value"] = unescape(item["value"])
+                response["extracted"] = extracted_value
+                if extraction_strategy == "css" and extracted_value == []:
+                    response["extraction_empty"] = True
+                    response["markdown"] = ""
 
             if include_links and result.links:
                 internal = result.links.get("internal", [])
@@ -560,6 +838,38 @@ async def _scrape_with_crawl4ai(
         return {"success": False, "url": url, "error": str(e)}
 
 
+async def _pollinations_extract(content: str, instruction: str, schema: dict | None) -> str:
+    """Extract through Pollinations' configured gateway, not a Crawl4AI dummy provider."""
+    from ..ai.client import pollinations_client
+
+    max_content_chars = 24_000
+    bounded_content = content[:max_content_chars]
+    schema_prompt = (
+        f"\nReturn JSON conforming to this schema: {json.dumps(schema, ensure_ascii=False)}"
+        if schema
+        else "\nReturn valid JSON only."
+    )
+    result = await pollinations_client.generate_text(
+        system_prompt=(
+            "You extract requested facts from supplied web content. Do not invent facts. Return only valid JSON."
+        ),
+        user_prompt=(
+            f"Instruction: {instruction}{schema_prompt}\n\n"
+            f"Content (limited to {max_content_chars} characters):\n{bounded_content}"
+        ),
+        temperature=0.0,
+    )
+    if not isinstance(result, str) or not result.strip():
+        raise ValueError("Configured Pollinations extraction returned no output.")
+    try:
+        parsed = json.loads(result)
+    except ValueError as e:
+        raise ValueError("Configured Pollinations extraction returned invalid JSON.") from e
+    if isinstance(parsed, dict) and parsed.get("error"):
+        raise ValueError(f"Configured Pollinations extraction failed: {parsed['error']}")
+    return json.dumps(parsed, ensure_ascii=False)
+
+
 def _build_extraction_strategy(
     strategy_type: str,
     schema: dict | None = None,
@@ -568,23 +878,7 @@ def _build_extraction_strategy(
     regex_patterns: list[str] | None = None,
 ):
     if strategy_type == "llm":
-        from crawl4ai import LLMConfig, LLMExtractionStrategy
-
-        llm_config = LLMConfig(
-            provider="openai/gpt-4o-mini",
-            api_token="dummy",
-        )
-
-        return LLMExtractionStrategy(
-            llm_config=llm_config,
-            instruction=instruction or "Extract the main content and key information.",
-            schema=schema,
-            extraction_type="schema" if schema else "block",
-            apply_chunking=True,
-            chunk_token_threshold=4000,
-            overlap_rate=0.1,
-            input_format="markdown",
-        )
+        raise ValueError("LLM extraction is handled by the configured Pollinations gateway.")
 
     elif strategy_type == "css":
         from crawl4ai import JsonCssExtractionStrategy
@@ -603,9 +897,23 @@ def _build_extraction_strategy(
         return JsonXPathExtractionStrategy(schema=schema, verbose=False)
 
     elif strategy_type == "cosine":
+        try:
+            import torch  # noqa: F401
+        except ImportError as e:
+            raise ImportError(
+                "Semantic extraction requires the Crawl4AI CPU embedding dependencies, including "
+                "a CPU-compatible torch installation."
+            ) from e
         from crawl4ai import CosineStrategy
 
-        return CosineStrategy(
+        class SingleChunkCosineStrategy(CosineStrategy):
+            def hierarchical_clustering(self, sentences):
+                # SciPy linkage requires two observations; one chunk is one cluster.
+                if len(sentences) == 1:
+                    return [0]
+                return super().hierarchical_clustering(sentences)
+
+        return SingleChunkCosineStrategy(
             semantic_filter=semantic_filter,
             word_count_threshold=20,
             max_dist=0.2,
@@ -617,17 +925,7 @@ def _build_extraction_strategy(
     elif strategy_type == "regex":
         from crawl4ai import RegexExtractionStrategy
 
-        pattern_map = {
-            "email": RegexExtractionStrategy.Email,
-            "phone": RegexExtractionStrategy.PhoneIntl,
-            "url": RegexExtractionStrategy.URL,
-            "date": RegexExtractionStrategy.DateISO,
-            "currency": RegexExtractionStrategy.Currency,
-            "ip": RegexExtractionStrategy.IPV4,
-            "hashtag": RegexExtractionStrategy.Hashtag,
-            "twitter": RegexExtractionStrategy.TwitterHandle,
-            "all": RegexExtractionStrategy.All,
-        }
+        pattern_map = _regex_pattern_map(RegexExtractionStrategy)
 
         patterns = regex_patterns or ["email", "url", "phone"]
         combined_pattern = RegexExtractionStrategy.Nothing
@@ -653,11 +951,9 @@ def _build_content_filter(filter_type: str, query: str | None = None):
         return PruningContentFilter(user_query=query, threshold=0.48, threshold_type="fixed")
 
     elif filter_type == "llm":
-        from crawl4ai import LLMConfig, LLMContentFilter
-
-        return LLMContentFilter(
-            llm_config=LLMConfig(provider="openai/gpt-4o-mini", api_token="dummy"),
-            instruction=query or "Extract relevant content",
+        raise ValueError(
+            "LLM content filtering is not configured for Crawl4AI; use a configured Pollinations "
+            "LLM route or configure a real Crawl4AI provider."
         )
 
     else:
@@ -707,12 +1003,49 @@ async def scrape_multiple(
             processed_results.append(result)
             failed += 1
 
+    per_item_limit = 12_000
+    response_limit = 48_000
+    bounded_results: list[dict] = []
+    omitted = 0
+    for item in processed_results:
+        serialized = json.dumps(item, ensure_ascii=False, separators=(",", ":"), default=str)
+        if len(serialized) > per_item_limit:
+            item = {
+                "success": item.get("success", False),
+                "url": str(item.get("url", ""))[:2_000],
+                "url_truncated": len(str(item.get("url", ""))) > 2_000,
+                "output_truncated": True,
+                "output_limit_chars": per_item_limit,
+                "original_output_chars": len(serialized),
+            }
+        candidate = {
+            "success": succeeded > 0,
+            "results": [*bounded_results, item],
+            "succeeded": succeeded,
+            "failed": failed,
+            "total": len(urls),
+            "results_omitted": len(processed_results) - len(bounded_results) - 1,
+            "response_truncated": len(bounded_results) + 1 < len(processed_results),
+            "response_limit_chars": response_limit,
+            "per_item_limit_chars": per_item_limit,
+        }
+        if len(json.dumps(candidate, ensure_ascii=False, separators=(",", ":"), default=str)) > response_limit:
+            omitted = len(processed_results) - len(bounded_results)
+            break
+        bounded_results.append(item)
+    else:
+        omitted = 0
+
     return {
         "success": succeeded > 0,
-        "results": processed_results,
+        "results": bounded_results,
         "succeeded": succeeded,
         "failed": failed,
         "total": len(urls),
+        "results_omitted": omitted,
+        "response_truncated": bool(omitted),
+        "response_limit_chars": response_limit,
+        "per_item_limit_chars": per_item_limit,
     }
 
 
@@ -761,13 +1094,7 @@ async def parse_file_content(
         try:
             from crawl4ai import RegexExtractionStrategy
 
-            pattern_map = {
-                "email": RegexExtractionStrategy.Email,
-                "phone": RegexExtractionStrategy.PhoneIntl,
-                "url": RegexExtractionStrategy.URL,
-                "date": RegexExtractionStrategy.DateISO,
-                "ip": RegexExtractionStrategy.IPV4,
-            }
+            pattern_map = _regex_pattern_map(RegexExtractionStrategy)
 
             combined = RegexExtractionStrategy.Nothing
             for p in extract_patterns:
@@ -778,8 +1105,22 @@ async def parse_file_content(
                 strategy = RegexExtractionStrategy(pattern=combined, input_format="text")
                 extracted = strategy.extract("file", content)
                 response["extracted_patterns"] = extracted
-        except ImportError:
-            pass
+        except ImportError as e:
+            return {
+                "success": False,
+                "file_type": file_type,
+                "length": len(content),
+                "content": content,
+                "error": f"crawl4ai not installed or missing dependency: {e}",
+            }
+        except Exception as e:
+            return {
+                "success": False,
+                "file_type": file_type,
+                "length": len(content),
+                "content": content,
+                "error": f"Regex extraction failed: {e}",
+            }
 
     if instruction:
         try:

--- a/apps/polli/src/search/code_graph.py
+++ b/apps/polli/src/search/code_graph.py
@@ -1,59 +1,83 @@
-"""Structural queries over the local clone via CodeGraph.
-
-Grep answers "where does this string appear"; the graph answers "what calls this, what
-does it call, and what breaks if it changes". The difference matters most for impact
-analysis, which reaches files that never mention the symbol at all — grep cannot find
-those no matter how many times it runs.
-
-The graph is a snapshot built by `codegraph index`, so it needs `sync_graph()` whenever
-the clone moves, or answers silently go stale.
-"""
+"""Structural queries over the local clone via the pinned CodeGraph package."""
 
 from __future__ import annotations
 
 import asyncio
 import json
-import logging
+from pathlib import Path
+from typing import TypeAlias
 
-from ..core.config import config
 from . import local_repo
 from .local_repo import REPO_DIR, RepoError
-
-logger = logging.getLogger(__name__)
 
 COMMAND_TIMEOUT_SECONDS = 60
 MAX_RESULTS = 50
 MAX_IMPACT_DEPTH = 4
+APP_DIR = Path(__file__).resolve().parents[2]
+API_HELPER = Path(__file__).with_name("code_graph_api.js")
+CLI_SHIM = APP_DIR / "node_modules" / "@colbymchenry" / "codegraph" / "npm-shim.js"
+JsonData: TypeAlias = dict | list[dict]
 
 
-async def _run_codegraph(*args: str) -> dict:
-    """Run a codegraph subcommand and parse its JSON output."""
-    if not (REPO_DIR / ".codegraph").is_dir():
-        raise RepoError("No code graph built yet — run sync_graph() first.")
-
+async def _run_process(*args: str, timeout: int = COMMAND_TIMEOUT_SECONDS) -> tuple[str, str]:
     proc = await asyncio.create_subprocess_exec(
-        config.code_search.codegraph_binary,
         *args,
         cwd=str(REPO_DIR),
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
     try:
-        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=COMMAND_TIMEOUT_SECONDS)
-    except TimeoutError:
-        proc.kill()
-        raise RepoError(f"codegraph timed out after {COMMAND_TIMEOUT_SECONDS}s") from None
-
-    out = stdout.decode("utf-8", "replace").strip()
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except (TimeoutError, asyncio.CancelledError) as error:
+        if proc.returncode is None:
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+        await proc.communicate()
+        if isinstance(error, asyncio.CancelledError):
+            raise
+        raise RepoError(f"CodeGraph timed out after {timeout}s") from None
+    stderr_text = stderr.decode("utf-8", "replace").strip()
     if proc.returncode != 0:
-        raise RepoError(f"codegraph failed: {stderr.decode('utf-8', 'replace').strip()[:200]}")
-    if not out:
+        raise RepoError(f"CodeGraph failed: {stderr_text[:200]}")
+    return stdout.decode("utf-8", "replace").strip(), stderr_text
+
+
+async def _run_codegraph(*args: str) -> JsonData:
+    """Backward-compatible name for JSON-producing pinned CLI commands."""
+    return await _run_codegraph_json(*args)
+
+
+async def _run_codegraph_json(*args: str) -> JsonData:
+    """Run the locally pinned CLI and parse a JSON-producing command."""
+    if not (REPO_DIR / ".codegraph").is_dir():
+        raise RepoError("No code graph built yet — run sync_graph() first.")
+    if not CLI_SHIM.is_file():
+        raise RepoError("Pinned CodeGraph dependency is not installed.")
+    stdout, _ = await _run_process("node", str(CLI_SHIM), *args)
+    if not stdout:
         return {}
     try:
-        return json.loads(out)
+        return json.loads(stdout)
     except json.JSONDecodeError:
-        # A symbol that isn't in the graph prints a plain-text notice rather than JSON.
-        raise RepoError(out[:200]) from None
+        raise RepoError(stdout[:200]) from None
+
+
+async def _run_graph_api(action: str, identifier: str, depth: int = 1) -> dict:
+    """Resolve and traverse a node through CodeGraph's public exact-ID API."""
+    if not API_HELPER.is_file():
+        raise RepoError("CodeGraph API helper is unavailable.")
+    stdout, _ = await _run_process("node", str(API_HELPER), action, identifier, str(depth))
+    try:
+        data = json.loads(stdout)
+    except json.JSONDecodeError:
+        raise RepoError("CodeGraph API returned invalid JSON") from None
+    return data if isinstance(data, dict) else {}
+
+
+def _as_dict(data: JsonData) -> dict:
+    return data if isinstance(data, dict) else {}
 
 
 def _format_nodes(nodes: list[dict], limit: int) -> list[dict]:
@@ -74,7 +98,7 @@ def _format_nodes(nodes: list[dict], limit: int) -> list[dict]:
 
 
 async def graph_status() -> dict:
-    data = await _run_codegraph("status", "--json")
+    data = _as_dict(await _run_codegraph("status", "--json"))
     repo = await local_repo.repo_status()
     changes = data.get("pendingChanges") or {}
     pending = sum(int(changes.get(key, 0)) for key in ("added", "modified", "removed"))
@@ -92,10 +116,14 @@ async def graph_status() -> dict:
 
 
 async def symbols(query: str, *, limit: int = 20) -> dict:
+    """Fuzzy symbol discovery; use a returned stable ID for traversal."""
     limit = max(1, min(limit, MAX_RESULTS))
     data = await _run_codegraph("query", query, "--json", "--limit", str(limit))
     status = await graph_status()
-    results = _format_nodes([item.get("node", item) for item in data], limit)
+    items = data if isinstance(data, list) else []
+    nodes = [item.get("node", item) for item in items if isinstance(item, dict)]
+    exact = [node for node in nodes if query in (node.get("id"), node.get("name"), node.get("qualifiedName"))]
+    results = _format_nodes(exact or nodes, limit)
     return {
         "query": query,
         "relation": "symbols",
@@ -106,78 +134,47 @@ async def symbols(query: str, *, limit: int = 20) -> dict:
     }
 
 
-async def callers(symbol: str, *, limit: int = 20) -> dict:
-    """Which functions call `symbol`."""
-    limit = max(1, min(limit, MAX_RESULTS))
-    data = await _run_codegraph("callers", symbol, "--json", "--limit", str(limit))
+async def _relationship(action: str, symbol: str, *, limit: int, depth: int = 1) -> dict:
+    data = await _run_graph_api(action, symbol, depth)
+    target = data.get("target", {})
+    target_id = target.get("id")
+    if not isinstance(target_id, str):
+        raise RepoError("CodeGraph API did not return a stable target ID.")
     status = await graph_status()
-    found = _format_nodes(data.get("callers", []), limit)
+    nodes = data.get("nodes", [])
+    if action == "impact":
+        nodes = [node for node in nodes if node.get("id") != target_id]
+    results = _format_nodes(nodes, limit)
     return {
-        "symbol": symbol,
-        "relation": "callers",
+        "symbol": target.get("qualifiedName") or target_id,
+        "symbol_id": target_id,
+        "relation": action,
         "revision": status["revision"],
         "fresh": status["fresh"],
-        "count": len(found),
-        "results": found,
-        "message": f"{len(found)} caller(s) of {symbol}" if found else f"No callers found for {symbol}",
+        "depth": data.get("depth") if action == "impact" else None,
+        "count": len(results),
+        "results": results,
     }
+
+
+async def callers(symbol: str, *, limit: int = 20) -> dict:
+    return await _relationship("callers", symbol, limit=max(1, min(limit, MAX_RESULTS)))
 
 
 async def callees(symbol: str, *, limit: int = 20) -> dict:
-    """Which functions `symbol` calls."""
-    limit = max(1, min(limit, MAX_RESULTS))
-    data = await _run_codegraph("callees", symbol, "--json", "--limit", str(limit))
-    status = await graph_status()
-    found = _format_nodes(data.get("callees", []), limit)
-    return {
-        "symbol": symbol,
-        "relation": "callees",
-        "revision": status["revision"],
-        "fresh": status["fresh"],
-        "count": len(found),
-        "results": found,
-        "message": f"{symbol} calls {len(found)} symbol(s)" if found else f"No callees found for {symbol}",
-    }
+    return await _relationship("callees", symbol, limit=max(1, min(limit, MAX_RESULTS)))
 
 
 async def impact(symbol: str, *, depth: int = 2) -> dict:
-    """Everything transitively affected by changing `symbol`."""
     depth = max(1, min(depth, MAX_IMPACT_DEPTH))
-    data = await _run_codegraph("impact", symbol, "--json", "--depth", str(depth))
-    status = await graph_status()
-    affected = _format_nodes(data.get("affected", []), MAX_RESULTS)
-    return {
-        "symbol": symbol,
-        "relation": "impact",
-        "revision": status["revision"],
-        "fresh": status["fresh"],
-        "depth": data.get("depth", depth),
-        "count": len(affected),
-        "results": affected,
-        "message": (
-            f"{len(affected)} symbol(s) affected by changing {symbol} (depth {depth}). "
-            "Includes files that never name the symbol directly."
-        ),
-    }
+    return await _relationship("impact", symbol, limit=MAX_RESULTS, depth=depth)
 
 
 async def sync_graph() -> dict:
-    """Bring the graph up to date with the clone. Cheap enough to run on every merge."""
+    """Build or synchronize the graph with the same pinned CLI package."""
+    if not CLI_SHIM.is_file():
+        raise RepoError("Pinned CodeGraph dependency is not installed.")
     graph_exists = (REPO_DIR / ".codegraph").is_dir()
-    args = ("sync", "--quiet") if graph_exists else ("init", ".")
-
-    proc = await asyncio.create_subprocess_exec(
-        config.code_search.codegraph_binary,
-        *args,
-        cwd=str(REPO_DIR),
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
-    try:
-        _, stderr = await asyncio.wait_for(proc.communicate(), timeout=300)
-    except TimeoutError:
-        proc.kill()
-        raise RepoError("codegraph sync timed out") from None
-    if proc.returncode != 0:
-        raise RepoError(f"codegraph {args[0]} failed: {stderr.decode('utf-8', 'replace').strip()[:200]}")
+    args = ("sync", "--quiet") if graph_exists else ("init", ".", "--yes")
+    await _run_process("node", str(CLI_SHIM), *args, timeout=300)
     return {"action": args[0], "ok": True}

--- a/apps/polli/src/search/code_graph_api.js
+++ b/apps/polli/src/search/code_graph_api.js
@@ -4,68 +4,81 @@ const [action, identifier, depthArgument] = process.argv.slice(2);
 const depth = Number.parseInt(depthArgument, 10);
 
 function serializeNode(node) {
-  return {
-    id: node.id,
-    name: node.name,
-    qualifiedName: node.qualifiedName,
-    signature: node.signature,
-    kind: node.kind,
-    language: node.language,
-    filePath: node.filePath,
-    startLine: node.startLine,
-    endLine: node.endLine,
-  };
+    return {
+        id: node.id,
+        name: node.name,
+        qualifiedName: node.qualifiedName,
+        signature: node.signature,
+        kind: node.kind,
+        language: node.language,
+        filePath: node.filePath,
+        startLine: node.startLine,
+        endLine: node.endLine,
+    };
 }
 
 function resolveNode(graph, value) {
-  const byId = graph.getNode(value);
-  if (byId) return byId;
+    const byId = graph.getNode(value);
+    if (byId) return byId;
 
-  const matches = graph
-    .getNodesByName(value)
-    .filter((node) => node.name === value || node.qualifiedName === value);
-  if (matches.length === 0) throw new Error(`No exact symbol for '${value}'`);
-  if (matches.length > 1) {
-    const candidates = matches
-      .slice(0, 5)
-      .map((node) => `${node.qualifiedName || node.name} (${node.filePath}:${node.startLine})`)
-      .join(", ");
-    throw new Error(`Ambiguous symbol '${value}'. Use a stable ID. Candidates: ${candidates}`);
-  }
-  return matches[0];
+    const matches = graph
+        .getNodesByName(value)
+        .filter((node) => node.name === value || node.qualifiedName === value);
+    if (matches.length === 0) throw new Error(`No exact symbol for '${value}'`);
+    if (matches.length > 1) {
+        const candidates = matches
+            .slice(0, 5)
+            .map(
+                (node) =>
+                    `${node.qualifiedName || node.name} (${node.filePath}:${node.startLine})`,
+            )
+            .join(", ");
+        throw new Error(
+            `Ambiguous symbol '${value}'. Use a stable ID. Candidates: ${candidates}`,
+        );
+    }
+    return matches[0];
 }
 
 async function main() {
-  const graph = await CodeGraph.open(process.cwd());
-  try {
-    const target = resolveNode(graph, identifier);
-    let nodes;
-    let resultDepth;
-    if (action === "resolve") {
-      nodes = [];
-    } else if (action === "callers") {
-      nodes = graph.getCallers(target.id).map(({ node }) => node);
-    } else if (action === "callees") {
-      nodes = graph.getCallees(target.id).map(({ node }) => node);
-    } else if (action === "impact") {
-      const impact = graph.getImpactRadius(target.id, depth);
-      const nodeIds = new Set([target.id, ...impact.nodes.keys()]);
-      for (const edge of impact.edges) {
-        nodeIds.add(edge.source);
-        nodeIds.add(edge.target);
-      }
-      nodes = [...nodeIds].map((nodeId) => graph.getNode(nodeId)).filter(Boolean);
-      resultDepth = depth;
-    } else {
-      throw new Error(`Unknown action '${action}'`);
+    const graph = await CodeGraph.open(process.cwd());
+    try {
+        const target = resolveNode(graph, identifier);
+        let nodes;
+        let resultDepth;
+        if (action === "resolve") {
+            nodes = [];
+        } else if (action === "callers") {
+            nodes = graph.getCallers(target.id).map(({ node }) => node);
+        } else if (action === "callees") {
+            nodes = graph.getCallees(target.id).map(({ node }) => node);
+        } else if (action === "impact") {
+            const impact = graph.getImpactRadius(target.id, depth);
+            const nodeIds = new Set([target.id, ...impact.nodes.keys()]);
+            for (const edge of impact.edges) {
+                nodeIds.add(edge.source);
+                nodeIds.add(edge.target);
+            }
+            nodes = [...nodeIds]
+                .map((nodeId) => graph.getNode(nodeId))
+                .filter(Boolean);
+            resultDepth = depth;
+        } else {
+            throw new Error(`Unknown action '${action}'`);
+        }
+        process.stdout.write(
+            JSON.stringify({
+                target: serializeNode(target),
+                nodes: nodes.map(serializeNode),
+                depth: resultDepth,
+            }),
+        );
+    } finally {
+        graph.close();
     }
-    process.stdout.write(JSON.stringify({ target: serializeNode(target), nodes: nodes.map(serializeNode), depth: resultDepth }));
-  } finally {
-    graph.close();
-  }
 }
 
 main().catch((error) => {
-  process.stderr.write(`${error.message}\n`);
-  process.exit(1);
+    process.stderr.write(`${error.message}\n`);
+    process.exit(1);
 });

--- a/apps/polli/src/search/code_graph_api.js
+++ b/apps/polli/src/search/code_graph_api.js
@@ -1,0 +1,71 @@
+const { CodeGraph } = require("@colbymchenry/codegraph");
+
+const [action, identifier, depthArgument] = process.argv.slice(2);
+const depth = Number.parseInt(depthArgument, 10);
+
+function serializeNode(node) {
+  return {
+    id: node.id,
+    name: node.name,
+    qualifiedName: node.qualifiedName,
+    signature: node.signature,
+    kind: node.kind,
+    language: node.language,
+    filePath: node.filePath,
+    startLine: node.startLine,
+    endLine: node.endLine,
+  };
+}
+
+function resolveNode(graph, value) {
+  const byId = graph.getNode(value);
+  if (byId) return byId;
+
+  const matches = graph
+    .getNodesByName(value)
+    .filter((node) => node.name === value || node.qualifiedName === value);
+  if (matches.length === 0) throw new Error(`No exact symbol for '${value}'`);
+  if (matches.length > 1) {
+    const candidates = matches
+      .slice(0, 5)
+      .map((node) => `${node.qualifiedName || node.name} (${node.filePath}:${node.startLine})`)
+      .join(", ");
+    throw new Error(`Ambiguous symbol '${value}'. Use a stable ID. Candidates: ${candidates}`);
+  }
+  return matches[0];
+}
+
+async function main() {
+  const graph = await CodeGraph.open(process.cwd());
+  try {
+    const target = resolveNode(graph, identifier);
+    let nodes;
+    let resultDepth;
+    if (action === "resolve") {
+      nodes = [];
+    } else if (action === "callers") {
+      nodes = graph.getCallers(target.id).map(({ node }) => node);
+    } else if (action === "callees") {
+      nodes = graph.getCallees(target.id).map(({ node }) => node);
+    } else if (action === "impact") {
+      const impact = graph.getImpactRadius(target.id, depth);
+      const nodeIds = new Set([target.id, ...impact.nodes.keys()]);
+      for (const edge of impact.edges) {
+        nodeIds.add(edge.source);
+        nodeIds.add(edge.target);
+      }
+      nodes = [...nodeIds].map((nodeId) => graph.getNode(nodeId)).filter(Boolean);
+      resultDepth = depth;
+    } else {
+      throw new Error(`Unknown action '${action}'`);
+    }
+    process.stdout.write(JSON.stringify({ target: serializeNode(target), nodes: nodes.map(serializeNode), depth: resultDepth }));
+  } finally {
+    graph.close();
+  }
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error.message}\n`);
+  process.exit(1);
+});

--- a/apps/polli/tests/test_code_intelligence.py
+++ b/apps/polli/tests/test_code_intelligence.py
@@ -1,5 +1,84 @@
+import json
+import subprocess
+import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
+
+APP_DIR = Path(__file__).resolve().parents[1]
+API_HELPER = APP_DIR / "src" / "search" / "code_graph_api.js"
+CODEGRAPH = APP_DIR / "node_modules" / ".bin" / ("codegraph.cmd" if __import__("os").name == "nt" else "codegraph")
+NODE = "node"
+
+
+def run_graph_command(fixture: Path, *args: str) -> dict | list:
+    result = subprocess.run(
+        args,
+        cwd=fixture,
+        capture_output=True,
+        check=True,
+        text=True,
+        timeout=120,
+    )
+    return json.loads(result.stdout)
+
+
+def node_available() -> bool:
+    return (
+        API_HELPER.is_file()
+        and CODEGRAPH.is_file()
+        and subprocess.run([NODE, "--version"], capture_output=True, check=False, timeout=10).returncode == 0
+    )
+
+
+@unittest.skipUnless(node_available(), "pinned CodeGraph Node dependency is not installed")
+class CodeGraphApiIntegrationTests(unittest.TestCase):
+    def test_stable_ids_isolate_duplicate_callers_callees_and_impact(self):
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Path(directory)
+            (fixture / "one.py").write_text(
+                "def duplicate():\n    return 'one'\n\ndef caller_one():\n    return duplicate()\n"
+            )
+            (fixture / "two.py").write_text(
+                "def duplicate():\n    return 'two'\n\ndef caller_two():\n    return duplicate()\n"
+            )
+            subprocess.run(
+                [str(CODEGRAPH), "init", ".", "--yes"], cwd=fixture, check=True, capture_output=True, timeout=120
+            )
+            symbols = run_graph_command(fixture, str(CODEGRAPH), "query", "duplicate", "--json", "--limit", "10")
+            one_id = next(item["node"]["id"] for item in symbols if item["node"]["filePath"] == "one.py")
+            two_id = next(item["node"]["id"] for item in symbols if item["node"]["filePath"] == "two.py")
+
+            one_callers = run_graph_command(fixture, NODE, str(API_HELPER), "callers", one_id, "1")
+            two_callers = run_graph_command(fixture, NODE, str(API_HELPER), "callers", two_id, "1")
+            one_callees = run_graph_command(
+                fixture, NODE, str(API_HELPER), "callees", one_callers["nodes"][0]["id"], "1"
+            )
+            one_impact = run_graph_command(fixture, NODE, str(API_HELPER), "impact", one_id, "2")
+
+            self.assertEqual([node["name"] for node in one_callers["nodes"]], ["caller_one"])
+            self.assertEqual([node["name"] for node in two_callers["nodes"]], ["caller_two"])
+            self.assertEqual([node["id"] for node in one_callees["nodes"]], [one_id])
+            self.assertEqual({node["name"] for node in one_impact["nodes"]}, {"duplicate", "caller_one"})
+
+    def test_unknown_stable_id_fails(self):
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Path(directory)
+            (fixture / "source.py").write_text("def target():\n    return None\n")
+            subprocess.run(
+                [str(CODEGRAPH), "init", ".", "--yes"], cwd=fixture, check=True, capture_output=True, timeout=120
+            )
+            result = subprocess.run(
+                [NODE, str(API_HELPER), "callers", "function:missing", "1"],
+                cwd=fixture,
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("No exact symbol", result.stderr)
+
 
 from src.ai.tool_filters import get_tools_with_embeddings
 from src.ai.tools import GITHUB_TOOLS
@@ -30,7 +109,8 @@ class GraphResultTests(unittest.IsolatedAsyncioTestCase):
                     "language": "python",
                 },
                 "score": 99.5,
-            }
+            },
+            {"node": {"id": "method:unrelated", "name": "canCoverEstimatedCharge"}, "score": 50},
         ]
         with (
             patch.object(code_graph, "_run_codegraph", AsyncMock(return_value=response)),
@@ -38,9 +118,34 @@ class GraphResultTests(unittest.IsolatedAsyncioTestCase):
         ):
             result = await code_graph.symbols("process_with_tools", limit=5)
 
+        self.assertEqual(result["count"], 1)
         self.assertEqual(result["results"][0]["id"], "method:abc")
         self.assertEqual(result["results"][0]["qualified_name"], "PollinationsClient::process_with_tools")
         self.assertEqual(result["revision"], "abc123")
+
+    @unittest.skipUnless(node_available(), "pinned CodeGraph Node dependency is not installed")
+    async def test_python_wrapper_uses_pinned_cli_and_exact_id_api(self):
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Path(directory)
+            (fixture / "one.py").write_text(
+                "def duplicate():\n    return 'one'\n\ndef caller_one():\n    return duplicate()\n"
+            )
+            (fixture / "two.py").write_text(
+                "def duplicate():\n    return 'two'\n\ndef caller_two():\n    return duplicate()\n"
+            )
+            with (
+                patch.object(code_graph, "REPO_DIR", fixture),
+                patch("src.search.code_graph.local_repo.repo_status", AsyncMock(return_value={"commit": "fixture"})),
+            ):
+                synced = await code_graph.sync_graph()
+                discovered = await code_graph.symbols("duplicate", limit=10)
+                one_id = next(node["id"] for node in discovered["results"] if node["file"] == "one.py")
+                callers = await code_graph.callers(one_id)
+                impacted = await code_graph.impact(one_id, depth=2)
+
+            self.assertEqual(synced, {"action": "init", "ok": True})
+            self.assertEqual([node["symbol"] for node in callers["results"]], ["caller_one"])
+            self.assertEqual([node["symbol"] for node in impacted["results"]], ["caller_one"])
 
     async def test_status_marks_graph_stale_when_clone_has_changes(self):
         status = {"pendingChanges": {"modified": 1}, "lastIndexed": "2026-09-04T00:00:00Z"}

--- a/apps/polli/tests/test_conversation_admission.py
+++ b/apps/polli/tests/test_conversation_admission.py
@@ -1,0 +1,54 @@
+import ast
+import asyncio
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+
+class ConversationAdmissionTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        path = Path(__file__).parents[1] / "src" / "bot.py"
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        function = next(
+            node for node in tree.body if isinstance(node, ast.AsyncFunctionDef) and node.name == "process_message"
+        )
+        module = ast.Module(
+            body=[ast.ImportFrom(module="__future__", names=[ast.alias(name="annotations")], level=0), function],
+            type_ignores=[],
+        )
+        self.namespace = {"_active_conversations": set(), "_process_message": AsyncMock()}
+        exec(compile(ast.fix_missing_locations(module), str(path), "exec"), self.namespace)
+        self.call = self.namespace["process_message"]
+
+    async def test_overlap_rejected_and_other_channel_runs(self):
+        entered = asyncio.Event()
+        release = asyncio.Event()
+
+        async def work(channel, *args):
+            if channel.id == 1:
+                entered.set()
+                await release.wait()
+
+        worker = self.namespace["_process_message"]
+        worker.side_effect = work
+        channel = SimpleNamespace(id=1, send=AsyncMock())
+        first = asyncio.create_task(self.call(channel, None, "first", [], None))
+        await entered.wait()
+        try:
+            await self.call(channel, None, "second", [], None)
+            channel.send.assert_awaited_once()
+            await self.call(SimpleNamespace(id=2, send=AsyncMock()), None, "other", [], None)
+            self.assertEqual(worker.await_count, 2)
+        finally:
+            release.set()
+            await first
+        self.assertEqual(self.namespace["_active_conversations"], set())
+
+    async def test_failure_and_cancellation_release_admission(self):
+        channel = SimpleNamespace(id=1, send=AsyncMock())
+        for error in (RuntimeError("failed"), asyncio.CancelledError()):
+            self.namespace["_process_message"].side_effect = error
+            with self.assertRaises(type(error)):
+                await self.call(channel, None, "test", [], None)
+            self.assertEqual(self.namespace["_active_conversations"], set())

--- a/apps/polli/tests/test_discord_search_hardening.py
+++ b/apps/polli/tests/test_discord_search_hardening.py
@@ -15,6 +15,8 @@ class FakePermissions:
 
 class FakeThread:
     def __init__(self, *, private=True, members=(), permissions=None, guild=None):
+        self.id: int = 0
+        self.name: str = ""
         self.type = "private_thread" if private else "public_thread"
         self.members = list(members)
         self.guild = guild
@@ -94,6 +96,25 @@ class HandlerValidationAndScopeTests(unittest.IsolatedAsyncioTestCase):
             result = await tool_discord_search("thread_history", 5, thread_id=55, _context=context)
         self.assertIn("permission", result["error"])
 
+    async def test_cached_thread_resolves_as_context_channel(self):
+        thread = FakeThread(private=False)
+        thread.id = 55
+        thread.name = "cached"
+        guild = self.guild(threads=[thread])
+        guild.me = object()
+        guild.get_member = lambda _id: object()
+        guild.get_channel = lambda _id: None
+        with patch("src.discord.search.discord.Thread", FakeThread):
+            with patch(
+                "src.discord.search.discord_search_client.get_message_context",
+                AsyncMock(return_value={"success": True}),
+            ) as context:
+                result = await tool_discord_search(
+                    "context", 5, channel_id=55, message_id=10, _context={"discord_guild": guild, "user_id": 1}
+                )
+        self.assertTrue(result["success"])
+        self.assertIs(context.await_args.kwargs["channel"], thread)
+
     async def test_history_requires_read_message_history(self):
         channel = SimpleNamespace(
             id=10, name="private", permissions_for=lambda _member: FakePermissions(read_message_history=False)
@@ -131,6 +152,97 @@ class SearchClientTests(unittest.IsolatedAsyncioTestCase):
             with self.assertRaises(asyncio.CancelledError):
                 await client.search_messages(1, "hello")
         sleep.assert_awaited_once_with(11.0)
+
+
+class ThreadHistoryRegressionTests(unittest.IsolatedAsyncioTestCase):
+    async def test_oldest_first_history_does_not_advertise_an_older_page(self):
+        client = DiscordSearchClient()
+        first = SimpleNamespace(
+            id=10,
+            content="first",
+            author=SimpleNamespace(id=1, name="one"),
+            created_at=SimpleNamespace(isoformat=lambda: "first"),
+            attachments=[],
+            jump_url="first-url",
+        )
+        second = SimpleNamespace(
+            id=20,
+            content="second",
+            author=SimpleNamespace(id=2, name="two"),
+            created_at=SimpleNamespace(isoformat=lambda: "second"),
+            attachments=[],
+            jump_url="second-url",
+        )
+        history_calls = []
+
+        async def history(**kwargs):
+            history_calls.append(kwargs)
+            for message in (first, second):
+                yield message
+
+        thread = SimpleNamespace(
+            id=55,
+            name="thread",
+            parent=SimpleNamespace(name="parent"),
+            owner_id=None,
+            created_at=None,
+            archived=False,
+            locked=False,
+            message_count=999,
+            history=history,
+        )
+        result = await client.get_thread_history(thread, limit=2, before=99, oldest_first=True)
+
+        self.assertTrue(history_calls[0]["oldest_first"])
+        self.assertEqual(history_calls[0]["before"].id, 99)
+        self.assertEqual([message["id"] for message in result["messages"]], ["10", "20"])
+        self.assertIsNone(result["oldest_id"])
+        self.assertEqual(result["reported_message_count"], 999)
+        self.assertEqual(result["retrieved_message_count"], 2)
+        self.assertNotIn("total_messages", result)
+        self.assertIsNone(result["has_more"])
+        self.assertNotIn("before=", result["note"])
+
+    async def test_history_desc_and_asc_use_truthful_pagination(self):
+        client = DiscordSearchClient()
+        messages = [
+            SimpleNamespace(
+                id=message_id,
+                content=str(message_id),
+                author=SimpleNamespace(id=message_id, name=str(message_id)),
+                created_at=SimpleNamespace(isoformat=lambda: "time"),
+                attachments=[],
+                jump_url="url",
+            )
+            for message_id in (30, 20)
+        ]
+        calls = []
+
+        async def history(**kwargs):
+            calls.append(kwargs)
+            for message in messages:
+                yield message
+
+        thread = SimpleNamespace(
+            id=55,
+            name="thread",
+            parent=None,
+            owner_id=None,
+            created_at=None,
+            archived=False,
+            locked=False,
+            message_count=2,
+            history=history,
+        )
+        descending = await client.get_thread_history(thread, limit=2)
+        ascending = await client.get_thread_history(thread, limit=2, oldest_first=True)
+
+        self.assertFalse(calls[0]["oldest_first"])
+        self.assertTrue(calls[1]["oldest_first"])
+        self.assertTrue(descending["has_more"])
+        self.assertIn("before=20", descending["note"])
+        self.assertIsNone(ascending["has_more"])
+        self.assertNotIn("before=", ascending["note"])
 
 
 class RegressionCoverageTests(unittest.IsolatedAsyncioTestCase):
@@ -221,7 +333,10 @@ class RegressionCoverageTests(unittest.IsolatedAsyncioTestCase):
                 channel_id=10,
                 _context={"discord_guild": guild, "discord_bot": bot, "user_id": 1},
             )
-        self.assertIn(10, search.await_args.kwargs["accessible_channel_ids"])
+        call = search.await_args
+        self.assertIsNotNone(call)
+        assert call is not None
+        self.assertIn(10, call.kwargs["accessible_channel_ids"])
 
     async def test_missing_requester_denies_public_thread_and_roles_before_helpers(self):
         thread = FakeThread(private=False)
@@ -249,6 +364,30 @@ class RegressionCoverageTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(role_result["error"], "Unable to verify your Discord membership for this server.")
         history.assert_not_awaited()
         roles.assert_not_awaited()
+
+    async def test_role_name_filters_roles_without_query(self):
+        role = SimpleNamespace(
+            id=9,
+            name="Moderator",
+            color="blue",
+            position=1,
+            mentionable=True,
+            members=[],
+            mention="<@&9>",
+        )
+        guild = SimpleNamespace(
+            id=1,
+            me=object(),
+            channels=[],
+            threads=[],
+            roles=[SimpleNamespace(name="@everyone"), role],
+            default_role=object(),
+            chunked=True,
+            members=[],
+            get_member=lambda _id: object(),
+        )
+        result = await tool_discord_search("roles", 5, role_name="mod", _context={"discord_guild": guild, "user_id": 1})
+        self.assertEqual([item["id"] for item in result["roles"]], ["9"])
 
     async def test_missing_bot_member_fails_closed_before_search(self):
         channel = SimpleNamespace(id=10, name="public", permissions_for=lambda _member: FakePermissions())

--- a/apps/polli/tests/test_github_data_controls.py
+++ b/apps/polli/tests/test_github_data_controls.py
@@ -1,0 +1,569 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from urllib.parse import parse_qs, urlsplit
+
+from src.integrations.github.graphql import GitHubGraphQL
+from src.integrations.github.pr_review import PRReviewMixin
+
+
+def issue_node(number: int, body: str, author: str = "octocat") -> dict:
+    return {
+        "number": number,
+        "title": f"issue {number}",
+        "body": body,
+        "state": "OPEN",
+        "url": "https://example.test",
+        "createdAt": "2026-01-01T00:00:00Z",
+        "updatedAt": "2026-01-01T00:00:00Z",
+        "author": {"login": author},
+        "labels": {"nodes": []},
+        "comments": {"totalCount": 0},
+    }
+
+
+class SearchUserIssuesTests(unittest.IsolatedAsyncioTestCase):
+    async def test_searches_later_page_for_exact_canonical_author(self):
+        client = GitHubGraphQL()
+        client._execute = AsyncMock(
+            side_effect=[
+                {
+                    "data": {
+                        "search": {
+                            "pageInfo": {"hasNextPage": True, "endCursor": "next"},
+                            "nodes": [issue_node(1, "**Author:** Bea")],
+                        }
+                    }
+                },
+                {
+                    "data": {
+                        "search": {
+                            "pageInfo": {"hasNextPage": False, "endCursor": None},
+                            "nodes": [issue_node(2, "**Author:** Ada")],
+                        }
+                    }
+                },
+            ]
+        )
+
+        result = await client.search_user_issues("Ada")
+
+        self.assertEqual([issue["number"] for issue in result], [2])
+        self.assertIn('"Ada"', client._execute.await_args_list[0].args[1]["query"])
+        self.assertEqual(client._execute.await_args_list[1].args[1]["after"], "next")
+
+
+class CustomFilteringTests(unittest.IsolatedAsyncioTestCase):
+    async def test_custom_author_uses_server_filter_and_honors_include_body(self):
+        client = GitHubGraphQL()
+        client._execute = AsyncMock(
+            return_value={
+                "data": {
+                    "search": {
+                        "issueCount": 2,
+                        "pageInfo": {"hasNextPage": True},
+                        "nodes": [issue_node(9, "private body")],
+                    }
+                }
+            }
+        )
+
+        result = await client.execute_custom_request(request="issues", author="octocat", limit=1)
+
+        self.assertEqual(result["data"]["issues"]["matched_total"], 2)
+        self.assertNotIn("body", result["data"]["issues"]["items"][0])
+        variables = client._execute.await_args.args[1]
+        self.assertIn("repo:", variables["query"])
+        self.assertIn("author:octocat", variables["query"])
+        self.assertNotIn(" body ", client._execute.await_args.args[0])
+
+    async def test_custom_rejects_author_qualifier_injection(self):
+        result = await GitHubGraphQL().execute_custom_request(request="issues", author="octocat is:closed")
+
+        self.assertEqual(result["error"], "author must be a valid GitHub login")
+
+
+class RestEndpointTests(unittest.IsolatedAsyncioTestCase):
+    async def test_endpoint_query_is_normalized_before_pagination(self):
+        client = GitHubGraphQL()
+        client._rest_get = AsyncMock(return_value={"data": []})
+
+        await client.execute_custom_request(rest_endpoint="issues?state=open&page=99", request="", limit=20, page=2)
+
+        url = client._rest_get.await_args.args[0]
+        self.assertEqual(url.count("?"), 1)
+        self.assertEqual(parse_qs(urlsplit(url).query), {"state": ["open"], "page": ["2"], "per_page": ["20"]})
+
+
+class RestSearchPaginationTests(unittest.IsolatedAsyncioTestCase):
+    async def test_search_fetches_multiple_pages(self):
+        from src.integrations.github.client import GitHubManager
+
+        client = GitHubManager()
+        items = [
+            {
+                "number": number,
+                "title": str(number),
+                "body": "",
+                "state": "open",
+                "html_url": "https://example.test",
+                "labels": [],
+                "created_at": "2026-01-01T00:00:00Z",
+                "user": {"login": "ada"},
+            }
+            for number in range(150)
+        ]
+        payloads = [{"total_count": 250, "items": items[:100]}, {"total_count": 250, "items": items[100:]}]
+
+        class Request:
+            def __init__(self, payload):
+                self.payload = payload
+
+            async def __aenter__(self):
+                return SimpleNamespace(status=200, json=AsyncMock(return_value=self.payload))
+
+            async def __aexit__(self, *_args):
+                return None
+
+        calls = []
+        client.get_session = AsyncMock(
+            return_value=SimpleNamespace(get=lambda url, **_kwargs: calls.append(url) or Request(payloads.pop(0)))
+        )
+        client._get_headers = AsyncMock(return_value={})
+        with patch("src.integrations.github.client.has_github_auth", return_value=True):
+            result = await client.search_issues("bug", limit=150)
+        self.assertEqual(len(result), 150)
+        self.assertIn("page=2", calls[1])
+
+
+class CustomPullRequestIntentTests(unittest.IsolatedAsyncioTestCase):
+    async def test_natural_language_prs_by_author_does_not_query_issues(self):
+        client = GitHubGraphQL()
+        with patch(
+            "src.integrations.github.pull_requests.github_pr_manager.list_prs",
+            AsyncMock(return_value={"prs": [], "state": "all", "author": "octocat"}),
+        ) as list_prs:
+            result = await client.execute_custom_request(request="PRs by author", author="octocat")
+
+        self.assertNotIn("issues", result["data"])
+        self.assertEqual(result["data"]["pull_requests"]["author"], "octocat")
+        self.assertEqual(list_prs.await_args.kwargs["state"], "all")
+
+    async def test_bug_report_queries_issues_not_pull_requests(self):
+        client = GitHubGraphQL()
+        client._fetch_all_issues = AsyncMock(return_value={"items": []})
+        with patch("src.integrations.github.pull_requests.github_pr_manager.list_prs", AsyncMock()) as list_prs:
+            result = await client.execute_custom_request(request="bug report")
+
+        self.assertIn("issues", result["data"])
+        list_prs.assert_not_awaited()
+
+    async def test_explicit_issues_and_prs_query_both(self):
+        client = GitHubGraphQL()
+        client._fetch_all_issues = AsyncMock(return_value={"items": []})
+        with patch(
+            "src.integrations.github.pull_requests.github_pr_manager.list_prs", AsyncMock(return_value={"prs": []})
+        ) as list_prs:
+            result = await client.execute_custom_request(request="open issues and closed PRs")
+
+        self.assertIn("issues", result["data"])
+        self.assertIn("pull_requests", result["data"])
+        self.assertEqual(list_prs.await_args.kwargs["state"], "closed")
+
+
+class NativeQueryTests(unittest.IsolatedAsyncioTestCase):
+    def test_query_pins_scope_and_preserves_native_qualifiers(self):
+        from src.integrations.github.graphql import build_scoped_search_query
+
+        result = build_scoped_search_query(
+            'label:"help wanted" milestone:"v1" created:>=2026-01-01',
+            repository="pollinations/pollinations",
+            kind="pr",
+        )
+
+        self.assertEqual(
+            result,
+            'repo:pollinations/pollinations is:pr (label:"help wanted" milestone:"v1" created:>=2026-01-01)',
+        )
+
+    def test_query_rejects_conflicting_scope(self):
+        from src.integrations.github.graphql import build_scoped_search_query
+
+        result = build_scoped_search_query(
+            "repo:other/repo is:issue", repository="pollinations/pollinations", kind="pr"
+        )
+
+        self.assertEqual(result["error"], "query repo qualifier conflicts with the configured repository")
+
+    async def test_pr_query_does_not_default_to_open(self):
+        from src.integrations.github.pull_requests import GitHubPRManager
+
+        response = {"data": {"search": {"issueCount": 0, "pageInfo": {"hasNextPage": False}, "nodes": []}}}
+        with (
+            patch("src.integrations.github.pull_requests.has_github_auth", return_value=True),
+            patch(
+                "src.integrations.github.pull_requests.github_graphql._execute", AsyncMock(return_value=response)
+            ) as execute,
+        ):
+            await GitHubPRManager().list_prs(query='label:"help wanted"')
+
+        query = execute.await_args.args[1]["query"]
+        self.assertIn("is:pr", query)
+        self.assertNotIn("is:open", query)
+
+    async def test_pr_handler_omits_state_for_native_query(self):
+        from src.integrations.github.pull_requests import github_pr_manager, tool_github_pr
+
+        with patch.object(github_pr_manager, "list_prs", AsyncMock(return_value={})) as list_prs:
+            await tool_github_pr(action="list", query="is:closed")
+
+        self.assertIsNone(list_prs.await_args.kwargs["state"])
+
+    async def test_pr_query_forwards_cursor_to_search_document(self):
+        from src.integrations.github.pull_requests import GitHubPRManager
+
+        response = {
+            "data": {
+                "search": {
+                    "issueCount": 1,
+                    "pageInfo": {"hasNextPage": True, "endCursor": "next"},
+                    "nodes": [],
+                }
+            }
+        }
+        with (
+            patch("src.integrations.github.pull_requests.has_github_auth", return_value=True),
+            patch(
+                "src.integrations.github.pull_requests.github_graphql._execute", AsyncMock(return_value=response)
+            ) as execute,
+        ):
+            result = await GitHubPRManager().list_prs(query="is:closed", cursor="prior")
+
+        self.assertIn("SearchPullRequests", execute.await_args.args[0])
+        self.assertEqual(execute.await_args.args[1]["after"], "prior")
+        self.assertEqual(result["next_cursor"], "next")
+
+    async def test_issue_handler_query_preserves_closed_state_and_cursor(self):
+        from src.integrations.github.handlers import tool_github_issue
+
+        response = {
+            "data": {"search": {"issueCount": 2, "pageInfo": {"hasNextPage": True, "endCursor": "next"}, "nodes": []}}
+        }
+        with patch(
+            "src.integrations.github.handlers.github_graphql._execute", AsyncMock(return_value=response)
+        ) as execute:
+            result = await tool_github_issue(action="search", query='is:closed label:"help wanted"', cursor="prior")
+
+        self.assertIn("SearchIssuesFull", execute.await_args.args[0])
+        variables = execute.await_args.args[1]
+        self.assertIn('is:closed label:"help wanted"', variables["query"])
+        self.assertNotIn("is:open", variables["query"])
+        self.assertEqual(variables["after"], "prior")
+        self.assertTrue(result["truncated"])
+        self.assertEqual(result["next_cursor"], "next")
+
+    async def test_issue_query_rejects_explicit_open_conflict(self):
+        from src.integrations.github.handlers import tool_github_issue
+
+        result = await tool_github_issue(action="search", query="is:closed", state="open")
+
+        self.assertEqual(result["error"], "query state qualifier conflicts with state filter")
+
+    def test_query_rejects_other_repo_in_parenthesized_or_expression(self):
+        from src.integrations.github.graphql import build_scoped_search_query
+
+        result = build_scoped_search_query(
+            "(repo:pollinations/pollinations OR repo:other/repo)",
+            repository="pollinations/pollinations",
+            kind="issue",
+        )
+
+        self.assertEqual(result["error"], "query repo qualifier conflicts with the configured repository")
+
+    def test_query_rejects_parenthesized_wrong_item_kind(self):
+        from src.integrations.github.graphql import build_scoped_search_query
+
+        result = build_scoped_search_query("(is:pr OR is:open)", repository="pollinations/pollinations", kind="issue")
+
+        self.assertEqual(result["error"], "query must target issues, not the other item kind")
+
+    def test_query_rejects_state_qualifier_conflict(self):
+        from src.integrations.github.graphql import build_scoped_search_query
+
+        result = build_scoped_search_query(
+            "state:closed", repository="pollinations/pollinations", kind="issue", state="open"
+        )
+
+        self.assertEqual(result["error"], "query state qualifier conflicts with state filter")
+
+    async def test_blank_native_queries_are_rejected(self):
+        from src.integrations.github.handlers import tool_github_issue
+        from src.integrations.github.pull_requests import GitHubPRManager
+
+        issue_result = await tool_github_issue(action="search", query="")
+        with patch("src.integrations.github.pull_requests.has_github_auth", return_value=True):
+            pr_result = await GitHubPRManager().list_prs(query="")
+
+        self.assertEqual(issue_result["error"], "query must not be blank")
+        self.assertEqual(pr_result["error"], "query must not be blank")
+
+
+class PullRequestAuthorSearchTests(unittest.IsolatedAsyncioTestCase):
+    async def test_author_uses_server_search_before_limit(self):
+        from src.integrations.github.pull_requests import GitHubPRManager
+
+        response = {
+            "data": {
+                "search": {
+                    "issueCount": 2,
+                    "pageInfo": {"hasNextPage": True},
+                    "nodes": [
+                        {
+                            "number": 9,
+                            "title": "target",
+                            "state": "OPEN",
+                            "isDraft": False,
+                            "url": "https://example.test",
+                            "author": {"login": "target"},
+                            "headRefName": "head",
+                            "baseRefName": "main",
+                            "createdAt": "2026-01-01T00:00:00Z",
+                            "updatedAt": "2026-01-01T00:00:00Z",
+                            "labels": {"nodes": []},
+                        }
+                    ],
+                }
+            }
+        }
+        with (
+            patch("src.integrations.github.pull_requests.has_github_auth", return_value=True),
+            patch(
+                "src.integrations.github.pull_requests.github_graphql._execute", AsyncMock(return_value=response)
+            ) as execute,
+        ):
+            result = await GitHubPRManager().list_prs(state="open", base="main", author="target", limit=1)
+        self.assertEqual(result["matched_total"], 2)
+        self.assertTrue(result["truncated"])
+        self.assertIn('base:"main"', execute.await_args.args[1]["query"])
+
+    async def test_rejects_author_qualifier_injection(self):
+        from src.integrations.github.pull_requests import GitHubPRManager
+
+        with patch("src.integrations.github.pull_requests.has_github_auth", return_value=True):
+            result = await GitHubPRManager().list_prs(author="target is:closed")
+
+        self.assertEqual(result["error"], "author must be a valid GitHub login")
+
+    async def test_base_filter_uses_server_search_before_limit(self):
+        from src.integrations.github.pull_requests import GitHubPRManager
+
+        response = {"data": {"search": {"issueCount": 1, "pageInfo": {"hasNextPage": False}, "nodes": []}}}
+        with (
+            patch("src.integrations.github.pull_requests.has_github_auth", return_value=True),
+            patch(
+                "src.integrations.github.pull_requests.github_graphql._execute", AsyncMock(return_value=response)
+            ) as execute,
+        ):
+            await GitHubPRManager().list_prs(base="release/next", limit=1)
+
+        self.assertIn('base:"release/next"', execute.await_args.args[1]["query"])
+
+
+class HandlerForwardingTests(unittest.IsolatedAsyncioTestCase):
+    async def test_label_list_forwards_limit_and_cursor(self):
+        from src.integrations.github.handlers import tool_github_issue
+
+        with patch(
+            "src.integrations.github.handlers.github_graphql._fetch_labels", AsyncMock(return_value={"labels": []})
+        ) as fetch_labels:
+            await tool_github_issue(action="list_labels", limit=25, cursor="labels-after")
+
+        fetch_labels.assert_awaited_once_with(limit=25, after="labels-after")
+
+    async def test_milestone_list_forwards_limit_cursor_and_default_state(self):
+        from src.integrations.github.handlers import tool_github_issue
+
+        with patch(
+            "src.integrations.github.handlers.github_graphql._fetch_milestones",
+            AsyncMock(return_value={"milestones": []}),
+        ) as fetch_milestones:
+            await tool_github_issue(action="list_milestones", limit=25, cursor="milestones-after")
+
+        fetch_milestones.assert_awaited_once_with(state="open", limit=25, after="milestones-after")
+
+    async def test_custom_handler_forwards_author_and_page(self):
+        from src.integrations.github.handlers import tool_github_custom
+
+        with patch(
+            "src.integrations.github.handlers.github_graphql.execute_custom_request", AsyncMock(return_value={})
+        ) as custom_request:
+            await tool_github_custom(request="issues", author="octocat", limit=25, page=3)
+
+        self.assertEqual(custom_request.await_args.kwargs["author"], "octocat")
+        self.assertEqual(custom_request.await_args.kwargs["page"], 3)
+
+
+class ProjectTruncationTests(unittest.IsolatedAsyncioTestCase):
+    async def test_exact_limit_across_complete_scopes_is_not_truncated(self):
+        client = GitHubGraphQL()
+        client._execute = AsyncMock(
+            side_effect=[
+                {
+                    "data": {
+                        "organization": {
+                            "projectsV2": {
+                                "pageInfo": {"hasNextPage": False},
+                                "nodes": [
+                                    {
+                                        "id": "org-1",
+                                        "number": 1,
+                                        "title": "Org",
+                                        "shortDescription": "",
+                                        "url": "https://example.test/org",
+                                        "closed": False,
+                                    }
+                                ],
+                            }
+                        }
+                    }
+                },
+                {
+                    "data": {
+                        "repository": {
+                            "projectsV2": {
+                                "pageInfo": {"hasNextPage": False},
+                                "nodes": [
+                                    {
+                                        "id": "repo-2",
+                                        "number": 2,
+                                        "title": "Repo",
+                                        "shortDescription": "",
+                                        "url": "https://example.test/repo",
+                                        "closed": False,
+                                    }
+                                ],
+                            }
+                        }
+                    }
+                },
+            ]
+        )
+
+        result = await client.list_projects(limit=1)
+
+        self.assertEqual(result["count"], 2)
+        self.assertFalse(result["truncated"])
+
+
+class PaginationMetadataTests(unittest.IsolatedAsyncioTestCase):
+    async def test_milestones_omit_cursor_when_not_truncated(self):
+        client = GitHubGraphQL()
+        client._execute = AsyncMock(
+            return_value={
+                "data": {
+                    "repository": {
+                        "milestones": {"pageInfo": {"hasNextPage": False, "endCursor": "stale"}, "nodes": []}
+                    }
+                }
+            }
+        )
+
+        result = await client._fetch_milestones()
+
+        self.assertFalse(result["truncated"])
+        self.assertIsNone(result["next_cursor"])
+
+
+class OverviewProjectTests(unittest.IsolatedAsyncioTestCase):
+    async def test_overview_preserves_all_requested_projects(self):
+        client = GitHubGraphQL()
+        client._execute = AsyncMock(
+            return_value={
+                "data": {
+                    "repository": {
+                        "openIssues": {"totalCount": 0},
+                        "closedIssues": {"totalCount": 0},
+                        "issues": {"nodes": []},
+                        "labels": {"nodes": []},
+                        "milestones": {"nodes": []},
+                    }
+                }
+            }
+        )
+        client.list_projects = AsyncMock(
+            return_value={
+                "projects": [
+                    {"number": number, "title": str(number), "url": "https://example.test"} for number in range(26)
+                ],
+                "truncated": False,
+            }
+        )
+
+        result = await client.get_repo_overview()
+
+        self.assertEqual(len(result["projects"]), 26)
+        self.assertEqual(client.list_projects.await_args.kwargs["limit"], 100)
+
+
+class ReviewSummaryCountTests(unittest.IsolatedAsyncioTestCase):
+    async def test_counts_files_not_review_batches(self):
+        class Review(PRReviewMixin):
+            async def get_pr(self, _pr_number):
+                return {"number": 1, "title": "PR", "url": "https://example.test"}
+
+            async def get_pr_diff(self, _pr_number):
+                return {"diff": "diff"}
+
+            def _split_diff_by_file(self, _diff):
+                return [{"filename": name} for name in ("a.py", "b.py", "c.py")]
+
+            async def _review_files_concurrently(self, _files):
+                return [
+                    {"filenames": ["a.py", "b.py"], "findings": "LGTM", "high_priority": False},
+                    {"filenames": ["c.py"], "findings": "", "high_priority": False, "error": "review_timeout"},
+                ]
+
+            async def _synthesize_review(self, _pr, _reviewed, _errored):
+                return "LGTM"
+
+        result = await Review().review_pr(1)
+
+        self.assertEqual(result["files_requested"], 3)
+        self.assertEqual(result["files_successfully_reviewed"], 2)
+        self.assertEqual(result["successful_batches"], 1)
+        self.assertEqual(result["failed_batches"], 1)
+
+
+class GraphQLErrorPropagationTests(unittest.IsolatedAsyncioTestCase):
+    async def test_custom_graphql_preserves_partial_data(self):
+        client = GitHubGraphQL()
+        client._execute = AsyncMock(
+            return_value={"data": {"repository": None}, "error": "field unavailable", "partial": True}
+        )
+        result = await client.execute_custom_request(request="", graphql_query="query { repository { name } }")
+        self.assertEqual(result["data"], {"repository": None})
+        self.assertTrue(result["partial"])
+
+
+class ReviewFailureCategoryTests(unittest.IsolatedAsyncioTestCase):
+    async def test_review_allows_reasoning_output_budget(self):
+        client = AsyncMock()
+        client.generate_text.return_value = "LGTM"
+        with patch("src.ai.client.pollinations_client", client):
+            result = await PRReviewMixin()._review_files_concurrently(
+                [{"filename": "a.py", "diff": "+x", "high_priority": False}]
+            )
+        self.assertEqual(client.generate_text.await_args.kwargs["max_tokens"], 4096)
+        self.assertNotIn("error", result[0])
+
+    async def test_timeout_uses_safe_error_category(self):
+        class Review(PRReviewMixin):
+            pass
+
+        client = AsyncMock()
+        client.generate_text.side_effect = TimeoutError()
+        with patch("src.ai.client.pollinations_client", client):
+            result = await Review()._review_files_concurrently(
+                [{"filename": "a.py", "diff": "diff --git a/a.py b/a.py\n@@ +1 @@\n+x", "high_priority": False}]
+            )
+        self.assertEqual(result[0]["error"], "review_timeout")

--- a/apps/polli/tests/test_logging_safeguards.py
+++ b/apps/polli/tests/test_logging_safeguards.py
@@ -1,0 +1,107 @@
+import io
+import logging
+import unittest
+from unittest.mock import AsyncMock
+
+from src.ai.client import PollinationsClient
+from src.context.manager import SessionManager
+from src.core.logging import CleanFormatter
+
+
+class LoggingSafeguardsTests(unittest.IsolatedAsyncioTestCase):
+    def test_formatter_excludes_exception_message_and_traceback(self):
+        stream = io.StringIO()
+        handler = logging.StreamHandler(stream)
+        handler.setFormatter(CleanFormatter())
+        logger = logging.getLogger("test.logging.safeguards")
+        logger.handlers = [handler]
+        logger.setLevel(logging.ERROR)
+        logger.propagate = False
+
+        try:
+            raise ValueError("private exception body")
+        except ValueError:
+            logger.exception("operation failed")
+
+        output = stream.getvalue()
+        self.assertIn("operation failed (exception=ValueError)", output)
+        self.assertNotIn("private exception body", output)
+        self.assertNotIn("Traceback", output)
+
+    def test_formatter_handles_missing_exception_class(self):
+        record = logging.LogRecord(
+            name="test.logging.safeguards",
+            level=logging.ERROR,
+            pathname=__file__,
+            lineno=1,
+            msg="operation failed",
+            args=(),
+            exc_info=(None, None, None),
+        )
+
+        output = CleanFormatter().format(record)
+
+        self.assertIn("operation failed (exception=UnknownException)", output)
+
+    def test_session_creation_log_excludes_topic_summary(self):
+        manager = SessionManager()
+        logger = logging.getLogger("src.context.manager")
+        with self.assertLogs(logger, level="INFO") as captured:
+            manager.create_session(1, 2, 3, "user", "private body", "private topic")
+
+        self.assertIn("Created session for thread 2", captured.output[0])
+        self.assertNotIn("private topic", captured.output[0])
+
+    async def test_process_with_tools_accepts_user_message_keyword(self):
+        class SuccessResponse:
+            status = 200
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return None
+
+            async def json(self):
+                return {"choices": [{"message": {"content": "ok"}}], "usage": {}}
+
+        client = PollinationsClient()
+        session = type("Session", (), {"post": lambda *_args, **_kwargs: SuccessResponse()})()
+        client.get_session = AsyncMock(return_value=session)
+
+        result = await client.process_with_tools(
+            user_message="private body",
+            discord_username="tester",
+            raw_messages=[],
+        )
+
+        self.assertEqual(result["response"], "ok")
+
+    async def test_generate_text_log_excludes_upstream_error_body(self):
+        class ErrorResponse:
+            status = 500
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return None
+
+            async def text(self):
+                return "secret upstream error body"
+
+        client = PollinationsClient()
+        session = type("Session", (), {"post": lambda *_args, **_kwargs: ErrorResponse()})()
+        client.get_session = AsyncMock(return_value=session)
+
+        logger = logging.getLogger("src.ai.client")
+        with self.assertLogs(logger, level="ERROR") as captured:
+            result = await client.generate_text("system", "private prompt")
+
+        self.assertIsNone(result)
+        self.assertIn("generate_text error: HTTP 500", captured.output[0])
+        self.assertNotIn("secret upstream error body", captured.output[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/polli/tests/test_openai_api.py
+++ b/apps/polli/tests/test_openai_api.py
@@ -10,6 +10,11 @@ from src.ai.client import PollinationsClient
 from src.api.server import create_api_app
 
 
+async def _empty_chunks():
+    if False:
+        yield b""
+
+
 class FakePollinationsClient:
     async def process_with_tools(self, **kwargs):
         return {
@@ -32,10 +37,11 @@ class OpenAIAPITests(unittest.TestCase):
     def setUp(self):
         config = SimpleNamespace(
             api=SimpleNamespace(cors_origins=[]),
+            ai=SimpleNamespace(model="default-model"),
             bot=SimpleNamespace(name="Polli"),
         )
         self.client = TestClient(create_api_app(FakePollinationsClient(), config))
-        self.headers = {"Authorization": "Bearer test"}
+        self.headers = {"Authorization": "Bearer ag_test"}
 
     def test_chat_stream_emits_standard_deltas_and_hides_internal_tools(self):
         with self.client.stream(
@@ -116,6 +122,46 @@ class OpenAIAPITests(unittest.TestCase):
         self.assertEqual(response.json()["object"], "list")
         self.assertEqual(response.json()["data"][0]["id"], "polli")
 
+    def test_api_rejects_missing_public_and_secret_keys(self):
+        for authorization in (None, "Bearer pk_test", "Bearer sk_test", "Bearer test"):
+            headers = {"Authorization": authorization} if authorization else {}
+            response = self.client.get("/v1/models", headers=headers)
+            self.assertEqual(response.status_code, 401)
+            self.assertEqual(response.json()["error"]["code"], "invalid_api_key")
+
+    def test_explicit_model_is_forwarded_and_returned(self):
+        response = self.client.post(
+            "/v1/chat/completions",
+            headers=self.headers,
+            json={"model": "openai", "messages": [{"role": "user", "content": "Hi"}]},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["model"], "openai")
+
+    def test_blank_model_is_rejected(self):
+        response = self.client.post(
+            "/v1/responses",
+            headers=self.headers,
+            json={"model": "   ", "input": "Hi"},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "invalid_request")
+
+    def test_stream_reports_explicit_model(self):
+        with self.client.stream(
+            "POST",
+            "/v1/responses",
+            headers=self.headers,
+            json={"model": "openai", "input": "Hi", "stream": True},
+        ) as response:
+            body = "".join(response.iter_text())
+
+        self.assertEqual(response.status_code, 200)
+        created = json.loads(body.split("\n\n", 1)[0][6:])
+        self.assertEqual(created["response"]["model"], "openai")
+
     def test_validation_errors_use_openai_shape(self):
         response = self.client.post(
             "/v1/chat/completions",
@@ -139,7 +185,11 @@ class OpenAIAPITests(unittest.TestCase):
                 }
                 yield {"type": "completed", "finish_reason": "tool_calls", "usage": {}}
 
-        config = SimpleNamespace(api=SimpleNamespace(cors_origins=[]), bot=SimpleNamespace(name="Polli"))
+        config = SimpleNamespace(
+            api=SimpleNamespace(cors_origins=[]),
+            ai=SimpleNamespace(model="default-model"),
+            bot=SimpleNamespace(name="Polli"),
+        )
         client = TestClient(create_api_app(ToolClient(), config))
         with client.stream(
             "POST",
@@ -171,7 +221,11 @@ class OpenAIAPITests(unittest.TestCase):
                     "finish_reason": "tool_calls",
                 }
 
-        config = SimpleNamespace(api=SimpleNamespace(cors_origins=[]), bot=SimpleNamespace(name="Polli"))
+        config = SimpleNamespace(
+            api=SimpleNamespace(cors_origins=[]),
+            ai=SimpleNamespace(model="default-model"),
+            bot=SimpleNamespace(name="Polli"),
+        )
         client = TestClient(create_api_app(ToolClient(), config))
         response = client.post(
             "/v1/responses",
@@ -240,6 +294,129 @@ class StreamingClientTests(unittest.IsolatedAsyncioTestCase):
 
         payload = session.post.call_args.kwargs["json"]
         self.assertEqual(payload["seed"], 7)
+
+    async def test_api_model_and_ag_header_are_request_local(self):
+        client = PollinationsClient()
+        response = FakeHTTPResponse({"choices": [{"message": {"content": "ok", "tool_calls": []}}], "usage": {}})
+        session = SimpleNamespace(post=MagicMock(return_value=response))
+        client.get_session = AsyncMock(return_value=session)
+
+        from src.ai.client import _auth_override
+
+        token = _auth_override.set("Bearer ag_first")
+        try:
+            await client._call_api_with_tools(
+                [{"role": "user", "content": "hi"}],
+                mode="api",
+                api_params={"model": "first-model", "_explicit_model": True},
+            )
+        finally:
+            _auth_override.reset(token)
+
+        self.assertEqual(session.post.call_args.kwargs["headers"]["Authorization"], "Bearer ag_first")
+        self.assertEqual(session.post.call_args.kwargs["json"]["model"], "first-model")
+        self.assertNotIn("_explicit_model", session.post.call_args.kwargs["json"])
+
+    async def test_default_model_falls_back_without_internal_parameter(self):
+        client = PollinationsClient()
+        response = FakeHTTPResponse({"error": "unavailable"})
+        response.status = 503
+        response.text = AsyncMock(return_value="unavailable")
+        session = SimpleNamespace(post=MagicMock(return_value=response))
+        client.get_session = AsyncMock(return_value=session)
+
+        from src.ai.client import config
+
+        with patch("src.ai.client.asyncio.sleep", new=AsyncMock()):
+            await client._call_api_with_tools(
+                [{"role": "user", "content": "hi"}], api_params={"model": config.ai.model, "_explicit_model": False}
+            )
+
+        payloads = [call.kwargs["json"] for call in session.post.call_args_list]
+        self.assertEqual(payloads[0]["model"], config.ai.model)
+        self.assertEqual(payloads[1]["model"], config.ai.fallback_model)
+        self.assertTrue(all("_explicit_model" not in payload for payload in payloads))
+
+    async def test_stream_request_omits_internal_model_parameter(self):
+        client = PollinationsClient()
+        response = FakeHTTPResponse({})
+        response.content = SimpleNamespace(iter_any=lambda: _empty_chunks())
+        session = SimpleNamespace(post=MagicMock(return_value=response))
+        client.get_session = AsyncMock(return_value=session)
+
+        async def emit(_event):
+            return None
+
+        from src.ai.client import _auth_override
+
+        token = _auth_override.set("Bearer ag_stream")
+        try:
+            await client._call_api_with_tools_stream(
+                [{"role": "user", "content": "hi"}],
+                tools=None,
+                mode="api",
+                api_params={"model": "explicit", "_explicit_model": True},
+                event_handler=emit,
+            )
+        finally:
+            _auth_override.reset(token)
+
+        payload = session.post.call_args.kwargs["json"]
+        self.assertEqual(payload["model"], "explicit")
+        self.assertNotIn("_explicit_model", payload)
+
+    async def test_generate_text_uses_request_auth_and_cleans_up_after_failure(self):
+        client = PollinationsClient()
+        response = FakeHTTPResponse({"choices": [{"message": {"content": "ok"}}]})
+        session = SimpleNamespace(post=MagicMock(return_value=response))
+        client.get_session = AsyncMock(return_value=session)
+
+        from src.ai.client import _auth_override
+
+        async def generate(token):
+            context_token = _auth_override.set(token)
+            try:
+                return await client.generate_text("system", "prompt")
+            finally:
+                _auth_override.reset(context_token)
+
+        first, second = await asyncio.gather(generate("Bearer ag_first"), generate("Bearer ag_second"))
+        self.assertEqual((first, second), ("ok", "ok"))
+        self.assertEqual(
+            {call.kwargs["headers"]["Authorization"] for call in session.post.call_args_list},
+            {"Bearer ag_first", "Bearer ag_second"},
+        )
+        self.assertFalse(_auth_override.get())
+
+    async def test_generate_text_uses_discord_token_without_request_context(self):
+        client = PollinationsClient()
+        response = FakeHTTPResponse({"choices": [{"message": {"content": "ok"}}]})
+        session = SimpleNamespace(post=MagicMock(return_value=response))
+        client.get_session = AsyncMock(return_value=session)
+
+        await client.generate_text("system", "prompt")
+
+        self.assertEqual(
+            session.post.call_args.kwargs["headers"]["Authorization"],
+            "Bearer " + __import__("src.ai.client", fromlist=["config"]).config.ai.token,
+        )
+
+    async def test_explicit_model_does_not_fallback(self):
+        client = PollinationsClient()
+        response = FakeHTTPResponse({"error": "not found"})
+        response.status = 404
+        response.text = AsyncMock(return_value="not found")
+        session = SimpleNamespace(post=MagicMock(return_value=response))
+        client.get_session = AsyncMock(return_value=session)
+
+        with patch("src.ai.client.asyncio.sleep", new=AsyncMock()):
+            result = await client._call_api_with_tools(
+                [{"role": "user", "content": "hi"}],
+                api_params={"model": "missing", "_explicit_model": True},
+            )
+
+        self.assertIsNone(result)
+        self.assertEqual([call.kwargs["json"]["model"] for call in session.post.call_args_list], ["missing"] * 3)
 
     async def test_internal_tool_round_content_is_not_streamed(self):
         client = PollinationsClient()

--- a/apps/polli/tests/test_privacy_commands.py
+++ b/apps/polli/tests/test_privacy_commands.py
@@ -1,0 +1,31 @@
+import unittest
+from types import SimpleNamespace
+
+from src.bot import handle_dm_message
+
+
+class PrivacyCommandTests(unittest.IsolatedAsyncioTestCase):
+    async def test_privacy_commands_provide_contact_without_claiming_erasure(self):
+        for command in ("privacy", "privacy policy", "delete data", "delete my data"):
+            with self.subTest(command=command):
+                replies = []
+
+                async def reply(content, captured=replies):
+                    captured.append(content)
+
+                message = SimpleNamespace(
+                    content=command,
+                    author=SimpleNamespace(id=123),
+                    reply=reply,
+                )
+                await handle_dm_message(message)
+                self.assertEqual(len(replies), 1)
+                self.assertIn("https://pollinations.ai/privacy", replies[0])
+                self.assertIn("hello@pollinations.ai", replies[0])
+                self.assertIn("deletion or correction", replies[0])
+                self.assertIn("subscriptions only", replies[0])
+                self.assertIn("does not erase", replies[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/polli/tests/test_subscription_storage.py
+++ b/apps/polli/tests/test_subscription_storage.py
@@ -1,0 +1,107 @@
+import os
+import sqlite3
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.integrations.subscriptions import SubscriptionManager
+
+
+class SubscriptionStorageTests(unittest.IsolatedAsyncioTestCase):
+    async def test_reopen_preserves_subscriptions_and_user_isolation(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = Path(temp_dir) / "data" / "subscriptions.db"
+            manager = SubscriptionManager(db_path)
+            try:
+                await manager.initialize()
+                self.assertTrue(await manager.subscribe(101, 1, 1001))
+                self.assertTrue(await manager.subscribe(202, 2, 2002))
+            finally:
+                await manager.close()
+
+            reopened = SubscriptionManager(db_path)
+            try:
+                await reopened.initialize()
+                self.assertEqual(
+                    [1],
+                    [sub["issue_number"] for sub in await reopened.get_user_subscriptions(101)],
+                )
+                self.assertEqual(
+                    [2],
+                    [sub["issue_number"] for sub in await reopened.get_user_subscriptions(202)],
+                )
+                self.assertEqual(1, await reopened.unsubscribe_all(101))
+                self.assertFalse(await reopened.is_subscribed(101, 1))
+                self.assertTrue(await reopened.is_subscribed(202, 2))
+            finally:
+                await reopened.close()
+
+    async def test_initialization_enables_secure_delete(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manager = SubscriptionManager(Path(temp_dir) / "data" / "subscriptions.db")
+            try:
+                await manager.initialize()
+                db = await manager._ensure_initialized()
+                cursor = await db.execute("PRAGMA secure_delete")
+                self.assertEqual(1, (await cursor.fetchone())[0])
+            finally:
+                await manager.close()
+
+    async def test_initialization_failure_propagates_and_closes_connection(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = Path(temp_dir) / "data" / "subscriptions.db"
+            db_path.parent.mkdir()
+            db = sqlite3.connect(db_path)
+            try:
+                db.execute("CREATE VIEW subscriptions AS SELECT 1 AS id")
+            finally:
+                db.close()
+
+            manager = SubscriptionManager(db_path)
+            with self.assertRaises(sqlite3.OperationalError):
+                await manager.initialize()
+            self.assertIsNone(manager._db)
+            self.assertFalse(manager._initialized)
+
+    @unittest.skipUnless(os.name == "posix", "POSIX permission modes are not available on Windows")
+    async def test_initialization_sets_private_data_database_and_sidecar_modes(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            data_dir = Path(temp_dir) / "data"
+            db_path = data_dir / "subscriptions.db"
+            manager = SubscriptionManager(db_path)
+            try:
+                await manager.initialize()
+                self.assertTrue(await manager.subscribe(101, 1, 1001))
+
+                self.assertEqual(0o700, stat.S_IMODE(data_dir.stat().st_mode))
+                self.assertEqual(0o600, stat.S_IMODE(db_path.stat().st_mode))
+                for suffix in ("-wal", "-shm"):
+                    sidecar = Path(f"{db_path}{suffix}")
+                    self.assertTrue(sidecar.exists(), f"expected SQLite {suffix} sidecar")
+                    self.assertEqual(0o600, stat.S_IMODE(sidecar.stat().st_mode))
+            finally:
+                await manager.close()
+
+    @unittest.skipUnless(os.name == "posix", "POSIX permission modes are not available on Windows")
+    async def test_reopen_repairs_existing_database_mode(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            data_dir = Path(temp_dir) / "data"
+            db_path = data_dir / "subscriptions.db"
+            data_dir.mkdir()
+            with sqlite3.connect(db_path):
+                pass
+            data_dir.chmod(0o755)
+            db_path.chmod(0o644)
+
+            manager = SubscriptionManager(db_path)
+            try:
+                await manager.initialize()
+                self.assertEqual(0o700, stat.S_IMODE(data_dir.stat().st_mode))
+                self.assertEqual(0o600, stat.S_IMODE(db_path.stat().st_mode))
+            finally:
+                await manager.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/polli/tests/test_web_scraper.py
+++ b/apps/polli/tests/test_web_scraper.py
@@ -1,0 +1,562 @@
+import asyncio
+import json
+import sys
+import threading
+import types
+import unittest
+from unittest.mock import patch
+
+from src.integrations import web_scraper
+
+
+class SemanticSingleChunkTests(unittest.TestCase):
+    def test_single_chunk_is_one_cluster_and_multiple_chunks_delegate(self):
+        class Cosine:
+            def __init__(self, **kwargs):
+                pass
+
+            def hierarchical_clustering(self, sentences):
+                return [1, 2]
+
+        with patch.dict(
+            sys.modules, {"crawl4ai": types.SimpleNamespace(CosineStrategy=Cosine), "torch": types.ModuleType("torch")}
+        ):
+            strategy = web_scraper._build_extraction_strategy("cosine", semantic_filter="testing")
+
+        self.assertEqual(strategy.hierarchical_clustering(["one chunk"]), [0])
+        self.assertEqual(strategy.hierarchical_clustering(["first", "second"]), [1, 2])
+
+
+class _Regex:
+    Nothing = 0
+    Email = 1
+    PhoneIntl = 2
+    Url = 4
+    DateIso = 8
+    Currency = 16
+    IPv4 = 32
+    Hashtag = 64
+    TwitterHandle = 128
+    All = 255
+
+    def __init__(self, pattern, input_format="markdown"):
+        self.pattern = pattern
+        self.input_format = input_format
+
+    def extract(self, url, content):
+        return [{"url": url, "content": content, "pattern": self.pattern}]
+
+
+class _Result:
+    success = True
+    error_message = None
+    metadata = {}
+    html = "<main>content</main>"
+    markdown = types.SimpleNamespace(raw_markdown="page content", fit_markdown="")
+    links = {}
+    media = {}
+    screenshot = None
+    pdf = None
+
+    def __init__(self, extracted_content):
+        self.extracted_content = extracted_content
+
+
+class WebScraperTests(unittest.TestCase):
+    def setUp(self):
+        web_scraper._crawler_pool = None
+
+    def test_scrapling_uses_safe_redirects_and_native_markdown(self):
+        from unittest.mock import AsyncMock, Mock
+
+        page = types.SimpleNamespace(
+            status=200,
+            html_content="<main>Article content</main>",
+            markdown=Mock(return_value="Article content with enough useful text to retain as a successful scrape."),
+        )
+        fetcher = types.SimpleNamespace(get=AsyncMock(return_value=page))
+        with patch.dict(sys.modules, {"scrapling.fetchers": types.SimpleNamespace(AsyncFetcher=fetcher)}):
+            result = asyncio.run(web_scraper._try_scrapling("https://example.test", 10))
+        fetcher.get.assert_awaited_once_with("https://example.test", follow_redirects="safe")
+        page.markdown.assert_called_once_with(main_content_only=True)
+        self.assertIn("Article content", result)
+
+    def test_rnet_client_does_not_receive_unsupported_redirect_option(self):
+        captured = {}
+
+        class _Client:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+            async def get(self, url):
+                return types.SimpleNamespace(status=200, text=lambda: asyncio.sleep(0, result=""))
+
+        fake_module = types.SimpleNamespace(Client=_Client, Impersonate=types.SimpleNamespace(Chrome136="chrome"))
+        with patch.dict(sys.modules, {"rnet": fake_module}):
+            self.assertIsNone(asyncio.run(web_scraper._try_rnet("https://example.test", 1)))
+        self.assertNotIn("redirect", captured)
+
+    def test_regex_map_uses_crawl4ai_090_constant_names(self):
+        self.assertEqual(web_scraper._regex_pattern_map(_Regex)["url"], _Regex.Url)
+        self.assertEqual(web_scraper._regex_pattern_map(_Regex)["date"], _Regex.DateIso)
+        self.assertEqual(web_scraper._regex_pattern_map(_Regex)["ip"], _Regex.IPv4)
+
+    def test_file_regex_uses_shared_map_and_reports_missing_dependency(self):
+        fake_module = types.SimpleNamespace(RegexExtractionStrategy=_Regex)
+        with patch.dict(sys.modules, {"crawl4ai": fake_module}):
+            result = asyncio.run(web_scraper.parse_file_content("contact a@example.com", extract_patterns=["url"]))
+        self.assertTrue(result["success"])
+        self.assertEqual(result["extracted_patterns"][0]["pattern"], _Regex.Url)
+
+        with patch.dict(sys.modules, {"crawl4ai": None}):
+            missing = asyncio.run(web_scraper.parse_file_content("x", extract_patterns=["url"]))
+        self.assertFalse(missing["success"])
+        self.assertIn("missing dependency", missing["error"])
+
+    def test_css_empty_rows_are_successful_empty_structured_output(self):
+        result = _Result("[]")
+        crawler = types.SimpleNamespace(arun=lambda **kwargs: asyncio.sleep(0, result=result))
+        crawler.__aenter__ = lambda: asyncio.sleep(0, result=crawler)
+        crawler.__aexit__ = lambda *args: asyncio.sleep(0)
+
+        class _Crawler:
+            def __init__(self, config):
+                self.crawler = crawler
+
+            async def start(self):
+                return self
+
+            async def close(self):
+                pass
+
+            async def arun(self, **kwargs):
+                return await self.crawler.arun(**kwargs)
+
+        fake_module = types.SimpleNamespace(
+            AsyncWebCrawler=_Crawler,
+            BrowserConfig=lambda **kwargs: kwargs,
+            CacheMode=types.SimpleNamespace(DISABLED="disabled"),
+            CrawlerRunConfig=lambda **kwargs: kwargs,
+            JsonCssExtractionStrategy=lambda **kwargs: kwargs,
+        )
+        markdown_module = types.SimpleNamespace(DefaultMarkdownGenerator=lambda **kwargs: kwargs)
+        with patch.dict(
+            sys.modules, {"crawl4ai": fake_module, "crawl4ai.markdown_generation_strategy": markdown_module}
+        ):
+            output = asyncio.run(
+                web_scraper._scrape_with_crawl4ai(
+                    "https://example.test", extraction_strategy="css", schema={"baseSelector": ".missing"}
+                )
+            )
+        self.assertTrue(output["success"])
+        self.assertEqual(output["extracted"], [])
+        self.assertTrue(output["extraction_empty"])
+        self.assertEqual(output["markdown"], "")
+
+    def test_extraction_error_payload_is_failure(self):
+        result = _Result(json.dumps({"error": "provider unavailable"}))
+        crawler = types.SimpleNamespace(arun=lambda **kwargs: asyncio.sleep(0, result=result))
+
+        class _Crawler:
+            def __init__(self, config):
+                self.crawler = crawler
+
+            async def start(self):
+                return self
+
+            async def close(self):
+                pass
+
+            async def arun(self, **kwargs):
+                return await self.crawler.arun(**kwargs)
+
+        fake_module = types.SimpleNamespace(
+            AsyncWebCrawler=_Crawler,
+            BrowserConfig=lambda **kwargs: kwargs,
+            CacheMode=types.SimpleNamespace(DISABLED="disabled"),
+            CrawlerRunConfig=lambda **kwargs: kwargs,
+            RegexExtractionStrategy=_Regex,
+        )
+        markdown_module = types.SimpleNamespace(DefaultMarkdownGenerator=lambda **kwargs: kwargs)
+        with patch.dict(
+            sys.modules, {"crawl4ai": fake_module, "crawl4ai.markdown_generation_strategy": markdown_module}
+        ):
+            output = asyncio.run(web_scraper._scrape_with_crawl4ai("https://example.test", extraction_strategy="regex"))
+        self.assertFalse(output["success"])
+        self.assertIn("provider unavailable", output["error"])
+
+    def test_multi_bounds_outputs_with_valid_serialized_aggregate(self):
+        async def fake_scrape(url, **kwargs):
+            return {"success": True, "url": url, "markdown": "x" * 20_000}
+
+        with patch.object(web_scraper, "scrape_url", fake_scrape):
+            output = asyncio.run(web_scraper.scrape_multiple(["https://one.test", "https://two.test"]))
+        self.assertTrue(output["success"])
+        self.assertTrue(all(item["output_truncated"] for item in output["results"]))
+        self.assertLessEqual(len(json.dumps(output, ensure_ascii=False)), output["response_limit_chars"])
+        self.assertEqual(output["results_omitted"], 0)
+
+    def test_multi_response_bound_omits_late_unicode_and_oversized_url_results(self):
+        oversized_url = "https://example.test/" + ("ü" * 5_000)
+
+        async def fake_scrape(url, **kwargs):
+            return {"success": True, "url": url, "markdown": "界" * 11_500}
+
+        urls = [oversized_url] + [f"https://{index}.test" for index in range(9)]
+        with patch.object(web_scraper, "scrape_url", fake_scrape):
+            output = asyncio.run(web_scraper.scrape_multiple(urls))
+        self.assertLessEqual(len(json.dumps(output, ensure_ascii=False)), output["response_limit_chars"])
+        self.assertTrue(output["response_truncated"])
+        self.assertGreater(output["results_omitted"], 0)
+        self.assertEqual(output["results"][1]["url"], urls[1])
+        self.assertLessEqual(len(output["results"][0]["url"]), 2_000)
+        self.assertTrue(output["results"][0]["url_truncated"])
+
+    def test_regex_url_values_decode_html_entities(self):
+        from unittest.mock import AsyncMock
+
+        rows = [
+            {"label": "url", "value": "https://example.test/?a=1&amp;b=2", "span": [0, 33]},
+            {"label": "email", "value": "a&amp;b@example.test"},
+        ]
+        fake_module = types.SimpleNamespace(
+            BrowserConfig=lambda **kwargs: kwargs,
+            CacheMode=types.SimpleNamespace(DISABLED="disabled"),
+            CrawlerRunConfig=lambda **kwargs: kwargs,
+            RegexExtractionStrategy=_Regex,
+        )
+        with (
+            patch.dict(
+                sys.modules,
+                {
+                    "crawl4ai": fake_module,
+                    "crawl4ai.markdown_generation_strategy": types.SimpleNamespace(
+                        DefaultMarkdownGenerator=lambda **kwargs: kwargs
+                    ),
+                },
+            ),
+            patch.object(
+                web_scraper,
+                "_get_shared_crawler",
+                return_value=types.SimpleNamespace(submit=AsyncMock(return_value=_Result(json.dumps(rows)))),
+            ),
+        ):
+            output = asyncio.run(
+                web_scraper._scrape_with_crawl4ai(
+                    "https://example.test", extraction_strategy="regex", regex_patterns=["url"]
+                )
+            )
+        self.assertTrue(output["success"])
+        self.assertEqual(output["extracted"][0]["value"], "https://example.test/?a=1&b=2")
+        self.assertEqual(output["extracted"][0]["span"], [0, 33])
+        self.assertEqual(output["extracted"][1]["value"], rows[1]["value"])
+
+    def test_list_extraction_error_payload_is_failure(self):
+        result = _Result(json.dumps([{"error": "embedding unavailable"}]))
+        crawler = types.SimpleNamespace(arun=lambda **kwargs: asyncio.sleep(0, result=result))
+
+        class _Crawler:
+            def __init__(self, config):
+                self.crawler = crawler
+
+            async def start(self):
+                return self
+
+            async def close(self):
+                pass
+
+            async def arun(self, **kwargs):
+                return await self.crawler.arun(**kwargs)
+
+        fake_module = types.SimpleNamespace(
+            AsyncWebCrawler=_Crawler,
+            BrowserConfig=lambda **kwargs: kwargs,
+            CacheMode=types.SimpleNamespace(DISABLED="disabled"),
+            CrawlerRunConfig=lambda **kwargs: kwargs,
+            RegexExtractionStrategy=_Regex,
+        )
+        markdown_module = types.SimpleNamespace(DefaultMarkdownGenerator=lambda **kwargs: kwargs)
+        with patch.dict(
+            sys.modules,
+            {
+                "crawl4ai": fake_module,
+                "crawl4ai.markdown_generation_strategy": markdown_module,
+            },
+        ):
+            output = asyncio.run(web_scraper._scrape_with_crawl4ai("https://example.test", extraction_strategy="regex"))
+        self.assertFalse(output["success"])
+        self.assertIn("embedding unavailable", output["error"])
+
+    def test_llm_scrape_uses_configured_gateway_with_bounded_structured_input(self):
+        result = _Result(None)
+        crawler = types.SimpleNamespace(arun=lambda **kwargs: asyncio.sleep(0, result=result))
+
+        class _Crawler:
+            def __init__(self, config):
+                self.crawler = crawler
+
+            async def start(self):
+                return self
+
+            async def close(self):
+                pass
+
+            async def arun(self, **kwargs):
+                return await self.crawler.arun(**kwargs)
+
+        class _Gateway:
+            def __init__(self):
+                self.kwargs = None
+
+            async def generate_text(self, **kwargs):
+                self.kwargs = kwargs
+                return '{"title":"extracted"}'
+
+        gateway = _Gateway()
+        fake_crawl4ai = types.SimpleNamespace(
+            AsyncWebCrawler=_Crawler,
+            BrowserConfig=lambda **kwargs: kwargs,
+            CacheMode=types.SimpleNamespace(DISABLED="disabled"),
+            CrawlerRunConfig=lambda **kwargs: kwargs,
+        )
+        fake_client_module = types.SimpleNamespace(pollinations_client=gateway)
+        markdown_module = types.SimpleNamespace(DefaultMarkdownGenerator=lambda **kwargs: kwargs)
+        with patch.dict(
+            sys.modules,
+            {
+                "crawl4ai": fake_crawl4ai,
+                "crawl4ai.markdown_generation_strategy": markdown_module,
+                "src.ai.client": fake_client_module,
+            },
+        ):
+            output = asyncio.run(
+                web_scraper._scrape_with_crawl4ai(
+                    "https://example.test",
+                    extraction_strategy="llm",
+                    instruction="Find the title",
+                    schema={"type": "object"},
+                )
+            )
+        self.assertTrue(output["success"])
+        self.assertEqual(output["extracted"], {"title": "extracted"})
+        self.assertIn("Find the title", gateway.kwargs["user_prompt"])
+        self.assertIn("limited to 24000", gateway.kwargs["user_prompt"])
+
+    def test_llm_content_filter_is_an_actionable_configuration_failure(self):
+        with self.assertRaisesRegex(ValueError, "not configured"):
+            web_scraper._build_content_filter("llm")
+
+    def test_regex_handler_forwards_patterns_to_scrape_url(self):
+        captured = {}
+
+        async def fake_scrape_url(**kwargs):
+            captured.update(kwargs)
+            return {"success": True, "extracted": []}
+
+        with patch.object(web_scraper, "scrape_url", fake_scrape_url):
+            result = asyncio.run(
+                web_scraper.web_scrape_handler(action="regex", url="https://fixture.test", patterns=["url"])
+            )
+        self.assertTrue(result["success"])
+        self.assertEqual(captured["regex_patterns"], ["url"])
+        self.assertEqual(captured["extraction_strategy"], "regex")
+
+    def test_shared_browser_bounds_admission_and_cancellation_releases_tab(self):
+        active = 0
+        peak = 0
+        started = threading.Event()
+        unblock = threading.Event()
+
+        class _Crawler:
+            def __init__(self, config):
+                self.config = config
+
+            async def start(self):
+                return self
+
+            async def close(self):
+                pass
+
+            async def arun(self, **kwargs):
+                nonlocal active, peak
+                active += 1
+                peak = max(peak, active)
+                started.set()
+                try:
+                    await asyncio.to_thread(unblock.wait)
+                    return _Result(None)
+                finally:
+                    active -= 1
+
+        fake_crawl4ai = types.SimpleNamespace(
+            AsyncWebCrawler=_Crawler,
+            BrowserConfig=lambda **kwargs: types.SimpleNamespace(**kwargs),
+            CacheMode=types.SimpleNamespace(DISABLED="disabled"),
+            CrawlerRunConfig=lambda **kwargs: types.SimpleNamespace(**kwargs),
+        )
+        markdown_module = types.SimpleNamespace(DefaultMarkdownGenerator=lambda **kwargs: kwargs)
+
+        async def scenario():
+            web_scraper._crawler_pool = None
+            with patch.dict(
+                sys.modules,
+                {"crawl4ai": fake_crawl4ai, "crawl4ai.markdown_generation_strategy": markdown_module},
+            ):
+                jobs = [
+                    asyncio.create_task(web_scraper._scrape_with_crawl4ai(f"https://{index}.test"))
+                    for index in range(4)
+                ]
+                await asyncio.to_thread(started.wait)
+                for _ in range(20):
+                    if peak == 2:
+                        break
+                    await asyncio.sleep(0.01)
+                self.assertEqual(peak, 2)
+                busy = await web_scraper._scrape_with_crawl4ai("https://busy.test")
+                self.assertFalse(busy["success"])
+                self.assertIn("busy", busy["error"])
+                jobs[2].cancel()
+                with self.assertRaises(asyncio.CancelledError):
+                    await jobs[2]
+                jobs[3].cancel()
+                with self.assertRaises(asyncio.CancelledError):
+                    await jobs[3]
+                unblock.set()
+                await asyncio.gather(*jobs[:2])
+                self.assertLessEqual(peak, 2)
+                await web_scraper.close_web_scraper()
+
+        asyncio.run(scenario())
+
+    def test_shared_browser_rejects_sessions_and_conflicting_headless_mode(self):
+        async def scenario():
+            web_scraper._crawler_pool = None
+            rejected = await web_scraper._scrape_with_crawl4ai("https://example.test", session_id="persist")
+            self.assertFalse(rejected["success"])
+            self.assertIn("session_id", rejected["error"])
+
+            pool = web_scraper._SharedCrawlerPool(types.SimpleNamespace(headless=True))
+            web_scraper._crawler_pool = pool
+            with self.assertRaisesRegex(ValueError, "headless mode"):
+                await web_scraper._get_shared_crawler(types.SimpleNamespace(headless=False))
+            web_scraper._crawler_pool = None
+
+        asyncio.run(scenario())
+
+    def test_dedicated_crawler_reuses_one_browser_across_two_caller_loops(self):
+        created = []
+        active = 0
+        peak = 0
+        lock = threading.Lock()
+
+        class _Crawler:
+            def __init__(self, config):
+                created.append(self)
+
+            async def start(self):
+                return self
+
+            async def close(self):
+                pass
+
+            async def arun(self, **kwargs):
+                nonlocal active, peak
+                with lock:
+                    active += 1
+                    peak = max(peak, active)
+                try:
+                    await asyncio.sleep(0.03)
+                    return _Result(None)
+                finally:
+                    with lock:
+                        active -= 1
+
+        fake = types.SimpleNamespace(AsyncWebCrawler=_Crawler)
+        pool = None
+        with patch.dict(sys.modules, {"crawl4ai": fake}):
+            pool = web_scraper._SharedCrawlerPool(types.SimpleNamespace(headless=True))
+
+            def caller():
+                return asyncio.run(pool.submit("https://example.test", object(), 1))
+
+            threads = [threading.Thread(target=caller) for _ in range(2)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+            self.assertEqual(len(created), 1)
+            self.assertEqual(peak, 2)
+            asyncio.run(pool.close())
+
+    def test_semantic_spawn_failure_releases_admission(self):
+        class _Context:
+            def Queue(self, maxsize):
+                raise RuntimeError("spawn setup failed")
+
+        async def scenario():
+            with patch.object(web_scraper.multiprocessing, "get_context", return_value=_Context()):
+                with self.assertRaisesRegex(RuntimeError, "spawn setup failed"):
+                    await web_scraper._semantic_extract("https://example.test", "content", None, 1)
+            self.assertTrue(web_scraper._semantic_slots.acquire(blocking=False))
+            web_scraper._semantic_slots.release()
+
+        asyncio.run(scenario())
+
+    def test_semantic_timeout_keeps_loop_responsive_and_terminates_worker(self):
+        class _Output:
+            def get_nowait(self):
+                raise web_scraper.queue.Empty
+
+            def close(self):
+                pass
+
+        class _Process:
+            def __init__(self):
+                self.terminated = False
+                self.killed = False
+
+            def start(self):
+                pass
+
+            def is_alive(self):
+                return not self.terminated and not self.killed
+
+            def terminate(self):
+                self.terminated = True
+
+            def kill(self):
+                self.killed = True
+
+            def join(self):
+                pass
+
+        process = _Process()
+        context = types.SimpleNamespace(
+            Queue=lambda maxsize: _Output(),
+            Process=lambda target, args: process,
+        )
+
+        async def scenario():
+            ticks = 0
+
+            async def tick():
+                nonlocal ticks
+                while True:
+                    ticks += 1
+                    await asyncio.sleep(0.01)
+
+            ticker = asyncio.create_task(tick())
+            with patch.object(web_scraper.multiprocessing, "get_context", return_value=context):
+                with self.assertRaises(TimeoutError):
+                    await web_scraper._semantic_extract("https://example.test", "content", None, 0.05)
+            ticker.cancel()
+            with self.assertRaises(asyncio.CancelledError):
+                await ticker
+            self.assertTrue(process.terminated)
+            self.assertGreater(ticks, 1)
+
+        asyncio.run(scenario())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/polli/tests/test_web_search_sources.py
+++ b/apps/polli/tests/test_web_search_sources.py
@@ -1,0 +1,65 @@
+import unittest
+from unittest.mock import AsyncMock, Mock, patch
+
+from src.ai.client import pollinations_client, web_search_handler
+
+
+class WebSearchSourcesTests(unittest.IsolatedAsyncioTestCase):
+    async def search(self, payload):
+        response = AsyncMock()
+        response.status = 200
+        response.json.return_value = payload
+        response.__aenter__.return_value = response
+        session = Mock()
+        session.post.return_value = response
+        with patch.object(pollinations_client, "get_session", AsyncMock(return_value=session)):
+            return await web_search_handler("test query")
+
+    async def test_text_helper_omits_unsupported_seed(self):
+        response = AsyncMock()
+        response.status = 200
+        response.json.return_value = {"choices": [{"message": {"content": "review"}}]}
+        response.__aenter__.return_value = response
+        session = Mock()
+        session.post.return_value = response
+        with patch.object(pollinations_client, "get_session", AsyncMock(return_value=session)):
+            result = await pollinations_client.generate_text("Review", "Public diff", model="test-model")
+        self.assertEqual(result, "review")
+        payload = session.post.call_args.kwargs["json"]
+        self.assertNotIn("seed", payload)
+        self.assertEqual(payload["model"], "test-model")
+
+    async def test_citations_keep_provider_indexes(self):
+        result = await self.search(
+            {
+                "choices": [{"message": {"content": "Evidence [1] and [3]."}}],
+                "citations": ["https://example.org/one", None, "https://example.org/three"],
+            }
+        )
+        self.assertEqual([source["index"] for source in result["sources"]], [1, 3])
+        self.assertIn("[3] https://example.org/three", result["result"])
+
+    async def test_annotations_expose_urls_without_inventing_indexes(self):
+        result = await self.search(
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "content": "Evidence.",
+                            "annotations": [
+                                None,
+                                {"url_citation": None},
+                                {"url_citation": {"url": "https://example.org/source", "title": "Source"}},
+                            ],
+                        }
+                    }
+                ]
+            }
+        )
+        self.assertEqual(result["sources"], [{"url": "https://example.org/source", "title": "Source"}])
+        self.assertIn("https://example.org/source", result["result"])
+
+    async def test_missing_metadata_does_not_invent_sources(self):
+        result = await self.search({"choices": [{"message": {"content": "Evidence [8]."}}]})
+        self.assertEqual(result["sources"], [])
+        self.assertEqual(result["result"], "Evidence [8].")


### PR DESCRIPTION
## Browser workload and production responsiveness

- Reuse one Crawl4AI browser on a dedicated event-loop thread across Discord and Granian API callers.
- Give browser jobs isolated contexts/pages; cap execution at two active jobs with two bounded waiting slots.
- Bound queue waits by request timeout, reject excess load, and release capacity after cancellation cleanup.
- Serialize browser startup, close partially initialized crawlers, and drain active tasks before browser shutdown.
- Reject persistent session IDs and conflicting headless settings instead of accumulating retained pages.
- Run semantic extraction in a spawned subprocess with one-job admission, CPU-thread limits, timeout termination and process reaping.
- Handle Crawl4AI cosine extraction with one remaining text chunk without SciPy clustering failure.
- Close shared scraper resources during bot shutdown.
- Reject overlapping conversations in the same channel while allowing other channels to proceed.
- Retry empty model replies and provide a fallback response instead of silently ending after typing.

## Web tools and dependencies

- Upgrade Crawl4AI to 0.9.3, Scrapling to 0.4.15 and Python Playwright to 1.62.0.
- Install Scrapling fetcher/RAG extras; use class-based AsyncFetcher, safe redirects and native main-content Markdown.
- Pin sentence-transformers/Transformers to a compatible pairing; update supporting dependency constraints.
- Remove redundant unpinned Playwright installation from Docker.
- Correct rnet constructor options and Crawl4AI regex constant mappings.
- Preserve honest empty structured extraction results and report provider extraction errors as failures.
- Decode HTML entities in extracted URL values while preserving original source spans and non-URL values.
- Bound serialized multi-scrape responses, including Unicode and oversized URLs, with explicit truncation/omission metadata.
- Preserve usable web-search source URLs and annotation/citation context.

## GitHub data and PR reviews

- Add native GitHub query/cursor controls for issue search and PR listing.
- Pin repository/type scope while preserving supported qualifiers and grouped expressions; reject conflicting or empty explicit queries.
- Correct author/state/base filtering and distinguish natural-language PR requests from issue requests.
- Support combined issue/PR requests and paginate REST/GraphQL results with accurate totals and partial-result metadata.
- Improve repository overview pagination for projects, milestones and labels.
- Preserve edit-history selection controls and compact tool schemas.
- Remove unsupported PR-review seed arguments, increase per-file review output allowance, and accurately report reviewed files and failures.

## Discord, API, privacy and storage

- Improve permission-aware Discord search, thread context, role/name handling, chronological history and cursors.
- Require delegated `ag_` credentials at the Polli API boundary rather than direct `sk_`/`pk_` keys.
- Keep credentials request-local and forward delegated authorization to helper calls.
- Improve OpenAI-compatible chat/response handling and model selection behavior.
- Add privacy/help/deletion/unsubscribe handling and conversation retention controls.
- Harden subscription SQLite storage permissions, deletion and cleanup.
- Reduce exception/provider error logging to avoid exposing credentials or response bodies.

## Code intelligence and documentation

- Add the pinned CodeGraph Node dependency and lockfile, including installation in Docker.
- Resolve exact symbols and stable IDs; report ambiguous candidates rather than silently selecting fuzzy matches.
- Add a JavaScript bridge for symbol resolution, callers, callees and impact queries.
- Refresh the README and add hero/architecture SVG assets with contributor attribution.

## Validation and scope

- Include all 35 Polli files from this work; exclude unrelated scratch files, local settings and worktrees.
- Add/extend regressions for scraper concurrency, cancellation, semantic extraction, URL entities, search sources, GitHub controls, Discord permissions, API behavior, privacy, storage, logging and code intelligence.
- Full Linux regression suite: 154 tests run, one skipped, all remaining tests passed.
- Real isolated Chromium canaries passed concurrent scraping and cancellation followed by successful reuse.
- Real semantic model canary passed singleton extraction and forced timeout with a responsive event loop.
- Queue burst/cancellation canary confirmed two active jobs, bounded waiting and overload rejection.
- Follow-up formatting commit uses `@biomejs/biome` 2.3.10 explicitly; the previous local command resolved an unrelated executable. CI rerun passed: formatting, lint/build, service checks and all CodeQL analyses.
- Docker image build and a clean local Pyright run were not verified. No secrets are included or rotated by this PR.
