### PR TITLE
fix: load TypeScript in Economics deployment validation

### DIFF
--- a/operations/deployment/economics-contract.test.cjs
+++ b/operations/deployment/economics-contract.test.cjs
@@ -1,0 +1,25 @@
+const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
+const { readFileSync } = require("node:fs");
+const { resolve } = require("node:path");
+const { test } = require("node:test");
+
+test("Economics deployment checker loads TypeScript before requesting credentials", () => {
+    const economics = resolve(__dirname, "../economics");
+    const manifest = JSON.parse(
+        readFileSync(resolve(economics, "deploy.json"), "utf8"),
+    );
+    // Exercise the real checker launcher without credentials or deployment.
+    const [runtime, ...args] = manifest.deploy
+        .split("'")[1]
+        .split(" --secrets-file")[0]
+        .split(" ");
+    assert.equal(runtime, "node");
+    const result = spawnSync(process.execPath, args, {
+        cwd: economics,
+        encoding: "utf8",
+    });
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /--secrets-file is required/);
+    assert.doesNotMatch(result.stderr, /ERR_MODULE_NOT_FOUND/);
+});

--- a/operations/economics/deploy.json
+++ b/operations/economics/deploy.json
@@ -4,7 +4,7 @@
   "sops": "economics",
   "install": "npm ci --prefix ../..",
   "build": "npm run build --prefix web",
-  "deploy": "sops exec-file --no-fifo secrets/web.json 'node web/scripts/check-tinybird-contract.mjs --secrets-file {} && npm exec --prefix web -- wrangler deploy --config web/dist/myceli_economics/wrangler.json --secrets-file {}'",
+  "deploy": "sops exec-file --no-fifo secrets/web.json 'node --import tsx web/scripts/check-tinybird-contract.mjs --secrets-file {} && npm exec --prefix web -- wrangler deploy --config web/dist/myceli_economics/wrangler.json --secrets-file {}'",
   "verify": [
     "https://economics.pollinations.ai/"
   ],

--- a/operations/economics/web/package.json
+++ b/operations/economics/web/package.json
@@ -35,6 +35,7 @@
     "vite": "^7.0.0",
     "vitest": "^3.2.4",
     "wrangler": "^4.111.0",
-    "@cloudflare/vite-plugin": "^1.15.2"
+    "@cloudflare/vite-plugin": "^1.15.2",
+    "tsx": "^4.21.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.1",
         "tailwindcss": "^4.0.0",
+        "tsx": "^4.21.0",
         "typescript": "^5.7.2",
         "vite": "^7.0.0",
         "vitest": "^3.2.4",


### PR DESCRIPTION
- Fixes the Economics deployment failure in [run 34218715892](https://github.com/pollinations/pollinations/actions/runs/34218715892/job/102036743776): plain Node cannot resolve the validator's extensionless TypeScript imports.
- Runs the existing contract checker with `node --import tsx` and declares the already-locked loader as an Economics development dependency. Contract validation still runs before Worker upload.
- Adds a regression test to the existing CI maintenance-script checks. It launches the actual deployment checker without credentials and verifies imports complete before the required-credentials check.
- Validated the original failure, fixed launcher, all 16 existing contract tests, five deployment-script tests, clean dependency installation and Biome. No production deployment or secret changes performed.
