### PR TITLE
fix: route aliased models correctly on the play page

### DIFF
--- a/pollinations.ai/src/hooks/useModelList.ts
+++ b/pollinations.ai/src/hooks/useModelList.ts
@@ -9,6 +9,7 @@ const AUDIO_MODELS_URL = `${API_BASE}/audio/models`;
 export interface Model {
     id: string;
     name: string;
+    aliases?: string[];
     title: string;
     description?: string;
     type: "image" | "text" | "audio";
@@ -41,6 +42,7 @@ type RawModel =
     | {
           id?: string;
           name?: string;
+          aliases?: string[];
           title?: string;
           description?: string;
           input_modalities?: string[];
@@ -99,6 +101,7 @@ function apiModelToModel(model: RawModel, type: Model["type"]): Model | null {
         name: id,
         title: model.title || model.description?.split(" - ")[0]?.trim() || id,
         description: model.description,
+        aliases: model.aliases,
         type,
         hasImageInput: model.input_modalities?.includes("image") || false,
         hasAudioOutput: model.output_modalities?.includes("audio") || false,

--- a/pollinations.ai/src/ui/pages/PlayPage.tsx
+++ b/pollinations.ai/src/ui/pages/PlayPage.tsx
@@ -22,7 +22,6 @@ function PlayPage() {
     const [prompt, setPrompt] = useState("");
     const { apiKey, isLoggedIn, login } = useAuth();
     const {
-        imageModels,
         allModels: registryModels,
         allowedImageModelIds,
         allowedTextModelIds,
@@ -54,15 +53,15 @@ function PlayPage() {
         );
     }, [registryModels]);
 
-    const currentModel = allModels.find((m) => m.id === selectedModel);
+    const currentModel = allModels.find(
+        (m) => m.id === selectedModel || m.aliases?.includes(selectedModel),
+    );
     const isVideoModel = !!currentModel?.hasVideoOutput;
     const isAudioModel =
         !isVideoModel &&
         (!!currentModel?.hasAudioOutput || currentModel?.type === "audio");
     const isImageModel =
-        !isVideoModel &&
-        !isAudioModel &&
-        imageModels.some((m) => m.id === selectedModel);
+        !isVideoModel && !isAudioModel && currentModel?.type === "image";
     const promptPlaceholder = isVideoModel
         ? pageCopy.videoPlaceholder
         : isAudioModel


### PR DESCRIPTION
- Keeps model aliases when loading website catalog metadata.
- Resolves aliases before choosing image, video, audio, or text request handling; old image links otherwise fall through to Chat Completions after the canonical rename.
- Leaves requested model IDs unchanged; no default-model or cosmetic selection changes.
- Verified with `npm run build` in `pollinations.ai` and Biome.

Addresses #13076