### PR TITLE
fix: migrate GitHub Actions off Node 20

### DIFF
--- a/.github/scripts/polli-workflows.test.mjs
+++ b/.github/scripts/polli-workflows.test.mjs
@@ -43,6 +43,20 @@ test("read execution and publication have separate permissions", () => {
     );
 });
 
+test("write assistant starts on trusted code before handling the target PR", () => {
+    const checkouts = full
+        .split(/^ {6}- /m)
+        .filter((step) => step.includes("uses: actions/checkout@"));
+    assert.equal(checkouts.length, 2);
+    assert.match(checkouts[0], /ref: \$\{\{ github\.workflow_sha \}\}/);
+    assert.match(
+        checkouts[1],
+        /ref: \$\{\{ github\.event\.repository\.default_branch \}\}/,
+    );
+    assert.doesNotMatch(checkouts[1], /pull_request\.head|refs\/pull\//);
+    assert.match(full, /uses: anthropics\/claude-code-action@v1/);
+});
+
 test("both first jobs whitelist callers before allocating a runner", () => {
     for (const source of [full, workflow]) {
         const gate = source

--- a/.github/workflows/apps-keepalive-screenshots.yml
+++ b/.github/workflows/apps-keepalive-screenshots.yml
@@ -17,5 +17,4 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 22
-          package-manager-cache: false
       - run: node operations/app-management/keepalive-screenshots.js

--- a/.github/workflows/apps-keepalive-screenshots.yml
+++ b/.github/workflows/apps-keepalive-screenshots.yml
@@ -13,8 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
+          package-manager-cache: false
       - run: node operations/app-management/keepalive-screenshots.js

--- a/.github/workflows/apps-review-submissions.yml
+++ b/.github/workflows/apps-review-submissions.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: Generate app token
         id: token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.POLLY_BOT_APP_ID }}
           private-key: ${{ secrets.POLLY_BOT_PRIVATE_KEY }}
@@ -55,15 +55,16 @@ jobs:
           BOT_ID=$(gh api "/users/${{ steps.token.outputs.app-slug }}[bot]" --jq .id)
           echo "bot-id=$BOT_ID" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: main
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "22"
+          package-manager-cache: false
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/apps-review-submissions.yml
+++ b/.github/workflows/apps-review-submissions.yml
@@ -62,7 +62,6 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: "22"
-          package-manager-cache: false
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/apps-update-metrics.yml
+++ b/.github/workflows/apps-update-metrics.yml
@@ -15,20 +15,21 @@ jobs:
     steps:
       - name: Generate Pollinations AI Token
         id: pollinations-ai
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.POLLY_BOT_APP_ID }}
           private-key: ${{ secrets.POLLY_BOT_PRIVATE_KEY }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ steps.pollinations-ai.outputs.token }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '24'
+          package-manager-cache: false
 
       - name: Configure git
         run: |

--- a/.github/workflows/apps-update-metrics.yml
+++ b/.github/workflows/apps-update-metrics.yml
@@ -29,7 +29,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: '24'
-          package-manager-cache: false
 
       - name: Configure git
         run: |

--- a/.github/workflows/build-klein-runpod-image.yml
+++ b/.github/workflows/build-klein-runpod-image.yml
@@ -19,15 +19,15 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v7
         with:
           context: operations/infrastructure/gpu/klein
           push: true

--- a/.github/workflows/ci-codeql.yml
+++ b/.github/workflows/ci-codeql.yml
@@ -21,20 +21,20 @@ jobs:
     steps:
       - &checkout_repository
         name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - &initialize_codeql
         name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
 
       - &autobuild
         name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
 
   # Keep the pre-rename categories available while historical branch results
   # still reference them. This can be removed after those stale analyses are
@@ -51,6 +51,6 @@ jobs:
       - *autobuild
 
       - name: Perform legacy CodeQL analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: .github/workflows/codeql.yml:analyze/language:${{ matrix.language }}

--- a/.github/workflows/ci-pull-request-checks.yml
+++ b/.github/workflows/ci-pull-request-checks.yml
@@ -15,14 +15,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies
@@ -107,7 +107,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 2
 
@@ -128,9 +128,9 @@ jobs:
 
       - name: Setup Node.js
         if: steps.enter-ts-files.outputs.any_changed == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies
@@ -180,7 +180,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 2
 
@@ -201,9 +201,9 @@ jobs:
 
       - name: Setup Node.js
         if: steps.gen-files.outputs.any_changed == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/data-sync-app-catalog-tinybird.yml
+++ b/.github/workflows/data-sync-app-catalog-tinybird.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Sync app.json to Tinybird
         env:

--- a/.github/workflows/data-sync-github-usernames.yml
+++ b/.github/workflows/data-sync-github-usernames.yml
@@ -24,15 +24,15 @@ jobs:
     steps:
       - name: Generate Pollinations AI token
         id: pollinations-ai
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.POLLY_BOT_APP_ID }}
           private-key: ${{ secrets.POLLY_BOT_PRIVATE_KEY }}
           owner: pollinations
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "24"
           cache: npm

--- a/.github/workflows/deploy-applications.yml
+++ b/.github/workflows/deploy-applications.yml
@@ -30,7 +30,7 @@ jobs:
       apps: ${{ steps.detect.outputs.apps }}
       skip: ${{ steps.detect.outputs.skip }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -92,15 +92,16 @@ jobs:
       group: deploy-${{ matrix.app.path }}
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "24"
+          package-manager-cache: false
 
       - name: Setup SOPS
         if: matrix.app.sops != 'none'
-        uses: nhedger/setup-sops@v2
+        uses: nhedger/setup-sops@v3
 
       - name: Verify Docker
         if: matrix.app.docker

--- a/.github/workflows/deploy-applications.yml
+++ b/.github/workflows/deploy-applications.yml
@@ -97,7 +97,6 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: "24"
-          package-manager-cache: false
 
       - name: Setup SOPS
         if: matrix.app.sops != 'none'

--- a/.github/workflows/deploy-cloudflare-production.yml
+++ b/.github/workflows/deploy-cloudflare-production.yml
@@ -60,7 +60,7 @@ jobs:
       canonical_permissions: ${{ inputs.finalize_canonical_permissions || steps.filter.outputs.canonical_permissions == 'true' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -84,7 +84,7 @@ jobs:
       - name: Detect changed services
         id: filter
         if: github.event_name == 'push'
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           # Required for long-lived branches. Without `base`, the action falls
           # back to the repository default branch and diffs
@@ -152,12 +152,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
+          package-manager-cache: false
 
       - name: Install dependencies
         run: npm ci
@@ -203,12 +204,13 @@ jobs:
             exit 1
           fi
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
+          package-manager-cache: false
 
       - name: Install root dependencies
         run: npm ci
@@ -231,19 +233,20 @@ jobs:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID_MYCELI }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
+          package-manager-cache: false
 
       - name: Install root dependencies
         run: npm ci
 
       - name: Setup SOPS
         if: github.event_name == 'workflow_dispatch' && inputs.sync_discord_secrets
-        uses: nhedger/setup-sops@v2
+        uses: nhedger/setup-sops@v3
 
       - name: Build and deploy to Cloudflare
         env:
@@ -274,14 +277,14 @@ jobs:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID_MYCELI }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Only this job sits on the post-migration critical path, so it is the
       # one place the npm cache is worth having: every second between `migrate`
       # finishing and gen deploying is a second the live worker queries a schema
       # its code predates.
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
           cache: 'npm'
@@ -290,7 +293,7 @@ jobs:
         run: npm ci
 
       - name: Setup SOPS
-        uses: nhedger/setup-sops@v2
+        uses: nhedger/setup-sops@v3
 
       # Deploy BEFORE pushing secrets: a fresh `wrangler deploy` makes the
       # latest worker version the deployed one. `wrangler secret bulk` edits
@@ -354,11 +357,12 @@ jobs:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID_MYCELI }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
+          package-manager-cache: false
       - name: Install dependencies
         run: npm ci
       - name: Finalize canonical model permissions
@@ -373,12 +377,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
+          package-manager-cache: false
 
       - name: Install shared dependencies
         run: npm install --workspace shared --include-workspace-root=false
@@ -424,15 +429,16 @@ jobs:
       group: deploy-${{ matrix.app.path }}
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '24'
+          package-manager-cache: false
 
       - name: Setup SOPS
         if: matrix.app.sops != 'none'
-        uses: nhedger/setup-sops@v2
+        uses: nhedger/setup-sops@v3
 
       - name: Verify Docker
         if: matrix.app.docker

--- a/.github/workflows/deploy-cloudflare-production.yml
+++ b/.github/workflows/deploy-cloudflare-production.yml
@@ -158,7 +158,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: '24'
-          package-manager-cache: false
 
       - name: Install dependencies
         run: npm ci
@@ -210,7 +209,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: '24'
-          package-manager-cache: false
 
       - name: Install root dependencies
         run: npm ci
@@ -239,7 +237,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: '24'
-          package-manager-cache: false
 
       - name: Install root dependencies
         run: npm ci
@@ -362,7 +359,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: '24'
-          package-manager-cache: false
       - name: Install dependencies
         run: npm ci
       - name: Finalize canonical model permissions
@@ -383,7 +379,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: '24'
-          package-manager-cache: false
 
       - name: Install shared dependencies
         run: npm install --workspace shared --include-workspace-root=false
@@ -434,7 +429,6 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: '24'
-          package-manager-cache: false
 
       - name: Setup SOPS
         if: matrix.app.sops != 'none'

--- a/.github/workflows/deploy-polli.yml
+++ b/.github/workflows/deploy-polli.yml
@@ -25,7 +25,6 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: "24"
-          package-manager-cache: false
 
       - name: Deploy apps/polli
         env:

--- a/.github/workflows/deploy-polli.yml
+++ b/.github/workflows/deploy-polli.yml
@@ -20,11 +20,12 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "24"
+          package-manager-cache: false
 
       - name: Deploy apps/polli
         env:

--- a/.github/workflows/deploy-portkey-cloudflare.yml
+++ b/.github/workflows/deploy-portkey-cloudflare.yml
@@ -19,12 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '24'
+          package-manager-cache: false
 
       - name: Deploy Portkey Gateway
         env:

--- a/.github/workflows/deploy-portkey-cloudflare.yml
+++ b/.github/workflows/deploy-portkey-cloudflare.yml
@@ -25,7 +25,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: '24'
-          package-manager-cache: false
 
       - name: Deploy Portkey Gateway
         env:

--- a/.github/workflows/deploy-website-cloudflare.yml
+++ b/.github/workflows/deploy-website-cloudflare.yml
@@ -17,12 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24'
+          package-manager-cache: false
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/deploy-website-cloudflare.yml
+++ b/.github/workflows/deploy-website-cloudflare.yml
@@ -23,7 +23,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: '24'
-          package-manager-cache: false
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/docs-regenerate-api-reference.yml
+++ b/.github/workflows/docs-regenerate-api-reference.yml
@@ -96,7 +96,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: '22'
-          package-manager-cache: false
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/docs-regenerate-api-reference.yml
+++ b/.github/workflows/docs-regenerate-api-reference.yml
@@ -80,22 +80,23 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.POLLY_BOT_APP_ID }}
           private-key: ${{ secrets.POLLY_BOT_PRIVATE_KEY }}
 
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.ref || github.event.client_payload.ref || 'main' }}
           token: ${{ steps.token.outputs.token }}
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
+          package-manager-cache: false
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/docs-update-readme-news.yml
+++ b/.github/workflows/docs-update-readme-news.yml
@@ -15,13 +15,13 @@ jobs:
     steps:
       - name: Generate Pollinations AI Token
         id: pollinations-ai
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.POLLY_BOT_APP_ID }}
           private-key: ${{ secrets.POLLY_BOT_PRIVATE_KEY }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -31,14 +31,15 @@ jobs:
           git restore --staged operations/social/news/ || true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
+          package-manager-cache: false
 
       - name: Update Latest News section
         run: python operations/social/scripts/update_readme.py

--- a/.github/workflows/docs-update-readme-news.yml
+++ b/.github/workflows/docs-update-readme-news.yml
@@ -39,7 +39,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: "22"
-          package-manager-cache: false
 
       - name: Update Latest News section
         run: python operations/social/scripts/update_readme.py

--- a/.github/workflows/news-create-pr-gist.yml
+++ b/.github/workflows/news-create-pr-gist.yml
@@ -24,18 +24,18 @@ jobs:
     steps:
       - name: Generate Pollinations AI Token
         id: pollinations-ai
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.POLLY_BOT_APP_ID }}
           private-key: ${{ secrets.POLLY_BOT_PRIVATE_KEY }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/news-generate-summary.yml
+++ b/.github/workflows/news-generate-summary.yml
@@ -34,18 +34,18 @@ jobs:
     steps:
       - name: Generate Pollinations AI Token
         id: pollinations-ai
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.POLLY_BOT_APP_ID }}
           private-key: ${{ secrets.POLLY_BOT_PRIVATE_KEY }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/news-publish-model-report.yml
+++ b/.github/workflows/news-publish-model-report.yml
@@ -37,13 +37,13 @@ jobs:
     steps:
       - name: Generate Pollinations AI Token
         id: pollinations-ai
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.POLLY_BOT_APP_ID }}
           private-key: ${{ secrets.POLLY_BOT_PRIVATE_KEY }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
@@ -51,7 +51,7 @@ jobs:
         run: git fetch origin news && git checkout origin/news -- operations/social/news/ || echo "No news branch data yet"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/news-publish-social.yml
+++ b/.github/workflows/news-publish-social.yml
@@ -27,18 +27,18 @@ jobs:
     steps:
       - name: Generate Pollinations AI Token
         id: pollinations-ai
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.POLLY_BOT_APP_ID }}
           private-key: ${{ secrets.POLLY_BOT_PRIVATE_KEY }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/release-publish-npm-packages.yml
+++ b/.github/workflows/release-publish-npm-packages.yml
@@ -19,7 +19,7 @@ jobs:
       ui: ${{ steps.changes.outputs.ui }}
       cli: ${{ steps.changes.outputs.cli }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -46,11 +46,12 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
+          package-manager-cache: false
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies & build
@@ -89,11 +90,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
+          package-manager-cache: false
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies & build
@@ -135,11 +137,12 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
+          package-manager-cache: false
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies & build

--- a/.github/workflows/release-publish-npm-packages.yml
+++ b/.github/workflows/release-publish-npm-packages.yml
@@ -51,7 +51,6 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 24
-          package-manager-cache: false
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies & build
@@ -95,7 +94,6 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 24
-          package-manager-cache: false
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies & build
@@ -142,7 +140,6 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 24
-          package-manager-cache: false
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies & build

--- a/.github/workflows/repo-askpolli.yml
+++ b/.github/workflows/repo-askpolli.yml
@@ -41,7 +41,7 @@ jobs:
     outputs:
       authorized: ${{ steps.authorization.outputs.authorized }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.workflow_sha }}
           persist-credentials: false
@@ -79,7 +79,7 @@ jobs:
     outputs:
       answer: ${{ steps.review.outputs.answer }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.workflow_sha }}
           persist-credentials: false

--- a/.github/workflows/repo-assign-pr-author.yml
+++ b/.github/workflows/repo-assign-pr-author.yml
@@ -13,13 +13,13 @@ jobs:
     steps:
       - name: Generate Pollinations AI Token
         id: pollinations-ai
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.POLLY_BOT_APP_ID }}
           private-key: ${{ secrets.POLLY_BOT_PRIVATE_KEY }}
 
       - name: Assign author
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ steps.pollinations-ai.outputs.token }}
           script: |

--- a/.github/workflows/repo-auto-fix-polli-issues.yml
+++ b/.github/workflows/repo-auto-fix-polli-issues.yml
@@ -24,7 +24,7 @@ jobs:
     env:
       POLLINATIONS_TOKEN: ${{ secrets.PLN_GITHUB_AUTOPOLLY_KEY }}
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@v3
         id: token
         with:
           app-id: ${{ secrets.POLLY_BOT_APP_ID }}
@@ -32,7 +32,7 @@ jobs:
 
       - name: Check Authorization
         id: whitelist
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ steps.token.outputs.token }}
           script: |
@@ -96,7 +96,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: steps.whitelist.outputs.authorized == 'true'
         with:
           fetch-depth: 0

--- a/.github/workflows/repo-close-discarded-issues.yml
+++ b/.github/workflows/repo-close-discarded-issues.yml
@@ -11,14 +11,14 @@ jobs:
     steps:
       - name: Generate Pollinations AI Token
         id: pollinations-ai
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.POLLY_BOT_APP_ID }}
           private-key: ${{ secrets.POLLY_BOT_PRIVATE_KEY }}
           owner: pollinations
 
       - name: Close issues in "Discarded" column
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ steps.pollinations-ai.outputs.token }}
           script: |

--- a/.github/workflows/repo-organize-issues-prs.yml
+++ b/.github/workflows/repo-organize-issues-prs.yml
@@ -19,18 +19,18 @@ jobs:
       contents: read
       repository-projects: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Generate Pollinations AI Token
         id: pollinations-ai
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.POLLY_BOT_APP_ID }}
           private-key: ${{ secrets.POLLY_BOT_PRIVATE_KEY }}
           owner: pollinations
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/repo-polli-assistant.yml
+++ b/.github/workflows/repo-polli-assistant.yml
@@ -30,7 +30,7 @@ jobs:
     outputs:
       authorized: ${{ steps.authorize.outputs.authorized }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.workflow_sha }}
           persist-credentials: false
@@ -61,7 +61,7 @@ jobs:
     env:
       POLLINATIONS_TOKEN: ${{ secrets.PLN_GITHUB_POLLY_KEY }}
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@v3
         id: token
         with:
           app-id: ${{ secrets.POLLY_BOT_APP_ID }}
@@ -190,7 +190,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: needs.authorize-write.outputs.authorized == 'true'
         with:
           fetch-depth: 0

--- a/.github/workflows/repo-polli-assistant.yml
+++ b/.github/workflows/repo-polli-assistant.yml
@@ -190,11 +190,14 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
 
-      - uses: actions/checkout@v5
+      # Start from trusted configuration. The assistant action checks out the
+      # target PR itself and restores its configuration from the base branch.
+      - name: Checkout trusted base
+        uses: actions/checkout@v5
         if: needs.authorize-write.outputs.authorized == 'true'
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha || (github.event.issue.pull_request && format('refs/pull/{0}/head', github.event.issue.number)) || github.sha }}
+          ref: ${{ github.event.repository.default_branch }}
           repository: ${{ github.repository }}
           token: ${{ steps.token.outputs.token }}
 

--- a/.github/workflows/repo-triage-new-issues.yml
+++ b/.github/workflows/repo-triage-new-issues.yml
@@ -19,14 +19,14 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@v3
         id: token
         with:
           app-id: ${{ secrets.POLLY_BOT_APP_ID }}
           private-key: ${{ secrets.POLLY_BOT_PRIVATE_KEY }}
 
       - name: Triage Issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           POLLINATIONS_TOKEN: ${{ secrets.PLN_GITHUB_AUTOPOLLY_KEY }}
         with:

--- a/.github/workflows/vectorize-code-embeddings.yml
+++ b/.github/workflows/vectorize-code-embeddings.yml
@@ -28,12 +28,12 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 


### PR DESCRIPTION
- Fix Node 20 action-runtime warnings across 28 workflows: upgrade checkout, Node/Python setup, GitHub Script/App token, CodeQL, Docker, paths-filter, and SOPS actions to Node 24-compatible releases; move all six remaining Node 20 job settings to Node 24.
- Fix the privileged Polli startup checkout flagged by CodeQL: start from the trusted default branch, then let the assistant action handle the target PR and restore base-branch configuration. Preserve maintainer authorization and PR editing.
- Validate all 111 action steps and inputs; 473 original tests passed under Node 24. All 18 assistant workflow/authorization tests pass after adding the checkout regression. Reviewer additionally reports 17 Gen and 518 Enter Workers-pool tests passing on Node 24.
- Workflow validation adds no diagnostics; actionlint still flags two existing `concurrency.queue` fields. Deployment/publishing workflows and a live Polli invocation were not dispatched.

Addresses the remaining workflow migration discussed in #12145. Trusted checkout follows the [assistant action’s security guidance](https://github.com/anthropics/claude-code-action/blob/v1/docs/security.md).
