### PR TITLE
fix: avoid duplicate image edit safety checks

### DIFF
--- a/gen.pollinations.ai/src/routes/generation-executor.ts
+++ b/gen.pollinations.ai/src/routes/generation-executor.ts
@@ -51,7 +51,7 @@ import {
 } from "./generation-handlers.ts";
 import {
     handleImageGeneration,
-    prepareOpenAIImageEdit,
+    prepareOpenAIImageEditReplay,
     prepareOpenAIImageGeneration,
 } from "./images.ts";
 
@@ -198,7 +198,7 @@ generationExecutorRoutes.post(
     "/v1/images/edits",
     resolveModel("generate.image", { defaultModel: "flux" }),
     track("generate.image"),
-    prepareOpenAIImageEdit,
+    prepareOpenAIImageEditReplay,
     prepareGenerationRequest,
     imageExecutionCache,
     apiKeyBudgetReservation,

--- a/gen.pollinations.ai/src/routes/images.ts
+++ b/gen.pollinations.ai/src/routes/images.ts
@@ -258,6 +258,22 @@ export const prepareOpenAIImageEdit = createMiddleware<Env>(async (c, next) => {
     await next();
 });
 
+/** Parse the normalized, already-safe edit body replayed by the coordinator. */
+export const prepareOpenAIImageEditReplay = createMiddleware<Env>(
+    async (c, next) => {
+        const { imageUrls, extra, response_format, ...input } =
+            await parseEditInput(c);
+        c.req.addValidatedData("json", {
+            ...extra,
+            ...input,
+            model: c.var.model.requested,
+            image: imageUrls,
+            response_format,
+        });
+        await next();
+    },
+);
+
 /** Resolve the POST body to the equivalent public media URL used for caching. */
 export const prepareOpenAIImageGeneration = createMiddleware<Env>(
     async (c, next) => {

--- a/gen.pollinations.ai/test/openai-image-cache.test.ts
+++ b/gen.pollinations.ai/test/openai-image-cache.test.ts
@@ -17,6 +17,7 @@ import { MediaUpload } from "../../media.pollinations.ai/src/media-upload.ts";
 import {
     formatOpenAIImageResponse,
     prepareOpenAIImageEdit,
+    prepareOpenAIImageEditReplay,
     prepareOpenAIImageGeneration,
 } from "../src/routes/images.ts";
 
@@ -175,6 +176,40 @@ describe("OpenAI image cache", () => {
         expect((await changed.json<{ identity: string }>()).identity).not.toBe(
             results[0].identity,
         );
+    });
+    it("does not apply safety again when replaying an image edit", async () => {
+        const app = new Hono<Env>()
+            .use("*", async (c, next) => {
+                c.set("model", {
+                    requested: "flux",
+                    resolved: "flux",
+                    definition: {} as Env["Variables"]["model"]["definition"],
+                });
+                await next();
+            })
+            .post("/v1/images/edits", prepareOpenAIImageEditReplay, (c) =>
+                c.json(c.req.valid("json" as never)),
+            );
+
+        const response = await app.fetch(
+            new Request("https://gen.pollinations.ai/v1/images/edits", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    prompt: "already checked",
+                    image: [{ image_url: "https://example.com/image.png" }],
+                    safe: "true",
+                }),
+            }),
+            {} as CloudflareBindings,
+        );
+
+        expect(response.status).toBe(200);
+        expect(await response.json()).toMatchObject({
+            prompt: "already checked",
+            image: ["https://example.com/image.png"],
+            safe: "true",
+        });
     });
     it("labels base64 video responses with their media type", async () => {
         const app = new Hono<Env>()

--- a/gen.pollinations.ai/test/openai-image-cache.test.ts
+++ b/gen.pollinations.ai/test/openai-image-cache.test.ts
@@ -85,6 +85,12 @@ describe("OpenAI image cache", () => {
                         contentType: c.var.generationRequestContentType,
                         input: c.req.valid("json" as never),
                     }),
+            )
+            .post(
+                "/generation-executor/v1/images/edits",
+                prepareOpenAIImageEditReplay,
+                prepareGenerationRequest,
+                (c) => c.json({ identity: c.var.generationCacheBody }),
             );
         const results = [];
         for (const response_format of ["b64_json", "url"]) {
@@ -149,11 +155,14 @@ describe("OpenAI image cache", () => {
                 ]);
             }
             const replay = await app.fetch(
-                new Request(request.url, {
-                    method: "POST",
-                    headers: { "Content-Type": result.contentType },
-                    body: result.body,
-                }),
+                new Request(
+                    "https://gen.pollinations.ai/generation-executor/v1/images/edits",
+                    {
+                        method: "POST",
+                        headers: { "Content-Type": result.contentType },
+                        body: result.body,
+                    },
+                ),
                 {} as CloudflareBindings,
             );
             expect(replay.status).toBe(200);


### PR DESCRIPTION
- Applies image-edit input safety only on the public request; detached replay parses the already-safe normalized body.
- Preserves cache identity, edit parameters, and executor input without flags or new state.
- Tests: `npm run typecheck --workspace pollinations-gen`; `npx vitest run test/openai-image-cache.test.ts`