### PR TITLE
feat: expose model reliability and availability in catalogs

### DIFF
--- a/gen.pollinations.ai/src/model-registry.ts
+++ b/gen.pollinations.ai/src/model-registry.ts
@@ -6,6 +6,12 @@ import { DEFAULT_AUDIO_MODEL } from "@shared/registry/audio.ts";
 import { DEFAULT_EMBEDDING_MODEL } from "@shared/registry/embeddings.ts";
 import { DEFAULT_IMAGE_MODEL } from "@shared/registry/image.ts";
 import {
+    buildModelHealthIndex,
+    type ModelHealth,
+    type ModelHealthRow,
+    unknownModelHealth,
+} from "@shared/registry/model-health.ts";
+import {
     type ModelInfo,
     modelInfoFromDefinition,
 } from "@shared/registry/model-info.ts";
@@ -29,8 +35,13 @@ import {
     getCommunityModelRegistryEntries,
 } from "./community-models.ts";
 import { linkFallbackEntries } from "./fallback.ts";
+import { getModelHealthSnapshot } from "./routes/model-status.ts";
 
 const REGISTRY_TTL_MS = 60_000;
+// A wider window than the live /v1/models/status default (60m): catalog
+// health should stay populated for lower-traffic community models instead of
+// flipping to "unknown" between bursts of requests.
+const HEALTH_WINDOW_MINUTES = 24 * 60;
 // A static-only registry is cached briefly so the community models come back
 // seconds after D1 recovers, instead of being missing for a full TTL.
 const DEGRADED_REGISTRY_TTL_MS = 5_000;
@@ -224,6 +235,48 @@ function buildRegistry(
     };
 }
 
+// Attaches measured reliability to every entry from one shared Tinybird
+// snapshot (cached by getModelHealthSnapshot), never per model. A model with
+// no matching row -- no traffic, or the snapshot itself unavailable -- gets
+// "unknown" rather than being left off or implied healthy. Returns new entry
+// and info objects so STATIC_ENTRIES is never mutated (see buildRegistry).
+async function attachHealth(
+    entries: GenerationModelEntry[],
+): Promise<GenerationModelEntry[]> {
+    let healthIndex: Map<string, ModelHealth> | null = null;
+    let fallbackHealth = unknownModelHealth(HEALTH_WINDOW_MINUTES, null, true);
+    try {
+        const snapshot = await getModelHealthSnapshot(HEALTH_WINDOW_MINUTES);
+        if (snapshot) {
+            fallbackHealth = unknownModelHealth(
+                HEALTH_WINDOW_MINUTES,
+                snapshot.timestamp,
+                snapshot.stale,
+            );
+            healthIndex = buildModelHealthIndex(
+                snapshot.data.data as ModelHealthRow[],
+                HEALTH_WINDOW_MINUTES,
+                snapshot.timestamp,
+                snapshot.stale,
+            );
+        }
+    } catch (error) {
+        // Health is presentational: a Tinybird outage must never block model
+        // listing, so any failure here just falls back to "unknown".
+        console.error("Model health snapshot unavailable", error);
+    }
+
+    return entries.map((entry) => ({
+        ...entry,
+        info: {
+            ...entry.info,
+            health:
+                healthIndex?.get(`${entry.id}::${entry.eventType}`) ??
+                fallbackHealth,
+        },
+    }));
+}
+
 async function loadGenerationModelRegistry(
     env: CommunityModelEnv,
 ): Promise<{ registry: GenerationModelRegistry; degraded: boolean }> {
@@ -243,8 +296,12 @@ async function loadGenerationModelRegistry(
         degraded = true;
         console.error("Community model registry unavailable", error);
     }
+    const entries = await attachHealth([
+        ...STATIC_ENTRIES,
+        ...communityEntries,
+    ]);
     return {
-        registry: buildRegistry([...STATIC_ENTRIES, ...communityEntries]),
+        registry: buildRegistry(entries),
         degraded,
     };
 }

--- a/gen.pollinations.ai/src/routes/model-status.ts
+++ b/gen.pollinations.ai/src/routes/model-status.ts
@@ -17,13 +17,27 @@ const MAX_MINUTES = 7 * 24 * 60;
 const DATA_TIMESTAMP_HEADER = "X-Model-Status-Timestamp";
 const STALE_HEADER = "X-Model-Status-Stale";
 
-type ModelHealthResponse = {
+export type ModelHealthResponse = {
     data: unknown[];
     meta?: unknown;
     [key: string]: unknown;
 };
 
+function isModelHealthResponse(value: unknown): value is ModelHealthResponse {
+    return (
+        typeof value === "object" &&
+        value !== null &&
+        Array.isArray((value as { data?: unknown }).data)
+    );
+}
+
 type CacheEntry = { data: ModelHealthResponse; timestamp: number };
+
+export type ModelHealthSnapshot = {
+    data: ModelHealthResponse;
+    timestamp: number;
+    stale: boolean;
+};
 
 const cache = new Map<number, CacheEntry>();
 
@@ -44,6 +58,63 @@ function parseMinutes(value: string | undefined): number | null {
     const minutes = Number(value);
     if (minutes < 1 || minutes > MAX_MINUTES) return null;
     return minutes;
+}
+
+async function fetchFromTinybird(
+    minutes: number,
+): Promise<ModelHealthResponse> {
+    const url = new URL("/v0/pipes/model_health.json", TINYBIRD_HOST);
+    url.searchParams.set("token", TINYBIRD_PUBLIC_TOKEN);
+    url.searchParams.set("minutes", String(minutes));
+    log("Fetching model health from Tinybird: %s", url.toString());
+
+    const response = await fetch(url.toString());
+    if (!response.ok) {
+        throw new Error(`Tinybird responded with ${response.status}`);
+    }
+    const body = await response.json();
+    if (!isModelHealthResponse(body)) {
+        throw new Error("Tinybird returned an unexpected model health shape");
+    }
+    return body;
+}
+
+// Shared by the /v1/models/status route and catalog health enrichment
+// (model-registry.ts) so both reuse the same 60s Tinybird cache instead of
+// issuing separate fetches. Returns null only when there is no fresh data
+// and no stale cache to fall back to.
+export async function getModelHealthSnapshot(
+    minutes: number,
+): Promise<ModelHealthSnapshot | null> {
+    const now = Date.now();
+    const cached = cache.get(minutes);
+    if (cached && now - cached.timestamp < CACHE_TTL_MS) {
+        setCacheEntry(minutes, cached);
+        return { data: cached.data, timestamp: cached.timestamp, stale: false };
+    }
+
+    try {
+        const data = await fetchFromTinybird(minutes);
+        const timestamp = Date.now();
+        setCacheEntry(minutes, { data, timestamp });
+        return { data, timestamp, stale: false };
+    } catch (error) {
+        log("Error fetching model health: %O", error);
+        const stale = cache.get(minutes);
+        if (stale) {
+            setCacheEntry(minutes, stale);
+            return {
+                data: stale.data,
+                timestamp: stale.timestamp,
+                stale: true,
+            };
+        }
+        return null;
+    }
+}
+
+export function resetModelHealthCache(): void {
+    cache.clear();
 }
 
 export const modelStatusRoutes = new Hono<Env>().get(
@@ -94,51 +165,16 @@ export const modelStatusRoutes = new Hono<Env>().get(
             );
         }
 
-        const now = Date.now();
-        const cached = cache.get(minutes);
-        if (cached && now - cached.timestamp < CACHE_TTL_MS) {
-            log(
-                "Returning cached model health response for %d minutes",
-                minutes,
-            );
-            setCacheEntry(minutes, cached);
-            c.header(
-                DATA_TIMESTAMP_HEADER,
-                new Date(cached.timestamp).toISOString(),
-            );
-            return c.json(cached.data);
-        }
-
-        try {
-            const url = new URL("/v0/pipes/model_health.json", TINYBIRD_HOST);
-            url.searchParams.set("token", TINYBIRD_PUBLIC_TOKEN);
-            url.searchParams.set("minutes", String(minutes));
-            log("Fetching model health from Tinybird: %s", url.toString());
-
-            const response = await fetch(url.toString());
-            if (!response.ok) {
-                throw new Error(`Tinybird responded with ${response.status}`);
-            }
-
-            const tinybirdData = (await response.json()) as ModelHealthResponse;
-            const timestamp = Date.now();
-            setCacheEntry(minutes, { data: tinybirdData, timestamp });
-            c.header(DATA_TIMESTAMP_HEADER, new Date(timestamp).toISOString());
-            return c.json(tinybirdData);
-        } catch (error) {
-            log("Error fetching model health: %O", error);
-            const stale = cache.get(minutes);
-            if (stale) {
-                log("Falling back to stale cache for %d minutes", minutes);
-                setCacheEntry(minutes, stale);
-                c.header(
-                    DATA_TIMESTAMP_HEADER,
-                    new Date(stale.timestamp).toISOString(),
-                );
-                c.header(STALE_HEADER, "true");
-                return c.json(stale.data);
-            }
+        const snapshot = await getModelHealthSnapshot(minutes);
+        if (!snapshot) {
             return c.json({ error: "Failed to fetch model health data" }, 502);
         }
+
+        c.header(
+            DATA_TIMESTAMP_HEADER,
+            new Date(snapshot.timestamp).toISOString(),
+        );
+        if (snapshot.stale) c.header(STALE_HEADER, "true");
+        return c.json(snapshot.data);
     },
 );

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -302,6 +302,7 @@ function toOpenAIModelEntry(entry: GenerationModelEntry) {
         }),
         pricing: entry.info.pricing,
         capabilities: entry.info.capabilities,
+        health: entry.info.health,
         ...(entry.info.tools && { tools: entry.info.tools }),
         ...(entry.info.reasoning && { reasoning: entry.info.reasoning }),
         ...(entry.info.context_length && {

--- a/gen.pollinations.ai/test/model-registry.test.ts
+++ b/gen.pollinations.ai/test/model-registry.test.ts
@@ -1,13 +1,64 @@
 import { env } from "cloudflare:test";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CommunityModelEnv } from "../src/community-models.ts";
 import {
     getGenerationModelRegistry,
     resetGenerationModelRegistryCache,
 } from "../src/model-registry.ts";
+import { resetModelHealthCache } from "../src/routes/model-status.ts";
+
+const MODEL_HEALTH_URL =
+    "https://api.europe-west2.gcp.tinybird.co/v0/pipes/model_health.json";
+
+function healthRow(overrides: {
+    model: string;
+    event_type: string;
+    status_2xx: number;
+    errors_5xx: number;
+}) {
+    const { status_2xx, errors_5xx } = overrides;
+    return {
+        ...overrides,
+        provider: "test-provider",
+        model_used: overrides.model,
+        total_requests: status_2xx + errors_5xx,
+        errors_4xx: 0,
+        own_calls: status_2xx + errors_5xx,
+        own_calls_ok: status_2xx,
+        primary_5xx: errors_5xx,
+        primary_retried_503s: 0,
+        fallback_rescues: 0,
+        last_error_at: "1970-01-01 00:00:00",
+        latency_p50_ms: null,
+        latency_p95_ms: null,
+        avg_latency_ms: null,
+        last_request_at: "1970-01-01 00:00:00",
+        tokens_per_second: null,
+    };
+}
+
+// Stands in for Tinybird: every model-registry rebuild fetches one health
+// snapshot, so tests control it the same way provider tests mock upstream
+// APIs (see test/image/ideogramModel.test.ts).
+function mockModelHealth(rows: ReturnType<typeof healthRow>[] = []) {
+    return vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+        const href = typeof input === "string" ? input : input.toString();
+        if (!href.startsWith(MODEL_HEALTH_URL)) {
+            throw new Error(`Unexpected fetch in test: ${href}`);
+        }
+        return new Response(JSON.stringify({ data: rows }), {
+            headers: { "Content-Type": "application/json" },
+        });
+    });
+}
+
+beforeEach(() => {
+    mockModelHealth();
+});
 
 afterEach(() => {
     resetGenerationModelRegistryCache();
+    resetModelHealthCache();
     vi.restoreAllMocks();
 });
 
@@ -64,5 +115,90 @@ describe("getGenerationModelRegistry", () => {
             "Community model registry unavailable",
             expect.any(Error),
         );
+    });
+});
+
+describe("model health enrichment", () => {
+    it("reports healthy status for a high success-rate window", async () => {
+        mockModelHealth([
+            healthRow({
+                model: "openai",
+                event_type: "generate.text",
+                status_2xx: 98,
+                errors_5xx: 2,
+            }),
+        ]);
+
+        const registry = await getGenerationModelRegistry(env);
+        const health = registry.resolve("openai")?.info.health;
+        expect(health?.status).toBe("healthy");
+        expect(health?.success_rate).toBeCloseTo(0.98);
+        expect(health?.sample_size).toBe(100);
+        expect(health?.window_minutes).toBe(24 * 60);
+        expect(health?.stale).toBe(false);
+        expect(typeof health?.checked_at).toBe("string");
+    });
+
+    it("reports degraded and unavailable status as the failure share rises", async () => {
+        mockModelHealth([
+            healthRow({
+                model: "openai",
+                event_type: "generate.text",
+                status_2xx: 90,
+                errors_5xx: 10,
+            }),
+        ]);
+        expect(
+            (await getGenerationModelRegistry(env)).resolve("openai")?.info
+                .health?.status,
+        ).toBe("degraded");
+
+        resetGenerationModelRegistryCache();
+        resetModelHealthCache();
+        mockModelHealth([
+            healthRow({
+                model: "openai",
+                event_type: "generate.text",
+                status_2xx: 50,
+                errors_5xx: 50,
+            }),
+        ]);
+        expect(
+            (await getGenerationModelRegistry(env)).resolve("openai")?.info
+                .health?.status,
+        ).toBe("unavailable");
+    });
+
+    it("marks a low-sample or untracked model unknown, never healthy by default", async () => {
+        mockModelHealth([
+            healthRow({
+                model: "openai",
+                event_type: "generate.text",
+                status_2xx: 3,
+                errors_5xx: 0,
+            }),
+        ]);
+
+        const registry = await getGenerationModelRegistry(env);
+        const lowSample = registry.resolve("openai")?.info.health;
+        expect(lowSample?.status).toBe("unknown");
+        expect(lowSample?.sample_size).toBe(3);
+
+        const untracked = registry.resolve("krea")?.info.health;
+        expect(untracked?.status).toBe("unknown");
+        expect(untracked?.sample_size).toBe(0);
+        expect(untracked?.success_rate).toBeNull();
+    });
+
+    it("degrades to unknown rather than healthy when the health source is unavailable", async () => {
+        vi.spyOn(globalThis, "fetch").mockRejectedValue(
+            new Error("network down"),
+        );
+
+        const registry = await getGenerationModelRegistry(env);
+        const health = registry.resolve("openai")?.info.health;
+        expect(health?.status).toBe("unknown");
+        expect(health?.checked_at).toBeNull();
+        expect(health?.stale).toBe(true);
     });
 });

--- a/gen.pollinations.ai/test/models-retrieve.test.ts
+++ b/gen.pollinations.ai/test/models-retrieve.test.ts
@@ -3,11 +3,30 @@ import {
     RESTRICTED_TEXT_TEST_MODEL,
     test,
 } from "@shared/test/fixtures/index.ts";
-import { expect } from "vitest";
+import { afterEach, beforeEach, expect, vi } from "vitest";
+import { resetGenerationModelRegistryCache } from "../src/model-registry.ts";
+import { resetModelHealthCache } from "../src/routes/model-status.ts";
 
 async function fetchWorker(path: string, init: RequestInit = {}) {
     return SELF.fetch(new Request(`https://gen.pollinations.ai${path}`, init));
 }
+
+// A model-list request fetches one Tinybird health snapshot; keep it
+// deterministic and network-free the same way provider tests mock upstream
+// APIs (see test/image/ideogramModel.test.ts).
+beforeEach(() => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify({ data: [] }), {
+            headers: { "Content-Type": "application/json" },
+        }),
+    );
+});
+
+afterEach(() => {
+    resetGenerationModelRegistryCache();
+    resetModelHealthCache();
+    vi.restoreAllMocks();
+});
 
 test("retrieves a model by canonical ID", async () => {
     const response = await fetchWorker("/v1/models/openai-fast");
@@ -66,6 +85,36 @@ test("retrieve matches the list entry exactly (shared mapper)", async () => {
         unknown
     >;
     expect(retrieved).toEqual(listed);
+});
+
+test("exposes health metadata consistently on list and retrieve", async () => {
+    const listResponse = await fetchWorker("/v1/models");
+    const list = (await listResponse.json()) as {
+        data: { id: string; health?: Record<string, unknown> }[];
+    };
+    const listed = list.data.find((m) => m.id === "openai-fast");
+    expect(listed?.health).toMatchObject({
+        status: "unknown",
+        success_rate: null,
+        sample_size: 0,
+        stale: false,
+    });
+    expect(typeof listed?.health?.checked_at).toBe("string");
+
+    const retrieveResponse = await fetchWorker("/v1/models/openai-fast");
+    const retrieved = (await retrieveResponse.json()) as {
+        health?: Record<string, unknown>;
+    };
+    expect(retrieved.health).toEqual(listed?.health);
+
+    const catalogResponse = await fetchWorker("/models");
+    const catalog = (await catalogResponse.json()) as {
+        name: string;
+        health?: Record<string, unknown>;
+    }[];
+    expect(catalog.find((m) => m.name === "openai-fast")?.health).toMatchObject(
+        { status: "unknown" },
+    );
 });
 
 test("returns 404 for an unknown model", async () => {

--- a/shared/registry/model-health.ts
+++ b/shared/registry/model-health.ts
@@ -1,0 +1,96 @@
+import { z } from "zod";
+
+export const MODEL_HEALTH_STATUSES = [
+    "healthy",
+    "degraded",
+    "unavailable",
+    "unknown",
+] as const;
+
+export type ModelHealthStatus = (typeof MODEL_HEALTH_STATUSES)[number];
+
+export const ModelHealthSchema = z
+    .object({
+        status: z.enum(MODEL_HEALTH_STATUSES),
+        success_rate: z.number().min(0).max(1).nullable(),
+        sample_size: z.number().int().nonnegative(),
+        window_minutes: z.number().int().positive(),
+        checked_at: z.string().datetime().nullable(),
+        stale: z.boolean(),
+    })
+    .meta({
+        description:
+            'Measured reliability from recent traffic, not a live probe. success_rate is final-response 2xx / (2xx + 5xx) over window_minutes; requests that failed on their own upstream but succeeded on a fallback count as successes, and caller-side errors (bad auth, no balance, invalid request) are excluded from the sample. status is "unknown" when sample_size is below the confidence threshold or no measurement could be taken, and is never reported as healthy in that case. checked_at is null and stale is true when no health data has ever been fetched.',
+    });
+
+export type ModelHealth = z.infer<typeof ModelHealthSchema>;
+
+export type ModelHealthRow = {
+    model: string;
+    event_type: string;
+    status_2xx: number;
+    errors_5xx: number;
+};
+
+// A model's own upstream failures matter for reliability; the caller's 4xx
+// errors (bad key, no balance, malformed request) don't, so they're excluded
+// from the sample entirely rather than counted against the model. Mirrors
+// operations/model-monitor's computeHealthStatus, minus its "no traffic reads
+// healthy" default -- this feature must not imply 100% reliable from silence.
+const MIN_SAMPLE_SIZE = 10;
+const DEGRADED_FAILURE_PERCENT = 5;
+const UNAVAILABLE_FAILURE_PERCENT = 20;
+
+function statusFor(
+    successRate: number | null,
+    sampleSize: number,
+): ModelHealthStatus {
+    if (successRate === null || sampleSize < MIN_SAMPLE_SIZE) return "unknown";
+    const failurePercent = (1 - successRate) * 100;
+    if (failurePercent >= UNAVAILABLE_FAILURE_PERCENT) return "unavailable";
+    if (failurePercent >= DEGRADED_FAILURE_PERCENT) return "degraded";
+    return "healthy";
+}
+
+function checkedAtIso(checkedAt: number | null): string | null {
+    return checkedAt !== null ? new Date(checkedAt).toISOString() : null;
+}
+
+export function unknownModelHealth(
+    windowMinutes: number,
+    checkedAt: number | null,
+    stale: boolean,
+): ModelHealth {
+    return {
+        status: "unknown",
+        success_rate: null,
+        sample_size: 0,
+        window_minutes: windowMinutes,
+        checked_at: checkedAtIso(checkedAt),
+        stale,
+    };
+}
+
+// Keyed on "model::event_type" so a name shared across categories (unlikely,
+// but the health rows are grouped that way) never merges unrelated traffic.
+export function buildModelHealthIndex(
+    rows: readonly ModelHealthRow[],
+    windowMinutes: number,
+    checkedAt: number | null,
+    stale: boolean,
+): Map<string, ModelHealth> {
+    const index = new Map<string, ModelHealth>();
+    for (const row of rows) {
+        const sampleSize = row.status_2xx + row.errors_5xx;
+        const successRate = sampleSize > 0 ? row.status_2xx / sampleSize : null;
+        index.set(`${row.model}::${row.event_type}`, {
+            status: statusFor(successRate, sampleSize),
+            success_rate: successRate,
+            sample_size: sampleSize,
+            window_minutes: windowMinutes,
+            checked_at: checkedAtIso(checkedAt),
+            stale,
+        });
+    }
+    return index;
+}

--- a/shared/registry/model-info.ts
+++ b/shared/registry/model-info.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { ModelHealthSchema } from "./model-health.ts";
 import { publicPriceInfo, toFixedPoint } from "./public-pricing";
 import {
     type BillingAdjustmentRule,
@@ -115,6 +116,7 @@ export const ModelInfoSchema = z.object({
     alpha: z.boolean().optional(),
     flat_rate: z.boolean().optional(),
     added_date: z.number().optional(),
+    health: ModelHealthSchema.optional(),
 });
 
 export type ModelInfo = z.infer<typeof ModelInfoSchema>;

--- a/shared/schemas/openai.ts
+++ b/shared/schemas/openai.ts
@@ -1,6 +1,7 @@
 // AI generated based on `https://github.com/Portkey-AI/openapi/blob/master/openapi.yaml` and adaped
 
 import { z } from "zod";
+import { ModelHealthSchema } from "../registry/model-health.ts";
 import { AUDIO_VOICES, DEFAULT_TEXT_MODEL } from "../registry/text.ts";
 import { SafeSchema } from "./safety.ts";
 
@@ -532,6 +533,7 @@ export const OpenAIModelSchema = z
         reasoning: z.boolean().optional(),
         context_length: z.number().optional(),
         per_user_rpm: z.number().positive().nullable().optional(),
+        health: ModelHealthSchema.optional(),
     })
     .meta({
         description: "OpenAI-compatible model object with capability metadata",


### PR DESCRIPTION
Fixes #14535

Adds measured reliability/availability metadata to model catalog responses.

- `shared/registry/model-health.ts` (new): computes `status` (`healthy`/`degraded`/`unavailable`/`unknown`), `success_rate`, `sample_size`, `window_minutes`, `checked_at`, `stale` from the existing `model_health` Tinybird pipe rows. Sample is `2xx / (2xx + 5xx)`; 4xx (bad auth, no balance, invalid request, rate limits) is excluded from the denominator entirely rather than counted against the model. Below a sample-size threshold or with no data, status is `"unknown"`, never `"healthy"`.
- `gen.pollinations.ai/src/routes/model-status.ts`: extracted the existing fetch/cache logic into `getModelHealthSnapshot()` so catalog enrichment reuses the same 60s-cached Tinybird call the `/v1/models/status` route already makes — no per-model fetches, no new endpoint. Also validates the Tinybird response against the existing zod schema instead of an unchecked cast.
- `gen.pollinations.ai/src/model-registry.ts`: attaches health to every registry entry (official + community) from one shared snapshot per rebuild (24h window, so lower-traffic models stay populated). A Tinybird outage never blocks model listing — it falls back to `"unknown"`.
- `shared/registry/model-info.ts`, `shared/schemas/openai.ts`: add the optional `health` field to `ModelInfoSchema`/`OpenAIModelSchema`, so it's present on `/v1/models`, `/v1/models/:model`, `/models`, and every category list (`/image/models`, `/text/models`, etc.) via the shared mapper — no per-endpoint changes needed.
- `gen.pollinations.ai/src/routes/proxy.ts`: passes `health` through in the OpenAI-compatible mapper.

No changes to response shape/ordering/filtering/visibility beyond the new optional field; no new endpoints or Tinybird pipe changes.

Verified: `tsc --noEmit` clean for both `gen.pollinations.ai` and `enter.pollinations.ai` workspaces (shared schema change), `biome check` clean. Added focused tests in `test/model-registry.test.ts` (status thresholds, low-sample handling, unavailable-source fallback) and `test/models-retrieve.test.ts` (health present and consistent across list/retrieve/`/models`). Core classification logic double-checked directly with `tsx`. The Cloudflare Workers vitest pool (`workerd`) could not run in this sandbox (glibc too old for the pinned binary) — untouched pre-existing test files fail the same way, confirming it's an environment limitation, not a regression; CI should run the full suite.
