### PR TITLE
fix: clarify community monitor stream errors

### DIFF
--- a/operations/community-monitor/README.md
+++ b/operations/community-monitor/README.md
@@ -113,7 +113,7 @@ updater knows only the legacy path and cannot migrate itself.
 Run from the merged `main` revision. Never deploy an unmerged prompt snapshot.
 
 ```bash
-scp operations/community-monitor/{CYCLE.md,probe.mjs,loop.sh,healthcheck.sh,update-from-repo.sh} \
+scp operations/community-monitor/{CYCLE.md,probe.mjs,chat-stream.mjs,loop.sh,healthcheck.sh,update-from-repo.sh} \
   community-monitor:/home/ubuntu/monitor/
 ssh community-monitor "mkdir -p /home/ubuntu/monitor/.claude"
 scp operations/community-monitor/.claude/settings.json \

--- a/operations/community-monitor/chat-stream.mjs
+++ b/operations/community-monitor/chat-stream.mjs
@@ -1,0 +1,62 @@
+export function parseChatStream(body) {
+    let content = "";
+    let usage;
+    let done = false;
+    let dataLines = [];
+
+    const fail = (protocolError) => ({ content, usage, protocolError });
+    const flushEvent = () => {
+        if (!dataLines.length) return;
+        const data = dataLines.join("\n");
+        dataLines = [];
+        if (data === "[DONE]") {
+            done = true;
+            return;
+        }
+        let chunk;
+        try {
+            chunk = JSON.parse(data);
+        } catch {
+            throw new Error("stream contained invalid JSON");
+        }
+        if (!Array.isArray(chunk.choices)) {
+            throw new Error(
+                chunk.error?.code === "usage_missing"
+                    ? "stream returned usage_missing: missing or invalid token usage"
+                    : chunk.error
+                      ? "stream returned an error event"
+                      : "stream event is missing a choices array",
+            );
+        }
+        for (const choice of chunk.choices) {
+            if (typeof choice?.delta?.content === "string") {
+                content += choice.delta.content;
+            }
+        }
+        if (chunk.usage) usage = chunk.usage;
+    };
+
+    try {
+        for (const line of body.split(/\r\n|\n|\r/)) {
+            if (!line) {
+                flushEvent();
+                continue;
+            }
+            if (done) return fail("stream contained data after [DONE]");
+            if (dataLines.includes("[DONE]")) {
+                return fail("[DONE] was not terminated by a blank line");
+            }
+            if (line.startsWith(":")) continue;
+            if (line.startsWith("data:")) {
+                dataLines.push(line.slice(5).replace(/^ /, ""));
+            }
+        }
+        if (dataLines.length) {
+            return fail("stream ended with an unterminated SSE event");
+        }
+        if (!done) return fail("stream is missing [DONE]");
+        return { content, usage };
+    } catch (err) {
+        return fail(err.message);
+    }
+}

--- a/operations/community-monitor/chat-stream.test.mjs
+++ b/operations/community-monitor/chat-stream.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { parseChatStream } from "./chat-stream.mjs";
+
+const content = 'data: {"choices":[{"delta":{"content":"ok-marker"}}]}\n\n';
+const usage = { prompt_tokens: 2, completion_tokens: 1, total_tokens: 3 };
+const counts = `data: ${JSON.stringify({ choices: [], usage })}\n\n`;
+const done = "data: [DONE]\n\n";
+
+test("reports missing usage even after a successful-looking answer", () => {
+    const error =
+        'data: {"error":{"code":"usage_missing","message":"internal diagnostic"}}\n\n';
+    for (const newline of ["\n", "\r\n"]) {
+        assert.deepEqual(
+            parseChatStream(
+                (content + counts + error).replaceAll("\n", newline),
+            ),
+            {
+                content: "ok-marker",
+                usage,
+                protocolError:
+                    "stream returned usage_missing: missing or invalid token usage",
+            },
+        );
+    }
+});
+
+test("recognizes other errors without exposing provider messages", () => {
+    const result = parseChatStream(
+        `${content}data: {"error":{"message":"private diagnostic","code":"private-code"}}\n\n${done}`,
+    );
+    assert.equal(result.protocolError, "stream returned an error event");
+});
+
+test("preserves healthy streams and existing non-error validation", () => {
+    assert.deepEqual(parseChatStream(content + counts + done), {
+        content: "ok-marker",
+        usage,
+    });
+    for (const [body, error] of [
+        [`data: {}\n\n${done}`, "stream event is missing a choices array"],
+        [`data: {broken}\n\n${done}`, "stream contained invalid JSON"],
+        [content + counts, "stream is missing [DONE]"],
+        [content + done + counts, "stream contained data after [DONE]"],
+    ]) {
+        assert.equal(parseChatStream(body).protocolError, error);
+    }
+});

--- a/operations/community-monitor/probe.mjs
+++ b/operations/community-monitor/probe.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
+import { parseChatStream } from "./chat-stream.mjs";
 
 // One probe sweep across listed community text and image models via
 // gen.pollinations.ai. Text models get one request every cycle; image models
@@ -167,63 +168,6 @@ function finalCompletionContent(content) {
     // answer. Do not accept a copy of the marker from inside that reasoning.
     if (/<(?:thought|think)>/i.test(withoutReasoning)) return "";
     return withoutReasoning.trim();
-}
-
-function parseChatStream(body) {
-    let content = "";
-    let usage;
-    let done = false;
-    let dataLines = [];
-
-    const fail = (protocolError) => ({ content, usage, protocolError });
-    const flushEvent = () => {
-        if (!dataLines.length) return;
-        const data = dataLines.join("\n");
-        dataLines = [];
-        if (data === "[DONE]") {
-            done = true;
-            return;
-        }
-        let chunk;
-        try {
-            chunk = JSON.parse(data);
-        } catch {
-            throw new Error("stream contained invalid JSON");
-        }
-        if (!Array.isArray(chunk.choices)) {
-            throw new Error("stream event is missing a choices array");
-        }
-        for (const choice of chunk.choices) {
-            if (typeof choice?.delta?.content === "string") {
-                content += choice.delta.content;
-            }
-        }
-        if (chunk.usage) usage = chunk.usage;
-    };
-
-    try {
-        for (const line of body.split(/\r\n|\n|\r/)) {
-            if (!line) {
-                flushEvent();
-                continue;
-            }
-            if (done) return fail("stream contained data after [DONE]");
-            if (dataLines.includes("[DONE]")) {
-                return fail("[DONE] was not terminated by a blank line");
-            }
-            if (line.startsWith(":")) continue;
-            if (line.startsWith("data:")) {
-                dataLines.push(line.slice(5).replace(/^ /, ""));
-            }
-        }
-        if (dataLines.length) {
-            return fail("stream ended with an unterminated SSE event");
-        }
-        if (!done) return fail("stream is missing [DONE]");
-        return { content, usage };
-    } catch (err) {
-        return fail(err.message);
-    }
 }
 
 async function probeText(model) {

--- a/operations/community-monitor/update-from-repo.sh
+++ b/operations/community-monitor/update-from-repo.sh
@@ -38,6 +38,7 @@ install_from_main() {
 }
 
 install_from_main CYCLE.md 0644
+install_from_main chat-stream.mjs 0644
 install_from_main probe.mjs 0755
 install_from_main seven-day-health.mjs 0755
 install_from_main loop.sh 0755


### PR DESCRIPTION
- Reports usage_missing as missing or invalid token usage instead of a missing choices array.
- Identifies other error events without exposing private provider messages.
- Extracts the existing parser for regression tests and includes it in monitor installation.
- Leaves billing, stream acceptance, cadence, and hiding rules unchanged.

Tests: 3 parser tests pass; Biome, Node syntax checks, and updater shell syntax check pass.