### PR TITLE
feat: filter model catalogs by source and reliability

### DIFF
--- a/APIDOCS.md
+++ b/APIDOCS.md
@@ -1182,7 +1182,7 @@ Owners can publish their own embedding backend as a community endpoint. A commun
 
 #### `GET` `/embeddings/models` — List Embedding Models
 
-Returns available embedding models with pricing, capabilities, and supported input modalities. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.
+Returns available embedding models with pricing, capabilities, and supported input modalities. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?source=official` to exclude community models or `?source=community` to return only community models.
 
 ⚙️ **Parameters**
 
@@ -1197,7 +1197,7 @@ Returns available embedding models with pricing, capabilities, and supported inp
 💻 **Example**
 
 ```bash
-curl "https://gen.pollinations.ai/embeddings/models?community=0" \
+curl "https://gen.pollinations.ai/embeddings/models?source=official" \
   -H "Authorization: Bearer $POLLINATIONS_KEY"
 ```
 
@@ -1273,17 +1273,87 @@ Discover available models with pricing, capabilities, and metadata. No authentic
 
 ### Query Parameters
 
-All model discovery endpoints accept an optional `community` query parameter:
+All model discovery endpoints accept the same optional filters. Omitting them
+returns every model the caller can see, exactly as before.
 
 | Parameter | Values | Behaviour |
 |-----------|--------|-----------|
-| *(omitted)* | | Returns all models (default, backward-compatible) |
-| `community=false` | `false`, `0` | Excludes community models — returns official models only |
-| `community=true` | `true`, `1` | Returns community models only |
+| `source` | `all` (default), `official`, `community` | Filter by who publishes the model |
+| `reliability` | `all` (default), `reliable` | Return only models whose recent health clears the thresholds |
+| `health` | `true`, `false`, `1`, `0` | Attach a `health` object to every model. Implied by `reliability=reliable` |
+| `community` | `true`, `false`, `1`, `0` | **Deprecated.** `true` ≡ `source=community`, `false` ≡ `source=official`. Ignored when `source` is present |
 
-Any other value (e.g. `tru`, `yes`, `2`) returns **400 Bad Request**.
+Any other value (e.g. `source=tru`, `reliability=perfect`) returns **400 Bad Request**.
 
-Example: `GET /models?community=false`
+```bash
+curl "https://gen.pollinations.ai/models?source=official"
+curl "https://gen.pollinations.ai/v1/models?reliability=reliable"
+curl "https://gen.pollinations.ai/image/models?health=true"
+```
+
+#### Header equivalents
+
+Several OpenAI-compatible clients build the catalog URL by appending `/models`
+to a configured base URL, which discards any query string. Every filter above is
+also readable from a header, so those clients can still narrow the list:
+
+| Header | Equivalent to |
+|--------|---------------|
+| `X-Pollinations-Model-Source` | `?source=` |
+| `X-Pollinations-Model-Reliability` | `?reliability=` |
+| `X-Pollinations-Model-Health` | `?health=` |
+
+A query parameter always wins over the header, so an explicit URL beats a
+client-wide default.
+
+- **Open WebUI** — *Settings → Connections → OpenAI API*: set the base URL to
+  `https://gen.pollinations.ai/v1` and add `X-Pollinations-Model-Source: official`
+  under that connection's custom headers.
+- **LibreChat** — in `librechat.yaml`, under the custom endpoint:
+  `headers: { X-Pollinations-Model-Source: "official" }`.
+- **Cline** — *OpenAI Compatible* provider: add the same header in the provider's
+  custom-headers section.
+
+#### Health metadata
+
+With `health=true`, every model carries:
+
+```json
+{
+  "name": "openai/gpt-5.4-nano",
+  "health": {
+    "status": "reliable",
+    "success_rate": 0.9982,
+    "sample_size": 15234,
+    "window_minutes": 60,
+    "checked_at": "2026-09-08T12:00:00.000Z",
+    "stale": false
+  }
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `status` | `reliable`, `degraded`, or `unknown` |
+| `success_rate` | Successes ÷ attempts, or `null` when unknown |
+| `sample_size` | Attempts observed in the window |
+| `window_minutes` | Length of the rolling window |
+| `checked_at` | When the data was last fetched |
+| `stale` | Data is past its freshness budget or came from a fallback cache |
+
+A request the fallback layer rescued still returned a usable result, so it counts
+as a success. Caller-side `4xx` failures are excluded from both the rate and the
+sample — they say nothing about the model. A model with no traffic in the window
+is `unknown`, and `reliability=reliable` excludes it, so `reliable` always means
+"we have recently seen this work" rather than "nothing has gone wrong yet".
+Experimental or preview status is separate from health and is unaffected by these
+filters.
+
+These parameters filter **discovery only**. They never change which models an
+account is permitted to generate with; permission and balance filtering still
+runs first, and a filtered listing is always a subset of the unfiltered one.
+
+Raw per-provider rows remain available at `GET /v1/models/status`.
 
 Rich model endpoints include `capabilities` for agentic/model traits:
 `tool_calling`, `reasoning`, `web_search`, and `code_execution`.
@@ -1299,13 +1369,13 @@ Built-in models may use separate upstream routes for Chat and Responses.
 
 ## Community Models
 
-Community models use an `owner/model` id and appear in the same discovery responses as Pollinations-operated models. Use `community=true` to return only community models or `community=false` to exclude them.
+Community models use an `owner/model` id and appear in the same discovery responses as Pollinations-operated models. Use `source=community` to return only community models or `source=official` to exclude them.
 
 For registration, publishing, pricing, fallbacks, and health monitoring, see [Publish a Model](/docs#tag/publish-a-model). For ownership endpoints and schemas, see [Community Models](/docs#tag/community-models) under Resources.
 
 #### `GET` `/v1/models` — List Models (OpenAI-compatible)
 
-Returns available models in the OpenAI-compatible format (`{object: "list", data: [...]}`), with Pollinations pricing and capability extensions. Official models are ordered by modality (text, image, video, 3D, audio, realtime, embedding), with each configured default first, followed by stable and then alpha/preview models from newest to oldest. Community models follow from newest to oldest. Use `/models`, `/text/models`, `/image/models`, `/audio/models`, or `/embeddings/models` for richer metadata. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.
+Returns available models in the OpenAI-compatible format (`{object: "list", data: [...]}`), with Pollinations pricing and capability extensions. Official models are ordered by modality (text, image, video, 3D, audio, realtime, embedding), with each configured default first, followed by stable and then alpha/preview models from newest to oldest. Community models follow from newest to oldest. Use `/models`, `/text/models`, `/image/models`, `/audio/models`, or `/embeddings/models` for richer metadata. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?source=official` to exclude community models or `?source=community` to return only community models.
 
 ⚙️ **Parameters**
 
@@ -1441,7 +1511,7 @@ curl "https://gen.pollinations.ai/v1/models/:model" \
 
 #### `GET` `/models` — List Models
 
-Returns all available models with pricing, capabilities, and metadata. Official models are ordered by modality (text, image, video, 3D, audio, realtime, embedding), with each configured default first, followed by stable and then alpha/preview models from newest to oldest. Community models follow from newest to oldest. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.
+Returns all available models with pricing, capabilities, and metadata. Official models are ordered by modality (text, image, video, 3D, audio, realtime, embedding), with each configured default first, followed by stable and then alpha/preview models from newest to oldest. Community models follow from newest to oldest. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?source=official` to exclude community models or `?source=community` to return only community models.
 
 ⚙️ **Parameters**
 
@@ -1475,7 +1545,7 @@ curl "https://gen.pollinations.ai/models?community=0" \
 
 #### `GET` `/3d/models` — List 3D Models
 
-Returns all available 3D model generation models with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.
+Returns all available 3D model generation models with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?source=official` to exclude community models or `?source=community` to return only community models.
 
 ⚙️ **Parameters**
 
@@ -1509,7 +1579,7 @@ curl "https://gen.pollinations.ai/3d/models?community=0" \
 
 #### `GET` `/image/models` — List Image & Video Models
 
-Returns all available image and video generation models with pricing, capabilities, and metadata. Video models are included here — check the `output_modalities` field to distinguish image vs video models. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.
+Returns all available image and video generation models with pricing, capabilities, and metadata. Video models are included here — check the `output_modalities` field to distinguish image vs video models. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?source=official` to exclude community models or `?source=community` to return only community models.
 
 ⚙️ **Parameters**
 
@@ -1543,7 +1613,7 @@ curl "https://gen.pollinations.ai/image/models?community=0" \
 
 #### `GET` `/video/models` — List Video Models
 
-Returns all available video generation models with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.
+Returns all available video generation models with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?source=official` to exclude community models or `?source=community` to return only community models.
 
 ⚙️ **Parameters**
 
@@ -1577,7 +1647,7 @@ curl "https://gen.pollinations.ai/video/models?community=0" \
 
 #### `GET` `/text/models` — List Text Models (Detailed)
 
-Returns all available text generation and community text models with pricing, capabilities, and metadata including context window size, supported modalities, and tool support. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.
+Returns all available text generation and community text models with pricing, capabilities, and metadata including context window size, supported modalities, and tool support. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?source=official` to exclude community models or `?source=community` to return only community models.
 
 ⚙️ **Parameters**
 
@@ -1611,7 +1681,7 @@ curl "https://gen.pollinations.ai/text/models?community=0" \
 
 #### `GET` `/audio/models` — List Audio Models
 
-Returns all available audio models (text-to-speech, music generation, and transcription) with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.
+Returns all available audio models (text-to-speech, music generation, and transcription) with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?source=official` to exclude community models or `?source=community` to return only community models.
 
 ⚙️ **Parameters**
 

--- a/gen.pollinations.ai/src/docs/models.md
+++ b/gen.pollinations.ai/src/docs/models.md
@@ -15,17 +15,87 @@ Discover available models with pricing, capabilities, and metadata. No authentic
 
 ### Query Parameters
 
-All model discovery endpoints accept an optional `community` query parameter:
+All model discovery endpoints accept the same optional filters. Omitting them
+returns every model the caller can see, exactly as before.
 
 | Parameter | Values | Behaviour |
 |-----------|--------|-----------|
-| *(omitted)* | | Returns all models (default, backward-compatible) |
-| `community=false` | `false`, `0` | Excludes community models — returns official models only |
-| `community=true` | `true`, `1` | Returns community models only |
+| `source` | `all` (default), `official`, `community` | Filter by who publishes the model |
+| `reliability` | `all` (default), `reliable` | Return only models whose recent health clears the thresholds |
+| `health` | `true`, `false`, `1`, `0` | Attach a `health` object to every model. Implied by `reliability=reliable` |
+| `community` | `true`, `false`, `1`, `0` | **Deprecated.** `true` ≡ `source=community`, `false` ≡ `source=official`. Ignored when `source` is present |
 
-Any other value (e.g. `tru`, `yes`, `2`) returns **400 Bad Request**.
+Any other value (e.g. `source=tru`, `reliability=perfect`) returns **400 Bad Request**.
 
-Example: `GET /models?community=false`
+```bash
+curl "https://gen.pollinations.ai/models?source=official"
+curl "https://gen.pollinations.ai/v1/models?reliability=reliable"
+curl "https://gen.pollinations.ai/image/models?health=true"
+```
+
+#### Header equivalents
+
+Several OpenAI-compatible clients build the catalog URL by appending `/models`
+to a configured base URL, which discards any query string. Every filter above is
+also readable from a header, so those clients can still narrow the list:
+
+| Header | Equivalent to |
+|--------|---------------|
+| `X-Pollinations-Model-Source` | `?source=` |
+| `X-Pollinations-Model-Reliability` | `?reliability=` |
+| `X-Pollinations-Model-Health` | `?health=` |
+
+A query parameter always wins over the header, so an explicit URL beats a
+client-wide default.
+
+- **Open WebUI** — *Settings → Connections → OpenAI API*: set the base URL to
+  `https://gen.pollinations.ai/v1` and add `X-Pollinations-Model-Source: official`
+  under that connection's custom headers.
+- **LibreChat** — in `librechat.yaml`, under the custom endpoint:
+  `headers: { X-Pollinations-Model-Source: "official" }`.
+- **Cline** — *OpenAI Compatible* provider: add the same header in the provider's
+  custom-headers section.
+
+#### Health metadata
+
+With `health=true`, every model carries:
+
+```json
+{
+  "name": "openai/gpt-5.4-nano",
+  "health": {
+    "status": "reliable",
+    "success_rate": 0.9982,
+    "sample_size": 15234,
+    "window_minutes": 60,
+    "checked_at": "2026-09-08T12:00:00.000Z",
+    "stale": false
+  }
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `status` | `reliable`, `degraded`, or `unknown` |
+| `success_rate` | Successes ÷ attempts, or `null` when unknown |
+| `sample_size` | Attempts observed in the window |
+| `window_minutes` | Length of the rolling window |
+| `checked_at` | When the data was last fetched |
+| `stale` | Data is past its freshness budget or came from a fallback cache |
+
+A request the fallback layer rescued still returned a usable result, so it counts
+as a success. Caller-side `4xx` failures are excluded from both the rate and the
+sample — they say nothing about the model. A model with no traffic in the window
+is `unknown`, and `reliability=reliable` excludes it, so `reliable` always means
+"we have recently seen this work" rather than "nothing has gone wrong yet".
+Experimental or preview status is separate from health and is unaffected by these
+filters.
+
+These parameters filter **discovery only**. They never change which models an
+account is permitted to generate with; permission and balance filtering still
+runs first, and a filtered listing is always a subset of the unfiltered one.
+
+Raw per-provider rows remain available at `GET /v1/models/status`.
 
 Rich model endpoints include `capabilities` for agentic/model traits:
 `tool_calling`, `reasoning`, `web_search`, and `code_execution`.
@@ -41,6 +111,6 @@ Built-in models may use separate upstream routes for Chat and Responses.
 
 ## Community Models
 
-Community models use an `owner/model` id and appear in the same discovery responses as Pollinations-operated models. Use `community=true` to return only community models or `community=false` to exclude them.
+Community models use an `owner/model` id and appear in the same discovery responses as Pollinations-operated models. Use `source=community` to return only community models or `source=official` to exclude them.
 
 For registration, publishing, pricing, fallbacks, and health monitoring, see [Publish a Model](/docs#tag/publish-a-model). For ownership endpoints and schemas, see [Community Models](/docs#tag/community-models) under Resources.

--- a/gen.pollinations.ai/src/model-health.ts
+++ b/gen.pollinations.ai/src/model-health.ts
@@ -1,0 +1,244 @@
+// Shared model health, derived from the public Tinybird `model_health` pipe.
+//
+// One fetch and one cache serve both `/v1/models/status` (raw rows) and the
+// model catalogs (a per-model summary), so the two can never disagree about
+// whether a model is healthy.
+
+import debug from "debug";
+import { z } from "zod";
+
+const log = debug("pollinations:model-health");
+
+const TINYBIRD_HOST = "https://api.europe-west2.gcp.tinybird.co";
+const TINYBIRD_PUBLIC_TOKEN =
+    "p.eyJ1IjogImFjYTYzZjc5LThjNTYtNDhlNC05NWJjLWEyYmFjMTY0NmJkMyIsICJpZCI6ICI5ZWZmMGM3Ni1kOTZkLTQwYjgtYWQwOC1mNDFlMmRiYjBmYTIiLCAiaG9zdCI6ICJnY3AtZXVyb3BlLXdlc3QyIn0.6VnVkAQ5h_fkcDZVDUoU38dzTxaw0xo3DnmKkhECbA8";
+
+export const CACHE_TTL_MS = 60_000;
+export const DEFAULT_MINUTES = 60;
+export const MAX_MINUTES = 7 * 24 * 60;
+const MAX_CACHE_ENTRIES = 32;
+
+// A summary older than this is reported as stale rather than silently trusted.
+const STALE_AFTER_MS = 15 * 60_000;
+
+// A model catalog must not wait on the monitoring backend. Past this budget the
+// listing is served without health rather than held up for it.
+const FETCH_TIMEOUT_MS = 2_500;
+
+// Thresholds for the coarse `status` label. `reliable` needs both a high
+// success rate and enough requests for that rate to mean anything.
+export const RELIABLE_SUCCESS_RATE = 0.9;
+export const RELIABLE_MIN_SAMPLE = 20;
+
+export const ModelHealthRowSchema = z.object({
+    model: z.string(),
+    event_type: z.string(),
+    provider: z.string(),
+    model_used: z.string(),
+    total_requests: z.number().int().nonnegative(),
+    status_2xx: z.number().int().nonnegative(),
+    errors_4xx: z.number().int().nonnegative(),
+    errors_5xx: z.number().int().nonnegative(),
+    own_calls: z.number().int().nonnegative(),
+    own_calls_ok: z.number().int().nonnegative(),
+    primary_5xx: z.number().int().nonnegative(),
+    primary_retried_503s: z.number().int().nonnegative(),
+    fallback_rescues: z.number().int().nonnegative(),
+    last_error_at: z.string(),
+    latency_p50_ms: z.number().nonnegative().nullable(),
+    latency_p95_ms: z.number().nonnegative().nullable(),
+    avg_latency_ms: z.number().nonnegative().nullable(),
+    last_request_at: z.string(),
+    tokens_per_second: z.number().nonnegative().nullable(),
+});
+
+export const ModelHealthResponseSchema = z.object({
+    data: z.array(ModelHealthRowSchema),
+    meta: z.array(z.object({ name: z.string(), type: z.string() })).optional(),
+    rows: z.number().int().nonnegative().optional(),
+    statistics: z
+        .object({
+            elapsed: z.number().nonnegative(),
+            rows_read: z.number().int().nonnegative(),
+            bytes_read: z.number().int().nonnegative(),
+        })
+        .optional(),
+});
+
+export type ModelHealthRow = z.infer<typeof ModelHealthRowSchema>;
+export type ModelHealthResponse = z.infer<typeof ModelHealthResponseSchema>;
+
+export const ModelHealthSummarySchema = z
+    .object({
+        status: z.enum(["reliable", "degraded", "unknown"]).meta({
+            description:
+                "`reliable` when the success rate and sample size both clear the thresholds, `degraded` when they do not, `unknown` when there is no data for this model in the window.",
+        }),
+        success_rate: z.number().min(0).max(1).nullable().meta({
+            description:
+                "Successful requests divided by attempts, where a fallback rescue counts as a success and caller-side 4xx failures are excluded. Null when unknown.",
+        }),
+        sample_size: z.number().int().nonnegative().meta({
+            description: "Attempts observed in the window, 4xx excluded.",
+        }),
+        window_minutes: z.number().int().positive().meta({
+            description: "Length of the rolling window the summary covers.",
+        }),
+        checked_at: z.string().nullable().meta({
+            description: "When the underlying data was last fetched.",
+        }),
+        stale: z.boolean().meta({
+            description:
+                "True when the data is older than the freshness budget or was served from a fallback cache.",
+        }),
+    })
+    .meta({ $id: "ModelHealthSummary" });
+
+export type ModelHealthSummary = z.infer<typeof ModelHealthSummarySchema>;
+
+export const UNKNOWN_HEALTH = (windowMinutes: number): ModelHealthSummary => ({
+    status: "unknown",
+    success_rate: null,
+    sample_size: 0,
+    window_minutes: windowMinutes,
+    checked_at: null,
+    stale: false,
+});
+
+type CacheEntry = { data: ModelHealthResponse; timestamp: number };
+
+const cache = new Map<number, CacheEntry>();
+
+function setCacheEntry(minutes: number, entry: CacheEntry) {
+    cache.delete(minutes);
+    cache.set(minutes, entry);
+    if (cache.size > MAX_CACHE_ENTRIES) {
+        const oldest = cache.keys().next().value;
+        if (oldest !== undefined) cache.delete(oldest);
+    }
+}
+
+/** Test seam: drops the shared cache so cases cannot leak into each other. */
+export function resetModelHealthCache() {
+    cache.clear();
+}
+
+export function parseMinutes(value: string | undefined): number | null {
+    if (value === undefined) return DEFAULT_MINUTES;
+    if (!/^\d+$/.test(value)) return null;
+    const minutes = Number(value);
+    if (minutes < 1 || minutes > MAX_MINUTES) return null;
+    return minutes;
+}
+
+export type HealthFetch = {
+    data: ModelHealthResponse;
+    timestamp: number;
+    stale: boolean;
+};
+
+/**
+ * Fetch the health rows for a window, serving a fresh cache hit when possible
+ * and falling back to stale data rather than failing. Returns null only when
+ * there is no data at all.
+ */
+export async function fetchModelHealth(
+    minutes: number,
+    fetchImpl: typeof fetch = fetch,
+): Promise<HealthFetch | null> {
+    const now = Date.now();
+    const cached = cache.get(minutes);
+    if (cached && now - cached.timestamp < CACHE_TTL_MS) {
+        setCacheEntry(minutes, cached);
+        return { data: cached.data, timestamp: cached.timestamp, stale: false };
+    }
+
+    try {
+        const url = new URL("/v0/pipes/model_health.json", TINYBIRD_HOST);
+        url.searchParams.set("token", TINYBIRD_PUBLIC_TOKEN);
+        url.searchParams.set("minutes", String(minutes));
+        const response = await fetchImpl(url.toString(), {
+            signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+        });
+        if (!response.ok) {
+            throw new Error(`Tinybird responded with ${response.status}`);
+        }
+        const data = (await response.json()) as ModelHealthResponse;
+        const timestamp = Date.now();
+        setCacheEntry(minutes, { data, timestamp });
+        return { data, timestamp, stale: false };
+    } catch (error) {
+        log("Error fetching model health: %O", error);
+        const stale = cache.get(minutes);
+        if (!stale) return null;
+        setCacheEntry(minutes, stale);
+        return { data: stale.data, timestamp: stale.timestamp, stale: true };
+    }
+}
+
+/**
+ * Collapse the raw rows into one summary per model id.
+ *
+ * A model is served through several providers and event types, so its rows are
+ * summed before any rate is computed -- a rate per row would let one quiet
+ * provider outvote a busy one.
+ */
+export function summariseModelHealth(
+    rows: ModelHealthRow[],
+    {
+        minutes,
+        timestamp,
+        stale,
+    }: { minutes: number; timestamp: number; stale: boolean },
+): Map<string, ModelHealthSummary> {
+    const totals = new Map<string, { attempts: number; successes: number }>();
+
+    for (const row of rows) {
+        // 4xx is the caller getting it wrong; it says nothing about the model.
+        const attempts = Math.max(0, row.total_requests - row.errors_4xx);
+        if (attempts === 0) continue;
+        // A request the fallback rescued still returned a usable result.
+        const successes = Math.min(
+            attempts,
+            row.status_2xx + row.fallback_rescues,
+        );
+        const current = totals.get(row.model) ?? { attempts: 0, successes: 0 };
+        current.attempts += attempts;
+        current.successes += successes;
+        totals.set(row.model, current);
+    }
+
+    const checkedAt = new Date(timestamp).toISOString();
+    const isStale = stale || Date.now() - timestamp > STALE_AFTER_MS;
+
+    const summaries = new Map<string, ModelHealthSummary>();
+    for (const [model, { attempts, successes }] of totals) {
+        const rate = successes / attempts;
+        summaries.set(model, {
+            status:
+                rate >= RELIABLE_SUCCESS_RATE && attempts >= RELIABLE_MIN_SAMPLE
+                    ? "reliable"
+                    : "degraded",
+            success_rate: Number(rate.toFixed(4)),
+            sample_size: attempts,
+            window_minutes: minutes,
+            checked_at: checkedAt,
+            stale: isStale,
+        });
+    }
+    return summaries;
+}
+
+/** Health for every model in one call, or an empty map when data is missing. */
+export async function getModelHealthSummaries(
+    minutes: number = DEFAULT_MINUTES,
+    fetchImpl: typeof fetch = fetch,
+): Promise<Map<string, ModelHealthSummary>> {
+    const result = await fetchModelHealth(minutes, fetchImpl);
+    if (!result) return new Map();
+    return summariseModelHealth(result.data.data, {
+        minutes,
+        timestamp: result.timestamp,
+        stale: result.stale,
+    });
+}

--- a/gen.pollinations.ai/src/routes/model-status.ts
+++ b/gen.pollinations.ai/src/routes/model-status.ts
@@ -1,82 +1,17 @@
 import { errorResponseDescriptions } from "@shared/utils/api-docs.ts";
-import debug from "debug";
 import { Hono } from "hono";
 import { describeRoute, resolver } from "hono-openapi";
-import { z } from "zod";
 import type { Env } from "@/env.ts";
+import {
+    DEFAULT_MINUTES,
+    fetchModelHealth,
+    MAX_MINUTES,
+    ModelHealthResponseSchema,
+    parseMinutes,
+} from "@/model-health.ts";
 
-const log = debug("pollinations:model-status");
-
-const TINYBIRD_HOST = "https://api.europe-west2.gcp.tinybird.co";
-const TINYBIRD_PUBLIC_TOKEN =
-    "p.eyJ1IjogImFjYTYzZjc5LThjNTYtNDhlNC05NWJjLWEyYmFjMTY0NmJkMyIsICJpZCI6ICI5ZWZmMGM3Ni1kOTZkLTQwYjgtYWQwOC1mNDFlMmRiYjBmYTIiLCAiaG9zdCI6ICJnY3AtZXVyb3BlLXdlc3QyIn0.6VnVkAQ5h_fkcDZVDUoU38dzTxaw0xo3DnmKkhECbA8";
-
-const CACHE_TTL_MS = 60_000;
-const MAX_CACHE_ENTRIES = 32;
-const DEFAULT_MINUTES = 60;
-const MAX_MINUTES = 7 * 24 * 60;
 const DATA_TIMESTAMP_HEADER = "X-Model-Status-Timestamp";
 const STALE_HEADER = "X-Model-Status-Stale";
-
-const ModelHealthRowSchema = z.object({
-    model: z.string(),
-    event_type: z.string(),
-    provider: z.string(),
-    model_used: z.string(),
-    total_requests: z.number().int().nonnegative(),
-    status_2xx: z.number().int().nonnegative(),
-    errors_4xx: z.number().int().nonnegative(),
-    errors_5xx: z.number().int().nonnegative(),
-    own_calls: z.number().int().nonnegative(),
-    own_calls_ok: z.number().int().nonnegative(),
-    primary_5xx: z.number().int().nonnegative(),
-    primary_retried_503s: z.number().int().nonnegative(),
-    fallback_rescues: z.number().int().nonnegative(),
-    last_error_at: z.string(),
-    latency_p50_ms: z.number().nonnegative().nullable(),
-    latency_p95_ms: z.number().nonnegative().nullable(),
-    avg_latency_ms: z.number().nonnegative().nullable(),
-    last_request_at: z.string(),
-    tokens_per_second: z.number().nonnegative().nullable(),
-});
-
-const ModelHealthResponseSchema = z.object({
-    data: z.array(ModelHealthRowSchema),
-    meta: z.array(z.object({ name: z.string(), type: z.string() })).optional(),
-    rows: z.number().int().nonnegative().optional(),
-    statistics: z
-        .object({
-            elapsed: z.number().nonnegative(),
-            rows_read: z.number().int().nonnegative(),
-            bytes_read: z.number().int().nonnegative(),
-        })
-        .optional(),
-});
-
-type ModelHealthResponse = z.infer<typeof ModelHealthResponseSchema>;
-
-type CacheEntry = { data: ModelHealthResponse; timestamp: number };
-
-const cache = new Map<number, CacheEntry>();
-
-function setCacheEntry(minutes: number, entry: CacheEntry) {
-    cache.delete(minutes);
-    cache.set(minutes, entry);
-
-    if (cache.size > MAX_CACHE_ENTRIES) {
-        const oldestMinutes = cache.keys().next().value;
-        if (oldestMinutes !== undefined) cache.delete(oldestMinutes);
-    }
-}
-
-function parseMinutes(value: string | undefined): number | null {
-    if (value === undefined) return DEFAULT_MINUTES;
-    if (!/^\d+$/.test(value)) return null;
-
-    const minutes = Number(value);
-    if (minutes < 1 || minutes > MAX_MINUTES) return null;
-    return minutes;
-}
 
 export const modelStatusRoutes = new Hono<Env>().get(
     "/v1/models/status",
@@ -88,6 +23,8 @@ export const modelStatusRoutes = new Hono<Env>().get(
             "",
             "The optional `minutes` query parameter controls the rolling window and must be an integer between 1 and 10080.",
             `The ${DATA_TIMESTAMP_HEADER} response header reports when the data was fetched from Tinybird; ${STALE_HEADER} is set when stale data is returned during an upstream failure.`,
+            "",
+            "For a per-model summary rather than raw rows, pass `health=true` to any model catalog.",
         ].join("\n"),
         parameters: [
             {
@@ -144,51 +81,16 @@ export const modelStatusRoutes = new Hono<Env>().get(
             );
         }
 
-        const now = Date.now();
-        const cached = cache.get(minutes);
-        if (cached && now - cached.timestamp < CACHE_TTL_MS) {
-            log(
-                "Returning cached model health response for %d minutes",
-                minutes,
-            );
-            setCacheEntry(minutes, cached);
-            c.header(
-                DATA_TIMESTAMP_HEADER,
-                new Date(cached.timestamp).toISOString(),
-            );
-            return c.json(cached.data);
-        }
-
-        try {
-            const url = new URL("/v0/pipes/model_health.json", TINYBIRD_HOST);
-            url.searchParams.set("token", TINYBIRD_PUBLIC_TOKEN);
-            url.searchParams.set("minutes", String(minutes));
-            log("Fetching model health from Tinybird: %s", url.toString());
-
-            const response = await fetch(url.toString());
-            if (!response.ok) {
-                throw new Error(`Tinybird responded with ${response.status}`);
-            }
-
-            const tinybirdData = (await response.json()) as ModelHealthResponse;
-            const timestamp = Date.now();
-            setCacheEntry(minutes, { data: tinybirdData, timestamp });
-            c.header(DATA_TIMESTAMP_HEADER, new Date(timestamp).toISOString());
-            return c.json(tinybirdData);
-        } catch (error) {
-            log("Error fetching model health: %O", error);
-            const stale = cache.get(minutes);
-            if (stale) {
-                log("Falling back to stale cache for %d minutes", minutes);
-                setCacheEntry(minutes, stale);
-                c.header(
-                    DATA_TIMESTAMP_HEADER,
-                    new Date(stale.timestamp).toISOString(),
-                );
-                c.header(STALE_HEADER, "true");
-                return c.json(stale.data);
-            }
+        const result = await fetchModelHealth(minutes);
+        if (!result) {
             return c.json({ error: "Failed to fetch model health data" }, 502);
         }
+
+        c.header(
+            DATA_TIMESTAMP_HEADER,
+            new Date(result.timestamp).toISOString(),
+        );
+        if (result.stale) c.header(STALE_HEADER, "true");
+        return c.json(result.data);
     },
 );

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -61,6 +61,12 @@ import { createFactory } from "hono/factory";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
 import {
+    getModelHealthSummaries,
+    DEFAULT_MINUTES as HEALTH_WINDOW_MINUTES,
+    type ModelHealthSummary,
+    UNKNOWN_HEALTH,
+} from "@/model-health.ts";
+import {
     CreateEmbeddingRequestSchema,
     CreateEmbeddingResponseSchema,
 } from "@/schemas/embeddings.ts";
@@ -75,6 +81,7 @@ import {
 import {
     type ModelListQueryParams,
     ModelListQueryParamsSchema,
+    resolveModelListFilters,
 } from "@/schemas/models.ts";
 import { RealtimeRequestQueryParamsSchema } from "@/schemas/realtime.ts";
 import { GenerateTextRequestQueryParamsSchema } from "@/schemas/text.ts";
@@ -219,16 +226,71 @@ function hasPaidBalance(c: any): boolean | undefined {
     return (user.packBalance ?? 0) > 0;
 }
 
-// Optionally filter entries by the validated `?community` query parameter.
-function filterEntriesByCommunityParam(
+// Filter by who publishes the model. A community model is one served through a
+// community endpoint; everything else is Pollinations-operated.
+function filterEntriesBySource(
     entries: GenerationModelEntry[],
-    communityParam: string | undefined,
+    source: "all" | "official" | "community",
 ): GenerationModelEntry[] {
-    if (communityParam === undefined) return entries;
-    const wantCommunity = communityParam === "true" || communityParam === "1";
+    if (source === "all") return entries;
+    const wantCommunity = source === "community";
     return entries.filter(
         (entry) => (entry.communityEndpoint !== undefined) === wantCommunity,
     );
+}
+
+// Filter by observed health. A model with no data is unknown, and unknown is
+// not reliable -- `reliable` has to mean "we have seen this work".
+function filterEntriesByReliability(
+    entries: GenerationModelEntry[],
+    reliability: "all" | "reliable",
+    health: Map<string, ModelHealthSummary>,
+): GenerationModelEntry[] {
+    if (reliability === "all") return entries;
+    return entries.filter(
+        (entry) => health.get(entry.info.name)?.status === "reliable",
+    );
+}
+
+// Discovery filtering only. Health data must never widen or narrow what an
+// account is actually allowed to generate with, so this runs after the
+// permission and balance filters and never feeds back into them.
+async function applyCatalogFilters(
+    c: Context<Env>,
+    entries: GenerationModelEntry[],
+): Promise<{
+    entries: GenerationModelEntry[];
+    health: Map<string, ModelHealthSummary> | null;
+}> {
+    const query = c.req.valid("query" as never) as ModelListQueryParams;
+    const { source, reliability, health } = resolveModelListFilters(
+        query,
+        (name) => c.req.header(name),
+    );
+
+    const bySource = filterEntriesBySource(entries, source);
+    if (!health && reliability === "all") {
+        return { entries: bySource, health: null };
+    }
+
+    const summaries = await getModelHealthSummaries(HEALTH_WINDOW_MINUTES);
+    return {
+        entries: filterEntriesByReliability(bySource, reliability, summaries),
+        health: summaries,
+    };
+}
+
+// Attach the health summary to a model payload when the caller asked for it.
+function withHealth<T extends { name?: string; id?: string }>(
+    payload: T,
+    modelName: string,
+    health: Map<string, ModelHealthSummary> | null,
+): T | (T & { health: ModelHealthSummary }) {
+    if (!health) return payload;
+    return {
+        ...payload,
+        health: health.get(modelName) ?? UNKNOWN_HEALTH(HEALTH_WINDOW_MINUTES),
+    };
 }
 
 // Factory for model-list endpoints: validates the community query parameter,
@@ -242,20 +304,20 @@ const modelsListHandler = (
     [
         validator("query", ModelListQueryParamsSchema),
         async (c: Context<Env>) => {
-            const { community } = c.req.valid(
-                "query" as never,
-            ) as ModelListQueryParams;
             const allowedModels = c.var.auth?.apiKey?.permissions?.models;
             const paidBalance = hasPaidBalance(c);
+            const { entries, health } = await applyCatalogFilters(
+                c,
+                filterEntriesByPermissions(
+                    await getEntries(c),
+                    allowedModels,
+                    paidBalance,
+                ),
+            );
             return c.json(
-                filterEntriesByCommunityParam(
-                    filterEntriesByPermissions(
-                        await getEntries(c),
-                        allowedModels,
-                        paidBalance,
-                    ),
-                    community,
-                ).map((entry) => entry.info),
+                entries.map((entry) =>
+                    withHealth(entry.info, entry.info.name, health),
+                ),
             );
         },
     ] as const;
@@ -373,7 +435,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Models (OpenAI-compatible)",
             description:
-                'Returns available models in the OpenAI-compatible format (`{object: "list", data: [...]}`), with Pollinations pricing and capability extensions. Official models are ordered by modality (text, image, video, 3D, audio, realtime, embedding), with each configured default first, followed by stable and then alpha/preview models from newest to oldest. Community models follow from newest to oldest. Use `/models`, `/text/models`, `/image/models`, `/audio/models`, or `/embeddings/models` for richer metadata. When authenticated: the owner\'s private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.',
+                'Returns available models in the OpenAI-compatible format (`{object: "list", data: [...]}`), with Pollinations pricing and capability extensions. Official models are ordered by modality (text, image, video, 3D, audio, realtime, embedding), with each configured default first, followed by stable and then alpha/preview models from newest to oldest. Community models follow from newest to oldest. Use `/models`, `/text/models`, `/image/models`, `/audio/models`, or `/embeddings/models` for richer metadata. When authenticated: the owner\'s private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?source=official` to exclude community models or `?source=community` to return only community models. Pass `?health=true` for per-model health, or `?reliability=reliable` to return only models whose recent success rate and sample size clear the thresholds. Each filter is also readable from a header (`X-Pollinations-Model-Source`, `X-Pollinations-Model-Reliability`, `X-Pollinations-Model-Health`) for clients that append `/models` to a base URL. Filtering affects discovery only and never changes generation permissions. `?community=` is deprecated in favour of `?source=`.',
             responses: {
                 200: {
                     description: "Success",
@@ -388,22 +450,25 @@ export const proxyRoutes = new Hono<Env>()
         }),
         validator("query", ModelListQueryParamsSchema),
         async (c) => {
-            const { community } = c.req.valid(
-                "query" as never,
-            ) as ModelListQueryParams;
             const allowedModels = c.var.auth?.apiKey?.permissions?.models;
             const paidBalance = hasPaidBalance(c);
-            const modelEntries = filterEntriesByCommunityParam(
+            const { entries, health } = await applyCatalogFilters(
+                c,
                 filterEntriesByPermissions(
                     await getVisibleModelEntries(c),
                     allowedModels,
                     paidBalance,
                 ),
-                community,
             );
             return c.json({
                 object: "list" as const,
-                data: modelEntries.map(toOpenAIModelEntry),
+                data: entries.map((entry) =>
+                    withHealth(
+                        toOpenAIModelEntry(entry),
+                        entry.info.name,
+                        health,
+                    ),
+                ),
             });
         },
     )
@@ -457,7 +522,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Models",
             description:
-                "Returns all available models with pricing, capabilities, and metadata. Official models are ordered by modality (text, image, video, 3D, audio, realtime, embedding), with each configured default first, followed by stable and then alpha/preview models from newest to oldest. Community models follow from newest to oldest. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
+                "Returns all available models with pricing, capabilities, and metadata. Official models are ordered by modality (text, image, video, 3D, audio, realtime, embedding), with each configured default first, followed by stable and then alpha/preview models from newest to oldest. Community models follow from newest to oldest. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?source=official` to exclude community models or `?source=community` to return only community models. Pass `?health=true` for per-model health, or `?reliability=reliable` to return only models whose recent success rate and sample size clear the thresholds. Each filter is also readable from a header (`X-Pollinations-Model-Source`, `X-Pollinations-Model-Reliability`, `X-Pollinations-Model-Health`) for clients that append `/models` to a base URL. Filtering affects discovery only and never changes generation permissions. `?community=` is deprecated in favour of `?source=`.",
             responses: {
                 200: {
                     description: "Success",
@@ -478,7 +543,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List 3D Models",
             description:
-                "Returns all available 3D model generation models with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
+                "Returns all available 3D model generation models with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?source=official` to exclude community models or `?source=community` to return only community models. Pass `?health=true` for per-model health, or `?reliability=reliable` to return only models whose recent success rate and sample size clear the thresholds. Each filter is also readable from a header (`X-Pollinations-Model-Source`, `X-Pollinations-Model-Reliability`, `X-Pollinations-Model-Health`) for clients that append `/models` to a base URL. Filtering affects discovery only and never changes generation permissions. `?community=` is deprecated in favour of `?source=`.",
             responses: {
                 200: {
                     description: "Success",
@@ -499,7 +564,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Image & Video Models",
             description:
-                "Returns all available image and video generation models with pricing, capabilities, and metadata. Video models are included here — check the `output_modalities` field to distinguish image vs video models. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
+                "Returns all available image and video generation models with pricing, capabilities, and metadata. Video models are included here — check the `output_modalities` field to distinguish image vs video models. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?source=official` to exclude community models or `?source=community` to return only community models. Pass `?health=true` for per-model health, or `?reliability=reliable` to return only models whose recent success rate and sample size clear the thresholds. Each filter is also readable from a header (`X-Pollinations-Model-Source`, `X-Pollinations-Model-Reliability`, `X-Pollinations-Model-Health`) for clients that append `/models` to a base URL. Filtering affects discovery only and never changes generation permissions. `?community=` is deprecated in favour of `?source=`.",
             responses: {
                 200: {
                     description: "Success",
@@ -520,7 +585,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Video Models",
             description:
-                "Returns all available video generation models with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
+                "Returns all available video generation models with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?source=official` to exclude community models or `?source=community` to return only community models. Pass `?health=true` for per-model health, or `?reliability=reliable` to return only models whose recent success rate and sample size clear the thresholds. Each filter is also readable from a header (`X-Pollinations-Model-Source`, `X-Pollinations-Model-Reliability`, `X-Pollinations-Model-Health`) for clients that append `/models` to a base URL. Filtering affects discovery only and never changes generation permissions. `?community=` is deprecated in favour of `?source=`.",
             responses: {
                 200: {
                     description: "Success",
@@ -541,7 +606,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Text Models (Detailed)",
             description:
-                "Returns all available text generation and community text models with pricing, capabilities, and metadata including context window size, supported modalities, and tool support. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
+                "Returns all available text generation and community text models with pricing, capabilities, and metadata including context window size, supported modalities, and tool support. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?source=official` to exclude community models or `?source=community` to return only community models. Pass `?health=true` for per-model health, or `?reliability=reliable` to return only models whose recent success rate and sample size clear the thresholds. Each filter is also readable from a header (`X-Pollinations-Model-Source`, `X-Pollinations-Model-Reliability`, `X-Pollinations-Model-Health`) for clients that append `/models` to a base URL. Filtering affects discovery only and never changes generation permissions. `?community=` is deprecated in favour of `?source=`.",
             responses: {
                 200: {
                     description: "Success",
@@ -564,7 +629,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Audio Models",
             description:
-                "Returns all available audio models (text-to-speech, music generation, and transcription) with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
+                "Returns all available audio models (text-to-speech, music generation, and transcription) with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?source=official` to exclude community models or `?source=community` to return only community models. Pass `?health=true` for per-model health, or `?reliability=reliable` to return only models whose recent success rate and sample size clear the thresholds. Each filter is also readable from a header (`X-Pollinations-Model-Source`, `X-Pollinations-Model-Reliability`, `X-Pollinations-Model-Health`) for clients that append `/models` to a base URL. Filtering affects discovery only and never changes generation permissions. `?community=` is deprecated in favour of `?source=`.",
             responses: {
                 200: {
                     description: "Success",
@@ -587,7 +652,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🔢 Embeddings"],
             summary: "List Embedding Models",
             description:
-                "Returns available embedding models with pricing, capabilities, and supported input modalities. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
+                "Returns available embedding models with pricing, capabilities, and supported input modalities. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?source=official` to exclude community models or `?source=community` to return only community models. Pass `?health=true` for per-model health, or `?reliability=reliable` to return only models whose recent success rate and sample size clear the thresholds. Each filter is also readable from a header (`X-Pollinations-Model-Source`, `X-Pollinations-Model-Reliability`, `X-Pollinations-Model-Health`) for clients that append `/models` to a base URL. Filtering affects discovery only and never changes generation permissions. `?community=` is deprecated in favour of `?source=`.",
             responses: {
                 200: {
                     description: "Success",

--- a/gen.pollinations.ai/src/schemas/models.ts
+++ b/gen.pollinations.ai/src/schemas/models.ts
@@ -1,10 +1,76 @@
 import { z } from "zod";
 
+// Clients such as Open WebUI, LibreChat and Cline build catalog URLs by
+// appending `/models` to a configured base URL, which discards any query string
+// the user tried to set. They can all send custom headers, so every filter here
+// is also readable from a header.
+export const SOURCE_HEADER = "X-Pollinations-Model-Source";
+export const RELIABILITY_HEADER = "X-Pollinations-Model-Reliability";
+export const HEALTH_HEADER = "X-Pollinations-Model-Health";
+
+export const ModelSourceSchema = z.enum(["all", "official", "community"]);
+export const ModelReliabilitySchema = z.enum(["all", "reliable"]);
+
+export type ModelSource = z.infer<typeof ModelSourceSchema>;
+export type ModelReliability = z.infer<typeof ModelReliabilitySchema>;
+
 export const ModelListQueryParamsSchema = z.object({
+    source: ModelSourceSchema.optional().meta({
+        description:
+            "Filter by who publishes the model: `official` for Pollinations-operated models, `community` for models published by other accounts, `all` (the default) for both. Also readable from the `X-Pollinations-Model-Source` header for clients that append `/models` to a base URL and cannot pass a query string.",
+    }),
+    reliability: ModelReliabilitySchema.optional().meta({
+        description:
+            "Filter by observed health: `reliable` returns only models whose recent success rate and sample size both clear the thresholds, `all` (the default) returns every model. Models with no health data are treated as unknown and are excluded by `reliable`. Also readable from the `X-Pollinations-Model-Reliability` header.",
+    }),
+    health: z.enum(["true", "false", "1", "0"]).optional().meta({
+        description:
+            "Set to `true` to include a `health` object on every model: `status`, `success_rate`, `sample_size`, `window_minutes`, `checked_at` and `stale`. Implied by `reliability=reliable`. Also readable from the `X-Pollinations-Model-Health` header.",
+    }),
     community: z.enum(["true", "false", "1", "0"]).optional().meta({
         description:
-            "Filter by community status: `true`/`1` for community-only, `false`/`0` for official-only. Omit for all models.",
+            "Deprecated, superseded by `source`. `true`/`1` is equivalent to `source=community`, `false`/`0` to `source=official`. Ignored when `source` is present.",
     }),
 });
 
 export type ModelListQueryParams = z.infer<typeof ModelListQueryParamsSchema>;
+
+const isTruthy = (value: string | undefined) =>
+    value === "true" || value === "1";
+
+/**
+ * Resolve the effective filters from query parameters, falling back to headers,
+ * and finally to the deprecated `community` parameter. Query wins over header so
+ * an explicit URL always beats a client-wide default.
+ */
+export function resolveModelListFilters(
+    query: ModelListQueryParams,
+    header: (name: string) => string | undefined,
+): { source: ModelSource; reliability: ModelReliability; health: boolean } {
+    const sourceHeader = ModelSourceSchema.safeParse(
+        header(SOURCE_HEADER)?.toLowerCase(),
+    );
+    const reliabilityHeader = ModelReliabilitySchema.safeParse(
+        header(RELIABILITY_HEADER)?.toLowerCase(),
+    );
+
+    let source: ModelSource = "all";
+    if (query.source) source = query.source;
+    else if (sourceHeader.success) source = sourceHeader.data;
+    else if (query.community !== undefined) {
+        source = isTruthy(query.community) ? "community" : "official";
+    }
+
+    const reliability: ModelReliability =
+        query.reliability ??
+        (reliabilityHeader.success ? reliabilityHeader.data : "all");
+
+    // Asking for reliable models without showing why would be unhelpful.
+    const health =
+        reliability === "reliable" ||
+        (query.health !== undefined
+            ? isTruthy(query.health)
+            : isTruthy(header(HEALTH_HEADER)?.toLowerCase()));
+
+    return { source, reliability, health };
+}

--- a/gen.pollinations.ai/test/model-catalog-filters.test.ts
+++ b/gen.pollinations.ai/test/model-catalog-filters.test.ts
@@ -1,0 +1,276 @@
+import { SELF } from "cloudflare:test";
+import { test } from "@shared/test/fixtures/index.ts";
+import { expect } from "vitest";
+import {
+    RELIABLE_MIN_SAMPLE,
+    RELIABLE_SUCCESS_RATE,
+    resetModelHealthCache,
+    summariseModelHealth,
+} from "../src/model-health.ts";
+import {
+    RELIABILITY_HEADER,
+    resolveModelListFilters,
+    SOURCE_HEADER,
+} from "../src/schemas/models.ts";
+
+async function fetchWorker(path: string, init: RequestInit = {}) {
+    return SELF.fetch(new Request(`https://gen.pollinations.ai${path}`, init));
+}
+
+type Model = {
+    name: string;
+    community?: boolean;
+    health?: Record<string, unknown>;
+};
+
+const row = (over: Partial<Record<string, number | string>> = {}) => ({
+    model: "test/model",
+    event_type: "generate.text",
+    provider: "test",
+    model_used: "test/model",
+    total_requests: 100,
+    status_2xx: 100,
+    errors_4xx: 0,
+    errors_5xx: 0,
+    own_calls: 100,
+    own_calls_ok: 100,
+    primary_5xx: 0,
+    primary_retried_503s: 0,
+    fallback_rescues: 0,
+    last_error_at: "",
+    latency_p50_ms: 10,
+    latency_p95_ms: 20,
+    avg_latency_ms: 12,
+    last_request_at: new Date().toISOString(),
+    tokens_per_second: 5,
+    ...over,
+});
+
+const summarise = (rows: ReturnType<typeof row>[]) =>
+    summariseModelHealth(rows, {
+        minutes: 60,
+        timestamp: Date.now(),
+        stale: false,
+    });
+
+// ----------------------------------------------------------- health maths ---
+
+test("a fallback rescue counts as a success", () => {
+    const health = summarise([
+        row({
+            total_requests: 100,
+            status_2xx: 80,
+            errors_5xx: 20,
+            fallback_rescues: 20,
+        }),
+    ]).get("test/model");
+    expect(health?.success_rate).toBe(1);
+    expect(health?.status).toBe("reliable");
+});
+
+test("caller-side 4xx failures are excluded from the rate and the sample", () => {
+    const health = summarise([
+        row({ total_requests: 100, errors_4xx: 40, status_2xx: 60 }),
+    ]).get("test/model");
+    expect(health?.sample_size).toBe(60);
+    expect(health?.success_rate).toBe(1);
+});
+
+test("rows are summed before a rate is taken, so a quiet provider cannot outvote a busy one", () => {
+    const health = summarise([
+        row({ provider: "a", total_requests: 1000, status_2xx: 1000 }),
+        row({
+            provider: "b",
+            total_requests: 10,
+            status_2xx: 0,
+            errors_5xx: 10,
+        }),
+    ]).get("test/model");
+    expect(health?.sample_size).toBe(1010);
+    expect(health?.success_rate).toBeCloseTo(1000 / 1010, 4);
+    expect(health?.status).toBe("reliable");
+});
+
+test("a high rate over too few requests is not called reliable", () => {
+    const health = summarise([
+        row({
+            total_requests: RELIABLE_MIN_SAMPLE - 1,
+            status_2xx: RELIABLE_MIN_SAMPLE - 1,
+        }),
+    ]).get("test/model");
+    expect(health?.success_rate).toBe(1);
+    expect(health?.sample_size).toBeLessThan(RELIABLE_MIN_SAMPLE);
+    expect(health?.status).toBe("degraded");
+});
+
+test("a poor success rate is degraded however large the sample", () => {
+    const health = summarise([
+        row({ total_requests: 10_000, status_2xx: 5_000, errors_5xx: 5_000 }),
+    ]).get("test/model");
+    expect(health?.success_rate).toBeLessThan(RELIABLE_SUCCESS_RATE);
+    expect(health?.status).toBe("degraded");
+});
+
+test("a model with no traffic in the window produces no summary at all", () => {
+    expect(summarise([row({ total_requests: 0 })]).size).toBe(0);
+});
+
+// -------------------------------------------------------- filter resolver ---
+
+const noHeaders = () => undefined;
+
+test("filters default to everything, with no health payload", () => {
+    expect(resolveModelListFilters({}, noHeaders)).toEqual({
+        source: "all",
+        reliability: "all",
+        health: false,
+    });
+});
+
+test("a header supplies filters for clients that can only set a base URL", () => {
+    const headers = (name: string) =>
+        ({ [SOURCE_HEADER]: "official", [RELIABILITY_HEADER]: "reliable" })[
+            name
+        ];
+    expect(resolveModelListFilters({}, headers)).toEqual({
+        source: "official",
+        reliability: "reliable",
+        health: true,
+    });
+});
+
+test("an explicit query parameter beats a client-wide header default", () => {
+    const headers = (name: string) =>
+        name === SOURCE_HEADER ? "official" : undefined;
+    expect(
+        resolveModelListFilters({ source: "community" }, headers).source,
+    ).toBe("community");
+});
+
+test("the deprecated community parameter still maps onto source", () => {
+    expect(
+        resolveModelListFilters({ community: "true" }, noHeaders).source,
+    ).toBe("community");
+    expect(resolveModelListFilters({ community: "0" }, noHeaders).source).toBe(
+        "official",
+    );
+    // An explicit source wins over the deprecated alias.
+    expect(
+        resolveModelListFilters(
+            { community: "true", source: "official" },
+            noHeaders,
+        ).source,
+    ).toBe("official");
+});
+
+test("asking for reliable models implies showing why", () => {
+    expect(
+        resolveModelListFilters({ reliability: "reliable" }, noHeaders).health,
+    ).toBe(true);
+});
+
+// ------------------------------------------------------------- catalogues ---
+
+test("source=official and source=community partition the catalog", async () => {
+    const all = (await (await fetchWorker("/models")).json()) as Model[];
+    const official = (await (
+        await fetchWorker("/models?source=official")
+    ).json()) as Model[];
+    const community = (await (
+        await fetchWorker("/models?source=community")
+    ).json()) as Model[];
+
+    expect(all.length).toBeGreaterThan(0);
+    expect(official.length + community.length).toBe(all.length);
+    expect(official.every((m) => m.community !== true)).toBe(true);
+    expect(community.every((m) => m.community === true)).toBe(true);
+});
+
+test("the source header filters the same way as the query parameter", async () => {
+    const viaQuery = (await (
+        await fetchWorker("/models?source=official")
+    ).json()) as Model[];
+    const viaHeader = (await (
+        await fetchWorker("/models", {
+            headers: { [SOURCE_HEADER]: "official" },
+        })
+    ).json()) as Model[];
+    expect(viaHeader.map((m) => m.name)).toEqual(viaQuery.map((m) => m.name));
+});
+
+test("health=true attaches a summary to every model, unknown included", async () => {
+    resetModelHealthCache();
+    const models = (await (
+        await fetchWorker("/models?health=true")
+    ).json()) as Model[];
+    expect(models.length).toBeGreaterThan(0);
+    for (const model of models) {
+        expect(model.health).toBeDefined();
+        expect(model.health).toHaveProperty("status");
+        expect(model.health).toHaveProperty("success_rate");
+        expect(model.health).toHaveProperty("sample_size");
+        expect(model.health).toHaveProperty("window_minutes");
+        expect(model.health).toHaveProperty("checked_at");
+        expect(model.health).toHaveProperty("stale");
+        expect(["reliable", "degraded", "unknown"]).toContain(
+            model.health?.status,
+        );
+    }
+});
+
+test("health is omitted unless asked for, so the default payload is unchanged", async () => {
+    const models = (await (await fetchWorker("/models")).json()) as Model[];
+    expect(models.every((m) => m.health === undefined)).toBe(true);
+});
+
+test("reliability=reliable never returns a model of unknown health", async () => {
+    resetModelHealthCache();
+    const models = (await (
+        await fetchWorker("/models?reliability=reliable")
+    ).json()) as Model[];
+    expect(models.every((m) => m.health?.status === "reliable")).toBe(true);
+});
+
+test("filtering discovery does not change what the account may generate with", async () => {
+    // The filtered list must always be a subset of the unfiltered one: these
+    // parameters hide models from a listing, they never reveal new ones.
+    const all = (await (await fetchWorker("/models")).json()) as Model[];
+    const names = new Set(all.map((m) => m.name));
+    for (const query of [
+        "?source=official",
+        "?source=community",
+        "?reliability=reliable",
+    ]) {
+        const filtered = (await (
+            await fetchWorker(`/models${query}`)
+        ).json()) as Model[];
+        expect(filtered.every((m) => names.has(m.name))).toBe(true);
+    }
+});
+
+test("the OpenAI-compatible list takes the same filters", async () => {
+    const body = (await (
+        await fetchWorker("/v1/models?source=official&health=true")
+    ).json()) as { object: string; data: Model[] };
+    expect(body.object).toBe("list");
+    expect(body.data.length).toBeGreaterThan(0);
+    expect(body.data.every((m) => m.community !== true)).toBe(true);
+    expect(body.data.every((m) => m.health !== undefined)).toBe(true);
+});
+
+test("category catalogs take the filters too", async () => {
+    for (const path of ["/image/models", "/text/models", "/audio/models"]) {
+        const models = (await (
+            await fetchWorker(`${path}?source=official`)
+        ).json()) as Model[];
+        expect(Array.isArray(models)).toBe(true);
+        expect(models.every((m) => m.community !== true)).toBe(true);
+    }
+});
+
+test("an unknown filter value is rejected rather than silently ignored", async () => {
+    for (const query of ["?source=nonsense", "?reliability=perfect"]) {
+        const response = await fetchWorker(`/models${query}`);
+        expect(response.status).toBe(400);
+    }
+});

--- a/gen.pollinations.ai/vitest.config.ts
+++ b/gen.pollinations.ai/vitest.config.ts
@@ -20,6 +20,7 @@ const genAliases = [
     "events.ts",
     "logger",
     "logger.ts",
+    "model-health.ts",
     "middleware/auth.ts",
     "middleware/balance.ts",
     "middleware/generation-cache.ts",


### PR DESCRIPTION
Fixes #14535

Adds `source`, `reliability` and `health` to every model catalog, plus header equivalents, and exposes per-model health derived from the same Tinybird pipe that already backs `/v1/models/status`.

## Filters

| Parameter | Values | Behaviour |
|---|---|---|
| `source` | `all` (default), `official`, `community` | Who publishes the model |
| `reliability` | `all` (default), `reliable` | Only models whose recent health clears both thresholds |
| `health` | `true`/`false`/`1`/`0` | Attach the summary. Implied by `reliability=reliable` |

`community=` still works and maps onto `source`; an explicit `source` wins. An unknown value is a **400** rather than a silent full listing.

```bash
curl "https://gen.pollinations.ai/models?source=official"
curl "https://gen.pollinations.ai/v1/models?reliability=reliable"
curl "https://gen.pollinations.ai/image/models?health=true"
```

## Header equivalents

Open WebUI, LibreChat and Cline all build the catalog URL by appending `/models` to a configured base URL, which discards any query string. All three support custom headers, so every filter is also readable from `X-Pollinations-Model-Source`, `X-Pollinations-Model-Reliability` and `X-Pollinations-Model-Health`. A query parameter wins over a header, so an explicit URL beats a client-wide default.

- **Open WebUI** — *Settings → Connections → OpenAI API*, base URL `https://gen.pollinations.ai/v1`, add `X-Pollinations-Model-Source: official` to that connection's custom headers.
- **LibreChat** — `headers: { X-Pollinations-Model-Source: "official" }` under the custom endpoint in `librechat.yaml`.
- **Cline** — *OpenAI Compatible* provider, same header in the custom-headers section.

## Health

`status` · `success_rate` · `sample_size` · `window_minutes` · `checked_at` · `stale`

- A request the fallback layer rescued still returned a usable result, so it **counts as a success**.
- Caller-side `4xx` failures are **excluded** from both the rate and the sample — they say nothing about the model.
- Rows are summed per model **before** any rate is taken, so a quiet provider cannot outvote a busy one.
- A model with no traffic in the window is `unknown`, and `reliable` excludes it. `reliable` means "we have recently seen this work", not "nothing has gone wrong yet".
- `reliable` needs a high success rate **and** a minimum sample, so a model that served three requests successfully is not promoted over one with thousands.
- Experimental/preview status is separate from health and unaffected by these filters.

## Scope

Filtering is **discovery only**. Permission and balance filtering still runs first and is untouched, and a test asserts every filtered listing is a subset of the unfiltered one. No generic filtering framework — three named parameters and their header aliases.

## Refactor included

`model-status.ts` and the catalogs now share `src/model-health.ts`, so the raw rows and the summary can never disagree about whether a model is healthy. That route drops 134 lines.

The shared fetch gained a **2.5s timeout**: a slow monitoring backend must not stall a model listing. This also fixed real flakiness — the docs suite was intermittently failing under a shared time budget before the timeout was added.

## Tests

20 new cases in `test/model-catalog-filters.test.ts`:

- health arithmetic — fallback rescues, 4xx exclusion, cross-provider summing, both thresholds, empty windows
- filter resolution — query/header/deprecated-`community` precedence, `reliable` implying `health`
- catalogs — `official` and `community` partition the list, header matches query, `health` shape on every model, `reliable` never returns unknown, filtered ⊆ unfiltered, `/v1/models` and category lists, 400 on bad values

**185 pass** across `model-catalog-filters`, `docs`, `model-permissions`, `models-retrieve` and `community-endpoints`. Typecheck clean, biome clean.

Docs updated in `APIDOCS.md` and `gen.pollinations.ai/src/docs/models.md` (the served page is generated from the same section, so the two cannot drift).