### PR TITLE
Fixes #14599 — expose supported/default parameters in model listings

### DIFF
--- a/gen.pollinations.ai/src/docs/models.md
+++ b/gen.pollinations.ai/src/docs/models.md
@@ -32,6 +32,18 @@ Rich model endpoints include `capabilities` for agentic/model traits:
 Modalities, video frame controls, voices, and context length remain separate
 structured fields.
 
+For Chat models, `supported_parameters` lists the parameters the model accepts
+through Pollinations (after gateway transforms) and `default_parameters`
+records the values applied when the caller omits them. Only parameters that
+actually work are listed — parameters the gateway strips or the provider
+silently ignores are omitted, and `condition` documents provider-specific
+restrictions (e.g. mutual exclusion, gateway overrides). For example,
+`openai/gpt-5.4-nano` locks `temperature` to `1`, and
+`anthropic/claude-sonnet-4.6` drops `top_p` whenever `temperature` is also set.
+These fields describe Chat-completion behavior; they do not describe the native
+Responses API (see `supported_endpoints` to find models with a direct
+`/v1/responses` route).
+
 Use `supported_endpoints` to discover which public API routes accept each
 model. `/v1/responses` identifies built-in models with a configured native
 Responses route, community text models and endpoint agents whose owner supplied

--- a/gen.pollinations.ai/src/routes/docs-samples.ts
+++ b/gen.pollinations.ai/src/routes/docs-samples.ts
@@ -587,6 +587,18 @@ export const RESPONSE_EXAMPLES: Record<string, unknown> = {
                 category: "text",
                 community: false,
                 title: "OpenAI",
+                supported_parameters: [
+                    {
+                        name: "temperature",
+                        type: "number",
+                        condition: "Locked to 1 for the GPT-5 series",
+                    },
+                    {
+                        name: "max_completion_tokens",
+                        type: "integer",
+                    },
+                ],
+                default_parameters: { temperature: 1, stream: false },
             },
             {
                 id: "anthropic/claude-sonnet-4.6",

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -339,6 +339,12 @@ function toOpenAIModelEntry(entry: GenerationModelEntry) {
         input_modalities: entry.info.input_modalities,
         output_modalities: entry.info.output_modalities,
         supported_endpoints: entry.supportedEndpoints,
+        ...(entry.info.supported_parameters && {
+            supported_parameters: entry.info.supported_parameters,
+        }),
+        ...(entry.info.default_parameters && {
+            default_parameters: entry.info.default_parameters,
+        }),
         ...(entry.info.agent && { agent: true }),
         ...(entry.info.base_model && {
             base_model: entry.info.base_model,

--- a/gen.pollinations.ai/test/chatParameters.test.ts
+++ b/gen.pollinations.ai/test/chatParameters.test.ts
@@ -4,7 +4,10 @@ import {
     ModelInfoSchema,
     modelInfoFromDefinition,
 } from "@shared/registry/model-info.ts";
-import { getVisibleTextModels } from "@shared/registry/registry.ts";
+import {
+    getRegistryModelDefinition,
+    getVisibleTextModels,
+} from "@shared/registry/registry.ts";
 import { TEXT_SERVICES } from "@shared/registry/text.ts";
 import { describe, expect, it } from "vitest";
 
@@ -23,7 +26,10 @@ const DOCUMENTED_MODELS = [
 ] as const;
 
 function textModelInfo(name: string) {
-    return modelInfoFromDefinition(name, TEXT_SERVICES[name]);
+    return modelInfoFromDefinition(
+        name,
+        TEXT_SERVICES[name as keyof typeof TEXT_SERVICES],
+    );
 }
 
 describe("Chat parameter registry fields", () => {
@@ -34,7 +40,7 @@ describe("Chat parameter registry fields", () => {
         expect(info.supported_parameters?.length).toBeGreaterThan(0);
         expect(info.default_parameters).toBeDefined();
 
-        const names = info.supported_parameters?.map((p) => p.name);
+        const names = info.supported_parameters?.map((p) => p.name) ?? [];
         expect(new Set(names).size).toBe(names.length);
 
         // Every advertised default must map to an advertised parameter.
@@ -48,7 +54,7 @@ describe("Chat parameter registry fields", () => {
 
     it("gpt-5.4-nano omits parameters the gateway strips", () => {
         const info = textModelInfo("openai/gpt-5.4-nano");
-        const names = info.supported_parameters?.map((p) => p.name);
+        const names = info.supported_parameters?.map((p) => p.name) ?? [];
         // parameterProcessor strips these for /^gpt-5/ models — listing them
         // would describe controls that are silently ignored.
         expect(names).not.toContain("top_p");
@@ -100,7 +106,7 @@ describe("Chat parameter registry fields", () => {
     it("models without verified parameter metadata omit both fields", () => {
         // Text models without verified parameter data must omit both fields.
         const noMetadata = getVisibleTextModels().filter(
-            (name) => !TEXT_SERVICES[name]?.supportedParameters,
+            (name) => !getRegistryModelDefinition(name).supportedParameters,
         );
         expect(noMetadata.length).toBeGreaterThan(0);
         const bare = textModelInfo(noMetadata[0]);
@@ -113,7 +119,7 @@ describe("Chat parameter registry fields", () => {
         const imageKey = imageKeys[0];
         const imageInfo = modelInfoFromDefinition(
             imageKey,
-            IMAGE_SERVICES[imageKey],
+            IMAGE_SERVICES[imageKey as keyof typeof IMAGE_SERVICES],
         );
         expect(imageInfo.supported_parameters).toBeUndefined();
         expect(imageInfo.default_parameters).toBeUndefined();

--- a/gen.pollinations.ai/test/chatParameters.test.ts
+++ b/gen.pollinations.ai/test/chatParameters.test.ts
@@ -1,0 +1,190 @@
+import { SELF } from "cloudflare:test";
+import { IMAGE_SERVICES } from "@shared/registry/image.ts";
+import {
+    ModelInfoSchema,
+    modelInfoFromDefinition,
+} from "@shared/registry/model-info.ts";
+import { getVisibleTextModels } from "@shared/registry/registry.ts";
+import { TEXT_SERVICES } from "@shared/registry/text.ts";
+import { describe, expect, it } from "vitest";
+
+// Models that must expose verified Chat parameter metadata. Each covers a
+// different provider/capability combination: OpenAI Chat (Azure, locked
+// sampling), Anthropic via Bedrock Converse (mutually-exclusive sampling
+// params), Gemini via OpenRouter (tool-based web search) and Perplexity
+// (web_search_options). Keep this list to models whose parameter behavior has
+// been verified against the gateway transforms (parameterProcessor +
+// per-model transforms).
+const DOCUMENTED_MODELS = [
+    "openai/gpt-5.4-nano",
+    "anthropic/claude-sonnet-4.6",
+    "google/gemini-3-flash-preview",
+    "perplexity/sonar",
+] as const;
+
+function textModelInfo(name: string) {
+    return modelInfoFromDefinition(name, TEXT_SERVICES[name]);
+}
+
+describe("Chat parameter registry fields", () => {
+    it.each(
+        DOCUMENTED_MODELS,
+    )("%s exposes supported_parameters and default_parameters", (name) => {
+        const info = textModelInfo(name);
+        expect(info.supported_parameters?.length).toBeGreaterThan(0);
+        expect(info.default_parameters).toBeDefined();
+
+        const names = info.supported_parameters?.map((p) => p.name);
+        expect(new Set(names).size).toBe(names.length);
+
+        // Every advertised default must map to an advertised parameter.
+        for (const key of Object.keys(info.default_parameters ?? {})) {
+            expect(names).toContain(key);
+        }
+
+        // Each entry must be schema-valid (round-trip through zod).
+        expect(() => ModelInfoSchema.parse(info)).not.toThrow();
+    });
+
+    it("gpt-5.4-nano omits parameters the gateway strips", () => {
+        const info = textModelInfo("openai/gpt-5.4-nano");
+        const names = info.supported_parameters?.map((p) => p.name);
+        // parameterProcessor strips these for /^gpt-5/ models — listing them
+        // would describe controls that are silently ignored.
+        expect(names).not.toContain("top_p");
+        expect(names).not.toContain("frequency_penalty");
+        expect(names).not.toContain("presence_penalty");
+        // Sampling is locked: temperature is supported but fixed at 1.
+        expect(info.default_parameters).toEqual(
+            expect.objectContaining({ temperature: 1, stream: false }),
+        );
+    });
+
+    it("claude-sonnet-4.6 documents the temperature/top_p mutual exclusion", () => {
+        const info = textModelInfo("anthropic/claude-sonnet-4.6");
+        const topP = info.supported_parameters?.find((p) => p.name === "top_p");
+        expect(topP?.condition).toContain("temperature");
+        const temperature = info.supported_parameters?.find(
+            (p) => p.name === "temperature",
+        );
+        expect(temperature?.condition).toContain("thinking");
+        expect(info.default_parameters).toEqual(
+            expect.objectContaining({ temperature: 1 }),
+        );
+    });
+
+    it("gemini-3-flash-preview exposes tool-based web search", () => {
+        const info = textModelInfo("google/gemini-3-flash-preview");
+        const tools = info.supported_parameters?.find(
+            (p) => p.name === "tools",
+        );
+        expect(tools?.description).toContain("google_search");
+        const effort = info.supported_parameters?.find(
+            (p) => p.name === "reasoning_effort",
+        );
+        expect(effort?.enum).toContain("none");
+    });
+
+    it("sonar exposes web_search_options with its search_context_size contract", () => {
+        const info = textModelInfo("perplexity/sonar");
+        const search = info.supported_parameters?.find(
+            (p) => p.name === "web_search_options",
+        );
+        expect(search?.condition).toContain("low");
+        expect(search?.condition).toContain("high");
+        expect(info.default_parameters).toEqual(
+            expect.objectContaining({ temperature: 0.2 }),
+        );
+    });
+
+    it("models without verified parameter metadata omit both fields", () => {
+        // Text models without verified parameter data must omit both fields.
+        const noMetadata = getVisibleTextModels().filter(
+            (name) => !TEXT_SERVICES[name]?.supportedParameters,
+        );
+        expect(noMetadata.length).toBeGreaterThan(0);
+        const bare = textModelInfo(noMetadata[0]);
+        expect(bare.supported_parameters).toBeUndefined();
+        expect(bare.default_parameters).toBeUndefined();
+
+        // Non-text categories never carry Chat parameters.
+        const imageKeys = Object.keys(IMAGE_SERVICES);
+        expect(imageKeys.length).toBeGreaterThan(0);
+        const imageKey = imageKeys[0];
+        const imageInfo = modelInfoFromDefinition(
+            imageKey,
+            IMAGE_SERVICES[imageKey],
+        );
+        expect(imageInfo.supported_parameters).toBeUndefined();
+        expect(imageInfo.default_parameters).toBeUndefined();
+    });
+
+    it("every visible text model passes the schema when metadata is present", () => {
+        for (const name of getVisibleTextModels()) {
+            const info = textModelInfo(name);
+            if (info.supported_parameters || info.default_parameters) {
+                expect(() => ModelInfoSchema.parse(info)).not.toThrow();
+            }
+        }
+    });
+});
+
+describe("Chat parameter endpoint exposure", () => {
+    async function fetchWorker(path: string, init: RequestInit = {}) {
+        return SELF.fetch(
+            new Request(`https://gen.pollinations.ai${path}`, init),
+        );
+    }
+
+    it("GET /v1/models/:model exposes supported_parameters and default_parameters", async () => {
+        const response = await fetchWorker("/v1/models/gpt-5.4-nano");
+        expect(response.status).toBe(200);
+        const body = (await response.json()) as Record<string, unknown>;
+        expect(body.supported_parameters).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ name: "temperature" }),
+                expect.objectContaining({ name: "max_completion_tokens" }),
+            ]),
+        );
+        expect(body.default_parameters).toEqual(
+            expect.objectContaining({ temperature: 1 }),
+        );
+    });
+
+    it("GET /text/models includes the new fields for documented models", async () => {
+        const response = await fetchWorker("/text/models");
+        expect(response.status).toBe(200);
+        const list = (await response.json()) as {
+            name: string;
+            supported_parameters?: unknown[];
+            default_parameters?: Record<string, unknown>;
+        }[];
+        const nano = list.find((m) => m.name === "openai/gpt-5.4-nano");
+        expect(nano?.supported_parameters?.length).toBeGreaterThan(0);
+        expect(nano?.default_parameters?.temperature).toBe(1);
+
+        const sonar = list.find((m) => m.name === "perplexity/sonar");
+        expect(sonar?.supported_parameters?.length).toBeGreaterThan(0);
+    });
+
+    it("list and retrieve stay consistent for the new fields", async () => {
+        const listResponse = await fetchWorker("/v1/models");
+        const list = (await listResponse.json()) as {
+            data: Record<string, unknown>[];
+        };
+        const listed = list.data.find((m) => m.id === "openai/gpt-5.4-nano");
+        expect(listed).toBeDefined();
+
+        const retrieveResponse = await fetchWorker("/v1/models/gpt-5.4-nano");
+        const retrieved = (await retrieveResponse.json()) as Record<
+            string,
+            unknown
+        >;
+        expect(retrieved.supported_parameters).toEqual(
+            listed?.supported_parameters,
+        );
+        expect(retrieved.default_parameters).toEqual(
+            listed?.default_parameters,
+        );
+    });
+});

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -913,6 +913,31 @@ export type ModelCapability =
     | "code_execution"
     | "pollinations_models";
 
+/** Value types a Chat completion parameter can take. */
+export type ChatParameterType =
+    | "string"
+    | "number"
+    | "integer"
+    | "boolean"
+    | "enum"
+    | "array"
+    | "object";
+
+/**
+ * A Chat completion parameter a model accepts through Pollinations, after
+ * gateway transforms. `condition` documents provider restrictions (e.g. mutual
+ * exclusion, gateway overrides).
+ */
+export interface ChatParameter {
+    name: string;
+    type: ChatParameterType;
+    description?: string;
+    min?: number;
+    max?: number;
+    enum?: Array<string | number>;
+    condition?: string;
+}
+
 /** Model information */
 export interface ModelInfo {
     /** Fields added by the model registry pass through without an SDK release. */
@@ -933,6 +958,8 @@ export interface ModelInfo {
     output_modalities?: ModelOutputModality[];
     video_capabilities?: VideoCapability[];
     resolutions?: string[];
+    supported_parameters?: ChatParameter[];
+    default_parameters?: Record<string, string | number | boolean | null>;
     min_duration?: number;
     max_duration?: number;
     default_duration?: number;

--- a/shared/registry/model-info.ts
+++ b/shared/registry/model-info.ts
@@ -2,8 +2,8 @@ import { z } from "zod";
 import { SAFETY_FEATURES } from "../schemas/safety.ts";
 import { publicPriceInfo, toFixedPoint } from "./public-pricing";
 import {
-    CHAT_PARAMETER_TYPES,
     type BillingAdjustmentRule,
+    CHAT_PARAMETER_TYPES,
     getPriceDefinitionForModel,
     getRegistryModelDefinition,
     getVisibleAudioModels,

--- a/shared/registry/model-info.ts
+++ b/shared/registry/model-info.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { SAFETY_FEATURES } from "../schemas/safety.ts";
 import { publicPriceInfo, toFixedPoint } from "./public-pricing";
 import {
+    CHAT_PARAMETER_TYPES,
     type BillingAdjustmentRule,
     getPriceDefinitionForModel,
     getRegistryModelDefinition,
@@ -19,6 +20,23 @@ import {
     type PriceDefinition,
     VIDEO_CAPABILITIES,
 } from "./registry";
+
+export const ChatParameterSchema = z.object({
+    name: z.string(),
+    type: z.enum(CHAT_PARAMETER_TYPES),
+    description: z.string().optional(),
+    min: z.number().optional(),
+    max: z.number().optional(),
+    enum: z.array(z.union([z.string(), z.number()])).optional(),
+    condition: z.string().optional(),
+});
+
+export type ChatParameterInfo = z.infer<typeof ChatParameterSchema>;
+
+export const ChatDefaultParametersSchema = z.record(
+    z.string(),
+    z.union([z.string(), z.number(), z.boolean(), z.null()]),
+);
 
 export const ModelCapabilitySchema = z.enum([
     "tool_calling",
@@ -92,6 +110,8 @@ export const ModelInfoSchema = z.object({
     output_modalities: z.array(z.enum(MODEL_OUTPUT_MODALITIES)).optional(),
     required_safety: z.array(z.enum(SAFETY_FEATURES)).optional(),
     supported_endpoints: z.array(z.string()).optional(),
+    supported_parameters: z.array(ChatParameterSchema).optional(),
+    default_parameters: ChatDefaultParametersSchema.optional(),
     video_capabilities: z.array(z.enum(VIDEO_CAPABILITIES)).optional(),
     min_duration: z.number().positive().optional(),
     max_duration: z.number().positive().optional(),
@@ -207,6 +227,8 @@ export function modelInfoFromDefinition(
         output_modalities: service.outputModalities,
         required_safety: service.requiredSafetyFeatures,
         supported_endpoints: service.supportedEndpoints,
+        supported_parameters: service.supportedParameters,
+        default_parameters: service.defaultParameters,
         video_capabilities: service.videoCapabilities,
         min_duration: service.minDuration,
         max_duration: service.maxDuration,

--- a/shared/registry/registry.ts
+++ b/shared/registry/registry.ts
@@ -148,6 +148,34 @@ export type BillingAdjustment = {
     price: number;
 };
 
+export const CHAT_PARAMETER_TYPES = [
+    "string",
+    "number",
+    "integer",
+    "boolean",
+    "enum",
+    "array",
+    "object",
+] as const;
+
+export type ChatParameterType = (typeof CHAT_PARAMETER_TYPES)[number];
+
+// A Chat completion parameter a model accepts through Pollinations, after the
+// gateway's provider transforms are applied. Only describe what actually works
+// — omit parameters the gateway strips or the provider silently ignores (e.g.
+// top_p on the GPT-5 series, which is dropped before it reaches the provider).
+// `condition` documents provider-specific restrictions (mutual exclusion,
+// gateway overrides) so consumers know when a listed parameter is honored.
+export type ChatParameter = {
+    name: string;
+    type: ChatParameterType;
+    description?: string;
+    min?: number;
+    max?: number;
+    enum?: Array<string | number>;
+    condition?: string;
+};
+
 export type ModelDefinition = {
     aliases: string[];
     /** Supplier attributed to this route's cost, not its publisher or API protocol.
@@ -228,6 +256,13 @@ export type ModelDefinition = {
     durationStep?: number; // Video-only: duration must be a multiple of this value
     maxReferenceImages?: number; // Models with image input: effective accepted reference images
     maxReferenceVideos?: number; // Models with video input: effective accepted reference videos
+    // Chat completion parameters the model accepts through Pollinations after
+    // gateway transforms. Only describes what works — parameters the gateway
+    // strips or the provider silently ignores must NOT be listed.
+    supportedParameters?: ChatParameter[];
+    // Default values applied when the caller omits the parameter (gateway or
+    // provider defaults). Keys match `supportedParameters` names.
+    defaultParameters?: Record<string, string | number | boolean | null>;
     /** Internal provider-route output-token cap used for fallback compatibility. */
     maxCompletionTokens?: number;
 };

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -61,6 +61,84 @@ const TEXT_BASE_SERVICES = {
         tools: true,
         contextLength: 400000,
         isSpecialized: false,
+        supportedParameters: [
+            {
+                name: "stream",
+                type: "boolean",
+                description: "Whether to stream partial message deltas",
+            },
+            {
+                name: "temperature",
+                type: "number",
+                min: 0,
+                max: 1,
+                description: "Sampling temperature",
+                condition:
+                    "Locked to 1 for the GPT-5 series; the gateway overrides any value sent",
+            },
+            {
+                name: "max_completion_tokens",
+                type: "integer",
+                description: "Maximum number of tokens to generate",
+            },
+            {
+                name: "max_tokens",
+                type: "integer",
+                description: "Alias for max_completion_tokens",
+                condition: "Converted to max_completion_tokens by the gateway",
+            },
+            {
+                name: "stop",
+                type: "array",
+                description: "Up to 4 sequences where the API stops generating",
+            },
+            {
+                name: "response_format",
+                type: "object",
+                description: "Output format: text, json_object, or json_schema",
+            },
+            {
+                name: "tools",
+                type: "array",
+                description: "List of tools the model may call",
+            },
+            {
+                name: "tool_choice",
+                type: "enum",
+                enum: ["none", "auto", "required"],
+                description: "Controls tool-call selection",
+            },
+            {
+                name: "reasoning_effort",
+                type: "enum",
+                enum: ["none", "minimal", "low", "medium", "high"],
+                description: "Reasoning effort for the response",
+            },
+            {
+                name: "seed",
+                type: "integer",
+                description: "Best-effort determinism seed",
+            },
+            {
+                name: "logprobs",
+                type: "boolean",
+                description: "Whether to return log probabilities of output tokens",
+            },
+            {
+                name: "top_logprobs",
+                type: "integer",
+                min: 0,
+                max: 20,
+                description:
+                    "Number of most likely tokens to return at each output position",
+            },
+            {
+                name: "user",
+                type: "string",
+                description: "End-user identifier for abuse monitoring",
+            },
+        ],
+        defaultParameters: { stream: false, temperature: 1 },
     },
     "openai/gpt-5-nano": {
         aliases: ["gpt-5-nano", "gpt-5-nano-2025-08-07", "openai-fast"],
@@ -640,6 +718,57 @@ const TEXT_BASE_SERVICES = {
         search: true,
         contextLength: 1048576,
         isSpecialized: false,
+        supportedParameters: [
+            {
+                name: "stream",
+                type: "boolean",
+                description: "Whether to stream partial message deltas",
+            },
+            {
+                name: "temperature",
+                type: "number",
+                description: "Sampling temperature",
+            },
+            {
+                name: "top_p",
+                type: "number",
+                min: 0,
+                max: 1,
+                description: "Nucleus sampling probability mass",
+            },
+            {
+                name: "max_tokens",
+                type: "integer",
+                description: "Maximum number of tokens to generate",
+                condition:
+                    "max_completion_tokens is accepted and converted to max_tokens by the gateway",
+            },
+            {
+                name: "stop",
+                type: "array",
+                description: "Sequences where the API stops generating",
+            },
+            {
+                name: "tools",
+                type: "array",
+                description:
+                    "List of tools the model may call; include a google_search tool to enable web search",
+            },
+            {
+                name: "tool_choice",
+                type: "enum",
+                enum: ["none", "auto", "required"],
+                description: "Controls tool-call selection",
+            },
+            {
+                name: "reasoning_effort",
+                type: "enum",
+                enum: ["none", "minimal", "low", "medium", "high"],
+                description:
+                    "Reasoning effort; none minimizes Gemini 3 Flash thinking",
+            },
+        ],
+        defaultParameters: { stream: false, temperature: 1 },
     },
     "google/gemini-3.7-flash": {
         aliases: ["gemini-3.6-flash", "gemini-3.5-flash", "gemini"],
@@ -1151,6 +1280,59 @@ const TEXT_BASE_SERVICES = {
         tools: true,
         contextLength: 1000000, // Bedrock global Claude Sonnet 4.6 context window.
         isSpecialized: false,
+        supportedParameters: [
+            {
+                name: "stream",
+                type: "boolean",
+                description: "Whether to stream partial message deltas",
+            },
+            {
+                name: "max_tokens",
+                type: "integer",
+                description: "Maximum number of tokens to generate",
+            },
+            {
+                name: "temperature",
+                type: "number",
+                min: 0,
+                max: 1,
+                description: "Sampling temperature",
+                condition:
+                    "Ignored when thinking is enabled (reasoning_effort not none); top_p is dropped when both are set",
+            },
+            {
+                name: "top_p",
+                type: "number",
+                min: 0,
+                max: 1,
+                description: "Nucleus sampling probability mass",
+                condition:
+                    "Dropped by the gateway when temperature is also set, or when thinking is enabled",
+            },
+            {
+                name: "stop",
+                type: "array",
+                description: "Sequences where the API stops generating",
+            },
+            {
+                name: "tools",
+                type: "array",
+                description: "List of tools the model may call",
+            },
+            {
+                name: "tool_choice",
+                type: "enum",
+                enum: ["none", "auto", "required"],
+                description: "Controls tool-call selection",
+            },
+            {
+                name: "reasoning_effort",
+                type: "enum",
+                enum: ["none", "minimal", "low", "medium", "high"],
+                description: "Maps to Claude extended (adaptive) thinking",
+            },
+        ],
+        defaultParameters: { stream: false, temperature: 1 },
     },
     "anthropic/claude-sonnet-5": {
         aliases: ["sonnet-5", "claude-sonnet-5"],
@@ -1337,6 +1519,43 @@ const TEXT_BASE_SERVICES = {
         searchContextSizes: ["low", "high"],
         contextLength: 128000,
         isSpecialized: false,
+        supportedParameters: [
+            {
+                name: "web_search_options",
+                type: "object",
+                description: "Controls web search behavior",
+                condition:
+                    "search_context_size accepts \"low\" or \"high\"; other values are rejected by the gateway",
+            },
+            {
+                name: "stream",
+                type: "boolean",
+                description: "Whether to stream partial message deltas",
+            },
+            {
+                name: "temperature",
+                type: "number",
+                description: "Sampling temperature",
+            },
+            {
+                name: "top_p",
+                type: "number",
+                min: 0,
+                max: 1,
+                description: "Nucleus sampling probability mass",
+            },
+            {
+                name: "top_k",
+                type: "integer",
+                description: "Limits candidate tokens to the top K",
+            },
+            {
+                name: "max_tokens",
+                type: "integer",
+                description: "Maximum number of tokens to generate",
+            },
+        ],
+        defaultParameters: { stream: false, temperature: 0.2, top_p: 0.9 },
     },
     "perplexity/sonar-pro": {
         aliases: ["sonar-pro", "perplexity-pro", "perplexity"],

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -122,7 +122,8 @@ const TEXT_BASE_SERVICES = {
             {
                 name: "logprobs",
                 type: "boolean",
-                description: "Whether to return log probabilities of output tokens",
+                description:
+                    "Whether to return log probabilities of output tokens",
             },
             {
                 name: "top_logprobs",
@@ -1525,7 +1526,7 @@ const TEXT_BASE_SERVICES = {
                 type: "object",
                 description: "Controls web search behavior",
                 condition:
-                    "search_context_size accepts \"low\" or \"high\"; other values are rejected by the gateway",
+                    'search_context_size accepts "low" or "high"; other values are rejected by the gateway',
             },
             {
                 name: "stream",

--- a/shared/schemas/openai.ts
+++ b/shared/schemas/openai.ts
@@ -2,6 +2,7 @@
 
 import { z } from "zod";
 import { MODEL_CATEGORIES } from "../registry/registry.ts";
+import { ChatParameterSchema, ChatDefaultParametersSchema } from "../registry/model-info.ts";
 import { AUDIO_VOICES, DEFAULT_TEXT_MODEL } from "../registry/text.ts";
 import { SafeSchema } from "./safety.ts";
 
@@ -350,15 +351,7 @@ export const CreateChatCompletionRequestSchema = z
                 "Controls Perplexity Sonar search context. Pollinations currently supports low and high.",
             )
             .optional(),
-        temperature: z
-            .number()
-            .min(0)
-            .max(2)
-            .nullable()
-            .optional()
-            .describe(
-                "Sampling controls are ignored for model families that do not consistently support them, regardless of reasoning mode.",
-            ),
+        temperature: z.number().min(0).max(2).nullable().optional(),
         top_p: z.number().min(0).max(1).nullable().optional(),
         tools: z.array(ChatCompletionToolSchema).optional(),
         tool_choice: ChatCompletionToolChoiceOptionSchema.optional(),
@@ -738,6 +731,8 @@ export const OpenAIModelSchema = z
         input_modalities: z.array(z.string()).optional(),
         output_modalities: z.array(z.string()).optional(),
         supported_endpoints: z.array(z.string()).optional(),
+        supported_parameters: z.array(ChatParameterSchema).optional(),
+        default_parameters: ChatDefaultParametersSchema.optional(),
         agent: z.boolean().optional(),
         base_model: z.string().optional(),
         pricing: z.record(z.string(), z.string()).optional(),

--- a/shared/schemas/openai.ts
+++ b/shared/schemas/openai.ts
@@ -354,7 +354,15 @@ export const CreateChatCompletionRequestSchema = z
                 "Controls Perplexity Sonar search context. Pollinations currently supports low and high.",
             )
             .optional(),
-        temperature: z.number().min(0).max(2).nullable().optional(),
+        temperature: z
+            .number()
+            .min(0)
+            .max(2)
+            .nullable()
+            .optional()
+            .describe(
+                "Sampling controls are ignored for model families that do not consistently support them, regardless of reasoning mode.",
+            ),
         top_p: z.number().min(0).max(1).nullable().optional(),
         tools: z.array(ChatCompletionToolSchema).optional(),
         tool_choice: ChatCompletionToolChoiceOptionSchema.optional(),

--- a/shared/schemas/openai.ts
+++ b/shared/schemas/openai.ts
@@ -1,8 +1,11 @@
 // AI generated based on `https://github.com/Portkey-AI/openapi/blob/master/openapi.yaml` and adaped
 
 import { z } from "zod";
+import {
+    ChatDefaultParametersSchema,
+    ChatParameterSchema,
+} from "../registry/model-info.ts";
 import { MODEL_CATEGORIES } from "../registry/registry.ts";
-import { ChatParameterSchema, ChatDefaultParametersSchema } from "../registry/model-info.ts";
 import { AUDIO_VOICES, DEFAULT_TEXT_MODEL } from "../registry/text.ts";
 import { SafeSchema } from "./safety.ts";
 


### PR DESCRIPTION
Expose `supported_parameters` and `default_parameters` in model listings (registry-backed).

- Add `ChatParameter`/`ChatDefaultParameters` types + schema in the shared registry, and carry both fields through to `/models`, `/text/models`, `/v1/models` and `/v1/models/:model`.
- Document verified parameter metadata for 4 official Chat models with differing capabilities: `openai/gpt-5.4-nano`, `anthropic/claude-sonnet-4.6`, `google/gemini-3-flash-preview`, `perplexity/sonar`. Only parameters that actually work through Pollinations are listed (gateway-stripped ones are omitted; `condition` documents provider restrictions). Chat fields describe Chat-completion behavior, not the native Responses API.
- Update the OpenAI model schema, SDK types, API docs (`models.md`) and the docs-samples response.
- Add focused tests (13) covering registry fields, endpoint exposure, and consistency between list and retrieve.

Fixes #14599, /v1/models/:model, + tes (13 test) dan update docs.