### PR TITLE
feat(models): filter catalogs by source and reliability; expose health metadata

### DIFF
--- a/gen.pollinations.ai/src/docs/models.md
+++ b/gen.pollinations.ai/src/docs/models.md
@@ -15,17 +15,33 @@ Discover available models with pricing, capabilities, and metadata. No authentic
 
 ### Query Parameters
 
-All model discovery endpoints accept an optional `community` query parameter:
+All model discovery endpoints accept optional `source` and `reliable` query
+parameters, plus every listing response carries a minimal `health` block
+(success rate, sample count, window, freshness) when health data is
+available:
 
 | Parameter | Values | Behaviour |
 |-----------|--------|-----------|
-| *(omitted)* | | Returns all models (default, backward-compatible) |
-| `community=false` | `false`, `0` | Excludes community models — returns official models only |
-| `community=true` | `true`, `1` | Returns community models only |
+| `source` | `official`, `community`, `all` | `official` returns first-party models only, `community` returns community-published models only. Omitted or `all` returns every model |
+| `reliable` | `true`, `1` | Keeps only models with sufficient observed health: success rate >= 0.9 across >= 10 samples in the current health window. Models without health data are treated as unknown and excluded |
+| `reliable` | `false`, `0`, *(omitted)* | Keeps every model |
 
-Any other value (e.g. `tru`, `yes`, `2`) returns **400 Bad Request**.
+Any other value (e.g. `source=bogus`, `reliable=2`) returns
+**400 Bad Request**. Filtering discovery never changes generation
+permissions: a model hidden from a filtered listing can still be called and
+retrieved by id.
 
-Example: `GET /models?community=false`
+Example: `GET /models?source=official&reliable=true`
+
+Clients that append `/models` to a configured base URL (Open WebUI,
+LibreChat, Cline) cannot carry query parameters in the base URL, so the same
+filters may be sent as the `X-Pollinations-Model-Filter` header in URL query
+format. Explicit query parameters win over header values:
+
+```
+# LibreChat custom endpoint header
+X-Pollinations-Model-Filter: source=official&reliable=true
+```
 
 Rich model endpoints include `capabilities` for agentic/model traits:
 `tool_calling`, `reasoning`, `web_search`, and `code_execution`.
@@ -62,6 +78,6 @@ Reasoning effort levels and forced-tool restrictions remain model-specific.
 
 ## Community Models
 
-Community models use an `owner/model` id and appear in the same discovery responses as Pollinations-operated models. Use `community=true` to return only community models or `community=false` to exclude them.
+Community models use an `owner/model` id and appear in the same discovery responses as Pollinations-operated models. Use `source=community` to return only community models or `source=official` to exclude them.
 
 For registration, publishing, pricing, fallbacks, and health monitoring, see [Publish a Model](/docs#tag/publish-a-model). For ownership endpoints and schemas, see [Community Models](/docs#tag/community-models) under Resources.

--- a/gen.pollinations.ai/src/routes/model-status.ts
+++ b/gen.pollinations.ai/src/routes/model-status.ts
@@ -14,6 +14,7 @@ const TINYBIRD_PUBLIC_TOKEN =
 const CACHE_TTL_MS = 60_000;
 const MAX_CACHE_ENTRIES = 32;
 const DEFAULT_MINUTES = 60;
+export const MODEL_HEALTH_DEFAULT_MINUTES = DEFAULT_MINUTES;
 const MAX_MINUTES = 7 * 24 * 60;
 const DATA_TIMESTAMP_HEADER = "X-Model-Status-Timestamp";
 const STALE_HEADER = "X-Model-Status-Stale";
@@ -53,7 +54,8 @@ const ModelHealthResponseSchema = z.object({
         .optional(),
 });
 
-type ModelHealthResponse = z.infer<typeof ModelHealthResponseSchema>;
+export type ModelHealthResponse = z.infer<typeof ModelHealthResponseSchema>;
+export type ModelHealthRow = z.infer<typeof ModelHealthRowSchema>;
 
 type CacheEntry = { data: ModelHealthResponse; timestamp: number };
 
@@ -76,6 +78,61 @@ function parseMinutes(value: string | undefined): number | null {
     const minutes = Number(value);
     if (minutes < 1 || minutes > MAX_MINUTES) return null;
     return minutes;
+}
+
+export type ModelHealthSnapshot = {
+    data: ModelHealthResponse;
+    timestamp: number;
+    stale: boolean;
+};
+
+// Shared fetch+cache behind both /v1/models/status and the health metadata
+// on the model-list endpoints. The module-level cache keeps a 60s TTL and a
+// small LRU set; on upstream failure the last snapshot is served stale, and
+// null is returned only when no snapshot exists at all (callers treat
+// health as unknown).
+export async function getModelHealthSnapshot(
+    minutes: number = DEFAULT_MINUTES,
+): Promise<ModelHealthSnapshot | null> {
+    const now = Date.now();
+    const cached = cache.get(minutes);
+    if (cached && now - cached.timestamp < CACHE_TTL_MS) {
+        log("Returning cached model health response for %d minutes", minutes);
+        setCacheEntry(minutes, cached);
+        return { ...cached, stale: false };
+    }
+
+    try {
+        const url = new URL("/v0/pipes/model_health.json", TINYBIRD_HOST);
+        url.searchParams.set("token", TINYBIRD_PUBLIC_TOKEN);
+        url.searchParams.set("minutes", String(minutes));
+        log("Fetching model health from Tinybird: %s", url.toString());
+
+        const response = await fetch(url.toString());
+        if (!response.ok) {
+            throw new Error(`Tinybird responded with ${response.status}`);
+        }
+
+        const tinybirdData = (await response.json()) as ModelHealthResponse;
+        const entry = { data: tinybirdData, timestamp: Date.now() };
+        setCacheEntry(minutes, entry);
+        return { ...entry, stale: false };
+    } catch (error) {
+        log("Error fetching model health: %O", error);
+        const stale = cache.get(minutes);
+        if (stale) {
+            log("Falling back to stale cache for %d minutes", minutes);
+            setCacheEntry(minutes, stale);
+            return { ...stale, stale: true };
+        }
+        return null;
+    }
+}
+
+// Test-only: drop the module-level health cache so tests can install a new
+// mocked Tinybird response without waiting out the TTL.
+export function clearModelHealthCacheForTests() {
+    cache.clear();
 }
 
 export const modelStatusRoutes = new Hono<Env>().get(
@@ -144,51 +201,17 @@ export const modelStatusRoutes = new Hono<Env>().get(
             );
         }
 
-        const now = Date.now();
-        const cached = cache.get(minutes);
-        if (cached && now - cached.timestamp < CACHE_TTL_MS) {
-            log(
-                "Returning cached model health response for %d minutes",
-                minutes,
-            );
-            setCacheEntry(minutes, cached);
-            c.header(
-                DATA_TIMESTAMP_HEADER,
-                new Date(cached.timestamp).toISOString(),
-            );
-            return c.json(cached.data);
-        }
-
-        try {
-            const url = new URL("/v0/pipes/model_health.json", TINYBIRD_HOST);
-            url.searchParams.set("token", TINYBIRD_PUBLIC_TOKEN);
-            url.searchParams.set("minutes", String(minutes));
-            log("Fetching model health from Tinybird: %s", url.toString());
-
-            const response = await fetch(url.toString());
-            if (!response.ok) {
-                throw new Error(`Tinybird responded with ${response.status}`);
-            }
-
-            const tinybirdData = (await response.json()) as ModelHealthResponse;
-            const timestamp = Date.now();
-            setCacheEntry(minutes, { data: tinybirdData, timestamp });
-            c.header(DATA_TIMESTAMP_HEADER, new Date(timestamp).toISOString());
-            return c.json(tinybirdData);
-        } catch (error) {
-            log("Error fetching model health: %O", error);
-            const stale = cache.get(minutes);
-            if (stale) {
-                log("Falling back to stale cache for %d minutes", minutes);
-                setCacheEntry(minutes, stale);
-                c.header(
-                    DATA_TIMESTAMP_HEADER,
-                    new Date(stale.timestamp).toISOString(),
-                );
-                c.header(STALE_HEADER, "true");
-                return c.json(stale.data);
-            }
+        const snapshot = await getModelHealthSnapshot(minutes);
+        if (!snapshot) {
             return c.json({ error: "Failed to fetch model health data" }, 502);
         }
+        c.header(
+            DATA_TIMESTAMP_HEADER,
+            new Date(snapshot.timestamp).toISOString(),
+        );
+        if (snapshot.stale) {
+            c.header(STALE_HEADER, "true");
+        }
+        return c.json(snapshot.data);
     },
 );

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -43,7 +43,10 @@ import {
     getImageModelIds,
     getVideoModelIds,
 } from "@shared/registry/image.ts";
-import { ModelInfoSchema } from "@shared/registry/model-info.ts";
+import {
+    type ModelHealthSummary,
+    ModelInfoSchema,
+} from "@shared/registry/model-info.ts";
 import {
     DEFAULT_3D_MODEL,
     getModel3dModelIds,
@@ -84,6 +87,7 @@ import {
     Generate3dRequestQueryParamsSchema,
 } from "@/schemas/model3d.ts";
 import {
+    MODEL_FILTER_HEADER,
     type ModelListQueryParams,
     ModelListQueryParamsSchema,
 } from "@/schemas/models.ts";
@@ -109,6 +113,10 @@ import {
     simpleAudioQuerySchema,
     textBodyLimit,
 } from "./generation-handlers.ts";
+import {
+    getModelHealthSnapshot,
+    MODEL_HEALTH_DEFAULT_MINUTES,
+} from "./model-status.ts";
 import { handleRealtimeWebSocket } from "./realtime.ts";
 
 const ModelInfoListSchema = z.array(ModelInfoSchema).meta({
@@ -250,21 +258,117 @@ function hasPaidBalance(c: any): boolean | undefined {
     return (user.packBalance ?? 0) > 0;
 }
 
-// Optionally filter entries by the validated `?community` query parameter.
-function filterEntriesByCommunityParam(
+// Reliability thresholds: a model counts as reliable when the
+// caller-visible success rate over the current health window clears both
+// bars. Models without health data are unknown and never count as reliable.
+const RELIABLE_MIN_SUCCESS_RATE = 0.9;
+const RELIABLE_MIN_SAMPLES = 10;
+
+type ModelHealthSummaries = {
+    byModel: Map<string, ModelHealthSummary>;
+    windowMinutes: number;
+    observedAt: string;
+};
+
+// Optionally filter entries by the validated `?source` query parameter.
+function filterEntriesBySource(
     entries: GenerationModelEntry[],
-    communityParam: string | undefined,
+    source: ModelListQueryParams["source"],
 ): GenerationModelEntry[] {
-    if (communityParam === undefined) return entries;
-    const wantCommunity = communityParam === "true" || communityParam === "1";
+    if (source === undefined || source === "all") return entries;
+    const wantCommunity = source === "community";
     return entries.filter(
         (entry) => (entry.communityEndpoint !== undefined) === wantCommunity,
     );
 }
 
-// Factory for model-list endpoints: validates the community query parameter,
-// filters by API key permissions, paid balance, and community flag,
-// then returns the model list as JSON.
+// Summarize the shared health snapshot per registry model id. Successes are
+// final 2xx responses (fallback rescues included); caller-side 4xx errors
+// are excluded from the denominator. Models with no usable rows stay absent
+// from the map, which callers treat as unknown.
+async function loadModelHealthSummaries(): Promise<ModelHealthSummaries | null> {
+    const snapshot = await getModelHealthSnapshot();
+    if (!snapshot) return null;
+    const aggregates = new Map<
+        string,
+        { ok: number; samples: number; callerErrors: number }
+    >();
+    for (const row of snapshot.data.data ?? []) {
+        const agg = aggregates.get(row.model) ?? {
+            ok: 0,
+            samples: 0,
+            callerErrors: 0,
+        };
+        agg.ok += row.status_2xx;
+        agg.samples += row.total_requests;
+        agg.callerErrors += row.errors_4xx;
+        aggregates.set(row.model, agg);
+    }
+    const byModel = new Map<string, ModelHealthSummary>();
+    const observedAt = new Date(snapshot.timestamp).toISOString();
+    for (const [model, agg] of aggregates) {
+        const observed = agg.samples - agg.callerErrors;
+        if (observed <= 0) continue;
+        byModel.set(model, {
+            success_rate: agg.ok / observed,
+            samples: agg.samples,
+            window_minutes: MODEL_HEALTH_DEFAULT_MINUTES,
+            observed_at: observedAt,
+        });
+    }
+    return {
+        byModel,
+        windowMinutes: MODEL_HEALTH_DEFAULT_MINUTES,
+        observedAt,
+    };
+}
+
+// Optionally filter entries down to models with sufficient observed health.
+function filterEntriesByReliability(
+    entries: GenerationModelEntry[],
+    reliable: ModelListQueryParams["reliable"],
+    health: ModelHealthSummaries | null,
+): GenerationModelEntry[] {
+    if (reliable !== "true" && reliable !== "1") return entries;
+    if (!health) return [];
+    return entries.filter((entry) => {
+        const summary = health.byModel.get(entry.id);
+        return (
+            summary !== undefined &&
+            summary.success_rate >= RELIABLE_MIN_SUCCESS_RATE &&
+            summary.samples >= RELIABLE_MIN_SAMPLES
+        );
+    });
+}
+
+// Model filters may arrive as query parameters or, for clients that append
+// `/models` to a configured base URL and cannot carry query parameters, as
+// the `X-Pollinations-Model-Filter` header in URL query format. Explicit
+// query parameters win over header values.
+function mergeModelFilterParams(c: Context<Env>): ModelListQueryParams {
+    const query = c.req.valid("query" as never) as ModelListQueryParams;
+    const raw = c.req.header(MODEL_FILTER_HEADER);
+    if (raw === undefined || raw === "") return query;
+    let headerParams: ModelListQueryParams;
+    try {
+        headerParams = ModelListQueryParamsSchema.parse(
+            Object.fromEntries(new URLSearchParams(raw)),
+        );
+    } catch {
+        throw new HTTPException(400, {
+            message: `Invalid ${MODEL_FILTER_HEADER} header; expected URL query format such as 'source=official&reliable=true'.`,
+        });
+    }
+    const overrides = Object.entries(query).filter(
+        ([, value]) => value !== undefined,
+    );
+    return { ...headerParams, ...Object.fromEntries(overrides) };
+}
+
+// Factory for model-list endpoints: validates the source/reliable query
+// parameters (or the equivalent filter header), filters by API key
+// permissions, paid balance, source, and observed reliability, attaches
+// health metadata, then returns the model list as JSON.
 const modelsListHandler = (
     getEntries: (
         c: Context<Env>,
@@ -273,20 +377,22 @@ const modelsListHandler = (
     [
         validator("query", ModelListQueryParamsSchema),
         async (c: Context<Env>) => {
-            const { community } = c.req.valid(
-                "query" as never,
-            ) as ModelListQueryParams;
+            const { source, reliable } = mergeModelFilterParams(c);
             const allowedModels = c.var.auth?.apiKey?.permissions?.models;
             const paidBalance = hasPaidBalance(c);
+            let entries = filterEntriesByPermissions(
+                await getEntries(c),
+                allowedModels,
+                paidBalance,
+            );
+            entries = filterEntriesBySource(entries, source);
+            const health = await loadModelHealthSummaries();
+            entries = filterEntriesByReliability(entries, reliable, health);
             return c.json(
-                filterEntriesByCommunityParam(
-                    filterEntriesByPermissions(
-                        await getEntries(c),
-                        allowedModels,
-                        paidBalance,
-                    ),
-                    community,
-                ).map((entry) => entry.info),
+                entries.map((entry) => ({
+                    ...entry.info,
+                    health: health?.byModel.get(entry.id),
+                })),
             );
         },
     ] as const;
@@ -333,7 +439,10 @@ async function getVisibleVideoModelEntries(c: Context<Env>) {
 // /v1/models/:model (retrieve). `created` derives from the registry addedDate
 // so both endpoints return stable timestamps instead of per-request wall-clock
 // values.
-function toOpenAIModelEntry(entry: GenerationModelEntry) {
+function toOpenAIModelEntry(
+    entry: GenerationModelEntry,
+    health?: ModelHealthSummary,
+) {
     return {
         id: entry.info.name,
         object: "model" as const,
@@ -362,6 +471,7 @@ function toOpenAIModelEntry(entry: GenerationModelEntry) {
         ...(entry.info.per_user_rpm !== undefined && {
             per_user_rpm: entry.info.per_user_rpm,
         }),
+        ...(health && { health }),
     };
 }
 
@@ -405,7 +515,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Models (OpenAI-compatible)",
             description:
-                'Returns available models in the OpenAI-compatible format (`{object: "list", data: [...]}`), with Pollinations pricing and capability extensions. Official models are ordered by modality (text, image, video, 3D, audio, realtime, embedding), with each configured default first, followed by stable and then alpha/preview models from newest to oldest. Community models follow from newest to oldest. Use `/models`, `/text/models`, `/image/models`, `/audio/models`, or `/embeddings/models` for richer metadata. When authenticated: the owner\'s private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.',
+                'Returns available models in the OpenAI-compatible format (`{object: "list", data: [...]}`), with Pollinations pricing and capability extensions. Official models are ordered by modality (text, image, video, 3D, audio, realtime, embedding), with each configured default first, followed by stable and then alpha/preview models from newest to oldest. Community models follow from newest to oldest. Use `/models`, `/text/models`, `/image/models`, `/audio/models`, or `/embeddings/models` for richer metadata. When authenticated: the owner\'s private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Filter with `?source=official|community` to select the model source and `?reliable=true` to keep only models with sufficient observed health; clients that append `/models` to a configured base URL can send the same filters as the `X-Pollinations-Model-Filter` header (URL query format).',
             responses: {
                 200: {
                     description: "Success",
@@ -420,22 +530,26 @@ export const proxyRoutes = new Hono<Env>()
         }),
         validator("query", ModelListQueryParamsSchema),
         async (c) => {
-            const { community } = c.req.valid(
-                "query" as never,
-            ) as ModelListQueryParams;
+            const { source, reliable } = mergeModelFilterParams(c);
             const allowedModels = c.var.auth?.apiKey?.permissions?.models;
             const paidBalance = hasPaidBalance(c);
-            const modelEntries = filterEntriesByCommunityParam(
-                filterEntriesByPermissions(
-                    await getVisibleModelEntries(c),
-                    allowedModels,
-                    paidBalance,
-                ),
-                community,
+            let modelEntries = filterEntriesByPermissions(
+                await getVisibleModelEntries(c),
+                allowedModels,
+                paidBalance,
+            );
+            modelEntries = filterEntriesBySource(modelEntries, source);
+            const health = await loadModelHealthSummaries();
+            modelEntries = filterEntriesByReliability(
+                modelEntries,
+                reliable,
+                health,
             );
             return c.json({
                 object: "list" as const,
-                data: modelEntries.map(toOpenAIModelEntry),
+                data: modelEntries.map((entry) =>
+                    toOpenAIModelEntry(entry, health?.byModel.get(entry.id)),
+                ),
             });
         },
     )
@@ -480,7 +594,10 @@ export const proxyRoutes = new Hono<Env>()
                     message: `Model '${modelId}' not found`,
                 });
             }
-            return c.json(toOpenAIModelEntry(entry));
+            const health = await loadModelHealthSummaries();
+            return c.json(
+                toOpenAIModelEntry(entry, health?.byModel.get(entry.id)),
+            );
         },
     )
     .get(
@@ -489,7 +606,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Models",
             description:
-                "Returns all available models with pricing, capabilities, and metadata. Official models are ordered by modality (text, image, video, 3D, audio, realtime, embedding), with each configured default first, followed by stable and then alpha/preview models from newest to oldest. Community models follow from newest to oldest. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
+                "Returns all available models with pricing, capabilities, and metadata. Official models are ordered by modality (text, image, video, 3D, audio, realtime, embedding), with each configured default first, followed by stable and then alpha/preview models from newest to oldest. Community models follow from newest to oldest. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Filter with `?source=official|community` to select the model source and `?reliable=true` to keep only models with sufficient observed health; clients that append `/models` to a configured base URL can send the same filters as the `X-Pollinations-Model-Filter` header (URL query format).",
             responses: {
                 200: {
                     description: "Success",
@@ -510,7 +627,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List 3D Models",
             description:
-                "Returns all available 3D model generation models with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
+                "Returns all available 3D model generation models with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Filter with `?source=official|community` to select the model source and `?reliable=true` to keep only models with sufficient observed health; clients that append `/models` to a configured base URL can send the same filters as the `X-Pollinations-Model-Filter` header (URL query format).",
             responses: {
                 200: {
                     description: "Success",
@@ -531,7 +648,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Image & Video Models",
             description:
-                "Returns all available image and video generation models with pricing, capabilities, and metadata. Video models are included here — check the `output_modalities` field to distinguish image vs video models. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
+                "Returns all available image and video generation models with pricing, capabilities, and metadata. Video models are included here — check the `output_modalities` field to distinguish image vs video models. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Filter with `?source=official|community` to select the model source and `?reliable=true` to keep only models with sufficient observed health; clients that append `/models` to a configured base URL can send the same filters as the `X-Pollinations-Model-Filter` header (URL query format).",
             responses: {
                 200: {
                     description: "Success",
@@ -552,7 +669,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Video Models",
             description:
-                "Returns all available video generation models with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
+                "Returns all available video generation models with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Filter with `?source=official|community` to select the model source and `?reliable=true` to keep only models with sufficient observed health; clients that append `/models` to a configured base URL can send the same filters as the `X-Pollinations-Model-Filter` header (URL query format).",
             responses: {
                 200: {
                     description: "Success",
@@ -573,7 +690,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Text Models (Detailed)",
             description:
-                "Returns all available text generation and community text models with pricing, capabilities, and metadata including context window size, supported modalities, and tool support. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
+                "Returns all available text generation and community text models with pricing, capabilities, and metadata including context window size, supported modalities, and tool support. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Filter with `?source=official|community` to select the model source and `?reliable=true` to keep only models with sufficient observed health; clients that append `/models` to a configured base URL can send the same filters as the `X-Pollinations-Model-Filter` header (URL query format).",
             responses: {
                 200: {
                     description: "Success",
@@ -596,7 +713,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Audio Models",
             description:
-                "Returns all available audio models (text-to-speech, music generation, and transcription) with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
+                "Returns all available audio models (text-to-speech, music generation, and transcription) with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Filter with `?source=official|community` to select the model source and `?reliable=true` to keep only models with sufficient observed health; clients that append `/models` to a configured base URL can send the same filters as the `X-Pollinations-Model-Filter` header (URL query format).",
             responses: {
                 200: {
                     description: "Success",
@@ -619,7 +736,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🔢 Embeddings"],
             summary: "List Embedding Models",
             description:
-                "Returns available embedding models with pricing, capabilities, and supported input modalities. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
+                "Returns available embedding models with pricing, capabilities, and supported input modalities. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Filter with `?source=official|community` to select the model source and `?reliable=true` to keep only models with sufficient observed health; clients that append `/models` to a configured base URL can send the same filters as the `X-Pollinations-Model-Filter` header (URL query format).",
             responses: {
                 200: {
                     description: "Success",

--- a/gen.pollinations.ai/src/schemas/models.ts
+++ b/gen.pollinations.ai/src/schemas/models.ts
@@ -1,10 +1,20 @@
 import { z } from "zod";
 
 export const ModelListQueryParamsSchema = z.object({
-    community: z.enum(["true", "false", "1", "0"]).optional().meta({
+    source: z.enum(["official", "community", "all"]).optional().meta({
         description:
-            "Filter by community status: `true`/`1` for community-only, `false`/`0` for official-only. Omit for all models.",
+            "Filter by model source: `official` for first-party registry models, `community` for community-published models. Omit or `all` for every model.",
+    }),
+    reliable: z.enum(["true", "false", "1", "0"]).optional().meta({
+        description:
+            "`true`/`1` keeps only models with sufficient observed health (success rate >= 0.9 across >= 10 samples in the current health window). Models without health data are treated as unknown and excluded. `false`/`0` keeps every model.",
     }),
 });
 
 export type ModelListQueryParams = z.infer<typeof ModelListQueryParamsSchema>;
+
+// Clients such as Open WebUI, LibreChat, and Cline append `/models` to a
+// configured base URL, so query parameters embedded in the base URL break
+// discovery. The same filters can be sent as this header in URL query
+// format, e.g. `X-Pollinations-Model-Filter: source=official&reliable=true`.
+export const MODEL_FILTER_HEADER = "X-Pollinations-Model-Filter";

--- a/gen.pollinations.ai/test/community-endpoints.test.ts
+++ b/gen.pollinations.ai/test/community-endpoints.test.ts
@@ -4308,7 +4308,7 @@ fixtureTest(
 );
 
 fixtureTest(
-    "filters model catalogs with ?community query parameter",
+    "filters model catalogs with source and reliability query parameters",
     async () => {
         const suffix = crypto.randomUUID().slice(0, 8);
         const textOwner = `filter-text-${suffix}`;
@@ -4382,24 +4382,26 @@ fixtureTest(
             allOnlyNumeric,
         ] = await Promise.all([
             SELF.fetch("https://gen.pollinations.ai/models"),
-            SELF.fetch("https://gen.pollinations.ai/models?community=false"),
-            SELF.fetch("https://gen.pollinations.ai/models?community=true"),
+            SELF.fetch("https://gen.pollinations.ai/models?source=official"),
+            SELF.fetch("https://gen.pollinations.ai/models?source=community"),
             SELF.fetch(
-                "https://gen.pollinations.ai/text/models?community=false",
+                "https://gen.pollinations.ai/text/models?source=official",
             ),
             SELF.fetch(
-                "https://gen.pollinations.ai/text/models?community=true",
+                "https://gen.pollinations.ai/text/models?source=community",
             ),
-            SELF.fetch("https://gen.pollinations.ai/v1/models?community=false"),
-            SELF.fetch("https://gen.pollinations.ai/v1/models?community=true"),
+            SELF.fetch("https://gen.pollinations.ai/v1/models?source=official"),
             SELF.fetch(
-                "https://gen.pollinations.ai/image/models?community=false",
+                "https://gen.pollinations.ai/v1/models?source=community",
             ),
             SELF.fetch(
-                "https://gen.pollinations.ai/image/models?community=true",
+                "https://gen.pollinations.ai/image/models?source=official",
             ),
-            SELF.fetch("https://gen.pollinations.ai/models?community=0"),
-            SELF.fetch("https://gen.pollinations.ai/models?community=1"),
+            SELF.fetch(
+                "https://gen.pollinations.ai/image/models?source=community",
+            ),
+            SELF.fetch("https://gen.pollinations.ai/models?source=official"),
+            SELF.fetch("https://gen.pollinations.ai/models?source=community"),
         ]);
 
         for (const r of [
@@ -4480,12 +4482,10 @@ fixtureTest(
         );
 
         const invalidResponses = await Promise.all([
-            SELF.fetch("https://gen.pollinations.ai/models?community=tru"),
-            SELF.fetch("https://gen.pollinations.ai/models?community=yes"),
-            SELF.fetch("https://gen.pollinations.ai/v1/models?community=2"),
-            SELF.fetch(
-                "https://gen.pollinations.ai/image/models?community=nope",
-            ),
+            SELF.fetch("https://gen.pollinations.ai/models?source=tru"),
+            SELF.fetch("https://gen.pollinations.ai/models?source=yes"),
+            SELF.fetch("https://gen.pollinations.ai/v1/models?source=2"),
+            SELF.fetch("https://gen.pollinations.ai/image/models?source=nope"),
         ]);
         for (const r of invalidResponses) {
             expect(r.status).toBe(400);

--- a/gen.pollinations.ai/test/models-discovery.test.ts
+++ b/gen.pollinations.ai/test/models-discovery.test.ts
@@ -1,0 +1,303 @@
+import { SELF } from "cloudflare:test";
+import { test as baseTest } from "@shared/test/fixtures/index.ts";
+import {
+    createFetchMock,
+    teardownFetchMock,
+} from "@shared/test/mocks/fetch.ts";
+import {
+    createMockTinybird,
+    type MockTinybirdState,
+} from "@shared/test/mocks/tinybird.ts";
+import { beforeEach, expect } from "vitest";
+import { clearModelHealthCacheForTests } from "../src/routes/model-status.ts";
+
+const GPT5_NANO = "openai/gpt-5-nano";
+const FLUX_SCHNELL = "black-forest-labs/flux.1-schnell";
+
+async function fetchWorker(path: string, init: RequestInit = {}) {
+    return SELF.fetch(new Request(`https://gen.pollinations.ai${path}`, init));
+}
+
+type HealthRow = Record<string, unknown>;
+
+function healthRow(model: string, over: Partial<HealthRow> = {}): HealthRow {
+    return {
+        model,
+        event_type: "generate.text",
+        provider: "test-provider",
+        model_used: "test-upstream",
+        total_requests: 0,
+        status_2xx: 0,
+        errors_4xx: 0,
+        errors_5xx: 0,
+        own_calls: 0,
+        own_calls_ok: 0,
+        primary_5xx: 0,
+        primary_retried_503s: 0,
+        fallback_rescues: 0,
+        last_error_at: "",
+        latency_p50_ms: 100,
+        latency_p95_ms: 200,
+        avg_latency_ms: 120,
+        last_request_at: "2026-09-07T00:00:00Z",
+        tokens_per_second: null,
+        ...over,
+    };
+}
+
+const test = baseTest.extend<{ tinybird: MockTinybirdState }>({
+    // biome-ignore lint/correctness/noEmptyPattern: vitest fixture pattern
+    tinybird: async ({}, use) => {
+        const mock = createMockTinybird();
+        const fetchMock = createFetchMock({ tinybird: mock });
+        await fetchMock.enable("tinybird");
+        await use(mock.state);
+        await teardownFetchMock();
+    },
+});
+
+beforeEach(() => {
+    clearModelHealthCacheForTests();
+});
+
+test("list endpoints attach minimal health metadata with rescue and caller-error semantics", async ({
+    tinybird,
+}) => {
+    tinybird.modelHealthResponse = [
+        // 97/100 final 2xx; 5 of those successes were fallback rescues.
+        healthRow(GPT5_NANO, {
+            total_requests: 100,
+            status_2xx: 97,
+            errors_5xx: 3,
+            fallback_rescues: 5,
+            own_calls: 90,
+            own_calls_ok: 85,
+        }),
+        // 9 successes out of 10 finals, 1 caller-side 4xx excluded from the
+        // denominator: success rate is 9/9 = 1.0, not 0.9.
+        healthRow(FLUX_SCHNELL, {
+            total_requests: 10,
+            status_2xx: 9,
+            errors_4xx: 1,
+            event_type: "generate.image",
+        }),
+    ];
+
+    const response = await fetchWorker("/v1/models");
+    expect(response.status).toBe(200);
+    const { data } = (await response.json()) as {
+        data: Array<
+            Record<string, unknown> & {
+                id: string;
+                health?: {
+                    success_rate?: number;
+                    samples?: number;
+                    window_minutes?: number;
+                    observed_at?: string;
+                };
+            }
+        >;
+    };
+
+    const healthy = data.find((m) => m.id === GPT5_NANO);
+    expect(healthy?.health).toMatchObject({
+        success_rate: 0.97,
+        samples: 100,
+        window_minutes: 60,
+    });
+    expect(
+        typeof healthy?.health?.observed_at === "string" &&
+            !Number.isNaN(Date.parse(healthy.health.observed_at)),
+    ).toBe(true);
+
+    const rescued = data.find((m) => m.id === FLUX_SCHNELL);
+    expect(rescued?.health?.success_rate).toBe(1);
+
+    // Models without health rows are unknown: no field at all.
+    const noRow = data.filter(
+        (m) => m.id !== GPT5_NANO && m.id !== FLUX_SCHNELL,
+    );
+    expect(noRow.length).toBeGreaterThan(0);
+    for (const model of noRow) {
+        expect(model.health).toBeUndefined();
+    }
+});
+
+test("reliable=true keeps only sufficiently healthy models and treats unknown as unreliable", async ({
+    tinybird,
+}) => {
+    const all = (await (await fetchWorker("/v1/models")).json()) as {
+        data: Array<{ id: string; community: boolean }>;
+    };
+    const third = all.data.find(
+        (m) => !m.community && m.id !== GPT5_NANO && m.id !== FLUX_SCHNELL,
+    );
+    expect(third).toBeDefined();
+
+    tinybird.modelHealthResponse = [
+        healthRow(GPT5_NANO, {
+            total_requests: 100,
+            status_2xx: 97,
+            errors_5xx: 3,
+        }),
+        healthRow(FLUX_SCHNELL, {
+            total_requests: 20,
+            status_2xx: 5,
+            errors_5xx: 15,
+            event_type: "generate.image",
+        }),
+    ];
+
+    // The first fetch above already cached an empty health snapshot; drop it
+    // so the freshly configured Tinybird rows are picked up.
+    clearModelHealthCacheForTests();
+
+    const reliable = (await (
+        await fetchWorker("/v1/models?reliable=true")
+    ).json()) as { data: Array<{ id: string }> };
+    const ids = reliable.data.map((m) => m.id);
+    expect(ids).toContain(GPT5_NANO);
+    expect(ids).not.toContain(FLUX_SCHNELL);
+    expect(ids).not.toContain(third?.id);
+
+    // Without the filter every model is still listed.
+    const unfiltered = (await (await fetchWorker("/v1/models")).json()) as {
+        data: Array<{ id: string }>;
+    };
+    const unfilteredIds = unfiltered.data.map((m) => m.id);
+    expect(unfilteredIds).toContain(GPT5_NANO);
+    expect(unfilteredIds).toContain(FLUX_SCHNELL);
+    expect(unfilteredIds).toContain(third?.id);
+});
+
+test("source filter partitions listings without changing default output", async () => {
+    const all = (await (await fetchWorker("/v1/models")).json()) as {
+        data: Array<{ community: boolean }>;
+    };
+    const official = (await (
+        await fetchWorker("/v1/models?source=official")
+    ).json()) as { data: Array<{ community: boolean }> };
+    const community = (await (
+        await fetchWorker("/v1/models?source=community")
+    ).json()) as { data: Array<{ community: boolean }> };
+
+    for (const model of official.data) expect(model.community).toBe(false);
+    for (const model of community.data) expect(model.community).toBe(true);
+    expect(official.data.length + community.data.length).toBe(all.data.length);
+});
+
+test("filter header works for clients that append /models to a base URL", async ({
+    tinybird,
+}) => {
+    tinybird.modelHealthResponse = [
+        healthRow(GPT5_NANO, {
+            total_requests: 100,
+            status_2xx: 97,
+            errors_5xx: 3,
+        }),
+    ];
+
+    const viaHeader = (await (
+        await fetchWorker("/v1/models", {
+            headers: { "X-Pollinations-Model-Filter": "source=official" },
+        })
+    ).json()) as { data: Array<{ community: boolean }> };
+    for (const model of viaHeader.data) expect(model.community).toBe(false);
+
+    // Explicit query parameters win over header values.
+    const queryWins = (await (
+        await fetchWorker("/v1/models?source=community", {
+            headers: { "X-Pollinations-Model-Filter": "source=official" },
+        })
+    ).json()) as { data: Array<{ community: boolean }> };
+    for (const model of queryWins.data) expect(model.community).toBe(true);
+
+    // Reliable filter through the header alone.
+    const reliableViaHeader = (await (
+        await fetchWorker("/v1/models", {
+            headers: {
+                "X-Pollinations-Model-Filter": "source=official&reliable=true",
+            },
+        })
+    ).json()) as { data: Array<{ id: string; health?: unknown }> };
+    expect(reliableViaHeader.data.map((m) => m.id)).toContain(GPT5_NANO);
+    for (const model of reliableViaHeader.data) {
+        expect(model.health).toBeDefined();
+    }
+
+    const badHeader = await fetchWorker("/v1/models", {
+        headers: { "X-Pollinations-Model-Filter": "source=bogus" },
+    });
+    expect(badHeader.status).toBe(400);
+});
+
+test("detailed /models endpoint carries the same health metadata", async ({
+    tinybird,
+}) => {
+    tinybird.modelHealthResponse = [
+        healthRow(GPT5_NANO, {
+            total_requests: 100,
+            status_2xx: 97,
+            errors_5xx: 3,
+        }),
+    ];
+
+    const response = await fetchWorker("/models");
+    expect(response.status).toBe(200);
+    const models = (await response.json()) as Array<{
+        name: string;
+        health?: { success_rate: number; samples: number };
+    }>;
+    const target = models.find((m) => m.name === GPT5_NANO);
+    expect(target?.health?.success_rate).toBe(0.97);
+    expect(target?.health?.samples).toBe(100);
+});
+
+test("retrieve keeps unhealthy models reachable and exposes their health", async ({
+    tinybird,
+}) => {
+    tinybird.modelHealthResponse = [
+        healthRow(GPT5_NANO, {
+            total_requests: 100,
+            status_2xx: 97,
+            errors_5xx: 3,
+        }),
+        healthRow(FLUX_SCHNELL, {
+            total_requests: 20,
+            status_2xx: 5,
+            errors_5xx: 15,
+            event_type: "generate.image",
+        }),
+    ];
+
+    // Discovery filtering must not change generation-side access rules: an
+    // unreliable model is hidden from ?reliable=true but still retrievable.
+    const retrieved = await fetchWorker(
+        `/v1/models/${encodeURIComponent(FLUX_SCHNELL)}`,
+    );
+    expect(retrieved.status).toBe(200);
+    const body = (await retrieved.json()) as {
+        id: string;
+        health?: { success_rate: number };
+    };
+    expect(body.id).toBe(FLUX_SCHNELL);
+    expect(body.health?.success_rate).toBe(0.25);
+
+    const healthyRetrieved = await fetchWorker(
+        `/v1/models/${encodeURIComponent(GPT5_NANO)}`,
+    );
+    expect(healthyRetrieved.status).toBe(200);
+});
+
+test("/v1/models/status raw endpoint is unchanged", async ({ tinybird }) => {
+    tinybird.modelHealthResponse = [
+        healthRow(GPT5_NANO, { total_requests: 4, status_2xx: 4 }),
+    ];
+
+    const response = await fetchWorker("/v1/models/status");
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { data: Array<{ model: string }> };
+    expect(Array.isArray(body.data)).toBe(true);
+    expect(body.data.length).toBe(1);
+    expect(body.data[0].model).toBe(GPT5_NANO);
+});

--- a/shared/registry/model-info.ts
+++ b/shared/registry/model-info.ts
@@ -30,6 +30,40 @@ export const ModelCapabilitySchema = z.enum([
 
 export type ModelCapability = z.infer<typeof ModelCapabilitySchema>;
 
+// Minimal caller-visible health metadata exposed on model listings.
+// Successes are final 2xx responses (fallback rescues included); caller-side
+// 4xx errors are excluded from the success rate. Missing health data means
+// the value is unknown and the field is omitted entirely.
+export const ModelHealthSummarySchema = z
+    .object({
+        success_rate: z
+            .number()
+            .min(0)
+            .max(1)
+            .describe(
+                "Share of caller-visible final requests that succeeded (2xx, including fallback rescues), excluding caller-side 4xx errors.",
+            ),
+        samples: z
+            .number()
+            .int()
+            .nonnegative()
+            .describe("Total final requests observed in the window."),
+        window_minutes: z
+            .number()
+            .int()
+            .positive()
+            .describe("Rolling window the health data covers, in minutes."),
+        observed_at: z
+            .string()
+            .describe("When the health snapshot was fetched (ISO 8601)."),
+    })
+    .meta({
+        description:
+            "Observed caller-visible health over a rolling window. Omitted when no health data is available (unknown). Experimental status is tracked separately and is independent of this value.",
+    });
+
+export type ModelHealthSummary = z.infer<typeof ModelHealthSummarySchema>;
+
 // Pricing uses registry field names directly, filtering out zero/undefined values
 // Fields: promptTextTokens, promptCachedTokens, promptCacheWriteTokens,
 //         promptAudioTokens, promptAudioSeconds, promptImageTokens,
@@ -44,6 +78,7 @@ export const ModelInfoSchema = z.object({
         .describe("Human-readable model publisher, not the inference provider"),
     brand_url: z.string().url().optional(),
     community: z.boolean(),
+    health: ModelHealthSummarySchema.optional(),
     agent: z.boolean().optional(),
     base_model: z.string().optional(),
     per_user_rpm: z.number().positive().nullable().optional(),

--- a/shared/schemas/openai.ts
+++ b/shared/schemas/openai.ts
@@ -1,6 +1,7 @@
 // AI generated based on `https://github.com/Portkey-AI/openapi/blob/master/openapi.yaml` and adaped
 
 import { z } from "zod";
+import { ModelHealthSummarySchema } from "../registry/model-info.ts";
 import { MODEL_CATEGORIES } from "../registry/registry.ts";
 import { AUDIO_VOICES, DEFAULT_TEXT_MODEL } from "../registry/text.ts";
 import { SafeSchema } from "./safety.ts";
@@ -752,6 +753,7 @@ export const OpenAIModelSchema = z
         reasoning: z.boolean().optional(),
         context_length: z.number().optional(),
         per_user_rpm: z.number().positive().nullable().optional(),
+        health: ModelHealthSummarySchema.optional(),
     })
     .meta({
         description: "OpenAI-compatible model object with capability metadata",

--- a/shared/test/mocks/tinybird.ts
+++ b/shared/test/mocks/tinybird.ts
@@ -30,6 +30,7 @@ export type MockTinybirdState = {
     appDirectoryResponse: UsageRow[];
     appUsageResponse: UsageRow[];
     modelModalitiesResponse: UsageRow[];
+    modelHealthResponse: UsageRow[];
     pipeCalls: PipeCall[];
 };
 
@@ -46,6 +47,7 @@ export function createMockTinybird(): MockAPI<MockTinybirdState> {
         appDirectoryResponse: [],
         appUsageResponse: [],
         modelModalitiesResponse: [],
+        modelHealthResponse: [],
         pipeCalls: [],
     };
 
@@ -115,6 +117,10 @@ export function createMockTinybird(): MockAPI<MockTinybirdState> {
             state.pipeCalls.push({ url: c.req.url, query: c.req.query() });
             return c.json({ data: state.modelModalitiesResponse }, 200);
         })
+        .get("/v0/pipes/model_health.json", (c) => {
+            state.pipeCalls.push({ url: c.req.url, query: c.req.query() });
+            return c.json({ data: state.modelHealthResponse }, 200);
+        })
         .post("/v0/datasources/:datasource/delete", (c) => {
             return c.json({ delete_id: "mock-delete" }, 200);
         });
@@ -138,6 +144,7 @@ export function createMockTinybird(): MockAPI<MockTinybirdState> {
         state.appDirectoryResponse = [];
         state.appUsageResponse = [];
         state.modelModalitiesResponse = [];
+        state.modelHealthResponse = [];
         state.pipeCalls = [];
     };
 


### PR DESCRIPTION
Fixes #14535

- All discovery endpoints accept `?source=official|community|all` filtering
- `?reliable=true` keeps only sufficiently healthy models: success rate >= 0.9 across >= 10 samples; models without health data are treated as unknown and excluded
- New `X-Pollinations-Model-Filter` request header (URL query format) for clients that cannot append query parameters to a configured base URL; explicit query parameters win over header values
- Model entries in listing responses carry a minimal `health` block (success_rate / samples / window_minutes / observed_at), omitted when no health data is available
- Removes the legacy `?community=` parameter (no backward compatibility required per the quest); tests and docs migrated to the new parameters

Implementation notes: the health snapshot reuses the existing model-status Tinybird data (60s module cache with stale fallback), zero extra upstream calls. Success rate = 2xx / (total requests - caller-side 4xx), so caller errors do not count against a model.

Verified: tsc clean, docs:validate pass, full vitest suite green (126 files / 1851 tests).