### PR TITLE
fix: request JSON mode for PR gist analysis

### DIFF
--- a/operations/social/scripts/common.py
+++ b/operations/social/scripts/common.py
@@ -287,6 +287,7 @@ def call_pollinations_api(
     user_prompt: str,
     token: str,
     temperature: float = 0.7,
+    response_format: Optional[Dict] = None,
 ) -> Optional[str]:
     """Call pollinations.ai API with retry logic and exponential backoff
 
@@ -295,6 +296,7 @@ def call_pollinations_api(
         user_prompt: User prompt for the AI
         token: pollinations.ai API token
         temperature: Temperature for generation (default 0.7)
+        response_format: Optional OpenAI-compatible response format
 
     Returns:
         Response content or None if failed
@@ -315,6 +317,8 @@ def call_pollinations_api(
             ],
             "temperature": temperature
         }
+        if response_format is not None:
+            payload["response_format"] = response_format
 
         if attempt > 0:
             backoff_delay = INITIAL_RETRY_DELAY * (2 ** attempt)
@@ -333,6 +337,10 @@ def call_pollinations_api(
                 try:
                     result = response.json()
                     content = result['choices'][0]['message']['content']
+                    print(
+                        f"  Text response: cache={response.headers.get('X-Cache', 'unknown')}, "
+                        f"finish_reason={result['choices'][0].get('finish_reason')}, chars={len(content)}"
+                    )
                     return content
                 except (KeyError, IndexError, json.JSONDecodeError) as e:
                     last_error = f"Error parsing API response: {e}"

--- a/operations/social/scripts/generate_realtime.py
+++ b/operations/social/scripts/generate_realtime.py
@@ -142,7 +142,8 @@ Changed files:
 
     response = call_pollinations_api(
         system_prompt, user_prompt, token,
-        temperature=0.2
+        temperature=0.2,
+        response_format={"type": "json_object"},
     )
     return parse_json_response(response) if response else None
 


### PR DESCRIPTION
- Request `response_format: {type: json_object}` for PR gist analysis while preserving the existing gist schema validation.
- Fix repeated #14597 failures: the original prompt-only JSON request cached an unterminated `image_prompt` string. Every identical rerun replayed that response (`X-Cache: HIT`, cached September 8 at 21:56 UTC, provider finish reason `stop`).
- Log cache status, finish reason, and response length so future generation failures can be diagnosed without guessing.
- Verify the live differential: the original cached request still returns 1,839 characters of invalid JSON, while JSON mode uses a distinct cache entry containing 1,795 characters of valid JSON. Python imports and syntax pass; Biome does not process Python.
- Recover #14597 through the [successful workflow](https://github.com/pollinations/pollinations/actions/runs/34286546071); verify gist JSON, JPEG signature, schema validation, and Discord delivery.
