### PR TITLE
fix: retry oversized weekly LinkedIn drafts

### DIFF
--- a/.github/workflows/news-generate-summary.yml
+++ b/.github/workflows/news-generate-summary.yml
@@ -14,7 +14,7 @@ on:
         required: false
         type: string
       mode:
-        description: 'Choose a generator; daily-generation-only restores news files without staging posts to Buffer'
+        description: 'Choose a generator; generation-only modes restore news files without staging posts to Buffer'
         required: false
         type: choice
         options:
@@ -22,6 +22,7 @@ on:
           - daily
           - daily-generation-only
           - weekly
+          - weekly-generation-only
           - monthly
 
 jobs:
@@ -81,7 +82,7 @@ jobs:
             RUN_DAILY_BUFFER=true
           elif [ "$MODE" = "daily-generation-only" ]; then
             RUN_DAILY=true
-          elif [ "$MODE" = "weekly" ]; then
+          elif [ "$MODE" = "weekly" ] || [ "$MODE" = "weekly-generation-only" ]; then
             RUN_WEEKLY=true
           elif [ "$MODE" = "monthly" ]; then
             RUN_MONTHLY=true
@@ -125,7 +126,7 @@ jobs:
         run: python operations/social/scripts/generate_weekly.py
 
       - name: Stage weekly posts to Buffer
-        if: steps.mode.outputs.weekly == 'true'
+        if: steps.mode.outputs.weekly == 'true' && github.event.inputs.mode != 'weekly-generation-only'
         env:
           GITHUB_TOKEN: ${{ steps.pollinations-ai.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}

--- a/operations/social/scripts/generate_weekly.py
+++ b/operations/social/scripts/generate_weekly.py
@@ -201,40 +201,47 @@ def generate_twitter_post(digest: Dict, token: str) -> Optional[Dict]:
         temperature=0.8, extra_context=_weekly_image_context())
 
 def generate_linkedin_post(digest: Dict, token: str) -> Optional[Dict]:
-    post = generate_platform_post(
-        "linkedin",
-        digest,
-        token,
-        (
-            "Create a LinkedIn post about this week's development work. "
-            f"The final assembled post including hashtags MUST be {LINKEDIN_MAX_CHARS} characters or fewer "
-            "because Buffer rejects anything longer."
-        ),
-        extra_context=_weekly_image_context(),
+    instruction = (
+        "Create a LinkedIn post about this week's development work. "
+        f"The final assembled post including hashtags MUST be {LINKEDIN_MAX_CHARS} characters or fewer "
+        "because Buffer rejects anything longer."
     )
-    if not post:
-        return None
-
-    missing_fields = [field for field in ("hook", "body", "closing") if not post.get(field)]
-    if missing_fields:
-        print(f"  FATAL: Weekly LinkedIn post is missing required fields: {', '.join(missing_fields)}")
-        return None
-
-    full_post = build_linkedin_post_text(post)
-    if not full_post:
-        print("  FATAL: Weekly LinkedIn post text is empty")
-        return None
-
-    char_count = len(full_post)
-    post["full_post"] = full_post
-    post["char_count"] = char_count
-    if char_count > LINKEDIN_MAX_CHARS:
-        print(
-            f"  FATAL: Weekly LinkedIn post is {char_count} chars, exceeds Buffer limit of {LINKEDIN_MAX_CHARS}"
+    for attempt in range(2):
+        post = generate_platform_post(
+            "linkedin", digest, token, instruction,
+            extra_context=_weekly_image_context(),
         )
-        return None
+        if not post:
+            return None
 
-    return post
+        missing_fields = [field for field in ("hook", "body", "closing") if not post.get(field)]
+        if missing_fields:
+            print(f"  FATAL: Weekly LinkedIn post is missing required fields: {', '.join(missing_fields)}")
+            return None
+
+        full_post = build_linkedin_post_text(post)
+        if not full_post:
+            print("  FATAL: Weekly LinkedIn post text is empty")
+            return None
+
+        char_count = len(full_post)
+        post["full_post"] = full_post
+        post["char_count"] = char_count
+        if char_count <= LINKEDIN_MAX_CHARS:
+            return post
+
+        if attempt == 0:
+            print(f"  Weekly LinkedIn post is {char_count} chars; retrying with a shorter draft")
+            instruction += (
+                f"\n\nThe previous draft below was {char_count} characters, "
+                f"exceeding the limit by {char_count - LINKEDIN_MAX_CHARS}. "
+                "Rewrite it more concisely, preserving the facts, required fields, "
+                "and image prompt. Leave room for separators and hashtags.\n"
+                + json.dumps(post)
+            )
+
+    print(f"  FATAL: Weekly LinkedIn post is still {char_count} chars after retry, exceeds limit of {LINKEDIN_MAX_CHARS}")
+    return None
 
 def generate_instagram_post(digest: Dict, token: str) -> Optional[Dict]:
     return generate_platform_post("instagram", digest, token,


### PR DESCRIPTION
- Retry weekly LinkedIn generation once when the assembled post exceeds 1,248 characters, providing the previous draft and measured overflow to the model.
- Preserve required-field validation and the final length guard; fail if the rewrite is still oversized.
- Add `weekly-generation-only` to recover an archive without staging posts to Buffer.
- Verify the live retry shortened a 1,297-character draft to 1,237 characters. All six weekly JSON files and seven valid JPEGs are saved with the correct August 30–September 5 coverage; Buffer staging was skipped.
- Pass CI, Python imports, character counting, week dates, YAML, shell syntax, and mode selection. Biome does not process Python or YAML.

Addresses the [September 6 weekly failure](https://github.com/pollinations/pollinations/actions/runs/34016444931). [Recovery run passed](https://github.com/pollinations/pollinations/actions/runs/34284137997).
