### PR TITLE
fix: allow daily news generation without Buffer staging

### DIFF
--- a/.github/workflows/news-generate-summary.yml
+++ b/.github/workflows/news-generate-summary.yml
@@ -14,12 +14,13 @@ on:
         required: false
         type: string
       mode:
-        description: 'Choose one generator, or auto-run the calendar schedule'
+        description: 'Choose a generator; daily-generation-only restores news files without staging posts to Buffer'
         required: false
         type: choice
         options:
           - auto
           - daily
+          - daily-generation-only
           - weekly
           - monthly
 
@@ -78,6 +79,8 @@ jobs:
           elif [ "$MODE" = "daily" ]; then
             RUN_DAILY=true
             RUN_DAILY_BUFFER=true
+          elif [ "$MODE" = "daily-generation-only" ]; then
+            RUN_DAILY=true
           elif [ "$MODE" = "weekly" ]; then
             RUN_WEEKLY=true
           elif [ "$MODE" = "monthly" ]; then


### PR DESCRIPTION
- Add a `daily-generation-only` mode to restore a daily news archive without staging posts to Buffer.
- Keep the existing scheduled, daily, weekly, and monthly modes unchanged.
- Recover the September 7 archive after the failed image requests: summary, Twitter and Reddit JSON, and both JPEG images are now present on `news`.
- Validate YAML, shell syntax, mode selection and Buffer gating; verify the [successful recovery run](https://github.com/pollinations/pollinations/actions/runs/34282435760), saved dates, image links, and JPEG signatures. Biome does not process this YAML file.
