### PR TITLE
fix: preserve stream usage across cost-only updates

### DIFF
--- a/gen.pollinations.ai/src/text/chat/usage.ts
+++ b/gen.pollinations.ai/src/text/chat/usage.ts
@@ -52,6 +52,18 @@ export function createChatStreamUsageValidator() {
                 error?: unknown;
             };
             if (error && typeof error === "object") errorSeen = true;
+            // Some providers append cost/cache metadata after their token totals.
+            // It is not a new token count; billing also uses the last complete usage.
+            if (
+                usage &&
+                typeof usage === "object" &&
+                !Array.isArray(usage) &&
+                !["prompt_tokens", "completion_tokens", "total_tokens"].some(
+                    (key) => key in usage,
+                )
+            ) {
+                return;
+            }
             // Providers may send provisional counts; only the last update is final.
             if (usage !== null && usage !== undefined) lastUsage = usage;
         },

--- a/gen.pollinations.ai/test/generation-vcr.test.ts
+++ b/gen.pollinations.ai/test/generation-vcr.test.ts
@@ -459,8 +459,11 @@ async function fakePortkeyResponse(request: Request) {
                         },
               })}\n\n`
             : "";
+        const costTrailer = prompt.includes("vcr cost-only usage trailer")
+            ? 'data: {"choices":[],"usage":{"cost_usd":"0.00010310","prompt_tokens_details":{"cached_tokens":0}}}\n\n'
+            : "";
         return new Response(
-            `${earlyUsageChunk}data: ${JSON.stringify(streamEvent)}\n\n${usageChunk}${invalidUsageChunk}data: [DONE]\n\n`,
+            `${earlyUsageChunk}data: ${JSON.stringify(streamEvent)}\n\n${usageChunk}${invalidUsageChunk}${costTrailer}data: [DONE]\n\n`,
             {
                 headers: {
                     "content-type": "text/event-stream; charset=utf-8",
@@ -911,6 +914,49 @@ test.for([
     });
     expect(event.totalPrice).toBeGreaterThan(0);
     expect(mocks.tinybird.state.errorEvents).toHaveLength(0);
+    const balanceAfter = await getUserBalance(db, caller.userId);
+    expect(balanceBefore.packBalance - balanceAfter.packBalance).toBeCloseTo(
+        event.totalPrice,
+        12,
+    );
+});
+
+test("chat bills token usage once when a provider appends cost-only metadata", async ({
+    mocks,
+}) => {
+    await mocks.enable("tinybird", "portkeyDirect");
+    const caller = await createTestApiKey({ user: { packBalance: 100 } });
+    const db = drizzle(env.DB);
+    const balanceBefore = await getUserBalance(db, caller.userId);
+    const { response, wait } = await fetchWorker("/v1/chat/completions", {
+        method: "POST",
+        headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${caller.key}`,
+        },
+        body: JSON.stringify({
+            model: "openai/gpt-5-nano",
+            stream: true,
+            messages: [
+                { role: "user", content: "vcr cost-only usage trailer" },
+            ],
+        }),
+    });
+    expect(response.status).toBe(200);
+    const stream = await response.text();
+    expect(stream).toContain("[DONE]");
+    expect(stream).not.toContain("usage_missing");
+    await wait();
+    expect(mocks.tinybird.state.events).toHaveLength(1);
+    expect(mocks.tinybird.state.errorEvents).toHaveLength(0);
+    const event = mocks.tinybird.state.events[0];
+    expect(event).toMatchObject({
+        responseStatus: 200,
+        isBilledUsage: true,
+        tokenCountPromptText: 7,
+        tokenCountCompletionText: 3,
+    });
+    expect(event.totalPrice).toBeGreaterThan(0);
     const balanceAfter = await getUserBalance(db, caller.userId);
     expect(balanceBefore.packBalance - balanceAfter.packBalance).toBeCloseTo(
         event.totalPrice,

--- a/gen.pollinations.ai/test/text/streamUsageFraming.test.ts
+++ b/gen.pollinations.ai/test/text/streamUsageFraming.test.ts
@@ -6,6 +6,8 @@ const encoder = new TextEncoder();
 const delta = 'data: {"choices":[{"delta":{"content":"🌼"}}]}\n\n';
 const chatUsage =
     'data: {"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}\n\n';
+const costTrailer =
+    'data: {"choices":[],"usage":{"cost_usd":"0.00010310","prompt_tokens_details":{"cached_tokens":0}}}\n\n';
 const responseDelta =
     'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"🌼"}\n\n';
 const responseUsage =
@@ -23,6 +25,12 @@ function splitStream(bytes: Uint8Array<ArrayBuffer>, split: number) {
 
 describe.each([
     ["Chat", requireChatStreamUsage, delta, `${chatUsage}data: [DONE]\n\n`],
+    [
+        "Chat",
+        requireChatStreamUsage,
+        delta,
+        `${chatUsage}${costTrailer}data: [DONE]\n\n`,
+    ],
     ["Responses", requireResponsesStreamUsage, responseDelta, responseUsage],
 ] as const)("%s stream usage framing", (_name, validate, content, terminal) => {
     it.each([
@@ -93,5 +101,22 @@ describe.each([
                 validate(splitStream(bytes, bytes.length - 5)),
             ).text(),
         ).toBe(input);
+    });
+});
+
+describe("Chat token usage followed by accounting metadata", () => {
+    it.each([
+        "",
+        'data: {"usage":{"prompt_tokens":1}}\n\n',
+        `${chatUsage}data: {"usage":{"completion_tokens":-1}}\n\n`,
+    ])("does not let a cost-only trailer hide missing or invalid token counts (%j)", async (usage) => {
+        const bytes = encoder.encode(
+            `${delta}${usage}${costTrailer}data: [DONE]\n\n`,
+        );
+        const output = await new Response(
+            requireChatStreamUsage(splitStream(bytes, bytes.length - 5)),
+        ).text();
+        expect(output).toContain('"code":"usage_missing"');
+        expect(output).not.toContain("[DONE]");
     });
 });


### PR DESCRIPTION
- Keeps the latest token-count record when providers append cost/cache metadata without token totals.
- Still rejects missing counts and invalid later token-count records; never invents or merges usage.
- Leaves provider stream bytes unchanged. Runtime change: 12 lines in the existing validator.
- Tests byte preservation, invalid/missing usage, exactly one wallet debit, and one billed analytics event.

Validation: 40 focused tests pass; TypeScript and Biome pass. Separate from monitor error-message PR #14595.