### PR TITLE
fix: accept caller API keys in Floret

### DIFF
--- a/apps/floret/.env.example
+++ b/apps/floret/.env.example
@@ -1,8 +1,8 @@
 PYTHONPATH=src
 OPENAI_BASE_URL=https://gen.pollinations.ai
-# Local/dev only. Users call gen with pk_/sk_; hosted Floret receives the
-# gateway's short-lived ag_ token instead. Leave this and the flag below unset
-# in production so Floret never spends an operator key.
+# Local/dev fallback for requests without a bearer credential. Direct callers
+# supply pk_/sk_; hosted calls supply the gateway's short-lived ag_ token.
+# Leave this and the flag below unset in production to require a caller key.
 OPENAI_API_KEY=sk_your_key_here
 POLLI_ALLOW_OPERATOR_KEY=true
 

--- a/apps/floret/README.md
+++ b/apps/floret/README.md
@@ -50,7 +50,7 @@ curl https://gen.pollinations.ai/v1/chat/completions \
   }'
 ```
 
-Users authenticate to `gen.pollinations.ai` with their normal `pk_` or `sk_` key. The gateway calls Floret with a short-lived internal `ag_` token; Floret's direct endpoint rejects user keys.
+Users authenticate to `gen.pollinations.ai` with their normal `pk_` or `sk_` key. The gateway calls Floret with a short-lived internal `ag_` token. Direct calls to Floret also accept `pk_` and `sk_` keys: the supplied bearer is forwarded unchanged to gen for authentication and billing, so brain and tool requests spend the caller's key. Invalid keys return gen's 401 for non-streaming calls; once an SSE stream has opened, errors are reported inside the stream.
 
 - Every field is optional.
 - Omitted/`auto` lets Floret select; an explicitly supplied JSON `null` is invalid.

--- a/apps/floret/src/floret/api.py
+++ b/apps/floret/src/floret/api.py
@@ -15,6 +15,7 @@ from typing import Any, AsyncIterator
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, StreamingResponse
+from openai import AuthenticationError
 from pydantic import BaseModel
 
 from floret.agent import run_agent, run_agent_events
@@ -272,29 +273,29 @@ async def _sse_events(
     yield "data: [DONE]\n\n"
 
 
-def _agent_run_token(http_request: Request) -> str | None:
-    """Return the gateway-minted run token; reject direct user credentials."""
-    header = http_request.headers.get("Authorization", "")
-    if not header:
+def _request_api_key(http_request: Request) -> str | None:
+    """Pass the caller's bearer credential to gen for authentication and billing."""
+    header = http_request.headers.get("Authorization")
+    if header is None:
         return None
     token = header[7:].strip() if header[:7].lower() == "bearer " else ""
-    if not token.startswith("ag_"):
+    if not token:
         raise HTTPException(
             status_code=401,
-            detail="Floret requires an agent run token.",
+            detail="Expected a nonempty Bearer token.",
         )
     return token
 
 
 @app.post("/v1/chat/completions")
 async def chat_completions(request: ChatRequest, http_request: Request) -> Any:
-    api_key = _agent_run_token(http_request)
+    api_key = _request_api_key(http_request)
     # Fail here rather than part-way through a run: without a credential every
     # downstream generation 401s anyway, after the caller has already waited.
     if not api_key and not settings.allow_operator_key:
         raise HTTPException(
             status_code=401,
-            detail="Missing agent run token.",
+            detail="Missing API key.",
         )
 
     token = _api_key_override.set(api_key or None)
@@ -346,6 +347,8 @@ async def chat_completions(request: ChatRequest, http_request: Request) -> Any:
         }
     except HTTPException:
         raise
+    except AuthenticationError as exc:
+        raise HTTPException(status_code=401, detail=exc.message) from exc
     except Exception as exc:
         logger.exception("chat_completions failed")
         raise HTTPException(status_code=500, detail=str(exc))
@@ -370,7 +373,7 @@ async def chat_completions_get() -> dict[str, Any]:
             "method": "POST",
             "headers": {
                 "Content-Type": "application/json",
-                "Authorization": "Bearer <agent-run-token>",
+                "Authorization": "Bearer <api-key>",
             },
             "body": {
                 "model": "floret",
@@ -404,5 +407,5 @@ async def root() -> dict[str, Any]:
             "models": "GET /v1/models",
             "health": "GET /health",
         },
-        "auth": "Authorization: Bearer <agent-run-token>",
+        "auth": "Authorization: Bearer <api-key>",
     }

--- a/apps/floret/src/floret/config.py
+++ b/apps/floret/src/floret/config.py
@@ -53,10 +53,9 @@ settings = Settings()
 def resolve_api_key() -> str:
     """The credential this request may spend.
 
-    Normally the per-request token the gateway passed in — with run tokens that
-    is a short-lived `ag_` credential scoped to the calling user, so the agent
-    never holds anyone's long-lived key. Falls back to the operator's own key
-    only when `POLLI_ALLOW_OPERATOR_KEY` is set.
+    Use the caller's API key or the gateway's short-lived `ag_` run token.
+    Fall back to the operator's own key only when `POLLI_ALLOW_OPERATOR_KEY`
+    is set and the request has no bearer credential.
     """
     key = _current_api_key()
     if key:

--- a/apps/floret/tests/test_api_stream.py
+++ b/apps/floret/tests/test_api_stream.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import base64
 import json
 
+import httpx
 import pytest
 from fastapi.testclient import TestClient
+from openai import AuthenticationError
 
 from floret import api as api_mod
 from floret.config import _current_api_key
@@ -368,55 +370,107 @@ def test_request_without_credential_is_rejected(monkeypatch: pytest.MonkeyPatch)
     client = TestClient(api_mod.app)
     resp = client.post("/v1/chat/completions", json=_request_body(stream=False))
     assert resp.status_code == 401
-    assert resp.json() == {"detail": "Missing agent run token."}
+    assert resp.json() == {"detail": "Missing API key."}
 
 
-@pytest.mark.parametrize("key", ["sk_caller_key", "pk_caller_key", "invalid"])
-def test_direct_endpoint_rejects_non_agent_credentials(key):
-    """Users authenticate to gen; only its delegated token reaches Floret."""
+@pytest.mark.parametrize("header", ["", "Bearer ", "Basic credentials"])
+def test_malformed_bearer_does_not_fall_back_to_operator(monkeypatch, header):
+    monkeypatch.setattr(api_mod.settings, "allow_operator_key", True)
     response = TestClient(api_mod.app).post(
         "/v1/chat/completions",
         json=_request_body(stream=False),
-        headers={"Authorization": f"Bearer {key}"},
+        headers={"Authorization": header},
     )
 
     assert response.status_code == 401
-    assert response.json() == {"detail": "Floret requires an agent run token."}
+    assert response.json() == {"detail": "Expected a nonempty Bearer token."}
 
 
-def test_agent_run_token_reaches_brain_and_tools(monkeypatch):
-    """The same per-request run token is available to every generation path."""
-    from floret.config import _current_api_key
+@pytest.mark.parametrize("key", ["sk_caller_key", "pk_caller_key", "ag_run", "opaque"])
+@pytest.mark.parametrize("stream", [False, True])
+def test_caller_key_reaches_brain_and_tools(monkeypatch, key, stream):
+    """Every generation path bills the caller, even with operator fallback enabled."""
+    from floret import agent
     from floret.tools import gen
 
-    run_token = "ag_test-delegated-run-token"
+    monkeypatch.setattr(api_mod.settings, "allow_operator_key", True)
+    monkeypatch.setattr(api_mod.settings, "openai_api_key", "sk_operator_fixture")
 
     async def fake_run_agent(messages, **kwargs):
-        assert _current_api_key() == run_token
-        assert gen._key() == run_token
+        assert _current_api_key() == key
+        assert gen._key() == key
+        async with agent._client() as brain, gen._client() as tool:
+            assert brain.auth_headers == {"Authorization": f"Bearer {key}"}
+            assert tool.auth_headers == {"Authorization": f"Bearer {key}"}
         return {"text": "delegated", "artifacts": [], "iterations": 1}
 
+    async def fake_events(messages, **kwargs):
+        yield {"type": "final", **await fake_run_agent(messages, **kwargs)}
+
     monkeypatch.setattr(api_mod, "run_agent", fake_run_agent)
+    monkeypatch.setattr(api_mod, "run_agent_events", fake_events)
 
     client = TestClient(api_mod.app)
     response = client.post(
         "/v1/chat/completions",
-        json=_request_body(stream=False),
-        headers={"Authorization": f"Bearer {run_token}"},
+        json=_request_body(stream=stream),
+        headers={"Authorization": f"bEaReR {key}"},
     )
 
     assert response.status_code == 200
-    assert response.json()["choices"][0]["message"]["content"] == "delegated"
+    assert "delegated" in response.text
+    assert _current_api_key() is None
+
+
+@pytest.mark.parametrize("stream", [False, True])
+def test_invalid_key_is_rejected_by_gen(monkeypatch, stream):
+    monkeypatch.setattr(api_mod.settings, "allow_operator_key", True)
+    monkeypatch.setattr(api_mod.settings, "openai_api_key", "sk_operator_fixture")
+
+    async def rejected(messages, **kwargs):
+        assert _current_api_key() == "invalid"
+        raise AuthenticationError(
+            "Invalid API key",
+            response=httpx.Response(
+                401,
+                request=httpx.Request(
+                    "POST", "https://gen.pollinations.ai/v1/chat/completions"
+                ),
+            ),
+            body={"error": "Invalid API key"},
+        )
+
+    async def rejected_events(messages, **kwargs):
+        yield await rejected(messages, **kwargs)
+
+    monkeypatch.setattr(api_mod, "run_agent", rejected)
+    monkeypatch.setattr(api_mod, "run_agent_events", rejected_events)
+    response = TestClient(api_mod.app).post(
+        "/v1/chat/completions",
+        json=_request_body(stream=stream),
+        headers={"Authorization": "Bearer invalid"},
+    )
+
+    if stream:
+        assert "[error: Invalid API key]" in response.text
+        assert response.text.rstrip().endswith("data: [DONE]")
+    else:
+        assert response.status_code == 401
+        assert response.json() == {"detail": "Invalid API key"}
 
 
 def test_operator_key_fallback_is_opt_in(monkeypatch):
     """With POLLI_ALLOW_OPERATOR_KEY set, local/dev use still works unauthenticated."""
 
     async def fake_run_agent(messages, **kwargs):
+        from floret.config import resolve_api_key
+
+        assert resolve_api_key() == "sk_operator_fixture"
         return {"text": "plain", "artifacts": [], "iterations": 1}
 
     monkeypatch.setattr(api_mod, "run_agent", fake_run_agent)
     monkeypatch.setattr(api_mod.settings, "allow_operator_key", True)
+    monkeypatch.setattr(api_mod.settings, "openai_api_key", "sk_operator_fixture")
 
     client = TestClient(api_mod.app)
     resp = client.post("/v1/chat/completions", json=_request_body(stream=False))


### PR DESCRIPTION
- Accepts opaque bearer credentials, including `sk_`, `pk_`, and hosted `ag_` tokens; Gen authenticates and bills the supplied key.
- Preserves opt-in operator fallback only when no credential is supplied. Returns upstream authentication failures as HTTP 401 for JSON; already-open SSE streams report errors in-band.
- Updates auth examples and regression coverage for both response modes, malformed credentials, caller-key precedence, and upstream rejection.
- Validation: real direct `sk_` call succeeded and caller balance decreased by 0.0060908 Pollen; live invalid-key JSON/SSE checks and concurrent credential-isolation smoke checks passed. Python compilation passed; no new Ruff findings. Biome does not process these file types. Pytest suite not run: repository AGENTS.md forbids it; an exception has been requested.

Fixes #14170
