### PR TITLE
docs: reduce repository transfer size without changing runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@
 
 </div>
 
+> [!TIP]
+> Need the current source without downloading repository history? See [Keeping local clones small](docs/REPOSITORY_SIZE.md) for shallow and partial-clone commands.
+
 > [!IMPORTANT]
 > **Model IDs are now standardized**
 >

--- a/docs/REPOSITORY_SIZE.md
+++ b/docs/REPOSITORY_SIZE.md
@@ -1,0 +1,49 @@
+# Keeping local clones small
+
+The repository's runtime and application behavior do not depend on Git history. When an app only needs the current source tree, use a shallow or partial clone instead of downloading the full history.
+
+## Recommended clone commands
+
+### Current snapshot only
+
+```bash
+git clone --depth 1 --single-branch https://github.com/pollinations/pollinations.git
+```
+
+This downloads only the default branch's tip. It is the best default for imports, CI jobs, containers, and local builds that do not inspect history.
+
+### Current snapshot with lazy file contents
+
+```bash
+git clone --filter=blob:none --no-checkout https://github.com/pollinations/pollinations.git
+cd pollinations
+git checkout main
+```
+
+This uses Git's partial-clone support: file contents are fetched when Git needs them. It is useful when tooling checks only a subset of the tree. The remote and Git hosting provider must support upload-pack filtering.
+
+### Shallow + partial clone
+
+```bash
+git clone --depth 1 --filter=blob:none --single-branch https://github.com/pollinations/pollinations.git
+```
+
+This minimizes both commit history and initially transferred file contents while preserving a normal working tree after checkout.
+
+## When full history is required
+
+Use a full clone for `git blame`, archaeology, release analysis, or work that needs to create patches against older commits. A shallow clone can be expanded later:
+
+```bash
+git fetch --unshallow
+```
+
+## Maintainer guidance
+
+- Prefer shallow or partial clone instructions over rewriting public history. History rewrites invalidate existing clones, disrupt forks, and can break commit links and external automation.
+- Do not remove tracked source, assets, fixtures, or lockfiles solely to reduce repository size; those can affect builds or users.
+- Keep generated output, caches, local data, dependency directories, credentials, and temporary artifacts out of Git with `.gitignore`.
+- Review unusually large additions before merging. If a large binary must remain available to users, evaluate Git LFS or external artifact storage rather than committing repeated generated versions.
+- Repository maintenance (for example, repacking or server-side garbage collection) is an administrative operation for repository administrators; it does not change the checked-out application.
+
+These approaches change transfer and local storage behavior only. They do not change the code delivered by a checkout, the API, or the behavior of deployed applications.

--- a/scripts/clone-shallow.sh
+++ b/scripts/clone-shallow.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Use this for consumers that need the current source tree, not Git history.
+git clone --depth 1 --filter=blob:none --single-branch \
+  https://github.com/pollinations/pollinations.git


### PR DESCRIPTION
## Summary

- document shallow and partial clone options for consumers importing the repository
- add a copy/paste clone helper using depth and blob filtering
- link the guidance from the README

## Why this approach

The repository currently has a large commit history, while application behavior depends on the checked-out tree rather than historical commits. A history rewrite would invalidate existing clones, forks, commit links, and external automation, so this PR keeps history intact and gives importers a safe way to avoid downloading it.

The documented commands preserve a normal working tree and can be expanded with `git fetch --unshallow` when history is later needed. No runtime source, assets, fixtures, or lockfiles are removed.

## Validation

- `git diff --check`
- `bash -n scripts/clone-shallow.sh`
