### PR TITLE
feat: add paid-only GPT Image 2.5 models

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -1901,6 +1901,34 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.00000375,
     },
   },
+  "openai/gpt-image-2.5-flare": {
+    "cost": {
+      "completionImageTokens": 0.00003,
+      "promptCachedTokens": 0.00000125,
+      "promptImageTokens": 0.000008,
+      "promptTextTokens": 0.000005,
+    },
+    "price": {
+      "completionImageTokens": 0.00003,
+      "promptCachedTokens": 0.00000125,
+      "promptImageTokens": 0.000008,
+      "promptTextTokens": 0.000005,
+    },
+  },
+  "openai/gpt-image-2.5-sunburst": {
+    "cost": {
+      "completionImageTokens": 0.00003,
+      "promptCachedTokens": 0.00000125,
+      "promptImageTokens": 0.000008,
+      "promptTextTokens": 0.000005,
+    },
+    "price": {
+      "completionImageTokens": 0.00003,
+      "promptCachedTokens": 0.00000125,
+      "promptImageTokens": 0.000008,
+      "promptTextTokens": 0.000005,
+    },
+  },
   "openai/gpt-image-2:openai": {
     "cost": {
       "completionImageTokens": 0.00003,

--- a/gen.pollinations.ai/src/image/createAndReturnImages.ts
+++ b/gen.pollinations.ai/src/image/createAndReturnImages.ts
@@ -392,6 +392,24 @@ const GPTIMAGE_CONFIGS: Record<string, GPTImageConfig[]> = {
             region: "direct",
         },
     ],
+    "openai/gpt-image-2.5-flare": [
+        {
+            provider: "openai",
+            baseUrl: "https://api.openai.com/v1",
+            modelName: "gpt-image-2.5-flare",
+            apiKeyEnv: "OPENAI_API_KEY",
+            region: "direct",
+        },
+    ],
+    "openai/gpt-image-2.5-sunburst": [
+        {
+            provider: "openai",
+            baseUrl: "https://api.openai.com/v1",
+            modelName: "gpt-image-2.5-sunburst",
+            apiKeyEnv: "OPENAI_API_KEY",
+            region: "direct",
+        },
+    ],
 };
 
 const gptImageEndpointIndexes = new Map<string, number>();
@@ -434,7 +452,7 @@ const callGPTImageWithEndpoint = async (
     // gpt-image-2 supports arbitrary resolutions with constraints.
     // Older gpt-image-1 models (via Azure) only support 3 fixed sizes; snap via closest ratio.
     let size: string;
-    if (config.modelName === "gpt-image-2") {
+    if (config.modelName.startsWith("gpt-image-2")) {
         // gpt-image-2 constraints:
         //   Both edges multiples of 16px, long edge ≤ 3840px (4K)
         //   Aspect ratio ≤ 3:1, pixel count 655,360–8,294,400
@@ -543,8 +561,11 @@ const callGPTImageWithEndpoint = async (
                     // Resize large input images to reduce token costs
                     // GPT Image 1.5 calculates input tokens as: (width × height) / 750
                     // gpt-image-2 supports larger inputs up to 3840px
-                    const inputMaxDimension =
-                        config.modelName === "gpt-image-2" ? 3840 : 1536;
+                    const inputMaxDimension = config.modelName.startsWith(
+                        "gpt-image-2",
+                    )
+                        ? 3840
+                        : 1536;
                     const buffer = await resizeInputImageForGptImage(
                         originalBuffer,
                         inputMaxDimension,
@@ -595,6 +616,8 @@ const callGPTImageWithEndpoint = async (
         if (config.provider === "openai") {
             formData.append("model", config.modelName);
         }
+        formData.append("size", size);
+        formData.append("output_format", outputFormat);
         formData.append("quality", quality);
         formData.append("n", "1");
 
@@ -713,6 +736,8 @@ const generateImage = async (
         case "openai/gpt-image-1-mini":
         case "openai/gpt-image-1.5":
         case "openai/gpt-image-2":
+        case "openai/gpt-image-2.5-flare":
+        case "openai/gpt-image-2.5-sunburst":
         case "openai/gpt-image-1-mini:openai":
         case "openai/gpt-image-1.5:openai":
         case "openai/gpt-image-2:openai": {

--- a/gen.pollinations.ai/src/image/createAndReturnImages.ts
+++ b/gen.pollinations.ai/src/image/createAndReturnImages.ts
@@ -1018,9 +1018,11 @@ export async function createAndReturnImageCached(
         const { buffer: _buffer, ...maturity } = result;
         const metadataObj = prepareMetadata(prompt, originalPrompt, safeParams);
 
-        // SVG must stay vector; raster formats retain the existing JPEG + EXIF path.
+        // Preserve vector output and PNG alpha; JPEG conversion flattens transparency.
         const processedBuffer =
-            result.mimeType === "image/svg+xml"
+            result.mimeType === "image/svg+xml" ||
+            (safeParams.transparent &&
+                detectMimeType(result.buffer) === "image/png")
                 ? result.buffer
                 : await processImageBuffer(
                       result.buffer,

--- a/gen.pollinations.ai/test/image/gptImageRouting.test.ts
+++ b/gen.pollinations.ai/test/image/gptImageRouting.test.ts
@@ -1,4 +1,6 @@
 import { remapUpstreamStatus } from "@shared/error.ts";
+import { IMAGE_SERVICES } from "@shared/registry/image.ts";
+import { calculateCost, calculatePrice } from "@shared/registry/registry.ts";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
     type AuthResult,
@@ -105,6 +107,8 @@ describe("GPT Image OpenAI fallback routing", () => {
         ["openai/gpt-image-1-mini:openai", "gpt-image-1-mini"],
         ["openai/gpt-image-1.5:openai", "gpt-image-1.5"],
         ["openai/gpt-image-2:openai", "gpt-image-2"],
+        ["openai/gpt-image-2.5-flare", "gpt-image-2.5-flare"],
+        ["openai/gpt-image-2.5-sunburst", "gpt-image-2.5-sunburst"],
     ] as const;
 
     for (const [route, upstreamModel] of routes) {
@@ -152,4 +156,53 @@ describe("GPT Image OpenAI fallback routing", () => {
             .filter((host) => host !== "api.openai.com");
         expect(new Set(azureHosts)).toEqual(EXPECTED_HOSTS);
     });
+});
+
+describe("GPT Image 2.5", () => {
+    for (const model of [
+        "openai/gpt-image-2.5-flare",
+        "openai/gpt-image-2.5-sunburst",
+    ] as const) {
+        it(`${model} preserves custom dimensions and transparency`, async () => {
+            const fetchMock = vi
+                .spyOn(globalThis, "fetch")
+                .mockResolvedValue(successResponse());
+            await callGPTImage(
+                "test",
+                {
+                    ...params,
+                    model,
+                    width: 1536,
+                    height: 864,
+                    transparent: true,
+                },
+                userInfo,
+                model,
+            );
+            const body = JSON.parse(String(fetchMock.mock.calls[0][1]?.body));
+            expect(body).toMatchObject({
+                size: "1536x864",
+                background: "transparent",
+                output_format: "png",
+            });
+        });
+
+        it(`${model} charges paid balance at provider cost`, () => {
+            // Usage from the live low-quality generation probe, plus image input.
+            const usage = {
+                promptTextTokens: 14,
+                promptImageTokens: 100,
+                completionImageTokens: 196,
+            };
+            expect(IMAGE_SERVICES[model].paidOnly).toBe(true);
+            expect(calculateCost(model, usage).totalCost).toBeCloseTo(
+                0.00675,
+                8,
+            );
+            expect(calculatePrice(model, usage).totalPrice).toBeCloseTo(
+                0.00675,
+                8,
+            );
+        });
+    }
 });

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -422,6 +422,50 @@ const IMAGE_BASE_SERVICES = {
         outputModalities: ["image"],
         maxReferenceImages: 16, // GPT Image edit endpoint accepts up to 16 input images.
     },
+    "openai/gpt-image-2.5-flare": {
+        aliases: [],
+        provider: "openai",
+        publisher: "OpenAI",
+        category: "image",
+        addedDate: new Date("2026-09-08").getTime(),
+        paidOnly: true,
+        priceMultiplier: 1,
+        cost: {
+            // https://developers.openai.com/api/docs/models/gpt-image-2.5-flare
+            promptTextTokens: perMillion(5),
+            promptCachedTokens: perMillion(1.25),
+            promptImageTokens: perMillion(8),
+            completionImageTokens: perMillion(30),
+        },
+        title: "GPT Image 2.5 Flare",
+        description:
+            "Fast image generation and precise editing with reference images",
+        inputModalities: ["text", "image"],
+        outputModalities: ["image"],
+        maxReferenceImages: 16,
+    },
+    "openai/gpt-image-2.5-sunburst": {
+        aliases: [],
+        provider: "openai",
+        publisher: "OpenAI",
+        category: "image",
+        addedDate: new Date("2026-09-08").getTime(),
+        paidOnly: true,
+        priceMultiplier: 1,
+        cost: {
+            // https://developers.openai.com/api/docs/models/gpt-image-2.5-sunburst
+            promptTextTokens: perMillion(5),
+            promptCachedTokens: perMillion(1.25),
+            promptImageTokens: perMillion(8),
+            completionImageTokens: perMillion(30),
+        },
+        title: "GPT Image 2.5 Sunburst",
+        description:
+            "Detailed image generation with precise control over reference-image edits",
+        inputModalities: ["text", "image"],
+        outputModalities: ["image"],
+        maxReferenceImages: 16,
+    },
     "black-forest-labs/flux.1-schnell": {
         aliases: ["flux"],
         provider: "vast",


### PR DESCRIPTION
- Adds `openai/gpt-image-2.5-flare` and `openai/gpt-image-2.5-sunburst` through direct OpenAI, with `paidOnly: true`, `priceMultiplier: 1`, no aliases, and no fallback. No equivalent route found on Azure, Fireworks, OpenRouter, or DeepInfra.
- Uses [official rates](https://developers.openai.com/api/docs/models/gpt-image-2.5-flare): $5/M text input, $1.25/M cached text, $8/M image input, $30/M image output. Reuses existing credentials, endpoints, and quality options.
- Forwards custom edit dimensions and preserves PNG transparency instead of flattening alpha to JPEG.
- Verified: 82 focused tests, pricing snapshot, Gen typecheck, build, catalog; authenticated local generation, multipart edits, native images, paid-only 402, disconnect/rejoin, and byte-identical cache reuse. Wallet/staging Tinybird reconcile: four unique requests per model, four billed events, $0.043726 cost = 0.043726 Pollen. Cache repeats incur no extra debit; Quest balance stays unchanged. Transparent outputs are PNGs with alpha.
- Draft gates: cached-image accounting at $2/M remains unverified because provider probes emitted no cached-input usage; production-load burst testing remains outstanding. No secret or production deployment changes.
