### PR TITLE
feat(models): expose supported and default chat parameters in model listings

### DIFF
--- a/gen.pollinations.ai/src/docs/models.md
+++ b/gen.pollinations.ai/src/docs/models.md
@@ -42,6 +42,36 @@ Supported media models also advertise both endpoints and return generated-file
 links as assistant text. Reference-required models return their normal missing-input
 error; use their native endpoint until attachments are supported here.
 
+### Chat parameter support
+
+`/models`, `/text/models`, and the OpenAI-compatible `/v1/models` endpoints
+expose two optional fields on official Chat models whose support is verified
+against the Pollinations Chat route:
+
+| Field | Meaning |
+|-------|---------|
+| `supported_parameters` | Controls accepted and forwarded by `/v1/chat/completions` for this model |
+| `default_parameters` | Values Pollinations applies when a Chat caller omits the control |
+
+Verified models today: `openai/gpt-5.4`, `openai/gpt-oss-20b`, and
+`anthropic/claude-sonnet-4.6`. Their routes differ (Azure OpenAI, OVHcloud,
+Bedrock), so their controls differ too:
+
+- `openai/gpt-5.4` routes through a transform that drops sampling controls
+  (`temperature`, `top_p`, penalties, `seed`) before dispatch. The request
+  schema still accepts them, but they are silently ignored — so they are not
+  listed.
+- `openai/gpt-oss-20b` passes standard Chat sampling controls through.
+- `anthropic/claude-sonnet-4.6` accepts `temperature` and `top_p` under a
+  condition: they are mutually exclusive, and `temperature` wins.
+  `reasoning_effort` maps onto adaptive thinking.
+
+Both fields describe the Pollinations Chat route only — they do not describe
+the native `/v1/responses` API. Models without an entry (including all
+community models) omit both fields; unknown support is never invented.
+Controls outside `supported_parameters` are not guaranteed: the request
+schema may accept them while the route ignores them.
+
 ## Community Models
 
 Community models use an `owner/model` id and appear in the same discovery responses as Pollinations-operated models. Use `community=true` to return only community models or `community=false` to exclude them.

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -352,6 +352,12 @@ function toOpenAIModelEntry(entry: GenerationModelEntry) {
         }),
         pricing: entry.info.pricing,
         capabilities: entry.info.capabilities,
+        ...(entry.info.supported_parameters && {
+            supported_parameters: entry.info.supported_parameters,
+        }),
+        ...(entry.info.default_parameters && {
+            default_parameters: entry.info.default_parameters,
+        }),
         ...(entry.info.tools && { tools: entry.info.tools }),
         ...(entry.info.reasoning && { reasoning: entry.info.reasoning }),
         ...(entry.info.context_length && {

--- a/gen.pollinations.ai/test/model-parameters.test.ts
+++ b/gen.pollinations.ai/test/model-parameters.test.ts
@@ -1,0 +1,94 @@
+import { SELF } from "cloudflare:test";
+import { test } from "@shared/test/fixtures/index.ts";
+import { expect } from "vitest";
+
+async function fetchWorker(path: string, init: RequestInit = {}) {
+    return SELF.fetch(new Request(`https://gen.pollinations.ai${path}`, init));
+}
+
+type ModelBody = {
+    id?: string;
+    name?: string;
+    supported_parameters?: string[];
+    default_parameters?: Record<string, unknown>;
+};
+
+test("verified models expose chat parameter support on /models", async () => {
+    const response = await fetchWorker("/models");
+    expect(response.status).toBe(200);
+    const models = (await response.json()) as ModelBody[];
+
+    const gpt54 = models.find((m) => m.name === "openai/gpt-5.4");
+    expect(gpt54?.supported_parameters).toContain("max_completion_tokens");
+    // Sampling controls are silently dropped by the route's transform.
+    expect(gpt54?.supported_parameters).not.toContain("temperature");
+    expect(gpt54?.supported_parameters).not.toContain("top_p");
+    expect(gpt54?.supported_parameters).not.toContain("seed");
+    expect(gpt54?.default_parameters).toMatchObject({
+        stream: false,
+        parallel_tool_calls: true,
+    });
+
+    const oss = models.find((m) => m.name === "openai/gpt-oss-20b");
+    expect(oss?.supported_parameters).toEqual(
+        expect.arrayContaining([
+            "temperature",
+            "top_p",
+            "seed",
+            "reasoning_effort",
+        ]),
+    );
+    // gpt-oss model-card documented sampling defaults.
+    expect(oss?.default_parameters).toMatchObject({
+        temperature: 1,
+        top_p: 1,
+    });
+
+    const claude = models.find((m) => m.name === "anthropic/claude-sonnet-4.6");
+    expect(claude?.supported_parameters).toEqual(
+        expect.arrayContaining(["temperature", "top_p", "reasoning_effort"]),
+    );
+    // Controls without a Bedrock Converse equivalent stay unlisted.
+    expect(claude?.supported_parameters).not.toContain("seed");
+    expect(claude?.supported_parameters).not.toContain("frequency_penalty");
+});
+
+test("/text/models carries the same parameter metadata", async () => {
+    const response = await fetchWorker("/text/models");
+    expect(response.status).toBe(200);
+    const models = (await response.json()) as ModelBody[];
+    const gpt54 = models.find((m) => m.name === "openai/gpt-5.4");
+    expect(gpt54?.supported_parameters).toContain("reasoning_effort");
+    const oss = models.find((m) => m.name === "openai/gpt-oss-20b");
+    expect(oss?.supported_parameters).toContain("temperature");
+});
+
+test("/v1/models and alias lookup share identical parameter metadata", async () => {
+    const listed = await fetchWorker("/v1/models");
+    expect(listed.status).toBe(200);
+    const list = (await listed.json()) as { data: ModelBody[] };
+    const listedEntry = list.data.find((m) => m.id === "openai/gpt-5.4");
+    expect(listedEntry?.supported_parameters).toContain("reasoning_effort");
+    expect(listedEntry?.supported_parameters).not.toContain("temperature");
+
+    const viaAlias = await fetchWorker("/v1/models/gpt-5.4");
+    expect(viaAlias.status).toBe(200);
+    const aliasBody = (await viaAlias.json()) as ModelBody;
+    expect(aliasBody.id).toBe("openai/gpt-5.4");
+    expect(aliasBody.supported_parameters).toEqual(
+        listedEntry?.supported_parameters,
+    );
+    expect(aliasBody.default_parameters).toEqual(
+        listedEntry?.default_parameters,
+    );
+});
+
+test("models without verified support omit the fields entirely", async () => {
+    const response = await fetchWorker("/text/models");
+    expect(response.status).toBe(200);
+    const models = (await response.json()) as ModelBody[];
+    const unverified = models.find((m) => m.name === "qwen/qwen3.8-max");
+    expect(unverified).toBeDefined();
+    expect(unverified?.supported_parameters).toBeUndefined();
+    expect(unverified?.default_parameters).toBeUndefined();
+});

--- a/shared/registry/model-info.ts
+++ b/shared/registry/model-info.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { SAFETY_FEATURES } from "../schemas/safety.ts";
+import { getChatParameterSupport } from "./parameter-support.ts";
 import { publicPriceInfo, toFixedPoint } from "./public-pricing";
 import {
     type BillingAdjustmentRule,
@@ -101,6 +102,18 @@ export const ModelInfoSchema = z.object({
     max_reference_images: z.number().int().positive().optional(),
     max_reference_videos: z.number().int().positive().optional(),
     capabilities: z.array(ModelCapabilitySchema),
+    supported_parameters: z
+        .array(z.string())
+        .optional()
+        .describe(
+            "Controls accepted and forwarded by the Pollinations Chat route (`/v1/chat/completions`) for this model, verified against the route's transforms. Omitted when unknown — absence does not imply rejection. Not applicable to the native `/v1/responses` API.",
+        ),
+    default_parameters: z
+        .record(z.string(), z.union([z.string(), z.number(), z.boolean()]))
+        .optional()
+        .describe(
+            "Values Pollinations applies when a Chat caller omits the control. Not applicable to the native `/v1/responses` API.",
+        ),
     tools: z.boolean().optional(),
     reasoning: z.boolean().optional(),
     context_length: z.number().optional(),
@@ -218,6 +231,9 @@ export function modelInfoFromDefinition(
         max_reference_images: service.maxReferenceImages,
         max_reference_videos: service.maxReferenceVideos,
         capabilities: getCapabilities(service),
+        supported_parameters:
+            getChatParameterSupport(name)?.supportedParameters,
+        default_parameters: getChatParameterSupport(name)?.defaultParameters,
         tools: service.tools,
         reasoning: service.reasoning,
         context_length: service.contextLength,

--- a/shared/registry/parameter-support.ts
+++ b/shared/registry/parameter-support.ts
@@ -1,0 +1,99 @@
+// Chat-route parameter support for official text models.
+//
+// Everything here is route-level truth for `/v1/chat/completions` on the
+// Pollinations gateway: entries record which request controls survive the
+// model's transform chain and are forwarded upstream, verified against
+// `gen.pollinations.ai/src/text/availableModels.ts` (transforms that silently
+// drop controls) and `gen.pollinations.ai/src/text/configs/modelConfigs.ts`.
+// Controls not listed are not guaranteed: the request schema may accept them
+// while the route silently ignores them.
+//
+// This is discovery metadata for the Chat route only. It does not describe
+// the native `/v1/responses` API. Models without an entry (including all
+// community models) omit `supported_parameters` / `default_parameters` —
+// unknown support is never invented.
+
+export type ChatParameterSupport = {
+    /** Controls accepted and forwarded for this model's Chat route. */
+    supportedParameters: string[];
+    /** Values Pollinations applies when a Chat caller omits the control. */
+    defaultParameters: Record<string, string | number | boolean>;
+};
+
+const support: Record<string, ChatParameterSupport> = {
+    // Azure OpenAI route: the omitOpenAISampling transform drops sampling
+    // controls (temperature, top_p, penalties, seed) before dispatch, so they
+    // are accepted by the request schema but silently ignored.
+    "openai/gpt-5.4": {
+        supportedParameters: [
+            "stream",
+            "max_tokens",
+            "max_completion_tokens",
+            "reasoning_effort",
+            "response_format",
+            "stop",
+            "tools",
+            "tool_choice",
+            "parallel_tool_calls",
+        ],
+        defaultParameters: {
+            stream: false,
+            parallel_tool_calls: true,
+        },
+    },
+    // OVHcloud OpenAI-compatible route: no transform strips controls, so the
+    // standard Chat sampling controls pass through to the model.
+    "openai/gpt-oss-20b": {
+        supportedParameters: [
+            "stream",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "frequency_penalty",
+            "presence_penalty",
+            "repetition_penalty",
+            "seed",
+            "reasoning_effort",
+            "response_format",
+            "stop",
+            "tools",
+            "tool_choice",
+            "parallel_tool_calls",
+        ],
+        // OpenAI documents the gpt-oss family sampling defaults as
+        // temperature=1.0 / top_p=1.0; reasoning effort is configurable but
+        // Pollinations injects no value when the caller omits it.
+        defaultParameters: {
+            temperature: 1,
+            top_p: 1,
+            stream: false,
+            parallel_tool_calls: true,
+        },
+    },
+    // Bedrock Converse route: temperature and top_p are mutually exclusive
+    // (preferTemperature drops top_p when temperature is set); reasoning_effort
+    // maps onto adaptive thinking. Penalties, seed, and parallel_tool_calls are
+    // not advertised because the native route has no equivalent controls.
+    "anthropic/claude-sonnet-4.6": {
+        supportedParameters: [
+            "stream",
+            "max_tokens",
+            "max_completion_tokens",
+            "temperature",
+            "top_p",
+            "reasoning_effort",
+            "tools",
+            "tool_choice",
+        ],
+        defaultParameters: {
+            stream: false,
+        },
+    },
+};
+
+/** Chat-route parameter metadata for one model, or undefined when unknown. */
+export function getChatParameterSupport(
+    modelName: string,
+): ChatParameterSupport | undefined {
+    return support[modelName];
+}

--- a/shared/schemas/openai.ts
+++ b/shared/schemas/openai.ts
@@ -742,6 +742,18 @@ export const OpenAIModelSchema = z
         base_model: z.string().optional(),
         pricing: z.record(z.string(), z.string()).optional(),
         capabilities: z.array(z.string()).optional(),
+        supported_parameters: z
+            .array(z.string())
+            .optional()
+            .describe(
+                "Controls accepted and forwarded by the Pollinations Chat route (`/v1/chat/completions`). Omitted when unknown. Not applicable to the native `/v1/responses` API.",
+            ),
+        default_parameters: z
+            .record(z.string(), z.union([z.string(), z.number(), z.boolean()]))
+            .optional()
+            .describe(
+                "Values Pollinations applies when a Chat caller omits the control. Not applicable to the native `/v1/responses` API.",
+            ),
         tools: z.boolean().optional(),
         reasoning: z.boolean().optional(),
         context_length: z.number().optional(),


### PR DESCRIPTION
## Summary

Model discovery now exposes **`supported_parameters`** and **`default_parameters`** for official Chat models whose support is verified against the Pollinations route — so apps can show real settings instead of guessing.

- New `shared/registry/parameter-support.ts`: a static, route-level truth table. Entries record which `/v1/chat/completions` controls survive the model's transform chain (cross-checked against `availableModels.ts` and `configs/modelConfigs.ts`), plus gateway-applied defaults.
- Wired into `/models` + `/text/models` via `ModelInfoSchema` and into `/v1/models` (list + retrieve) via the shared OpenAI mapper, so metadata is consistent across listings and aliases resolve identically.
- Three verified official Chat models with genuinely different routes:
  - `openai/gpt-5.4` (Azure): sampling controls (`temperature`, `top_p`, penalties, `seed`) are accepted by the request schema but silently dropped by the route transform — **not listed**, documenting conditional/ignored support honestly.
  - `openai/gpt-oss-20b` (OVHcloud): full standard sampling set passes through; defaults `temperature=1.0` / `top_p=1.0` per the OpenAI model card.
  - `anthropic/claude-sonnet-4.6` (Bedrock): `temperature` and `top_p` are conditionally supported (mutually exclusive, temperature wins); no seed/penalty equivalents exist, so they stay unlisted.
- Both fields describe the Pollinations Chat route only, never the native `/v1/responses` API. Models without a verified entry (including all community models) omit both fields — unknown support is never invented.
- Documentation section in `models.md` covering scope, verified models, and the mutual-exclusion caveat; 4 new focused tests (rich list, text list, OpenAI list + alias equivalence, omission for unverified models).

Information-only change: no generation behavior, billing, or access rules touched.

## Testing

- `tsc --noEmit` clean; `docs:generate` + `docs:validate` pass.
- Full `vitest run`: 1984 passed / 1 flaky pre-existing timeout (`community-endpoints.test.ts` account-API fixture, re-run in isolation → 142/142 pass).
- New `test/model-parameters.test.ts` covers: Azure model omits silently-dropped sampling controls, gpt-oss passthrough + model-card defaults, Claude conditional sampling, identical metadata across `/v1/models`, alias retrieve, and full omission for unverified models.

Fixes #14599
