### PR TITLE
fix: publish SDK through npm OIDC

### DIFF
--- a/.github/workflows/release-publish-npm-packages.yml
+++ b/.github/workflows/release-publish-npm-packages.yml
@@ -32,7 +32,7 @@ jobs:
           else
             changed=$(git diff --name-only "$before" "$GITHUB_SHA")
           fi
-          echo "sdk=$(echo "$changed" | grep -q '^packages/sdk/' && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "sdk=$(echo "$changed" | grep -Eq '^packages/sdk/|^\.github/workflows/release-publish-npm-packages\.yml$' && echo true || echo false)" >> "$GITHUB_OUTPUT"
           echo "ui=$(echo "$changed" | grep -q '^packages/ui/' && echo true || echo false)" >> "$GITHUB_OUTPUT"
           echo "cli=$(echo "$changed" | grep -Eq '^packages/polli-cli/|^\.github/workflows/release-publish-npm-packages\.yml$' && echo true || echo false)" >> "$GITHUB_OUTPUT"
           echo "Changed files:"
@@ -44,12 +44,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies & build
@@ -80,8 +81,6 @@ jobs:
           case "$v" in *-*) tag="${v#*-}"; tag="${tag%%.*}";; esac
           echo "Publishing $v under dist-tag: $tag"
           npm publish --access public --tag "$tag"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-ui:
     needs: detect-changes


### PR DESCRIPTION
- Fixes SDK publishing authentication by using GitHub OIDC and Node 24, following the existing CLI publisher.
- Triggers the SDK publisher when the release workflow changes so the unpublished `5.1.0-alpha.7` can be recovered on merge.
- Preserves the `alpha` dist-tag and already-published version check.
- Validated with actionlint, SDK build, 73 tests, and npm pack dry run. Biome does not process this YAML file.
- Requires npm Trusted Publishing for `@pollinations/sdk`: repository `pollinations/pollinations`, workflow `release-publish-npm-packages.yml`, permission to run `npm publish`. Package configuration and live publication are pending.

Addresses #14514
