### PR TITLE
fix: promote dashboard session configuration to production

### DIFF
--- a/.github/scripts/polli-workflows.test.mjs
+++ b/.github/scripts/polli-workflows.test.mjs
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 import vm from "node:vm";
 
 const workflow = await readFile(
@@ -65,6 +69,83 @@ test("both first jobs whitelist callers before allocating a runner", () => {
         /34513273|204561696|182555207|189873015|228371309/,
     );
 });
+
+// Preserve the block scalar's relative indentation, including heredoc delimiters.
+function runScripts(source) {
+    return [
+        ...source.matchAll(
+            /^ {8}run: \|\r?\n((?: {10}[^\r\n]*(?:\r?\n|$)|\r?\n)+)/gm,
+        ),
+    ].map((match) => match[1].replace(/^ {10}/gm, "").replace(/\r\n/g, "\n"));
+}
+
+const bash =
+    process.platform === "win32" ? "C:/Program Files/Git/bin/bash.exe" : "bash";
+const repository = fileURLToPath(new URL("../../", import.meta.url));
+
+for (const [name, source, command, ids] of [
+    ["askpolli", workflow, "!askpolli", [189873015, 1]],
+    ["polli", full, "!polli", [158852059, 189873015]],
+]) {
+    test(`${name} actual run blocks parse in Bash`, () => {
+        const scripts = runScripts(source);
+        assert.ok(scripts.length >= 2);
+        for (const script of scripts) {
+            const result = spawnSync(bash, ["-n"], {
+                input: script,
+                encoding: "utf8",
+            });
+            assert.equal(
+                result.status,
+                0,
+                result.error?.message || result.stderr,
+            );
+            assert.equal(result.stderr, "");
+        }
+    });
+
+    test(`${name} actual authorization shell emits allowed and denied results`, async () => {
+        const directory = await mkdtemp(join(tmpdir(), "polli-shell-"));
+        try {
+            for (const [index, id] of ids.entries()) {
+                const output = join(directory, `output-${index}`).replaceAll(
+                    "\\",
+                    "/",
+                );
+                const event = JSON.stringify({
+                    sender: { id, login: "fixture" },
+                    issue: { number: 42, pull_request: {} },
+                    comment: { body: command },
+                });
+                const result = spawnSync(bash, ["-e"], {
+                    cwd: repository,
+                    input: runScripts(source)[0],
+                    encoding: "utf8",
+                    env: {
+                        ...process.env,
+                        EVENT: event,
+                        EVENT_JSON: event,
+                        EVENT_NAME: "issue_comment",
+                        ACTOR: "fixture",
+                        TRIGGERING_ACTOR: "fixture",
+                        GITHUB_OUTPUT: output,
+                    },
+                });
+                assert.equal(
+                    result.status,
+                    0,
+                    result.error?.message || result.stderr,
+                );
+                assert.equal(
+                    await readFile(output, "utf8"),
+                    `authorized=${index === 0}\n`,
+                );
+            }
+        } finally {
+            await rm(directory, { recursive: true, force: true });
+        }
+    });
+}
 
 const publisher = workflow
     .split("  publish:")[1]

--- a/.github/workflows/repo-askpolli.yml
+++ b/.github/workflows/repo-askpolli.yml
@@ -53,20 +53,18 @@ jobs:
           ACTOR: ${{ github.actor }}
           TRIGGERING_ACTOR: ${{ github.triggering_actor }}
         run: |
-          {
-            node --input-type=module <<'NODE'
-            import { authorizePolli } from "./.github/scripts/polli-authorization.mjs";
-            const event = JSON.parse(process.env.EVENT_JSON);
-            const authorized = authorizePolli({
-              eventName: process.env.EVENT_NAME,
-              event,
-              actor: process.env.ACTOR,
-              triggeringActor: process.env.TRIGGERING_ACTOR,
-              mode: "read",
-            });
-            process.stdout.write(`authorized=${authorized}\n`);
-            NODE
-          } >> "$GITHUB_OUTPUT"
+          node --input-type=module <<'NODE' >> "$GITHUB_OUTPUT"
+          import { authorizePolli } from "./.github/scripts/polli-authorization.mjs";
+          const event = JSON.parse(process.env.EVENT_JSON);
+          const authorized = authorizePolli({
+            eventName: process.env.EVENT_NAME,
+            event,
+            actor: process.env.ACTOR,
+            triggeringActor: process.env.TRIGGERING_ACTOR,
+            mode: "read",
+          });
+          process.stdout.write(`authorized=${authorized}\n`);
+          NODE
 
   answer:
     needs: authorize

--- a/operations/deployment/observability-secrets.test.cjs
+++ b/operations/deployment/observability-secrets.test.cjs
@@ -1,0 +1,55 @@
+const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
+const { mkdtempSync, readFileSync, rmSync, writeFileSync } = require("node:fs");
+const { tmpdir } = require("node:os");
+const { join, resolve } = require("node:path");
+const { test } = require("node:test");
+
+test("Observability provisions its session secret and rejects missing configuration", () => {
+    const directory = mkdtempSync(
+        join(tmpdir(), "observability-secrets-test-"),
+    );
+    const script = resolve(
+        __dirname,
+        "../observability/scripts/push-secrets.mjs",
+    );
+    const input = join(directory, "input.json");
+    const secrets = {
+        POLLINATIONS_AUTH_SESSION_SECRET: "test-session-only",
+        GF_ADMIN_PASSWORD: "test-grafana-only",
+        TINYBIRD_READ_TOKEN: "test-read-only",
+        TINYBIRD_LEGACY_READ_TOKEN: "test-legacy-only",
+        DISCORD_WEBHOOK_URL: "https://example.invalid/webhook",
+        CLOUDFLARE_TUNNEL_TOKEN: "test-tunnel-only",
+    };
+
+    try {
+        writeFileSync(input, JSON.stringify(secrets));
+        const result = spawnSync(process.execPath, [script, input, "local"], {
+            cwd: directory,
+            encoding: "utf8",
+        });
+        assert.equal(result.status, 0, result.stderr);
+        const vars = readFileSync(join(directory, ".dev.vars"), "utf8");
+        assert.match(
+            vars,
+            /^POLLINATIONS_AUTH_SESSION_SECRET="test-session-only"$/m,
+        );
+        assert.doesNotMatch(vars, /CLOUDFLARE_TUNNEL_TOKEN/);
+
+        delete secrets.POLLINATIONS_AUTH_SESSION_SECRET;
+        writeFileSync(input, JSON.stringify(secrets));
+        const missing = spawnSync(process.execPath, [script, input, "local"], {
+            cwd: directory,
+            encoding: "utf8",
+        });
+        assert.equal(missing.status, 1);
+        assert.match(
+            missing.stderr,
+            /Missing required secret POLLINATIONS_AUTH_SESSION_SECRET/,
+        );
+        assert.equal(readFileSync(join(directory, ".dev.vars"), "utf8"), vars);
+    } finally {
+        rmSync(directory, { recursive: true, force: true });
+    }
+});

--- a/operations/economics/secrets/web.json
+++ b/operations/economics/secrets/web.json
@@ -1,6 +1,7 @@
 {
 	"ECONOMICS_PASSWORD": "ENC[AES256_GCM,data:+2MCUSFFCoBLZw==,iv:ebqin5KeSl/yocoqUNTjxOk/979bVyYzHiBHIbxNXGA=,tag:7VaEx62qGB52pEewVOxkLw==,type:str]",
 	"TINYBIRD_ECONOMICS_READ_TOKEN": "ENC[AES256_GCM,data:vg9G74LuhLRCye/1nWLItnPBH3iI6u5HRnahlOCIMGE4Krj1nNbaOKmXdmpYClHrbEDS6tX0UXZJ2+nf+dc1G8gbCnFcJdi2Ie1OCOfD0ruGbEvh//+6xC3qM0CnxmvUNog6hjiIXxfTnqQJBw+rcEUctv2x0O2X7ZPALobmf1wl1DxBcLZJbOEupWxEXrtuYjewhW/TLURv3t96SvNfcaILMjx8K6Rww2VJs8/eUKdL/htH9/pmkAOqeSNSbr+aCcdrabij4CxKSpnk9Q==,iv:sPsLfbTFRC2Fr8O7KS6LxMVlxqDihyWD2baClOiXge8=,tag:E2m2FqcLci4U0JrO3bmb6A==,type:str]",
+	"POLLINATIONS_AUTH_SESSION_SECRET": "ENC[AES256_GCM,data:MTClqaoded8kBr7MmVBdRv6+dLg827sBhQRhsUFdz7RtWrdcUCWP2wEi6nATbQkHbIfYmOuKLuopu958X/OKZQ==,iv:4EoYfk/+fhZ8B1C5f+mEUzQtBeV+wPsu2OxaimOYvYc=,tag:TQidnEPCjYz9DaMlQV1gWw==,type:str]",
 	"sops": {
 		"age": [
 			{
@@ -8,8 +9,8 @@
 				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByd1NiaFZqVm9hQzEwYi9t\nVThxUCt2NXRiZ3lZQ2FPc3lEcmwyRFI3ekhNCjJheDdBZkg1YThXMkxGSHVJWUNo\nM0tHSmc2aEllSHVockhSb3k4Njc1eFUKLS0tIGNiV09JUnlDOW54a2crdWI5VE1I\nRHY1RFVUOHhMQlRwZkcvbGdKWDVxTkEKI5MLBODf3HagktF+j8oU7p7RUOgAZYmx\nAdglYRfZKKlmCb5994hfw3teJw2EwnuXCF5h+1FdIJhpw0iCg77Gkw==\n-----END AGE ENCRYPTED FILE-----\n"
 			}
 		],
-		"lastmodified": "2026-07-12T23:05:53Z",
-		"mac": "ENC[AES256_GCM,data:+WdirYCOfxkRDtyeM646B5klF87M9j44iVQrkFkyvLy5QnAr77Ua9LUf1iEVR/qY+10CVhehGP0ROSuAERhxVtUFhK5Hb5kT37b5H8u3/1dZeLqBhXkMfHKpZ+0WuiWMlEJX0+NxklQJg0yi6qeZ5c6f1DVK3qAYQu6VR6F6fRA=,iv:gvnTUNG8uhV5enP+9ZQcMQP+pm2gLqBs6UwrCOGqHb8=,tag:fNDE/eNaqd/ocqdVkH17rQ==,type:str]",
+		"lastmodified": "2026-09-08T12:20:16Z",
+		"mac": "ENC[AES256_GCM,data:zTX1UjP71SAV6X2zvsHraDwx0x2RfGlqAOJWmAiMEluzKZ6z1CunMdqZI0X8FMK6WFfdhV9Kt2pUpProOdrSjcfPxWFDl0iiNkpSBnq8ZqsWtnVKJv9wxy5jb8ilQ9O/hnMlhybLs1AVQHbkw0Zf/9fZqH1FXkwVoeXuaM/0SRg=,iv:QQJs/9YRC/SNsSYlQTIZHjr05KF+aJu63r1256VsT7w=,tag:miGqQNF8OM+t8wW1VCvCIA==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.11.0"
 	}

--- a/operations/kpi/secrets/env.json
+++ b/operations/kpi/secrets/env.json
@@ -1,5 +1,6 @@
 {
 	"TINYBIRD_READ_TOKEN": "ENC[AES256_GCM,data:89X74PzztmH7y4AAGcdB0w5fAqJeyjh8MfnwXpeODVzAjchEL1ClxTW3z4t2H8jZobOjwyPbH5I4Q4hCLc/ZW8x9yn/r3Zihr7HI6y+0MhHUpqm9BUoQp5M4nHmJE63vfCrf99x40rMw7dBEN+UHVuCHTA2DXfeWbtjxfVJMa7w9ArEzd5EwDRh2zOvoS3TnFzDd5IsbJOSKl2gGE6rKmQp2JxooAshDclO68hhWlr9KnJkt1j8AsdPNVb5RcpeWZEIRHetCI/+ZfH+UQQ==,iv:4eUApo5lbqSowPGmIjx1s9WH415Qzxbb09aGnjgRuz8=,tag:iW/QLfWOGyV3m5oy6Uk/hw==,type:str]",
+	"POLLINATIONS_AUTH_SESSION_SECRET": "ENC[AES256_GCM,data:ywu1odBuX3ZVkdqB7dVQmXU4QZa9jFAlCKZz7XVOyu312Bvj3cKaWv7zEFks/dOErfyn4XuUX5BTrVdDwoGRfA==,iv:do2EhkVoiB2tINmcaGEEw0lzSwt59ZlzW0zRjwLAMCI=,tag:yDB8A4s9UIuVURUFVnWoTA==,type:str]",
 	"sops": {
 		"age": [
 			{
@@ -11,8 +12,8 @@
 				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6TmptdVlVVjUvcUhaMWo1\nQzJTbHdXamxSMGdjYWsyMkFvQ2tEcU9uZFU0Ci9TZjdENHlnaUdES214TDZFS2h3\nS1JsYmFHYlpGU1I1ZStXL3VCVUJodnMKLS0tIHAwSlU0ODhEdEJENHgrNTE3cnlO\nSWNTQTd4WVlmTWNCU0hWa0cyTlVzcUEKs+WrmBDOyPCmlqAI5Opdg3mGLJkDH+dL\nvpZ+7jtZZuOvlZUsvQ24b2VagBdvAnZ5N5VkZgb3q2y8QySx8gXtAA==\n-----END AGE ENCRYPTED FILE-----\n"
 			}
 		],
-		"lastmodified": "2026-07-10T16:58:09Z",
-		"mac": "ENC[AES256_GCM,data:2U1682C4saVAHDKDjMUN71bYxZEmMNasuLykq3lFZpVzA7JZFyiW+mxtQvSa6Xk8KOr/oxnnRB8FiiJXC1TZToblHKP3vm56S/lpEiLGwvUrlIYcUMm8nuPhTc5mSZJekrk8/6q3b0MZIQ8B1oOEhmkcJ9MUCesG22qhx+W8m/s=,iv:ab5ZplLLYcT4NSy18KhVm4TjsGJqu0eUbO1laXsCJ+0=,tag:cRBTSPSK1eFNOO8elsohOw==,type:str]",
+		"lastmodified": "2026-09-08T12:20:16Z",
+		"mac": "ENC[AES256_GCM,data:r0hDd0eQKKmADP83qcYlZVG0qM0unAI41aSObRwLHhqgWtXC7LILkXIqWqDpt6VdJx+A07n9XT+UpNzEIYv5GZ3uGh0fwJulOHq7uJzELvEiP3cPO88AKZnwhDKeBqluAj4sHrfUFT8SbuR7x3hWmgmePdTWEppYkG8Eys0oSfw=,iv:ioW7EBvBTHszbACEyUrzYeq7gykJvbDxf4b5Qul61JE=,tag:mkNN6c4DuDpCr2A2HJwbCQ==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.11.0"
 	}

--- a/operations/observability/scripts/push-secrets.mjs
+++ b/operations/observability/scripts/push-secrets.mjs
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 const REQUIRED_SECRET_NAMES = [
+    "POLLINATIONS_AUTH_SESSION_SECRET",
     "GF_ADMIN_PASSWORD",
     "TINYBIRD_READ_TOKEN",
     "TINYBIRD_LEGACY_READ_TOKEN",

--- a/operations/observability/secrets/secrets.vars.json
+++ b/operations/observability/secrets/secrets.vars.json
@@ -5,6 +5,7 @@
 	"DISCORD_WEBHOOK_URL": "ENC[AES256_GCM,data:9Lg53OwsX7zRpHsOJGbWW/vgPKVx2ycbOehfjIXP/fxP+C65BWi4ZouJqA5jXCdkSQX0eUcrn5mvw7Eyh8uSpeTAyOQeMQnbuxYUit2N192on/DjC3fr7r+k/qWuq9eLUrA/TT7U1qXQEALXrSNk1sSpLizbSsFdkQ==,iv:7QS0/3WYLlqiZFRbUygRlI6viaBDW/4Y15QW3WGaOss=,tag:sIHI+C5Z50Dm9Af9Gsn+HA==,type:str]",
 	"TINYBIRD_READ_TOKEN": "ENC[AES256_GCM,data:SJOuQiK0+NT3BXcz44mSwbTBprDpIqyg9A7TRh00Pxpdk5HZAI/JQkSpBk4VFCZ7gz0glU4EnS+1Ra4WsqhpSlCI+VNKRFlcOm+ksPOe+u8gYGHmtqJ+oba3dpajEwFrCWJobZ40POsMBXf9dJ0RyQBEEYup2FX+F8DxNuISqHdnJ/Hq5pOGymqkUO0iai8bTBN6QtK/Ygyy4B0btDnveCrvokAtCyEr18lr+ogidWWqwegHJFGTeWPX9QB5sX/KgSNXJGQB3OA+Z5cvNA==,iv:34VPP1nolLzDUQUWDxLO0IHGTcZCa4/QTLq1njHeOcg=,tag:N12ioUJhAVppkzUjL0CgGg==,type:str]",
 	"TINYBIRD_LEGACY_READ_TOKEN": "ENC[AES256_GCM,data:0olrnT98x+PH4PEpEq9XoiCrEhu6i+Mq/SE+CPn6XJkvPutGabSa/FPsio2QO+mHBHPYpr0rH6pGW8n8FBIP5OaJxGSpfYxsblRrbIZwcDPzpJ7/cmLZ2Ng2QJtcflhn4gFDlNP3iucuwBoNqj6I+sYyQitqCATiQPO48jE37sajPsEHL6bf6Zgtfqwi9zkiU3UawO+4eN33HS+k3tCmpBByX9mkRQ9ar+ZtTCkjt0uqcbM+rMh2v/m+RL55vxK4drV3HrGFer/w1N/1ag==,iv:96HY1WlwYEnkJYWp6a9ZyN1MHIixtt5FSyDEKUK9ehw=,tag:vt1beEt2xxhhfrYYphS7Tw==,type:str]",
+	"POLLINATIONS_AUTH_SESSION_SECRET": "ENC[AES256_GCM,data:x0/x1lOzmrrakHl/gqttfsMilkig0frWw6XwvRJDonh9X+/CA4IF8hLbP42AYANmYAvZDKQvunLyw2t9fbEVVw==,iv:tF5VQfBM5xtARHcu4k1T9VCp+AW8+MjuyuINTnEiRUI=,tag:8FXmU08loiZngUKK342S+A==,type:str]",
 	"sops": {
 		"age": [
 			{
@@ -16,8 +17,8 @@
 				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvU2lycG55RDArMmQ4dWRJ\na0h4SUNEczlydWRqeUx0Z1hOUy8zUEJ1eUVzCjlQR2dLMXRpNlJZNi9NTlRXSEk3\neEMvWnptV2hwZVRqYm56dXprUHQ3ancKLS0tIGk2dFJSTk94V3pqcUFLbGswclor\ncVBWV2RnODdPNkFUTmJRWEFYdzA3VlkKecRDv2an9LhmGA9uLSPtz07mHDM64C8n\nqeY0P8bds1SSfv7UIy0Djbm0cxC/CF91hdWiC3ZJRgT8iFbWpnKHdA==\n-----END AGE ENCRYPTED FILE-----\n"
 			}
 		],
-		"lastmodified": "2026-04-14T10:22:06Z",
-		"mac": "ENC[AES256_GCM,data:1kVKMKhcH/hJQ9LxXZgjGE2j+Y20hhWW/bSHvAeDDVM530X9q1/ZVXsDCEpNB5pU3U2DvYBq+e3hRoJ4lQXhIGJWtb19qm6lE8TuFWmBESeLBuOCDiUbAc0UHWKxuP5khqLcfo3utBfgyNOIhlQSMFMcKqCuyvgrrRcFeLhXuF0=,iv:4Ta+193sYh6ewqeYqjCSd8gqyZgd2Q71ey2DFUUDkqE=,tag:h/ZgMiEyEIb+Cecatqping==,type:str]",
+		"lastmodified": "2026-09-08T12:20:16Z",
+		"mac": "ENC[AES256_GCM,data:NZH7wrn4jIZ7gzwtHnerAYt5XL3LOffG+iDSEez82aaIeEc4UrImElN1PBZe7gkYyTfk+Gb/A8oqbGujDbsp6au8Kg56YEeGsoCoNnpPu4mVeet4k8RGw9B2r0+575P2CooReR4aElhvwzsPQpjVAAmCIxJjpZrom5jBh51kJzw=,iv:U7TVhK/3QcSpkEhBlOD0uj1sdNcdI2R4OfX106KF3rI=,tag:dnhXK6efh/b8qL1E6KnVPA==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.11.0"
 	}


### PR DESCRIPTION
- Promotes #14575 to provision the explicitly approved production session secrets for KPI, Economics, and Observability.
- Includes #14577, the already-merged Ask Polli workflow heredoc correction.
- #14575 checks passed; production dashboard deployments run through GitHub Actions after merge.
- Verify session endpoints, installed bindings, and Pollinations sign-in redirects after deployment.
