### PR TITLE
fix: resolve stored model aliases in permission reads

### DIFF
--- a/gen.pollinations.ai/src/middleware/auth.ts
+++ b/gen.pollinations.ai/src/middleware/auth.ts
@@ -7,6 +7,7 @@ import {
     StagingAccessDeniedError,
 } from "@shared/auth/api-key.ts";
 import type { CommunityEndpointRuntime } from "@shared/community-endpoints.ts";
+import { canonicalizeModelPermissionIds } from "@shared/registry/visible-model-ids.ts";
 import type { Context } from "hono";
 import { createMiddleware } from "hono/factory";
 import { HTTPException } from "hono/http-exception";
@@ -52,7 +53,20 @@ function installAuth(
         agentRun?: AgentRunClaims;
     },
 ): void {
-    const { user, apiKey, agentRun } = authResult;
+    const { user, agentRun } = authResult;
+    // Normalize the request snapshot once for generation, catalogs, realtime
+    // and fallback filtering. Stored permissions are canonicalized on writes.
+    const apiKey = authResult.apiKey?.permissions?.models
+        ? {
+              ...authResult.apiKey,
+              permissions: {
+                  ...authResult.apiKey.permissions,
+                  models: canonicalizeModelPermissionIds(
+                      authResult.apiKey.permissions.models,
+                  ),
+              },
+          }
+        : authResult.apiKey;
 
     const requireUser = (): AuthUser => {
         if (!user) {

--- a/gen.pollinations.ai/test/model-permissions.test.ts
+++ b/gen.pollinations.ai/test/model-permissions.test.ts
@@ -1,9 +1,12 @@
-import { SELF } from "cloudflare:test";
+import { env, SELF } from "cloudflare:test";
+import { apikey } from "@shared/db/better-auth.ts";
 import { getAudioModelsInfo } from "@shared/registry/model-info.ts";
 import {
     getRegistryModelDefinition,
     getVisibleTextModels,
+    resolveModelName,
 } from "@shared/registry/registry.ts";
+import { filterPermissionsToVisibleModels } from "@shared/registry/visible-model-ids.ts";
 import {
     createTestApiKey,
     RESTRICTED_IMAGE_TEST_MODEL,
@@ -11,11 +14,115 @@ import {
     RESTRICTED_TEXT_TEST_MODEL,
     test,
 } from "@shared/test/fixtures/index.ts";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import { Hono } from "hono";
 import { expect } from "vitest";
+import { type AuthEnv, authFromSnapshot } from "../src/middleware/auth.ts";
 
 async function fetchWorker(path: string, init: RequestInit = {}) {
     return SELF.fetch(new Request(`https://gen.pollinations.ai${path}`, init));
 }
+
+test("permission readback resolves future names against the current registry", () => {
+    const stored = {
+        models: ["openai-fast", "openai/gpt-5-nano", "owner/custom", "unknown"],
+        account: ["profile"],
+    };
+    const canonical = resolveModelName("openai-fast");
+    expect(
+        filterPermissionsToVisibleModels(
+            stored,
+            new Set([canonical, "owner/custom"]),
+        ),
+    ).toEqual({ models: [canonical, "owner/custom"], account: ["profile"] });
+    expect(stored.models).toEqual([
+        "openai-fast",
+        "openai/gpt-5-nano",
+        "owner/custom",
+        "unknown",
+    ]);
+    expect(
+        filterPermissionsToVisibleModels({ models: [] }, new Set([canonical])),
+    ).toEqual({ models: [] });
+    expect(
+        filterPermissionsToVisibleModels(null, new Set([canonical])),
+    ).toBeNull();
+});
+
+test("future-name stored allowlists filter catalogs without rewriting the database", async () => {
+    const { key, id } = await createTestApiKey({
+        allowedModels: ["flux"],
+        user: { packBalance: 100 },
+    });
+    const permissions = { models: ["black-forest-labs/flux.1-schnell"] };
+    // Simulate the rename migration reaching D1 before old workers are replaced.
+    await drizzle(env.DB)
+        .update(apikey)
+        .set({ permissions: JSON.stringify(permissions) })
+        .where(eq(apikey.id, id));
+    const headers = { Authorization: `Bearer ${key}` };
+    const catalog = await fetchWorker("/image/models", { headers });
+    expect(catalog.status).toBe(200);
+    expect(
+        ((await catalog.json()) as { name: string }[]).map(
+            (model) => model.name,
+        ),
+    ).toEqual([resolveModelName("flux")]);
+    expect(
+        (await fetchWorker("/text/test?model=openai", { headers })).status,
+    ).toBe(403);
+    const stored = await drizzle(env.DB)
+        .select({ permissions: apikey.permissions })
+        .from(apikey)
+        .where(eq(apikey.id, id));
+    expect(JSON.parse(stored[0].permissions ?? "null")).toEqual(permissions);
+});
+
+test("restored auth allows old and future names without expanding account or community scope", async () => {
+    const snapshot = {
+        user: { id: "permission-test", tier: "seed" },
+        apiKey: {
+            id: "test",
+            permissions: {
+                models: ["openai-fast", "openai/gpt-5-nano", "owner/custom"],
+                account: ["profile"],
+            },
+        },
+    };
+    const app = new Hono<AuthEnv>();
+    app.use("*", authFromSnapshot(snapshot));
+    app.get("/:model", (c) => {
+        const requested = c.req.param("model");
+        let resolved = requested;
+        try {
+            resolved = resolveModelName(requested);
+        } catch {
+            /* Community ID. */
+        }
+        c.set("model", { requested, resolved });
+        c.var.auth.requireModelAccess();
+        return c.json(c.var.auth.apiKey?.permissions);
+    });
+    for (const model of ["openai-fast", "openai/gpt-5-nano", "owner/custom"]) {
+        const response = await app.request(`/${encodeURIComponent(model)}`);
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual({
+            models: [resolveModelName("openai-fast"), "owner/custom"],
+            account: ["profile"],
+        });
+    }
+    for (const model of ["other/custom", "flux"]) {
+        expect(
+            (await app.request(`/${encodeURIComponent(model)}`)).status,
+        ).toBe(403);
+    }
+    expect(snapshot.apiKey.permissions.models).toEqual([
+        "openai-fast",
+        "openai/gpt-5-nano",
+        "owner/custom",
+    ]);
+});
 
 test("filters OpenAI-compatible model list by API key permissions", async ({
     restrictedApiKey,

--- a/shared/registry/visible-model-ids.ts
+++ b/shared/registry/visible-model-ids.ts
@@ -92,8 +92,8 @@ export function filterPermissionsToVisibleModels(
 
     return {
         ...permissions,
-        models: permissions.models.filter((modelId) =>
-            visibleModelIds.has(modelId),
+        models: canonicalizeModelPermissionIds(permissions.models).filter(
+            (modelId) => visibleModelIds.has(modelId),
         ),
     };
 }


### PR DESCRIPTION
- Normalizes stored model allowlists once in Gen auth snapshots and before Enter permission readback filtering.
- Preserves empty restrictions, account scopes, community IDs, and canonical writes. No model names, pricing, routes, migration SQL, or stored records change.
- Adds regression tests for future-name permissions against the current registry, old/new request names, denied models, community scope, and read-only behavior.
- Prerequisite for #13076: deploy this to production and verify scoped keys before promoting the canonical rename or its migration.

Validation: full Gen suite 1,833 passed / 6 skipped; full Enter suite 1,104 passed. Both worker typechecks and Biome pass. Live production verification remains pending.