### PR TITLE
fix: allow 127.0.0.1 redirects for local website auth

### DIFF
--- a/enter.pollinations.ai/test/url-utils.test.ts
+++ b/enter.pollinations.ai/test/url-utils.test.ts
@@ -151,6 +151,73 @@ describe("redirectUriMatchesAllowlist", () => {
         ).toBe(false);
     });
 
+    test("verifies localhost and 127.0.0.1 loopback registrations on different ports", () => {
+        const allowlist = [
+            "https://pollinations.ai/play",
+            "http://localhost/play",
+            "http://127.0.0.1/play",
+        ];
+
+        // Both registered loopback hostnames accept any local port
+        expect(
+            redirectUriMatchesAllowlist(
+                "http://localhost:5173/play",
+                allowlist,
+            ),
+        ).toBe(true);
+        expect(
+            redirectUriMatchesAllowlist(
+                "http://127.0.0.1:5173/play",
+                allowlist,
+            ),
+        ).toBe(true);
+        expect(
+            redirectUriMatchesAllowlist(
+                "http://localhost:3000/play",
+                allowlist,
+            ),
+        ).toBe(true);
+        expect(
+            redirectUriMatchesAllowlist(
+                "http://127.0.0.1:8080/play",
+                allowlist,
+            ),
+        ).toBe(true);
+
+        // When 127.0.0.1 is not in the allowlist, it is rejected even if localhost is registered
+        expect(
+            redirectUriMatchesAllowlist("http://127.0.0.1:5173/play", [
+                "http://localhost/play",
+            ]),
+        ).toBe(false);
+
+        // When localhost is not in the allowlist, it is rejected even if 127.0.0.1 is registered
+        expect(
+            redirectUriMatchesAllowlist("http://localhost:5173/play", [
+                "http://127.0.0.1/play",
+            ]),
+        ).toBe(false);
+
+        // Unregistered path on loopback is rejected
+        expect(
+            redirectUriMatchesAllowlist(
+                "http://localhost:5173/other",
+                allowlist,
+            ),
+        ).toBe(false);
+        expect(
+            redirectUriMatchesAllowlist(
+                "http://127.0.0.1:5173/other",
+                allowlist,
+            ),
+        ).toBe(false);
+
+        // Unregistered hostname is rejected
+        expect(
+            redirectUriMatchesAllowlist("http://0.0.0.0:5173/play", allowlist),
+        ).toBe(false);
+    });
+
     test("matches when any allowlist entry matches", () => {
         expect(
             redirectUriMatchesAllowlist("https://staging.app.com/cb", [

--- a/pollinations.ai/src/api.config.ts
+++ b/pollinations.ai/src/api.config.ts
@@ -4,6 +4,8 @@
 // Direct calls to gen.pollinations.ai. Users must log in and use their own
 // API key (sk_ / pk_ issued via enter.pollinations.ai) to generate.
 
+// Local redirects registered for this key: http://localhost/play and
+// http://127.0.0.1/play. Each accepts any port; the hostname must match.
 export const APP_KEY = "pk_5F0qxjbCjlgBODHa"; // BYOP app key for authorization flow
 export const API_BASE = "https://gen.pollinations.ai";
 


### PR DESCRIPTION
Fixes #14361. Supersedes #14455.

- Documents registered `http://localhost/play` and `http://127.0.0.1/play` loopback entries in `pollinations.ai/src/api.config.ts`.
- Adds unit test in `enter.pollinations.ai/test/url-utils.test.ts` verifying that both `localhost` and `127.0.0.1` are accepted when registered on the app key, and rejected when not registered.
- Keeps `shared/auth/redirect-uri.ts` strict without unnecessary fuzzy matching.

Co-authored-by: afanasevmylife <319410519+afanasevmylife@users.noreply.github.com>
