### PR TITLE
fix: reuse durable generation cache identity

### DIFF
--- a/gen.pollinations.ai/src/durable-objects/GenerationCoordinator.ts
+++ b/gen.pollinations.ai/src/durable-objects/GenerationCoordinator.ts
@@ -113,18 +113,7 @@ export class GenerationCoordinator extends DurableObject<CloudflareBindings> {
             }
 
             const job = await this.restore(stored);
-            const execution = await executeGeneration(
-                new Request(job.request.url, {
-                    method: job.request.method,
-                    headers: job.request.headers,
-                    body: job.request.body?.slice().buffer,
-                }),
-                job.auth,
-                job.requestId,
-                job.balanceCheckResult,
-                job.apiKeyBudgetEstimate,
-                this.env,
-            );
+            const execution = await executeGeneration(job, this.env);
             settlement = execution.settlement;
             await this.finish(execution.result, stored.bodyChunks);
         } catch (error) {

--- a/gen.pollinations.ai/src/middleware/generation-cache.ts
+++ b/gen.pollinations.ai/src/middleware/generation-cache.ts
@@ -32,8 +32,11 @@ export type GenerationCacheVariables = {
     generationRequestContentType?: string;
     /** Canonical body identity used by body-aware cache adapters. */
     generationCacheBody?: string;
-    /** Executor callback used to await durable cache materialization. */
-    registerGenerationCacheWrite?: (promise: Promise<void>) => void;
+    /** The detached executor writes to the identity chosen by its caller. */
+    generationExecution?: {
+        cacheKey: string;
+        registerCacheWrite: (promise: Promise<void>) => void;
+    };
 };
 
 export type GenerationCacheEnv = {
@@ -256,7 +259,10 @@ export function createGenerationExecutionCache(
 ) {
     return createMiddleware<GenerationCacheEnv>(async (c, next) => {
         const log = c.get("log").getChild(adapter.label);
-        const cacheKey = await adapter.getKey(c);
+        const execution = c.var.generationExecution;
+        if (!execution)
+            throw new Error("Generation execution context is missing");
+        const cacheKey = execution.cacheKey;
 
         try {
             const cached = await lookup(c, adapter, cacheKey);
@@ -275,8 +281,6 @@ export function createGenerationExecutionCache(
         const cacheWrite = capture(c, adapter, cacheKey);
         if (!cacheWrite) return;
 
-        const register = c.var.registerGenerationCacheWrite;
-        if (!register) throw new Error("Generation cache registrar is missing");
-        register(cacheWrite);
+        execution.registerCacheWrite(cacheWrite);
     });
 }

--- a/gen.pollinations.ai/src/utils/execute-generation.ts
+++ b/gen.pollinations.ai/src/utils/execute-generation.ts
@@ -1,14 +1,11 @@
-import type { BalanceCheckResult } from "@shared/billing/balance.ts";
 import { handleError } from "@shared/error.ts";
 import { Hono } from "hono";
 import type { Env } from "@/env.ts";
-import {
-    authFromSnapshot,
-    type GenerationAuthSnapshot,
-} from "@/middleware/auth.ts";
+import { authFromSnapshot } from "@/middleware/auth.ts";
 import { balance } from "@/middleware/balance.ts";
 import type {
     GenerationErrorSnapshot,
+    GenerationJob,
     GenerationOutcome,
 } from "@/middleware/generation-deduplication.ts";
 import { logger } from "@/middleware/logger.ts";
@@ -54,29 +51,29 @@ export type DetachedGeneration = {
 };
 
 function generationExecutor(
-    auth: GenerationAuthSnapshot,
-    requestId: string,
-    balanceCheckResult: BalanceCheckResult,
-    apiKeyBudgetEstimate: number | undefined,
-    registerGenerationCacheWrite: (promise: Promise<void>) => void,
+    job: GenerationJob,
+    registerCacheWrite: (promise: Promise<void>) => void,
 ): Hono<Env> {
     const executor = new Hono<Env>()
         .use("*", async (c, next) => {
-            c.set("requestId", requestId);
-            c.header("X-Request-Id", requestId);
+            c.set("requestId", job.requestId);
+            c.header("X-Request-Id", job.requestId);
             await next();
         })
         .use("*", logger)
-        .use("*", authFromSnapshot(auth))
+        .use("*", authFromSnapshot(job.auth))
         .use("*", async (c, next) => {
-            c.set("registerGenerationCacheWrite", registerGenerationCacheWrite);
+            c.set("generationExecution", {
+                cacheKey: job.cache.key,
+                registerCacheWrite,
+            });
             await next();
         })
         .use("*", frontendKeyBilling)
         .use("*", balance)
         .use("*", async (c, next) => {
-            c.var.balance.balanceCheckResult = balanceCheckResult;
-            c.var.balance.apiKeyBudgetEstimate = apiKeyBudgetEstimate;
+            c.var.balance.balanceCheckResult = job.balanceCheckResult;
+            c.var.balance.apiKeyBudgetEstimate = job.apiKeyBudgetEstimate;
             await next();
         })
         .route("/", generationExecutorRoutes);
@@ -86,11 +83,7 @@ function generationExecutor(
 
 /** Runs a provider handler under the Durable Object alarm's lifetime. */
 export async function executeGeneration(
-    request: Request,
-    auth: GenerationAuthSnapshot,
-    requestId: string,
-    balanceCheckResult: BalanceCheckResult,
-    apiKeyBudgetEstimate: number | undefined,
+    job: GenerationJob,
     env: CloudflareBindings,
 ): Promise<DetachedGeneration> {
     const promises: Promise<unknown>[] = [];
@@ -102,15 +95,14 @@ export async function executeGeneration(
         passThroughOnException() {},
     } as ExecutionContext;
 
-    const response = await generationExecutor(
-        auth,
-        requestId,
-        balanceCheckResult,
-        apiKeyBudgetEstimate,
-        (promise) => {
-            cacheWrite = promise;
-        },
-    ).fetch(request, env, executionCtx);
+    const request = new Request(job.request.url, {
+        method: job.request.method,
+        headers: job.request.headers,
+        body: job.request.body?.slice().buffer,
+    });
+    const response = await generationExecutor(job, (promise) => {
+        cacheWrite = promise;
+    }).fetch(request, env, executionCtx);
     const settlement = Promise.allSettled(promises).then(() => {});
 
     try {

--- a/gen.pollinations.ai/test/helpers/inline-generation-coordinator.ts
+++ b/gen.pollinations.ai/test/helpers/inline-generation-coordinator.ts
@@ -13,18 +13,7 @@ export function withInlineGenerationCoordinator(
                 async startAndWait(job: GenerationJob) {
                     let execution = active.get(name);
                     if (!execution) {
-                        execution = executeGeneration(
-                            new Request(job.request.url, {
-                                method: job.request.method,
-                                headers: job.request.headers,
-                                body: job.request.body?.slice().buffer,
-                            }),
-                            job.auth,
-                            job.requestId,
-                            job.balanceCheckResult,
-                            job.apiKeyBudgetEstimate,
-                            coordinated,
-                        );
+                        execution = executeGeneration(job, coordinated);
                         active.set(name, execution);
                     }
                     try {

--- a/gen.pollinations.ai/test/safety.test.ts
+++ b/gen.pollinations.ai/test/safety.test.ts
@@ -1,4 +1,9 @@
 import {
+    createExecutionContext,
+    waitOnExecutionContext,
+} from "cloudflare:test";
+import { env } from "cloudflare:workers";
+import {
     communityEndpointPrices,
     communityModelDefinition,
     type ProxyCommunityEndpointRuntime,
@@ -10,10 +15,12 @@ import {
     SafeSchema,
 } from "@shared/schemas/safety.ts";
 import { encryptSecret } from "@shared/secret-encryption.ts";
-import { Hono } from "hono";
+import { Hono, type MiddlewareHandler } from "hono";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Env } from "@/env.ts";
+import { prepareGenerationRequest } from "@/middleware/generation-cache.ts";
 import type { LoggerVariables } from "@/middleware/logger.ts";
+import { imageCache, imageExecutionCache } from "@/middleware/media-cache.ts";
 import type { ModelVariables } from "@/middleware/model.ts";
 import { getRequiredSafetyFeatures } from "@/middleware/model.ts";
 import { applySafetyToInput, withSafetyHeaders } from "@/middleware/safety.ts";
@@ -25,7 +32,10 @@ import {
     prepareMetadata as prepareTextCacheMetadata,
 } from "@/utils/text-cache.ts";
 import { generateChatCompletion } from "../src/routes/generation-handlers.ts";
-import { prepareOpenAIImageGeneration } from "../src/routes/images.ts";
+import {
+    prepareOpenAIImageEdit,
+    prepareOpenAIImageGeneration,
+} from "../src/routes/images.ts";
 
 const testLog = {
     getChild: () => testLog,
@@ -229,6 +239,109 @@ describe("applySafetyToInput text", { timeout: 30000 }, () => {
         expect(response.headers.get("X-Safety-Applied")).toBe("privacy");
         expect(response.headers.get("X-Safety-Redacted")).toBe("EMAIL");
     });
+
+    it.each(["generations", "edits"])(
+        "keeps the original %s cache identity when replay redacts again",
+        async (operation) => {
+            const path = `/v1/images/${operation}`;
+            let originalKey: string | undefined;
+            let cacheWrite: Promise<void> | undefined;
+            const app = safetyApp()
+                .use("*", async (c, next) => {
+                    c.req.addValidatedData("json", await c.req.json());
+                    if (originalKey) {
+                        c.set("generationExecution", {
+                            cacheKey: originalKey,
+                            registerCacheWrite: (write) => {
+                                cacheWrite = write;
+                            },
+                        });
+                    }
+                    await next();
+                })
+                .post(
+                    path,
+                    operation === "edits"
+                        ? prepareOpenAIImageEdit
+                        : prepareOpenAIImageGeneration,
+                    prepareGenerationRequest,
+                    (c, next) => {
+                        const cache = (originalKey
+                            ? imageExecutionCache
+                            : imageCache) as unknown as MiddlewareHandler<Env>;
+                        return cache(c, next);
+                    },
+                    (c) =>
+                        originalKey
+                            ? new Response(
+                                  (
+                                      c.req.valid("json" as never) as {
+                                          prompt: string;
+                                      }
+                                  ).prompt,
+                                  {
+                                      headers: { "Content-Type": "image/png" },
+                                  },
+                              )
+                            : c.json({
+                                  key: c.var.generationCache?.key,
+                                  body: c.var.generationRequestBody,
+                              }),
+                );
+            const bindings = { ...env, ...configuredEnv };
+            const ctx = createExecutionContext();
+            const prompt = `portrait ${crypto.randomUUID()}`;
+            guardrailResponse = intervened({}, [
+                { text: `${prompt} first redaction` },
+            ]);
+            const prepared = await app.request(
+                path,
+                {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({
+                        prompt,
+                        safe: true,
+                        seed: 7,
+                        image: "https://example.com/reference.png",
+                    }),
+                },
+                bindings,
+                ctx,
+            );
+            expect(prepared.status).toBe(200);
+            const snapshot = await prepared.json<{
+                key: string;
+                body: string;
+            }>();
+            originalKey = snapshot.key;
+            expect(originalKey).toMatch(/^[a-f0-9]{64}$/);
+
+            const secondPrompt = `${prompt} second redaction`;
+            guardrailResponse = intervened({}, [{ text: secondPrompt }]);
+            const replay = await app.request(
+                path,
+                {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: snapshot.body,
+                },
+                bindings,
+                ctx,
+            );
+            expect(replay.status).toBe(200);
+            expect(await replay.text()).toBe(secondPrompt);
+            expect(cacheWrite).toBeDefined();
+            await cacheWrite;
+            await waitOnExecutionContext(ctx);
+            expect(fetchMock).toHaveBeenCalledTimes(2);
+            const stored = await env.MEDIA.get(originalKey);
+            expect(stored?.headers.get("Link")).toBe(
+                `<https://media.pollinations.ai/${originalKey}>; rel="enclosure"`,
+            );
+            expect(await stored?.text()).toBe(secondPrompt);
+        },
+    );
 
     it("uses the redacted prompt for OpenAI image cache URLs", async () => {
         guardrailResponse = intervened(

--- a/gen.pollinations.ai/test/safety.test.ts
+++ b/gen.pollinations.ai/test/safety.test.ts
@@ -240,108 +240,108 @@ describe("applySafetyToInput text", { timeout: 30000 }, () => {
         expect(response.headers.get("X-Safety-Redacted")).toBe("EMAIL");
     });
 
-    it.each(["generations", "edits"])(
-        "keeps the original %s cache identity when replay redacts again",
-        async (operation) => {
-            const path = `/v1/images/${operation}`;
-            let originalKey: string | undefined;
-            let cacheWrite: Promise<void> | undefined;
-            const app = safetyApp()
-                .use("*", async (c, next) => {
-                    c.req.addValidatedData("json", await c.req.json());
-                    if (originalKey) {
-                        c.set("generationExecution", {
-                            cacheKey: originalKey,
-                            registerCacheWrite: (write) => {
-                                cacheWrite = write;
-                            },
-                        });
-                    }
-                    await next();
-                })
-                .post(
-                    path,
-                    operation === "edits"
-                        ? prepareOpenAIImageEdit
-                        : prepareOpenAIImageGeneration,
-                    prepareGenerationRequest,
-                    (c, next) => {
-                        const cache = (originalKey
-                            ? imageExecutionCache
-                            : imageCache) as unknown as MiddlewareHandler<Env>;
-                        return cache(c, next);
-                    },
-                    (c) =>
-                        originalKey
-                            ? new Response(
-                                  (
-                                      c.req.valid("json" as never) as {
-                                          prompt: string;
-                                      }
-                                  ).prompt,
-                                  {
-                                      headers: { "Content-Type": "image/png" },
-                                  },
-                              )
-                            : c.json({
-                                  key: c.var.generationCache?.key,
-                                  body: c.var.generationRequestBody,
-                              }),
-                );
-            const bindings = { ...env, ...configuredEnv };
-            const ctx = createExecutionContext();
-            const prompt = `portrait ${crypto.randomUUID()}`;
-            guardrailResponse = intervened({}, [
-                { text: `${prompt} first redaction` },
-            ]);
-            const prepared = await app.request(
+    it.each([
+        "generations",
+        "edits",
+    ])("keeps the original %s cache identity when replay redacts again", async (operation) => {
+        const path = `/v1/images/${operation}`;
+        let originalKey: string | undefined;
+        let cacheWrite: Promise<void> | undefined;
+        const app = safetyApp()
+            .use("*", async (c, next) => {
+                c.req.addValidatedData("json", await c.req.json());
+                if (originalKey) {
+                    c.set("generationExecution", {
+                        cacheKey: originalKey,
+                        registerCacheWrite: (write) => {
+                            cacheWrite = write;
+                        },
+                    });
+                }
+                await next();
+            })
+            .post(
                 path,
-                {
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({
-                        prompt,
-                        safe: true,
-                        seed: 7,
-                        image: "https://example.com/reference.png",
-                    }),
+                operation === "edits"
+                    ? prepareOpenAIImageEdit
+                    : prepareOpenAIImageGeneration,
+                prepareGenerationRequest,
+                (c, next) => {
+                    const cache = (originalKey
+                        ? imageExecutionCache
+                        : imageCache) as unknown as MiddlewareHandler<Env>;
+                    return cache(c, next);
                 },
-                bindings,
-                ctx,
+                (c) =>
+                    originalKey
+                        ? new Response(
+                              (
+                                  c.req.valid("json" as never) as {
+                                      prompt: string;
+                                  }
+                              ).prompt,
+                              {
+                                  headers: { "Content-Type": "image/png" },
+                              },
+                          )
+                        : c.json({
+                              key: c.var.generationCache?.key,
+                              body: c.var.generationRequestBody,
+                          }),
             );
-            expect(prepared.status).toBe(200);
-            const snapshot = await prepared.json<{
-                key: string;
-                body: string;
-            }>();
-            originalKey = snapshot.key;
-            expect(originalKey).toMatch(/^[a-f0-9]{64}$/);
+        const bindings = { ...env, ...configuredEnv };
+        const ctx = createExecutionContext();
+        const prompt = `portrait ${crypto.randomUUID()}`;
+        guardrailResponse = intervened({}, [
+            { text: `${prompt} first redaction` },
+        ]);
+        const prepared = await app.request(
+            path,
+            {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    prompt,
+                    safe: true,
+                    seed: 7,
+                    image: "https://example.com/reference.png",
+                }),
+            },
+            bindings,
+            ctx,
+        );
+        expect(prepared.status).toBe(200);
+        const snapshot = await prepared.json<{
+            key: string;
+            body: string;
+        }>();
+        originalKey = snapshot.key;
+        expect(originalKey).toMatch(/^[a-f0-9]{64}$/);
 
-            const secondPrompt = `${prompt} second redaction`;
-            guardrailResponse = intervened({}, [{ text: secondPrompt }]);
-            const replay = await app.request(
-                path,
-                {
-                    method: "POST",
-                    headers: { "Content-Type": "application/json" },
-                    body: snapshot.body,
-                },
-                bindings,
-                ctx,
-            );
-            expect(replay.status).toBe(200);
-            expect(await replay.text()).toBe(secondPrompt);
-            expect(cacheWrite).toBeDefined();
-            await cacheWrite;
-            await waitOnExecutionContext(ctx);
-            expect(fetchMock).toHaveBeenCalledTimes(2);
-            const stored = await env.MEDIA.get(originalKey);
-            expect(stored?.headers.get("Link")).toBe(
-                `<https://media.pollinations.ai/${originalKey}>; rel="enclosure"`,
-            );
-            expect(await stored?.text()).toBe(secondPrompt);
-        },
-    );
+        const secondPrompt = `${prompt} second redaction`;
+        guardrailResponse = intervened({}, [{ text: secondPrompt }]);
+        const replay = await app.request(
+            path,
+            {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: snapshot.body,
+            },
+            bindings,
+            ctx,
+        );
+        expect(replay.status).toBe(200);
+        expect(await replay.text()).toBe(secondPrompt);
+        expect(cacheWrite).toBeDefined();
+        await cacheWrite;
+        await waitOnExecutionContext(ctx);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        const stored = await env.MEDIA.get(originalKey);
+        expect(stored?.headers.get("Link")).toBe(
+            `<https://media.pollinations.ai/${originalKey}>; rel="enclosure"`,
+        );
+        expect(await stored?.text()).toBe(secondPrompt);
+    });
 
     it("uses the redacted prompt for OpenAI image cache URLs", async () => {
         guardrailResponse = intervened(


### PR DESCRIPTION
- Reuse the original cache key during background generation, so prompt changes during replay cannot leave callers looking for the wrong file.
- Pass the existing job directly to the executor, removing duplicated argument plumbing.
- Add regression tests for image generations and edits; both fail with the old key calculation.

Validation: 185 tests, TypeScript and Biome pass. Independent Fable review found no blockers.