### PR TITLE
fix: require Paid Pollen and canonical ID for Asset Harvester

### DIFF
--- a/gen.pollinations.ai/src/docs/3d-generation.md
+++ b/gen.pollinations.ai/src/docs/3d-generation.md
@@ -9,12 +9,12 @@ https://gen.pollinations.ai/3d/no_prompt_for_trellis_needed?model=microsoft%2Ftr
 
 **Available models:** {{3D_MODELS}}
 
-> **Note:** `hyper3d/rodin-2.5` requires Paid Pollen. `microsoft/trellis-2` (the default)
+> **Note:** `hyper3d/rodin-2.5` and `nvidia/asset-harvester` require Paid Pollen. `microsoft/trellis-2` (the default)
 > supports `low`, `medium`, and `high` resolution and works with Quest Pollen.
 
 ### NVIDIA Asset Harvester
 
-`nvidia/asset-harvester` (alias: `asset-harvester`) generates 3D Gaussian Splat
+`nvidia/asset-harvester` generates 3D Gaussian Splat
 models in PLY format. Unlike other 3D models that return GLB, Asset Harvester
 returns raw PLY binary suitable for real-time rendering in Gaussian Splat
 viewers (e.g. SuperSplat, Three.js with Gaussian PLY loader).

--- a/shared/registry/model3d.ts
+++ b/shared/registry/model3d.ts
@@ -61,6 +61,7 @@ const MODEL3D_BASE_SERVICES = {
         category: "3d",
         addedDate: new Date("2026-09-07").getTime(),
         priceMultiplier: 1,
+        paidOnly: true,
         flatRate: true,
         cost: {
             completionImageTokens: 0.07,

--- a/shared/registry/model3d.ts
+++ b/shared/registry/model3d.ts
@@ -55,7 +55,7 @@ const MODEL3D_BASE_SERVICES = {
         resolutions: ["low", "medium", "high"],
     },
     "nvidia/asset-harvester": {
-        aliases: ["asset-harvester"],
+        aliases: [],
         publisher: "NVIDIA",
         provider: "inferenceport",
         category: "3d",


### PR DESCRIPTION
- Require Paid Pollen for `nvidia/asset-harvester` and remove the public `asset-harvester` alias. Clients must use the full canonical ID; the short name is rejected.
- Keep the InferencePort upstream model `asset-harvester`, cost of 0.07 Pollen per generation, and multiplier 1. No provider fallback or Pollinations-operated GPU.
- Update the 3D documentation to show only the canonical name and its Paid Pollen requirement.
- Verified: 22 focused model/catalog tests, Gen typecheck and Biome pass. Direct registry and GET/POST schema checks accept the canonical ID and reject the removed alias. The existing paid-only access checks remain applicable.
- Follow-up to #14556. Independent of polling-retry PR #14626. Not deployed.
