### PR TITLE
feat: serve media models through Responses and Chat

### DIFF
--- a/apps/openwebui/README.md
+++ b/apps/openwebui/README.md
@@ -50,10 +50,13 @@ Secrets (per environment in `secrets/secrets.vars.json`):
 
 Production uses Chat Completions; staging uses Responses with
 `ENABLE_RESPONSES_API_STATEFUL=false`. Staging connects only to staging Gen
-and staging Enter, and has no external MCP tool server. Its `MODEL_IDS`
-allowlist initially contains `openai` and `gemini`; add test agents there when
-needed. Managed agents' own configured MCP tools are independent of Open
+and staging Enter, and has no external MCP tool server. Both discover the full
+model catalog (`MODEL_IDS=[]`). Managed agents' own configured MCP tools are independent of Open
 WebUI's external tool servers.
+
+Titles, tags and follow-up suggestions use `openai/gpt-5-nano`, not the selected
+chat model. For existing databases, set `task.model.external` to that ID; this
+global setting applies to existing users too.
 
 On an existing staging database, also update `openai.api_base_urls`,
 `openai.api_configs` (`api_type` and `model_ids`), and

--- a/apps/openwebui/worker.js
+++ b/apps/openwebui/worker.js
@@ -64,6 +64,8 @@ export class OpenWebUIContainer extends Container {
         // Without this the model picker defaults to the alphabetically first
         // community model.
         DEFAULT_MODELS: "openai",
+        // Titles, tags and follow-ups need text, even when the chat model generates media.
+        TASK_MODEL_EXTERNAL: "openai/gpt-5-nano",
 
         // Model backend: gen.pollinations.ai, bearer = the user's OAuth sk_.
         ENABLE_OLLAMA_API: "false",

--- a/apps/openwebui/wrangler.jsonc
+++ b/apps/openwebui/wrangler.jsonc
@@ -69,7 +69,7 @@
         // No production MCP connection in the staging instance.
         "MCP_URL": "",
         "API_TYPE": "responses",
-        "MODEL_IDS": ["openai", "gemini"],
+        "MODEL_IDS": [],
         "OAUTH_CLIENT_ID": "pk_sF4w5mlijzIgoCeh"
       }
     }

--- a/gen.pollinations.ai/src/docs/models.md
+++ b/gen.pollinations.ai/src/docs/models.md
@@ -38,6 +38,8 @@ Responses route, community text models and endpoint agents whose owner supplied
 the Responses API and one exact URL, and managed prompt agents. These community
 models and agents also accept `/v1/chat/completions` through the shared adapter.
 Built-in models may use separate upstream routes for Chat and Responses.
+Supported media models also advertise both endpoints and return generated-file
+links as assistant text. Models requiring image or audio input remain native-only.
 
 ## Community Models
 

--- a/gen.pollinations.ai/src/docs/models.md
+++ b/gen.pollinations.ai/src/docs/models.md
@@ -39,7 +39,8 @@ the Responses API and one exact URL, and managed prompt agents. These community
 models and agents also accept `/v1/chat/completions` through the shared adapter.
 Built-in models may use separate upstream routes for Chat and Responses.
 Supported media models also advertise both endpoints and return generated-file
-links as assistant text. Models requiring image or audio input remain native-only.
+links as assistant text. Reference-required models return their normal missing-input
+error; use their native endpoint until attachments are supported here.
 
 ## Community Models
 

--- a/gen.pollinations.ai/src/docs/text-generation.md
+++ b/gen.pollinations.ai/src/docs/text-generation.md
@@ -39,6 +39,8 @@ Managed prompt agents accept `reasoning.effort` (Responses) and `reasoning_effor
 
 Image, video, audio and 3D models that advertise these endpoints in [`/models`](/models) accept a text prompt. Only the last user message's text (or a string Responses `input`) is used; history, instructions and text-generation settings are ignored. Attachments return HTTP 400. Use the native media endpoints for edits and generation settings.
 
+Empty prompts, malformed Unicode and prompts consisting only of `.` or `..` return HTTP 400. Reference-required models return their normal missing-input error.
+
 Dialogue models expect one `<voice>: <text>` turn per line, just like `/audio`. Community speech models available only through `/v1/audio/speech` are not included.
 
 ```bash
@@ -55,7 +57,7 @@ curl https://gen.pollinations.ai/v1/chat/completions \
 
 Both return assistant text: a Markdown image embed for images, or a Markdown link for audio, video and 3D, followed by the plain public file URL. The URL is also in the `Link` header. With `stream: true`, events arrive after generation finishes.
 
-Media uses its normal billing units, not text tokens: Responses returns `usage: null`; Chat omits `usage`. Video uses the native model or provider's default duration.
+Media uses its normal billing units, not text tokens: Responses returns `usage: null`; Chat JSON omits `usage`. Chat streaming chunks contain `usage: null`, with no final usage chunk. Video uses the native model or provider's default duration.
 
 ### Reasoning
 

--- a/gen.pollinations.ai/src/docs/text-generation.md
+++ b/gen.pollinations.ai/src/docs/text-generation.md
@@ -25,7 +25,7 @@ curl https://gen.pollinations.ai/v1/responses \
   }'
 ```
 
-The endpoint is deliberately stateless. `store` must be `false`; `previous_response_id`, `conversation`, and `prompt` must be null or omitted; `background` must be false or omitted; and encrypted content or reusable item references are rejected. Streaming uses Responses event names and terminal usage events. Direct models preserve the provider's terminal marker; managed-agent streams add one `data: [DONE]` marker. Missing or malformed usage on a completed or incomplete response fails the request. Failed responses may report null usage. These failed requests are not billed, but completed child model calls and charged MCP operations within an agent run remain billable; the outer agent request adds no charge.
+The endpoint is deliberately stateless. `store` must be `false`; `previous_response_id`, `conversation`, and `prompt` must be null or omitted; `background` must be false or omitted; and encrypted content or reusable item references are rejected. Streaming uses Responses event names and terminal usage events. Direct models preserve the provider's terminal marker; managed-agent streams add one `data: [DONE]` marker. For text models, missing or malformed usage on a completed or incomplete response fails the request. Failed responses may report null usage. These failed requests are not billed, but completed child model calls and charged MCP operations within an agent run remain billable; the outer agent request adds no charge.
 
 The stateless surface follows the OpenAI Responses API and OpenResponses item/event vocabulary. It does not claim full OpenResponses conformance: persisted continuation, conversations, compaction, background jobs, Responses WebSocket transport, and normalization of every direct provider stream are outside this subset.
 
@@ -34,6 +34,28 @@ Community text models and endpoint agents declare one upstream API and one exact
 Managed prompt agents use Pollinations' configured Responses runtime and have no publisher-configured endpoint URL. They use their configured MCP tools and ignore caller-supplied function tool definitions. Their Responses output contains assistant messages and `mcp_call` items describing tools already executed by the server. Chat clients receive those results as text and media links, not function calls to execute. For stateless continuation, send previous output items with the next input; completed MCP items are treated as history and are not executed again.
 
 Managed prompt agents accept `reasoning.effort` (Responses) and `reasoning_effort` (Chat Completions). Reasoning summaries are not supported: a non-null `reasoning.summary` returns HTTP 400.
+
+### Media models in conversations
+
+Image, video, audio and 3D models that advertise these endpoints in [`/models`](/models) accept a text prompt. Only the last user message's text (or a string Responses `input`) is used; history, instructions and text-generation settings are ignored. Attachments return HTTP 400. Use the native media endpoints for edits and generation settings.
+
+Dialogue models expect one `<voice>: <text>` turn per line, just like `/audio`. Community speech models available only through `/v1/audio/speech` are not included.
+
+```bash
+curl https://gen.pollinations.ai/v1/responses \
+  -H "Authorization: Bearer $POLLINATIONS_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"flux","input":"A lighthouse at dawn"}'
+
+curl https://gen.pollinations.ai/v1/chat/completions \
+  -H "Authorization: Bearer $POLLINATIONS_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"flux","messages":[{"role":"user","content":"A lighthouse at dawn"}]}'
+```
+
+Both return assistant text: a Markdown image embed for images, or a Markdown link for audio, video and 3D, followed by the plain public file URL. The URL is also in the `Link` header. With `stream: true`, events arrive after generation finishes.
+
+Media uses its normal billing units, not text tokens: Responses returns `usage: null`; Chat omits `usage`. Video uses the native model or provider's default duration.
 
 ### Reasoning
 

--- a/gen.pollinations.ai/src/image/handler.ts
+++ b/gen.pollinations.ai/src/image/handler.ts
@@ -120,14 +120,6 @@ async function readJsonBody(c: ImageContext): Promise<Record<string, unknown>> {
     }
 }
 
-function decodePrompt(rawPrompt: string): string {
-    try {
-        return decodeURIComponent(rawPrompt);
-    } catch {
-        return rawPrompt;
-    }
-}
-
 function parseImageParams(
     c: ImageContext,
     body: Record<string, unknown>,
@@ -403,7 +395,7 @@ export async function generateImageOrVideoResponse(
     body: Record<string, unknown> = {},
 ): Promise<Response> {
     syncImageEnvironment(c.env);
-    const originalPrompt = decodePrompt(prompt || "random_prompt");
+    const originalPrompt = prompt || "random_prompt";
     const parsedParams = parseImageParams(c, body);
     const definition = c.var.model.definition;
     const safeParams =

--- a/gen.pollinations.ai/src/media/prompt-route.ts
+++ b/gen.pollinations.ai/src/media/prompt-route.ts
@@ -1,6 +1,6 @@
 import type { GenerationModelEntry } from "../model-registry.ts";
 
-/** Only models that can generate from text alone belong on the text protocols. */
+/** Text-input media with a reachable native generation route. */
 export function mediaPromptRoute(
     entry: Pick<GenerationModelEntry, "definition" | "supportedEndpoints">,
 ): string | undefined {

--- a/gen.pollinations.ai/src/media/prompt-route.ts
+++ b/gen.pollinations.ai/src/media/prompt-route.ts
@@ -1,0 +1,21 @@
+import type { GenerationModelEntry } from "../model-registry.ts";
+
+/** Only models that can generate from text alone belong on the text protocols. */
+export function mediaPromptRoute(
+    entry: Pick<GenerationModelEntry, "definition" | "supportedEndpoints">,
+): string | undefined {
+    if (!entry.definition.inputModalities?.includes("text")) return;
+    switch (entry.definition.category) {
+        case "image":
+        case "video":
+            if (entry.supportedEndpoints.includes("/image/{prompt}"))
+                return "/image/";
+            return;
+        case "audio":
+            if (entry.supportedEndpoints.includes("/audio/{text}"))
+                return "/audio/";
+            return;
+        case "3d":
+            return "/3d/";
+    }
+}

--- a/gen.pollinations.ai/src/media/response-output.ts
+++ b/gen.pollinations.ai/src/media/response-output.ts
@@ -19,7 +19,7 @@ export const MediaChatCompletionSchema =
     });
 
 export const mediaResponseDescription =
-    "Media models that advertise this endpoint in `/models` also accept text prompts. Only the last user message's text is used (or a string `input` on Responses); history, instructions and text-generation settings are ignored. Attachments are not supported. Dialogue models expect one `<voice>: <text>` turn per line. Images return a Markdown image embed; audio, video and 3D return a Markdown link. Both include the plain public URL. With `stream: true`, events are emitted after generation finishes. Media is billed normally, without text-token usage (`usage: null` on Responses; omitted on Chat). Use the native media endpoints for generation settings.";
+    "Media models that advertise this endpoint in `/models` also accept text prompts. Only the last user message's text is used (or a string `input` on Responses); history, instructions and text-generation settings are ignored. Empty prompts, malformed Unicode and prompts consisting only of `.` or `..` return HTTP 400. Attachments are not supported; reference-required models return their normal missing-input error. Dialogue models expect one `<voice>: <text>` turn per line. Images return a Markdown image embed; audio, video and 3D return a Markdown link. Both include the plain public URL. With `stream: true`, events are emitted after generation finishes. Media is billed normally, without text-token usage: Responses returns `usage: null`; Chat JSON omits `usage`, while Chat streaming chunks contain `usage: null` and have no final usage chunk. Use the native media endpoints for generation settings.";
 
 export function createMediaResponse(
     model: string,

--- a/gen.pollinations.ai/src/media/response-output.ts
+++ b/gen.pollinations.ai/src/media/response-output.ts
@@ -1,0 +1,130 @@
+import {
+    CreateChatCompletionResponseSchema,
+    CreateResponseResponseSchema,
+} from "@shared/schemas/openai.ts";
+import { z } from "zod";
+
+// The existing schemas enforce text-token accounting. Media is billed in its
+// native units, so its text-protocol envelope must not invent token counts.
+export const MediaResponseSchema = z
+    .object({
+        ...CreateResponseResponseSchema.shape,
+        usage: z.null(),
+    })
+    .passthrough()
+    .meta({ $id: "MediaResponse" });
+export const MediaChatCompletionSchema =
+    CreateChatCompletionResponseSchema.omit({ usage: true }).meta({
+        $id: "MediaChatCompletion",
+    });
+
+export const mediaResponseDescription =
+    "Media models that advertise this endpoint in `/models` also accept text prompts. Only the last user message's text is used (or a string `input` on Responses); history, instructions and text-generation settings are ignored. Attachments are not supported. Dialogue models expect one `<voice>: <text>` turn per line. Images return a Markdown image embed; audio, video and 3D return a Markdown link. Both include the plain public URL. With `stream: true`, events are emitted after generation finishes. Media is billed normally, without text-token usage (`usage: null` on Responses; omitted on Chat). Use the native media endpoints for generation settings.";
+
+export function createMediaResponse(
+    model: string,
+    url: string,
+    contentType: string,
+) {
+    const label = contentType.startsWith("image/")
+        ? "Image"
+        : contentType.startsWith("video/")
+          ? "Video"
+          : contentType.startsWith("audio/")
+            ? "Audio"
+            : "3D model";
+    const text = `${label === "Image" ? "!" : ""}[${label}](${url})\n\n${url}`;
+    return {
+        id: `resp_${crypto.randomUUID()}`,
+        object: "response" as const,
+        created_at: Math.floor(Date.now() / 1000),
+        completed_at: Math.floor(Date.now() / 1000),
+        status: "completed" as const,
+        model,
+        error: null,
+        incomplete_details: null,
+        instructions: null,
+        max_output_tokens: null,
+        parallel_tool_calls: false,
+        previous_response_id: null,
+        reasoning: { effort: null, summary: null },
+        store: false,
+        temperature: null,
+        text: { format: { type: "text" } },
+        tool_choice: "none",
+        tools: [],
+        top_p: null,
+        truncation: "disabled",
+        metadata: {},
+        usage: null,
+        output: [
+            {
+                id: `msg_${crypto.randomUUID()}`,
+                type: "message" as const,
+                role: "assistant" as const,
+                status: "completed" as const,
+                content: [
+                    {
+                        type: "output_text" as const,
+                        text,
+                        annotations: [],
+                        logprobs: [],
+                    },
+                ],
+            },
+        ],
+    };
+}
+
+/** A completed generation presented as the normal Responses event lifecycle. */
+export function mediaResponseStream(
+    response: ReturnType<typeof createMediaResponse>,
+) {
+    const item = response.output[0];
+    const part = item.content[0];
+    const position = { item_id: item.id, output_index: 0, content_index: 0 };
+    const events: [string, Record<string, unknown>][] = [
+        [
+            "response.created",
+            {
+                response: {
+                    ...response,
+                    status: "in_progress",
+                    completed_at: null,
+                    output: [],
+                },
+            },
+        ],
+        [
+            "response.output_item.added",
+            {
+                output_index: 0,
+                item: { ...item, status: "in_progress", content: [] },
+            },
+        ],
+        [
+            "response.content_part.added",
+            { ...position, part: { ...part, text: "" } },
+        ],
+        [
+            "response.output_text.delta",
+            { ...position, delta: part.text, logprobs: [] },
+        ],
+        [
+            "response.output_text.done",
+            { ...position, text: part.text, logprobs: [] },
+        ],
+        ["response.content_part.done", { ...position, part }],
+        ["response.output_item.done", { output_index: 0, item }],
+        ["response.completed", { response }],
+    ];
+    return new Blob([
+        events
+            .map(
+                ([type, payload], sequence_number) =>
+                    `event: ${type}\ndata: ${JSON.stringify({ type, sequence_number, ...payload })}\n\n`,
+            )
+            .join(""),
+        "data: [DONE]\n\n",
+    ]).stream();
+}

--- a/gen.pollinations.ai/src/media/responses.ts
+++ b/gen.pollinations.ai/src/media/responses.ts
@@ -1,0 +1,154 @@
+import { every } from "hono/combine";
+import { createMiddleware } from "hono/factory";
+import { HTTPException } from "hono/http-exception";
+import type { Env } from "@/env.ts";
+import { deduplicateGeneration } from "@/middleware/generation-deduplication.ts";
+import {
+    audioCache,
+    imageCache,
+    model3dCache,
+} from "@/middleware/media-cache.ts";
+import { resolveModel } from "@/middleware/model.ts";
+import { track } from "@/middleware/track.ts";
+import {
+    responsesToChatCompletion,
+    responsesToChatStream,
+} from "@/text/responses/chatResponse.ts";
+import { generationAccess } from "@/utils/generation-access.ts";
+import { getGenerationModelRegistry } from "../model-registry.ts";
+import { mediaPromptRoute } from "./prompt-route.ts";
+import { createMediaResponse, mediaResponseStream } from "./response-output.ts";
+
+type MediaProtocol = "responses" | "chat/completions";
+
+/** Earlier conversation is context for text models, not a media prompt. */
+export function mediaPrompt(input: unknown): string {
+    let content: unknown = input;
+    if (Array.isArray(input)) {
+        content = input.findLast((item) => item?.role === "user")?.content;
+    }
+    if (Array.isArray(content)) {
+        if (
+            content.some(
+                (part) =>
+                    !part ||
+                    !["text", "input_text"].includes(part.type) ||
+                    typeof part.text !== "string",
+            )
+        ) {
+            throw new HTTPException(400, {
+                message:
+                    "Media generation accepts text only; use the native media endpoints for attachments.",
+            });
+        }
+        content = content.map((part) => part.text).join("\n");
+    }
+    if (typeof content !== "string" || !content.trim()) {
+        throw new HTTPException(400, {
+            message: "Media generation requires text in the last user message.",
+        });
+    }
+    return content;
+}
+
+/** Generate through the native durable pipeline, then only change presentation. */
+export function mediaResponses(protocol: MediaProtocol) {
+    return createMiddleware<Env>(async (c, next) => {
+        const body = c.req.valid("json" as never) as Record<string, unknown>;
+        const registry = await getGenerationModelRegistry(c.env);
+        const entry =
+            typeof body.model === "string"
+                ? registry.resolve(body.model)
+                : null;
+        const route = entry && mediaPromptRoute(entry);
+        if (!entry || !route) return next();
+
+        const cache =
+            entry.definition.category === "audio"
+                ? audioCache
+                : entry.definition.category === "3d"
+                  ? model3dCache
+                  : imageCache;
+        await every(
+            resolveModel(entry.eventType, {
+                supportedEndpoint: `/v1/${protocol}`,
+            }),
+            track(entry.eventType),
+            createMiddleware<Env>(async (ctx, proceed) => {
+                const prompt = mediaPrompt(
+                    protocol === "responses" ? body.input : body.messages,
+                );
+                const url = new URL(
+                    `${route}${encodeURIComponent(prompt)}`,
+                    ctx.req.url,
+                );
+                url.searchParams.set("model", entry.id);
+                if (body.safe !== undefined)
+                    url.searchParams.set("safe", String(body.safe));
+                ctx.set("generationRequestUrl", url);
+                ctx.set("generationRequestMethod", "GET");
+                // The provider is not a text stream; only the final wrapper is.
+                ctx.var.track.streamRequested = false;
+                await proceed();
+            }),
+            cache,
+            generationAccess,
+            deduplicateGeneration,
+        )(c, async () => {
+            throw new Error(
+                "Media generation must finish in the durable executor",
+            );
+        });
+
+        const media = c.res;
+        if (!media.ok) return media;
+        const mediaUrl = media.headers
+            .get("Link")
+            ?.match(/^<([^>]+)>; rel="enclosure"$/)?.[1];
+        if (!mediaUrl)
+            throw new HTTPException(502, {
+                message: "Media generation returned no public file URL",
+            });
+        await media.body?.pipeTo(new WritableStream());
+        const response = createMediaResponse(
+            entry.id,
+            mediaUrl,
+            media.headers.get("content-type") ?? "",
+        );
+        // Hono preserves the previous response's headers when replacing it.
+        const headers = media.headers;
+        for (const name of [
+            "content-length",
+            "content-disposition",
+            "content-encoding",
+        ])
+            headers.delete(name);
+        // The file is immutable, not the per-request protocol envelope.
+        headers.set("Cache-Control", "no-cache");
+        if (body.stream === true) {
+            const stream = mediaResponseStream(response);
+            headers.set("Content-Type", "text/event-stream; charset=utf-8");
+            c.res = new Response(
+                protocol === "responses"
+                    ? stream
+                    : responsesToChatStream(stream, entry.id, {
+                          requireUsage: false,
+                      }),
+                { headers },
+            );
+            return;
+        }
+        headers.set("Content-Type", "application/json; charset=utf-8");
+        c.res = Response.json(
+            protocol === "responses"
+                ? response
+                : responsesToChatCompletion(
+                      response,
+                      entry.id,
+                      new URL(c.req.url),
+                      { requireUsage: false },
+                  ),
+            { headers },
+        );
+    });
+}

--- a/gen.pollinations.ai/src/media/responses.ts
+++ b/gen.pollinations.ai/src/media/responses.ts
@@ -48,6 +48,17 @@ export function mediaPrompt(input: unknown): string {
             message: "Media generation requires text in the last user message.",
         });
     }
+    if (!content.isWellFormed()) {
+        throw new HTTPException(400, {
+            message: "Media prompt contains invalid Unicode.",
+        });
+    }
+    // URL normalization would remove these native-route path segments.
+    if (content === "." || content === "..") {
+        throw new HTTPException(400, {
+            message: "Media prompt cannot be only '.' or '..'.",
+        });
+    }
     return content;
 }
 

--- a/gen.pollinations.ai/src/media/responses.ts
+++ b/gen.pollinations.ai/src/media/responses.ts
@@ -109,7 +109,8 @@ export function mediaResponses(protocol: MediaProtocol) {
             throw new HTTPException(502, {
                 message: "Media generation returned no public file URL",
             });
-        await media.body?.pipeTo(new WritableStream());
+        // The file is already stored; this response only needs its URL.
+        await media.body?.cancel();
         const response = createMediaResponse(
             entry.id,
             mediaUrl,

--- a/gen.pollinations.ai/src/middleware/generation-cache.ts
+++ b/gen.pollinations.ai/src/middleware/generation-cache.ts
@@ -24,6 +24,9 @@ export type GenerationCacheVariables = {
     };
     /** Alternate request identity for routes which wrap a media response. */
     generationCacheUrl?: URL;
+    /** Native route replayed when a public endpoint only formats its result. */
+    generationRequestUrl?: URL;
+    generationRequestMethod?: string;
     /** Normalized POST body passed to the generation executor. */
     generationRequestBody?: string | Uint8Array;
     /** Multipart body parsed during model resolution and reused downstream. */
@@ -35,6 +38,8 @@ export type GenerationCacheVariables = {
     /** The detached executor writes to the identity chosen by its caller. */
     generationExecution?: {
         cacheKey: string;
+        originalPath?: string;
+        originalModel?: string;
         registerCacheWrite: (promise: Promise<void>) => void;
     };
 };

--- a/gen.pollinations.ai/src/middleware/generation-deduplication.ts
+++ b/gen.pollinations.ai/src/middleware/generation-deduplication.ts
@@ -1,5 +1,6 @@
 import type { BalanceCheckResult } from "@shared/billing/balance.ts";
 import { SAFETY_HEADER_NAME } from "@shared/schemas/safety.ts";
+import { getRoutePath } from "@shared/util.ts";
 import type { Context } from "hono";
 import { createMiddleware } from "hono/factory";
 import { HTTPException } from "hono/http-exception";
@@ -14,6 +15,7 @@ import type {
     GenerationCacheStorage,
 } from "@/middleware/generation-cache.ts";
 import { hashGenerationCacheIdentity } from "@/middleware/generation-cache.ts";
+import type { ModelVariables } from "@/middleware/model.ts";
 
 const EXECUTOR_HEADERS = new Set([
     "accept",
@@ -40,6 +42,9 @@ export type GenerationCacheIdentity = {
 export type GenerationRequestSnapshot = {
     url: string;
     method: string;
+    /** Public route when execution uses an adapted native request. */
+    originalPath?: string;
+    originalModel?: string;
     headers: [string, string][];
     body?: Uint8Array;
 };
@@ -66,7 +71,7 @@ type DeduplicationEnv = {
                 streamRequested?: boolean;
                 detachedExecutionTracked?: boolean;
             };
-        };
+        } & Partial<ModelVariables>;
 };
 
 function createAuthSnapshot(
@@ -117,8 +122,9 @@ async function createJob(
         throw new Error("Generation balance snapshot is missing");
     }
 
+    const method = c.var.generationRequestMethod ?? c.req.method;
     let body: Uint8Array | undefined;
-    if (c.req.method !== "GET" && c.req.method !== "HEAD") {
+    if (method !== "GET" && method !== "HEAD") {
         const captured = c.var.generationRequestBody;
         body =
             captured instanceof Uint8Array
@@ -143,8 +149,12 @@ async function createJob(
     return {
         cache: { storage: adapter.storage, key },
         request: {
-            url: sanitizeUrl(c.req.url),
-            method: c.req.method,
+            url: sanitizeUrl(c.var.generationRequestUrl?.href ?? c.req.url),
+            method,
+            ...(c.var.generationRequestUrl && {
+                originalPath: getRoutePath(c),
+                originalModel: c.var.model?.requested,
+            }),
             headers,
             ...(body !== undefined && { body }),
         },

--- a/gen.pollinations.ai/src/middleware/legacy-media-cache.ts
+++ b/gen.pollinations.ai/src/middleware/legacy-media-cache.ts
@@ -62,7 +62,9 @@ export function legacyMediaCacheKey(
 async function requestLegacyKey(
     c: Context<GenerationCacheEnv>,
 ): Promise<string> {
-    const url = new URL(c.var.generationCacheUrl ?? c.req.url);
+    const url = new URL(
+        c.var.generationCacheUrl ?? c.var.generationRequestUrl ?? c.req.url,
+    );
     if (!c.var.generationCacheUrl && c.var.generationCacheBody) {
         url.searchParams.set(
             "__request_body",

--- a/gen.pollinations.ai/src/middleware/media-cache.ts
+++ b/gen.pollinations.ai/src/middleware/media-cache.ts
@@ -41,7 +41,11 @@ function mediaCacheAdapter(config: MediaCacheConfig): GenerationCacheAdapter {
         label: config.label,
         async getKey(c) {
             const variables = c.var as typeof c.var & Partial<ModelVariables>;
-            const cacheUrl = c.var.generationCacheUrl ?? new URL(c.req.url);
+            const cacheUrl = new URL(
+                c.var.generationCacheUrl ??
+                    c.var.generationRequestUrl ??
+                    c.req.url,
+            );
             if (!c.var.generationCacheUrl && c.var.generationCacheBody) {
                 cacheUrl.searchParams.set(
                     "__request_body",

--- a/gen.pollinations.ai/src/middleware/track.ts
+++ b/gen.pollinations.ai/src/middleware/track.ts
@@ -191,6 +191,8 @@ export const track = (eventType: EventType) =>
         // Get model from resolveModel middleware
         const modelInfo = c.var.model;
         const requestTracking = await trackRequest(modelInfo, c.req);
+        requestTracking.modelRequested =
+            c.var.generationExecution?.originalModel ?? modelInfo.requested;
 
         const rawIp = getRealClientIp(c);
         const clientIp =
@@ -246,7 +248,8 @@ export const track = (eventType: EventType) =>
             const event = createTrackingEvent({
                 id: generateRandomId(),
                 requestId: c.get("requestId"),
-                requestPath: getRoutePath(c),
+                requestPath:
+                    c.var.generationExecution?.originalPath ?? getRoutePath(c),
                 environment: c.env.ENVIRONMENT,
                 eventType,
                 ipSubnet,

--- a/gen.pollinations.ai/src/model-registry.ts
+++ b/gen.pollinations.ai/src/model-registry.ts
@@ -30,6 +30,7 @@ import {
     getCommunityModelRegistryEntries,
 } from "./community-models.ts";
 import { linkFallbackEntries } from "./fallback.ts";
+import { mediaPromptRoute } from "./media/prompt-route.ts";
 import { supportsDirectResponses } from "./text/availableModels.ts";
 
 const REGISTRY_TTL_MS = 60_000;
@@ -203,7 +204,22 @@ function buildRegistry(
 ): GenerationModelRegistry {
     // Link on copies: STATIC_ENTRIES is module-level and shared across registry
     // rebuilds, so resolution must never mutate the originals.
-    const entries = sourceEntries.map((entry) => ({ ...entry }));
+    const entries = sourceEntries.map((entry) => {
+        const supportedEndpoints = mediaPromptRoute(entry)
+            ? [
+                  ...new Set([
+                      ...entry.supportedEndpoints,
+                      "/v1/responses",
+                      "/v1/chat/completions",
+                  ]),
+              ]
+            : entry.supportedEndpoints;
+        return {
+            ...entry,
+            supportedEndpoints,
+            info: { ...entry.info, supported_endpoints: supportedEndpoints },
+        };
+    });
     // Build lookup keys before presentation sorting so duplicate aliases keep
     // their declaration-order, first-wins resolution behavior.
     const byIdOrAlias = new Map<string, GenerationModelEntry>();

--- a/gen.pollinations.ai/src/model3d/handler.ts
+++ b/gen.pollinations.ai/src/model3d/handler.ts
@@ -21,7 +21,7 @@ export async function generate3dResponse(
     body: Record<string, unknown> = {},
 ): Promise<Response> {
     syncModel3dEnvironment(c.env);
-    const originalPrompt = decodePrompt(prompt || "");
+    const originalPrompt = prompt || "";
     const safeParams = parseModel3dParams(c, body);
     c.var.track.setPricingInput({ resolution: safeParams.resolution });
 
@@ -56,14 +56,6 @@ export async function handle3dPrompt(
             ? (c.req.valid("json" as never) as Record<string, unknown>)
             : {};
     return generate3dResponse(c, prompt, body);
-}
-
-export function decodePrompt(rawPrompt: string): string {
-    try {
-        return decodeURIComponent(rawPrompt);
-    } catch {
-        return rawPrompt;
-    }
 }
 
 export function parseModel3dParams(

--- a/gen.pollinations.ai/src/routes/audio.ts
+++ b/gen.pollinations.ai/src/routes/audio.ts
@@ -2872,16 +2872,7 @@ async function generateAudioFromSpeechRequest(
 export async function handleSimpleAudio(c: AudioContext): Promise<Response> {
     const log = c.get("log").getChild("generate");
 
-    const rawText = c.req.param("text");
-    let text: string;
-    try {
-        text = decodeURIComponent(rawText);
-    } catch {
-        throw new UpstreamError(400 as ContentfulStatusCode, {
-            message:
-                "Invalid percent-encoding in URL path. Make sure the text is properly URL-encoded (e.g. with encodeURIComponent), and that any literal '%' characters are written as '%25'.",
-        });
-    }
+    const text = c.req.param("text");
 
     const query = c.req.valid("query" as never) as SimpleAudioQuery;
     return await generateAudioFromSpeechRequest(

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -18,6 +18,12 @@ import { edgeRateLimit } from "@/middleware/rate-limit-edge.ts";
 import { textCache } from "@/middleware/text-cache.ts";
 import { track } from "@/middleware/track.ts";
 import {
+    MediaChatCompletionSchema,
+    MediaResponseSchema,
+    mediaResponseDescription,
+} from "../media/response-output.ts";
+import { mediaResponses } from "../media/responses.ts";
+import {
     formatOpenAIImageResponse,
     handleImageGeneration,
     prepareOpenAIImageEdit,
@@ -195,14 +201,15 @@ const model3dHandlers = factory.createHandlers(
     generateModel3d,
 );
 
+// Group access/coordination to stay within Hono's typed handler-count limit.
 const chatCompletionHandlers = factory.createHandlers(
     textBodyLimit,
     validator("json", CreateChatCompletionRequestSchema),
+    mediaResponses("chat/completions"),
     resolveModel("generate.text"),
     track("generate.text"),
     textCache,
-    generationAccess,
-    deduplicateGeneration,
+    every(generationAccess, deduplicateGeneration),
     apiKeyBudgetReservation,
     generateChatCompletion,
 );
@@ -210,11 +217,11 @@ const chatCompletionHandlers = factory.createHandlers(
 const responsesHandlers = factory.createHandlers(
     textBodyLimit,
     validator("json", CreateResponseRequestSchema),
+    mediaResponses("responses"),
     resolveModel("generate.text"),
     track("generate.text"),
     textCache,
-    generationAccess,
-    deduplicateGeneration,
+    every(generationAccess, deduplicateGeneration),
     apiKeyBudgetReservation,
     generateCreateResponse,
 );
@@ -661,22 +668,28 @@ export const proxyRoutes = new Hono<Env>()
                 "",
                 "Supports streaming, function calling, vision (image input), structured outputs, and reasoning/thinking modes depending on the model.",
                 "",
-                "Successful JSON responses contain usage. Streaming responses contain a usage chunk before `[DONE]`; missing provider usage fails the response.",
+                "Successful text JSON responses contain usage. Text streams contain a usage chunk before `[DONE]`; missing text-provider usage fails the response.",
+                "",
+                mediaResponseDescription,
             ].join("\n"),
             responses: {
                 200: {
                     description: "Chat completion JSON or SSE stream",
+                    headers: mediaResponseHeaders,
                     content: {
                         "application/json": {
                             schema: resolver(
-                                CreateChatCompletionResponseSchema,
+                                z.union([
+                                    CreateChatCompletionResponseSchema,
+                                    MediaChatCompletionSchema,
+                                ]),
                             ),
                         },
                         "text/event-stream": {
                             schema: resolver(
                                 z.string().meta({
                                     description:
-                                        "OpenAI-compatible Chat Completions SSE events ending with a usage chunk and data: [DONE]",
+                                        "OpenAI-compatible Chat Completions SSE events ending with data: [DONE]. Text models include a usage chunk; media models omit it.",
                                 }),
                             ),
                         },
@@ -701,20 +714,28 @@ export const proxyRoutes = new Hono<Env>()
                 "",
                 "Response storage, previous response IDs, conversations, background execution, and encrypted or referenced state are not supported. Direct providers may accept caller-supplied function tools; managed prompt agents ignore these definitions and use only their configured MCP tools. Completed MCP output items can be replayed as history without executing them again.",
                 "",
-                "Successful JSON responses and terminal streaming events contain usage; missing provider usage fails the response.",
+                "Successful text JSON responses and terminal streaming events contain usage; missing text-provider usage fails the response.",
+                "",
+                mediaResponseDescription,
             ].join("\n"),
             responses: {
                 200: {
                     description: "Responses JSON or semantic Responses SSE",
+                    headers: mediaResponseHeaders,
                     content: {
                         "application/json": {
-                            schema: resolver(CreateResponseResponseSchema),
+                            schema: resolver(
+                                z.union([
+                                    CreateResponseResponseSchema,
+                                    MediaResponseSchema,
+                                ]),
+                            ),
                         },
                         "text/event-stream": {
                             schema: resolver(
                                 z.string().meta({
                                     description:
-                                        "Responses API SSE events ending with response.completed, response.incomplete, or response.failed; completed and incomplete responses contain usage, and a data: [DONE] marker may follow",
+                                        "Responses API SSE events ending with response.completed, response.incomplete, or response.failed. Text models include usage; media models return usage: null. A data: [DONE] marker may follow.",
                                 }),
                             ),
                         },

--- a/gen.pollinations.ai/src/text/responses/chatResponse.ts
+++ b/gen.pollinations.ai/src/text/responses/chatResponse.ts
@@ -184,6 +184,7 @@ export function responsesToChatCompletion(
     value: unknown,
     requestedModel: string,
     requestUrl: URL,
+    options: { requireUsage?: boolean } = {},
 ): ChatCompletion {
     if (!value || typeof value !== "object") {
         throw serviceError(
@@ -209,8 +210,8 @@ export function responsesToChatCompletion(
             data,
         );
     }
-    const usage = ResponseUsageSchema.safeParse(data.usage);
-    if (!usage.success) {
+    const usage = ResponseUsageSchema.nullish().safeParse(data.usage);
+    if (!usage.success || (options.requireUsage !== false && !usage.data)) {
         throw serviceError(
             "Responses provider returned an invalid response or omitted usage",
             requestUrl,
@@ -230,7 +231,7 @@ export function responsesToChatCompletion(
                     finish_reason: finishReason(data),
                 },
             ],
-            usage: chatUsage(usage.data),
+            ...(usage.data ? { usage: chatUsage(usage.data) } : {}),
         },
         requestUrl,
     );
@@ -258,6 +259,7 @@ function withUpstreamRequestUrl(
 export function responsesToChatStream(
     source: ReadableStream<Uint8Array<ArrayBuffer>>,
     requestedModel: string,
+    options: { requireUsage?: boolean } = {},
 ): ReadableStream<Uint8Array<ArrayBuffer>> {
     let id = `chatcmpl-${crypto.randomUUID()}`;
     let created = Math.floor(Date.now() / 1000);
@@ -621,8 +623,14 @@ export function responsesToChatStream(
                     }
 
                     const response = (payload.response ?? {}) as ResponsesData;
-                    const usage = ResponseUsageSchema.safeParse(response.usage);
-                    if (!usage.success) {
+                    const usage = ResponseUsageSchema.nullish().safeParse(
+                        response.usage,
+                    );
+                    if (
+                        !payload.response ||
+                        !usage.success ||
+                        (options.requireUsage !== false && !usage.data)
+                    ) {
                         fail(
                             controller,
                             "Responses provider omitted valid terminal usage",
@@ -697,16 +705,17 @@ export function responsesToChatStream(
                     }
                     ensureRole(controller);
                     controller.enqueue(chunk({}, finishReason(response)));
-                    controller.enqueue(
-                        dataEvent({
-                            id,
-                            object: "chat.completion.chunk",
-                            created,
-                            model,
-                            choices: [],
-                            usage: chatUsage(usage.data),
-                        }),
-                    );
+                    if (usage.data)
+                        controller.enqueue(
+                            dataEvent({
+                                id,
+                                object: "chat.completion.chunk",
+                                created,
+                                model,
+                                choices: [],
+                                usage: chatUsage(usage.data),
+                            }),
+                        );
                     controller.enqueue(dataEvent("[DONE]"));
                     terminal = true;
                 },

--- a/gen.pollinations.ai/src/utils/execute-generation.ts
+++ b/gen.pollinations.ai/src/utils/execute-generation.ts
@@ -65,6 +65,8 @@ function generationExecutor(
         .use("*", async (c, next) => {
             c.set("generationExecution", {
                 cacheKey: job.cache.key,
+                originalPath: job.request.originalPath,
+                originalModel: job.request.originalModel,
                 registerCacheWrite,
             });
             await next();

--- a/gen.pollinations.ai/test/community-endpoints.test.ts
+++ b/gen.pollinations.ai/test/community-endpoints.test.ts
@@ -5639,16 +5639,18 @@ fixtureTest.each(["video", "image", "v1/images/generations"])(
                 expect(body).toEqual(
                     isProbe
                         ? { prompt: body.prompt, duration: 5 }
-                        : {
-                              prompt: "green sprout",
-                              ...(route !== "v1/images/generations"
-                                  ? {
-                                        reference_images: [
-                                            "https://media.example.com/style.jpg",
-                                        ],
-                                    }
-                                  : {}),
-                          },
+                        : body.prompt === "media video prompt"
+                          ? { prompt: body.prompt }
+                          : {
+                                prompt: "green sprout",
+                                ...(route !== "v1/images/generations"
+                                    ? {
+                                          reference_images: [
+                                              "https://media.example.com/style.jpg",
+                                          ],
+                                      }
+                                    : {}),
+                            },
                 );
                 return Response.json({
                     data: [{ b64_json: TEST_MP4_BASE64 }],
@@ -5895,7 +5897,59 @@ fixtureTest.each(["video", "image", "v1/images/generations"])(
         expect(
             openaiCatalog.data.find((model) => model.id === registered.modelId)
                 ?.supported_endpoints,
-        ).toEqual(communityEndpointSupportedEndpoints("video", ["text"]));
+        ).toEqual([
+            ...communityEndpointSupportedEndpoints("video", ["text"]),
+            "/v1/responses",
+            "/v1/chat/completions",
+        ]);
+
+        // Text protocols leave duration to the provider and only wrap its URL.
+        let mediaLink: string | null = null;
+        for (const protocol of ["responses", "chat/completions"]) {
+            const ctx = createExecutionContext();
+            const response = await worker.fetch(
+                new Request(`https://gen.pollinations.ai/v1/${protocol}`, {
+                    method: "POST",
+                    headers: {
+                        Authorization: `Bearer ${caller.key}`,
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify({
+                        model: registered.modelId,
+                        ...(protocol === "responses"
+                            ? { input: "media video prompt" }
+                            : {
+                                  messages: [
+                                      {
+                                          role: "user",
+                                          content: "media video prompt",
+                                      },
+                                  ],
+                                  stream: true,
+                              }),
+                    }),
+                }),
+                coordinatedEnv,
+                ctx,
+            );
+            expect(response.status, await response.clone().text()).toBe(200);
+            expect(await response.text()).toContain("[Video](https://media.");
+            if (mediaLink) expect(response.headers.get("Link")).toBe(mediaLink);
+            mediaLink = response.headers.get("Link");
+            await waitOnExecutionContext(ctx);
+        }
+        expect(generationCalls).toBe(2);
+        expect(
+            balanceAfter.tierBalance -
+                (await getUserBalance(db, caller.userId)).tierBalance,
+        ).toBeCloseTo(0.36, 10);
+        expect(
+            ingestedEvents.filter(
+                (event) =>
+                    event.modelUsed === registered.modelId &&
+                    event.isBilledUsage === true,
+            ),
+        ).toHaveLength(2);
 
         const excessivePriceResponse = await fetchEnterApi(
             enterApi,

--- a/gen.pollinations.ai/test/generation-vcr.test.ts
+++ b/gen.pollinations.ai/test/generation-vcr.test.ts
@@ -82,6 +82,9 @@ function createGenerationMocks() {
     const deepInfraState: { requests: Record<string, unknown>[] } = {
         requests: [],
     };
+    const elevenLabsState: { requests: Record<string, unknown>[] } = {
+        requests: [],
+    };
     const responsesHandler = async (request: Request) => {
         const body = (await request.clone().json()) as Record<string, unknown>;
         responsesState.requests.push({
@@ -169,6 +172,20 @@ function createGenerationMocks() {
     };
     return createFetchMock({
         tinybird: createMockTinybird(),
+        elevenLabs: {
+            state: elevenLabsState,
+            handlerMap: {
+                "api.elevenlabs.io": async (request: Request) => {
+                    elevenLabsState.requests.push(await request.json());
+                    return new Response("audio bytes", {
+                        headers: { "content-type": "audio/mpeg" },
+                    });
+                },
+            },
+            reset: () => {
+                elevenLabsState.requests = [];
+            },
+        },
         portkeyDirect: {
             state: portkeyState,
             handlerMap: {
@@ -675,11 +692,15 @@ function usageHeaders(headers: Record<string, string>) {
     };
 }
 
-async function fetchWorker(path: string, init: RequestInit) {
+async function fetchWorker(
+    path: string,
+    init: RequestInit,
+    bindings = withInlineGenerationCoordinator(env),
+) {
     const ctx = createExecutionContext();
     const response = await worker.fetch(
         new Request(`https://gen.pollinations.ai${path}`, init),
-        withInlineGenerationCoordinator(env),
+        bindings,
         ctx,
     );
 
@@ -688,6 +709,255 @@ async function fetchWorker(path: string, init: RequestInit) {
         wait: () => waitOnExecutionContext(ctx),
     };
 }
+
+test("media Responses and Chat share native generation, cache and one debit", async ({
+    mocks,
+}) => {
+    await mocks.enable("tinybird", "deepInfra");
+    const { key, userId } = await createTestApiKey({
+        user: { tierBalance: 100 },
+    });
+    const before = await getUserBalance(drizzle(env.DB), userId);
+    const prompt = `media wrapper 100% literal %2F ${crypto.randomUUID()}`;
+    const bindings = withInlineGenerationCoordinator(env);
+    const results = await Promise.all(
+        ["responses", "chat/completions"].map((protocol) =>
+            fetchWorker(
+                `/v1/${protocol}`,
+                {
+                    method: "POST",
+                    headers: {
+                        authorization: `Bearer ${key}`,
+                        "content-type": "application/json",
+                    },
+                    body: JSON.stringify({
+                        model: "flux",
+                        stream: protocol === "chat/completions",
+                        ...(protocol === "responses"
+                            ? { input: prompt }
+                            : {
+                                  messages: [
+                                      { role: "system", content: "ignored" },
+                                      { role: "user", content: prompt },
+                                  ],
+                              }),
+                    }),
+                },
+                bindings,
+            ),
+        ),
+    );
+    for (const { response } of results)
+        expect(response.status, await response.clone().text()).toBe(200);
+    const responseJson = (await results[0].response.json()) as {
+        usage: unknown;
+        output: { content: { text: string }[] }[];
+    };
+    const markdown = responseJson.output[0].content[0].text;
+    expect(responseJson.usage).toBeNull();
+    expect(markdown).toMatch(/^!\[Image\]\(https:\/\/media\./);
+    const chatStream = await results[1].response.text();
+    expect(results[0].response.headers.get("content-type")).toContain(
+        "application/json",
+    );
+    expect(results[1].response.headers.get("content-type")).toContain(
+        "text/event-stream",
+    );
+    expect(chatStream).toContain(JSON.stringify(markdown));
+    expect(chatStream).toContain("data: [DONE]");
+    expect(chatStream).not.toContain("usage_missing");
+    await Promise.all(results.map(({ wait }) => wait()));
+    expect(mocks.deepInfra.state.requests).toHaveLength(1);
+    expect(mocks.deepInfra.state.requests[0]).toMatchObject({ prompt });
+    expect(
+        mocks.tinybird.state.events.filter((event) => event.isBilledUsage),
+    ).toHaveLength(1);
+    expect(
+        mocks.tinybird.state.events.find((event) => event.isBilledUsage),
+    ).toMatchObject({
+        modelRequested: "flux",
+        resolvedModelRequested: "black-forest-labs/flux.1-schnell",
+    });
+    const after = await getUserBalance(drizzle(env.DB), userId);
+    expect(after.tierBalance).toBeLessThan(before.tierBalance);
+    for (const protocol of ["responses", "chat/completions"]) {
+        const repeated = await fetchWorker(
+            `/v1/${protocol}`,
+            {
+                method: "POST",
+                headers: {
+                    authorization: `Bearer ${key}`,
+                    "content-type": "application/json",
+                },
+                body: JSON.stringify({
+                    model: "black-forest-labs/flux.1-schnell",
+                    ...(protocol === "responses"
+                        ? { input: prompt }
+                        : { messages: [{ role: "user", content: prompt }] }),
+                }),
+            },
+            bindings,
+        );
+        expect(repeated.response.status).toBe(200);
+        expect(repeated.response.headers.get("X-Cache")).toBe("HIT");
+        expect(repeated.response.headers.get("Link")).toBe(
+            results[0].response.headers.get("Link"),
+        );
+        await repeated.response.text();
+        await repeated.wait();
+    }
+    const cached = await fetchWorker(
+        `/image/${encodeURIComponent(prompt)}?model=black-forest-labs/flux.1-schnell`,
+        { headers: { authorization: `Bearer ${key}` } },
+        bindings,
+    );
+    expect(cached.response.status).toBe(200);
+    expect(cached.response.headers.get("Link")).toBe(
+        results[0].response.headers.get("Link"),
+    );
+    await cached.response.arrayBuffer();
+    await cached.wait();
+    expect(mocks.deepInfra.state.requests).toHaveLength(1);
+    expect((await getUserBalance(drizzle(env.DB), userId)).tierBalance).toBe(
+        after.tierBalance,
+    );
+    expect(
+        mocks.tinybird.state.events.filter((event) => event.isBilledUsage),
+    ).toHaveLength(1);
+});
+
+test("media text protocols reject missing user text and attachments before generation", async ({
+    mocks,
+}) => {
+    await mocks.enable("tinybird", "deepInfra");
+    const { key } = await createTestApiKey({ user: { tierBalance: 100 } });
+    for (const protocol of ["responses", "chat/completions"]) {
+        for (const messages of [
+            [{ role: "assistant", content: "no user prompt" }],
+            [
+                {
+                    role: "user",
+                    content: [
+                        {
+                            type:
+                                protocol === "responses"
+                                    ? "input_image"
+                                    : "image_url",
+                            image_url:
+                                protocol === "responses"
+                                    ? "https://example.com/image.png"
+                                    : { url: "https://example.com/image.png" },
+                        },
+                    ],
+                },
+            ],
+        ]) {
+            const { response, wait } = await fetchWorker(`/v1/${protocol}`, {
+                method: "POST",
+                headers: {
+                    authorization: `Bearer ${key}`,
+                    "content-type": "application/json",
+                },
+                body: JSON.stringify({
+                    model: "flux",
+                    [protocol === "responses" ? "input" : "messages"]: messages,
+                }),
+            });
+            expect(response.status, await response.clone().text()).toBe(400);
+            await response.text();
+            await wait();
+        }
+    }
+    expect(mocks.deepInfra.state.requests).toHaveLength(0);
+    expect(
+        mocks.tinybird.state.events.some((event) => event.isBilledUsage),
+    ).toBe(false);
+});
+
+test("media model permissions apply on both text protocols", async ({
+    mocks,
+}) => {
+    await mocks.enable("tinybird", "deepInfra");
+    const { key } = await createTestApiKey({
+        allowedModels: ["openai/gpt-5-nano"],
+        user: { tierBalance: 100 },
+    });
+    for (const path of ["/v1/responses", "/v1/chat/completions"]) {
+        const { response, wait } = await fetchWorker(path, {
+            method: "POST",
+            headers: {
+                authorization: `Bearer ${key}`,
+                "content-type": "application/json",
+            },
+            body: JSON.stringify({
+                model: "flux",
+                ...(path === "/v1/responses"
+                    ? { input: "denied" }
+                    : { messages: [{ role: "user", content: "denied" }] }),
+            }),
+        });
+        expect(response.status).toBe(403);
+        await response.text();
+        await wait();
+    }
+    expect(mocks.deepInfra.state.requests).toHaveLength(0);
+});
+
+test("media audio uses native speech billing and preserves literal text", async ({
+    mocks,
+}) => {
+    await mocks.enable("tinybird", "elevenLabs");
+    const bindings = withInlineGenerationCoordinator({
+        ...env,
+        ELEVENLABS_API_KEY: "elevenlabs-test-key",
+    });
+    const { key, userId } = await createTestApiKey({
+        user: { packBalance: 100 },
+    });
+    const prompt = `100% literal %2F ${crypto.randomUUID()}`;
+    const before = await getUserBalance(drizzle(env.DB), userId);
+    let link: string | null = null;
+    for (const protocol of ["responses", "chat/completions"]) {
+        const { response, wait } = await fetchWorker(
+            `/v1/${protocol}`,
+            {
+                method: "POST",
+                headers: {
+                    authorization: `Bearer ${key}`,
+                    "content-type": "application/json",
+                },
+                body: JSON.stringify({
+                    model: "elevenlabs/eleven-v3",
+                    ...(protocol === "responses"
+                        ? { input: prompt, stream: true }
+                        : { messages: [{ role: "user", content: prompt }] }),
+                }),
+            },
+            bindings,
+        );
+        expect(response.status, await response.clone().text()).toBe(200);
+        const body = await response.text();
+        expect(body).toContain("[Audio](https://media.");
+        expect(body).not.toContain("![Audio]");
+        if (link) expect(response.headers.get("Link")).toBe(link);
+        link = response.headers.get("Link");
+        await wait();
+    }
+    expect(mocks.elevenLabs.state.requests).toHaveLength(1);
+    expect(mocks.elevenLabs.state.requests[0]).toMatchObject({ text: prompt });
+    const billed = mocks.tinybird.state.events.filter(
+        (event) => event.isBilledUsage,
+    );
+    expect(billed).toHaveLength(1);
+    expect(billed[0]).toMatchObject({
+        eventType: "generate.audio",
+        requestPath: "/v1/responses",
+        tokenCountCompletionAudio: prompt.length,
+    });
+    expect(
+        (await getUserBalance(drizzle(env.DB), userId)).packBalance,
+    ).toBeLessThan(before.packBalance);
+});
 
 test("chat completions use local text generation with VCR-backed Portkey", async ({
     paidApiKey,

--- a/gen.pollinations.ai/test/generation-vcr.test.ts
+++ b/gen.pollinations.ai/test/generation-vcr.test.ts
@@ -826,7 +826,7 @@ test("media Responses and Chat share native generation, cache and one debit", as
     ).toHaveLength(1);
 });
 
-test("media text protocols reject missing user text and attachments before generation", async ({
+test("media text protocols reject invalid prompts and attachments before generation", async ({
     mocks,
 }) => {
     await mocks.enable("tinybird", "deepInfra");
@@ -834,6 +834,9 @@ test("media text protocols reject missing user text and attachments before gener
     for (const protocol of ["responses", "chat/completions"]) {
         for (const messages of [
             [{ role: "assistant", content: "no user prompt" }],
+            ...[".", "..", "\ud800", "\udc00"].map((content) => [
+                { role: "user", content },
+            ]),
             [
                 {
                     role: "user",
@@ -867,6 +870,30 @@ test("media text protocols reject missing user text and attachments before gener
             await response.text();
             await wait();
         }
+    }
+    expect(mocks.deepInfra.state.requests).toHaveLength(0);
+    expect(
+        mocks.tinybird.state.events.some((event) => event.isBilledUsage),
+    ).toBe(false);
+});
+
+test("media Responses rejects invalid string input before generation", async ({
+    mocks,
+}) => {
+    await mocks.enable("tinybird", "deepInfra");
+    const { key } = await createTestApiKey({ user: { tierBalance: 100 } });
+    for (const input of [".", "..", "\ud800", "\udc00"]) {
+        const { response, wait } = await fetchWorker("/v1/responses", {
+            method: "POST",
+            headers: {
+                authorization: `Bearer ${key}`,
+                "content-type": "application/json",
+            },
+            body: JSON.stringify({ model: "flux", input }),
+        });
+        expect(response.status, await response.clone().text()).toBe(400);
+        expect(await response.text()).toContain("Media prompt");
+        await wait();
     }
     expect(mocks.deepInfra.state.requests).toHaveLength(0);
     expect(

--- a/gen.pollinations.ai/test/index.test.ts
+++ b/gen.pollinations.ai/test/index.test.ts
@@ -2521,7 +2521,7 @@ fixtureTest(
         await expect(response.json()).resolves.toMatchObject({
             error: {
                 message:
-                    'Model "elevenlabs" cannot be used on /v1/audio/transcriptions. Supported endpoints: /audio/{text}, /v1/audio/speech, /v1/audio/speech/with-timestamps.',
+                    'Model "elevenlabs" cannot be used on /v1/audio/transcriptions. Supported endpoints: /audio/{text}, /v1/audio/speech, /v1/audio/speech/with-timestamps, /v1/responses, /v1/chat/completions.',
             },
         });
     },

--- a/gen.pollinations.ai/test/media-responses.test.ts
+++ b/gen.pollinations.ai/test/media-responses.test.ts
@@ -1,0 +1,168 @@
+import { env } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import { mediaPromptRoute } from "../src/media/prompt-route.ts";
+import {
+    createMediaResponse,
+    MediaChatCompletionSchema,
+    MediaResponseSchema,
+    mediaResponseStream,
+} from "../src/media/response-output.ts";
+import { mediaPrompt } from "../src/media/responses.ts";
+import { getGenerationModelRegistry } from "../src/model-registry.ts";
+import {
+    responsesToChatCompletion,
+    responsesToChatStream,
+} from "../src/text/responses/chatResponse.ts";
+
+const url = "https://media.pollinations.ai/abc123";
+const requestUrl = new URL("https://gen.pollinations.ai/v1/chat/completions");
+
+describe("media text protocols", () => {
+    it("uses only the last user message, preserving all its text parts", () => {
+        expect(
+            mediaPrompt([
+                { role: "system", content: "ignore me" },
+                { role: "user", content: "earlier prompt" },
+                {
+                    role: "user",
+                    content: [
+                        { type: "input_text", text: "a cat" },
+                        { type: "text", text: "in space" },
+                    ],
+                },
+                { role: "assistant", content: "not the prompt" },
+            ]),
+        ).toBe("a cat\nin space");
+        expect(mediaPrompt(" literal prompt ")).toBe(" literal prompt ");
+    });
+
+    it.each([
+        null,
+        [],
+        " ",
+        [{ role: "assistant", content: "hello" }],
+        [{ role: "user", content: [{ type: "input_image", image_url: url }] }],
+    ])("rejects absent text and attachments: %j", (input) => {
+        expect(() => mediaPrompt(input)).toThrow();
+    });
+
+    it.each([
+        ["image/png", `![Image](${url})\n\n${url}`],
+        ["image/svg+xml", `![Image](${url})\n\n${url}`],
+        ["audio/mpeg", `[Audio](${url})\n\n${url}`],
+        ["video/mp4", `[Video](${url})\n\n${url}`],
+        ["model/gltf-binary", `[3D model](${url})\n\n${url}`],
+    ])("returns schema-valid Markdown in both protocols for %s", (mime, markdown) => {
+        const response = createMediaResponse("media-model", url, mime);
+        expect(MediaResponseSchema.safeParse(response).success).toBe(true);
+        expect(response.output[0].content[0].text).toBe(markdown);
+        expect(response.usage).toBeNull();
+        const chat = responsesToChatCompletion(
+            response,
+            "media-model",
+            requestUrl,
+            { requireUsage: false },
+        );
+        expect(MediaChatCompletionSchema.safeParse(chat).success).toBe(true);
+        expect(chat.choices?.[0].message?.content).toBe(markdown);
+        expect(chat).not.toHaveProperty("usage");
+        expect(() =>
+            responsesToChatCompletion(response, "media-model", requestUrl),
+        ).toThrow(/usage/);
+    });
+
+    it("emits ordered Responses events and adapts them to one Chat text delta", async () => {
+        const response = createMediaResponse("media-model", url, "image/png");
+        const events = (
+            await new Response(mediaResponseStream(response)).text()
+        )
+            .split("\n\n")
+            .filter((line) => line.startsWith("event:"))
+            .map((line) => JSON.parse(line.split("\ndata: ")[1]));
+        expect(events.map((event) => event.sequence_number)).toEqual(
+            events.map((_, index) => index),
+        );
+        expect(events.at(-1)).toMatchObject({
+            type: "response.completed",
+            response,
+        });
+        const chat = await new Response(
+            responsesToChatStream(
+                mediaResponseStream(response),
+                response.model,
+                { requireUsage: false },
+            ),
+        ).text();
+        const chunks = chat
+            .split("\n\n")
+            .filter((line) => line.startsWith("data: {"))
+            .map((line) => JSON.parse(line.slice(6)));
+        expect(
+            chunks
+                .filter((chunk) => chunk.choices[0]?.delta.content)
+                .map((chunk) => chunk.choices[0].delta.content),
+        ).toEqual([response.output[0].content[0].text]);
+        expect(chunks.at(-1).choices[0].finish_reason).toBe("stop");
+        expect(chunks.some((chunk) => chunk.usage != null)).toBe(false);
+        expect(chat).toContain("data: [DONE]");
+        const strict = await new Response(
+            responsesToChatStream(
+                mediaResponseStream(response),
+                response.model,
+            ),
+        ).text();
+        expect(strict).toContain("usage_missing");
+    });
+
+    it("rejects malformed terminal usage even in media mode", async () => {
+        const response = createMediaResponse("media-model", url, "image/png");
+        expect(() =>
+            responsesToChatCompletion(
+                { ...response, usage: {} },
+                response.model,
+                requestUrl,
+                { requireUsage: false },
+            ),
+        ).toThrow(/usage/);
+        const stream = new Blob([
+            'event: response.completed\ndata: {"type":"response.completed"}\n\n',
+        ]).stream();
+        expect(
+            await new Response(
+                responsesToChatStream(stream, response.model, {
+                    requireUsage: false,
+                }),
+            ).text(),
+        ).toContain("usage_missing");
+    });
+
+    it("advertises only text-input media with a native generation route", async () => {
+        const registry = await getGenerationModelRegistry(env);
+        for (const model of [
+            "flux",
+            "veo",
+            "elevenlabs/eleven-v3",
+            "hyper3d/rodin-2.5",
+        ]) {
+            const entry = registry.resolve(model);
+            if (!entry) throw new Error(`Missing registry model: ${model}`);
+            expect(mediaPromptRoute(entry), model).toBeTruthy();
+            expect(entry.info.supported_endpoints).toContain("/v1/responses");
+            expect(entry.info.supported_endpoints).toContain(
+                "/v1/chat/completions",
+            );
+        }
+        for (const model of [
+            "microsoft/trellis-2",
+            "nvidia/asset-harvester",
+            "elevenlabs/scribe-v2",
+        ]) {
+            const entry = registry.resolve(model);
+            if (!entry) throw new Error(`Missing registry model: ${model}`);
+            expect(mediaPromptRoute(entry), model).toBeUndefined();
+            expect(entry.info.supported_endpoints).not.toContain(
+                "/v1/responses",
+            );
+        }
+    });
+});

--- a/gen.pollinations.ai/test/media-responses.test.ts
+++ b/gen.pollinations.ai/test/media-responses.test.ts
@@ -34,12 +34,18 @@ describe("media text protocols", () => {
             ]),
         ).toBe("a cat\nin space");
         expect(mediaPrompt(" literal prompt ")).toBe(" literal prompt ");
+        expect(mediaPrompt("猫 🚀 ... %2F")).toBe("猫 🚀 ... %2F");
+        expect(mediaPrompt(" . ")).toBe(" . ");
     });
 
     it.each([
         null,
         [],
         " ",
+        ".",
+        "..",
+        "\ud800",
+        "\udc00",
         [{ role: "assistant", content: "hello" }],
         [{ role: "user", content: [{ type: "input_image", image_url: url }] }],
     ])("rejects absent text and attachments: %j", (input) => {
@@ -143,6 +149,7 @@ describe("media text protocols", () => {
             "veo",
             "elevenlabs/eleven-v3",
             "hyper3d/rodin-2.5",
+            "prunaai/p-image-edit",
         ]) {
             const entry = registry.resolve(model);
             if (!entry) throw new Error(`Missing registry model: ${model}`);

--- a/gen.pollinations.ai/test/model-registry.test.ts
+++ b/gen.pollinations.ai/test/model-registry.test.ts
@@ -58,6 +58,7 @@ describe("getGenerationModelRegistry", () => {
             .filter(
                 (entry) =>
                     !entry.communityEndpoint &&
+                    entry.definition.category === "text" &&
                     entry.supportedEndpoints.includes("/v1/responses"),
             )
             .map((entry) => entry.id)

--- a/gen.pollinations.ai/test/model3d/post.test.ts
+++ b/gen.pollinations.ai/test/model3d/post.test.ts
@@ -106,11 +106,12 @@ afterEach(async () => {
 async function fetch3d(
     path: string,
     init: RequestInit = {},
+    bindings = withInlineGenerationCoordinator(env),
 ): Promise<Response> {
     const ctx = createExecutionContext();
     const response = await worker.fetch(
         new Request(`https://gen.pollinations.ai${path}`, init),
-        withInlineGenerationCoordinator(env),
+        bindings,
         ctx,
     );
     await response.clone().arrayBuffer();
@@ -221,6 +222,44 @@ test("POST /3d sends JSON image and seed to the existing Rodin provider path", a
         tokenPriceCompletionImage: 0.1,
         totalPrice: 0.1,
     });
+}, 10_000);
+
+test("media Responses and Chat reuse native text-to-3D generation", async () => {
+    const bindings = withInlineGenerationCoordinator({
+        ...env,
+        FAL_KEY: "fal_test_key",
+    });
+    await mocks.enable("tinybird", "fal");
+    const { key } = await createTestApiKey({ user: { packBalance: 1 } });
+    const prompt = `a model with literal %2F ${crypto.randomUUID()}`;
+    let link: string | null = null;
+    for (const protocol of ["responses", "chat/completions"]) {
+        const response = await fetch3d(
+            `/v1/${protocol}`,
+            {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${key}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    model: "hyper3d/rodin-2.5",
+                    ...(protocol === "responses"
+                        ? { input: prompt }
+                        : { messages: [{ role: "user", content: prompt }] }),
+                }),
+            },
+            bindings,
+        );
+        expect(response.status, await response.clone().text()).toBe(200);
+        expect(await response.text()).toContain("[3D model](https://media.");
+        if (link) expect(response.headers.get("Link")).toBe(link);
+        link = response.headers.get("Link");
+    }
+    expect(mocks.fal.state.bodies).toEqual([{ prompt }]);
+    expect(
+        mocks.tinybird.state.events.filter((event) => event.isBilledUsage),
+    ).toHaveLength(1);
 }, 10_000);
 
 test("POST /3d preserves authentication and rejects ignored parameters", async ({


### PR DESCRIPTION
- Adds prompt-only image, video, audio and 3D generation to `/v1/responses` and `/v1/chat/completions` for models with supported native routes. Prices, providers and access rules stay unchanged.
- Reuses native generation, durable coordination, caching and billing. Builds Responses output once and uses the existing Chat converter; preserves the original route and model alias in logs.
- Returns Markdown embeds/links plus plain public URLs. Streaming emits events after generation finishes; media does not invent text-token usage.
- Sets Open WebUI background tasks to `openai/gpt-5-nano` and enables full staging model discovery. Updates Scalar docs, fixes double URL-decoding, and returns 400 for malformed Unicode or dot-only prompts. Reference-required models remain available and return their normal missing-input error.
- Verified: 1,981 Gen tests passed, 6 skipped; typecheck and Biome passed. Live staging passed all four modalities, JSON/SSE, cache sharing, disconnect/rejoin and the input-error checks with correct billing. Community speech remains native-only; duration-less community video needs provider usage. Attachments/settings stay on native endpoints.