### PR TITLE
feat: expose supported/default Chat parameters in model listings

### DIFF
--- a/gen.pollinations.ai/src/docs/models.md
+++ b/gen.pollinations.ai/src/docs/models.md
@@ -42,6 +42,17 @@ Supported media models also advertise both endpoints and return generated-file
 links as assistant text. Reference-required models return their normal missing-input
 error; use their native endpoint until attachments are supported here.
 
+`supported_parameters` and `default_parameters` let apps discover which
+Chat-completions controls a text model accepts and their defaults, backed by
+the model registry. `supported_parameters` lists parameters that actually reach
+the provider after Pollinations' gateway transforms — controls the gateway
+strips (for example, sampling parameters on models that do not accept them) or
+that the provider silently ignores are never listed. Each entry may carry a
+`condition` documenting gateway conversion, mutual exclusion, or provider-side
+caps. `default_parameters` lists values Pollinations applies when the caller
+omits the parameter. These fields describe Chat-Completions behaviour only and
+do not imply anything about a model's native `/v1/responses` contract.
+
 ## Community Models
 
 Community models use an `owner/model` id and appear in the same discovery responses as Pollinations-operated models. Use `community=true` to return only community models or `community=false` to exclude them.

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -360,6 +360,12 @@ function toOpenAIModelEntry(entry: GenerationModelEntry) {
         ...(entry.info.per_user_rpm !== undefined && {
             per_user_rpm: entry.info.per_user_rpm,
         }),
+        ...(entry.info.supported_parameters && {
+            supported_parameters: entry.info.supported_parameters,
+        }),
+        ...(entry.info.default_parameters && {
+            default_parameters: entry.info.default_parameters,
+        }),
     };
 }
 

--- a/gen.pollinations.ai/test/chatParameters.test.ts
+++ b/gen.pollinations.ai/test/chatParameters.test.ts
@@ -1,0 +1,112 @@
+import { SELF } from "cloudflare:test";
+import {
+    getAudioModelsInfo,
+    getImageModelsInfo,
+    ModelInfoSchema,
+    modelInfoFromDefinition,
+} from "@shared/registry/model-info.ts";
+import { getRegistryModelDefinition } from "@shared/registry/registry.ts";
+import { test } from "@shared/test/fixtures/index.ts";
+import { expect } from "vitest";
+
+async function fetchWorker(path: string, init: RequestInit = {}) {
+    return SELF.fetch(new Request(`https://gen.pollinations.ai${path}`, init));
+}
+
+test("modelInfoFromDefinition round-trips supported/default parameters", () => {
+    const definition = getRegistryModelDefinition("openai/gpt-5.4-nano");
+    expect(definition.supportedParameters?.length).toBeGreaterThan(0);
+
+    const info = modelInfoFromDefinition("openai/gpt-5.4-nano", definition);
+    // Round-trips through the schema unmodified.
+    const parsed = ModelInfoSchema.parse(info);
+    expect(parsed.supported_parameters).toEqual(definition.supportedParameters);
+    expect(parsed.default_parameters).toEqual(definition.defaultParameters);
+});
+
+test("supported/default parameters are omitted when a text model sets none", () => {
+    // A text model with no declared parameters must not expose the fields.
+    const info = modelInfoFromDefinition(
+        "perplexity/sonar",
+        getRegistryModelDefinition("perplexity/sonar"),
+    );
+    expect(info.supported_parameters).toBeUndefined();
+    expect(info.default_parameters).toBeUndefined();
+});
+
+test("non-text model listings never include supported/default parameters", () => {
+    // Even if a non-text definition hypothetically set these, model-info
+    // must not surface them (Chat-completion params don't apply there).
+    for (const info of getImageModelsInfo()) {
+        expect(info.supported_parameters).toBeUndefined();
+        expect(info.default_parameters).toBeUndefined();
+    }
+    for (const info of getAudioModelsInfo()) {
+        expect(info.supported_parameters).toBeUndefined();
+        expect(info.default_parameters).toBeUndefined();
+    }
+});
+
+test("openai/gpt-5.4-nano exposes declared parameters and omits stripped sampling", async () => {
+    const response = await fetchWorker("/v1/models/openai");
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+        supported_parameters?: Array<{ name: string }>;
+        default_parameters?: Record<string, unknown>;
+    };
+    expect(Array.isArray(body.supported_parameters)).toBe(true);
+    const names = (body.supported_parameters ?? []).map((p) => p.name);
+
+    // Parameters that actually survive the transform pipeline.
+    expect(names).toEqual(
+        expect.arrayContaining([
+            "max_completion_tokens",
+            "reasoning_effort",
+            "stream",
+            "tools",
+            "response_format",
+        ]),
+    );
+    // Regression guard against PR #14623: temperature and the other sampling
+    // controls are stripped by omitOpenAISampling, not "supported" or "locked
+    // to 1" — they must never appear.
+    for (const stripped of [
+        "temperature",
+        "top_p",
+        "top_k",
+        "frequency_penalty",
+        "presence_penalty",
+        "repetition_penalty",
+        "seed",
+    ]) {
+        expect(names).not.toContain(stripped);
+    }
+});
+
+test("claude-sonnet-5 exposes its default max_tokens and omits stripped sampling", () => {
+    // claude-sonnet-5 is paid-only, so exercise the registry-derived info
+    // directly instead of a live (possibly 404) request.
+    const definition = getRegistryModelDefinition("anthropic/claude-sonnet-5");
+    const info = modelInfoFromDefinition(
+        "anthropic/claude-sonnet-5",
+        definition,
+    );
+    const names = (info.supported_parameters ?? []).map((p) => p.name);
+    expect(info.default_parameters).toEqual({ max_tokens: 64000 });
+    expect(names).toContain("reasoning_effort");
+    // Stripped by omitClaudeSampling.
+    for (const stripped of ["temperature", "top_p", "top_k"]) {
+        expect(names).not.toContain(stripped);
+    }
+});
+
+test("grok-4.6 exposes supported sampling parameters", () => {
+    const definition = getRegistryModelDefinition("x-ai/grok-4.6");
+    const info = modelInfoFromDefinition("x-ai/grok-4.6", definition);
+    const names = (info.supported_parameters ?? []).map((p) => p.name);
+    // No sampling-omit transform is applied to grok-4.6, so temperature and
+    // top_p pass straight through.
+    expect(names).toEqual(
+        expect.arrayContaining(["temperature", "top_p", "reasoning_effort"]),
+    );
+});

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -954,6 +954,22 @@ export interface ModelInfo {
     is_specialized?: boolean;
     paid_only?: boolean;
     pricing?: Record<string, string> & { currency: "pollen" };
+    /** Chat-Completions parameters this model accepts (text models only). */
+    supported_parameters?: ChatParameterInfo[];
+    /** Default values applied when a parameter is omitted (text models only). */
+    default_parameters?: Record<string, string | number | boolean | null>;
+}
+
+/** Describes one Chat-Completions parameter a text model accepts. */
+export interface ChatParameterInfo {
+    name: string;
+    type: "string" | "number" | "boolean" | "integer";
+    description?: string;
+    min?: number;
+    max?: number;
+    enum?: string[];
+    /** Documents conditional behaviour (gateway conversion, provider caps, etc.). */
+    condition?: string;
 }
 
 // ============================================================================

--- a/shared/registry/model-info.ts
+++ b/shared/registry/model-info.ts
@@ -3,6 +3,7 @@ import { SAFETY_FEATURES } from "../schemas/safety.ts";
 import { publicPriceInfo, toFixedPoint } from "./public-pricing";
 import {
     type BillingAdjustmentRule,
+    CHAT_PARAMETER_TYPES,
     getPriceDefinitionForModel,
     getRegistryModelDefinition,
     getVisibleAudioModels,
@@ -29,6 +30,16 @@ export const ModelCapabilitySchema = z.enum([
 ]);
 
 export type ModelCapability = z.infer<typeof ModelCapabilitySchema>;
+
+const ChatParameterSchema = z.object({
+    name: z.string(),
+    type: z.enum(CHAT_PARAMETER_TYPES),
+    description: z.string().optional(),
+    min: z.number().optional(),
+    max: z.number().optional(),
+    enum: z.array(z.string()).optional(),
+    condition: z.string().optional(),
+});
 
 // Pricing uses registry field names directly, filtering out zero/undefined values
 // Fields: promptTextTokens, promptCachedTokens, promptCacheWriteTokens,
@@ -119,6 +130,13 @@ export const ModelInfoSchema = z.object({
     alpha: z.boolean().optional(),
     flat_rate: z.boolean().optional(),
     added_date: z.number().optional(),
+    supported_parameters: z.array(ChatParameterSchema).optional(),
+    default_parameters: z
+        .record(
+            z.string(),
+            z.union([z.string(), z.number(), z.boolean(), z.null()]),
+        )
+        .optional(),
 });
 
 export type ModelInfo = z.infer<typeof ModelInfoSchema>;
@@ -231,6 +249,12 @@ export function modelInfoFromDefinition(
                 ? service.cost.promptTextTokens === undefined
                 : undefined),
         added_date: service.addedDate,
+        supported_parameters:
+            service.category === "text"
+                ? service.supportedParameters
+                : undefined,
+        default_parameters:
+            service.category === "text" ? service.defaultParameters : undefined,
     };
 }
 

--- a/shared/registry/registry.ts
+++ b/shared/registry/registry.ts
@@ -114,6 +114,32 @@ export const VIDEO_CAPABILITIES = [
 
 export type VideoCapability = (typeof VIDEO_CAPABILITIES)[number];
 
+/**
+ * Describes a Chat-Completions parameter a model actually honors after the
+ * Pollinations gateway transform pipeline.  Only include parameters that
+ * survive the model's transforms in `availableModels.ts` and reach the
+ * provider — never parameters the gateway strips or the provider silently
+ * ignores.  This metadata is Chat-Completions-specific and does not imply
+ * anything about the native `/v1/responses` contract.
+ */
+export type ChatParameter = {
+    name: string;
+    type: "string" | "number" | "boolean" | "integer";
+    description?: string;
+    min?: number;
+    max?: number;
+    enum?: string[];
+    /** Documents conditional behaviour (e.g. mutual exclusion, gateway conversion, provider-side caps). */
+    condition?: string;
+};
+
+export const CHAT_PARAMETER_TYPES = [
+    "string",
+    "number",
+    "boolean",
+    "integer",
+] as const;
+
 export type BillingAdjustmentRule = BillingRateDefinition & {
     // Counts billable units from the response output (stream outputs carry a
     // `streamEvents` array). Returning 0 skips the rule for this request.
@@ -230,6 +256,18 @@ export type ModelDefinition = {
     maxReferenceVideos?: number; // Models with video input: effective accepted reference videos
     /** Internal provider-route output-token cap used for fallback compatibility. */
     maxCompletionTokens?: number;
+    /**
+     * Chat-Completions parameters this model actually accepts after gateway
+     * transforms.  Only text-category models should populate this; it must
+     * stay `undefined` for image/audio/video/3d/embedding/realtime models.
+     */
+    supportedParameters?: ChatParameter[];
+    /**
+     * Default values Pollinations applies when the caller omits a parameter.
+     * Only populate for values the gateway explicitly sets (e.g. via provider
+     * config `defaultOptions`), never for unknown provider-side defaults.
+     */
+    defaultParameters?: Record<string, string | number | boolean | null>;
 };
 
 // Helper: Convert usage counts to rated USD-equivalent cost or Pollen charge.

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -16,7 +16,7 @@ import {
     PERPLEXITY_SONAR_BILLING,
 } from "./perplexity-billing";
 import { perMillion } from "./price-helpers";
-import type { ModelDefinition } from "./registry";
+import type { ChatParameter, ModelDefinition } from "./registry";
 import { TEXT_FALLBACKS } from "./text-fallbacks";
 
 // Voices available for openai-audio model - exported for schema validation
@@ -38,6 +38,199 @@ export const AUDIO_VOICES = [
 
 export const DEFAULT_TEXT_MODEL = "openai/gpt-5.4-nano" as const;
 export type TextModelName = keyof typeof TEXT_SERVICES;
+
+// Chat-Completions parameters that actually reach the provider for GPT-5-family
+// models. `omitOpenAISampling` in availableModels.ts strips
+// temperature/top_p/top_k/frequency_penalty/presence_penalty/repetition_penalty/
+// seed before the request leaves the gateway, so those are deliberately absent.
+// Only documentary metadata — generation behaviour is unchanged.
+const gpt5FamilySamplingOmittedParameters: ChatParameter[] = [
+    {
+        name: "reasoning_effort",
+        type: "string",
+        enum: ["none", "minimal", "low", "medium", "high", "xhigh", "max"],
+        description:
+            "Reasoning depth. Passed through unchanged; the provider chooses the effort.",
+    },
+    {
+        name: "max_completion_tokens",
+        type: "integer",
+        min: 0,
+        description: "Maximum number of output tokens.",
+    },
+    {
+        name: "max_tokens",
+        type: "integer",
+        min: 0,
+        condition:
+            "Alias converted to max_completion_tokens before reaching the provider.",
+        description: "Alternative way to set the maximum output tokens.",
+    },
+    {
+        name: "stream",
+        type: "boolean",
+        description: "Stream the response (adds a usage chunk).",
+    },
+    {
+        name: "tools",
+        type: "string",
+        condition: "Requires tool_calling capability.",
+        description: "Function tools the model may call.",
+    },
+    {
+        name: "tool_choice",
+        type: "string",
+        enum: ["none", "auto", "required"],
+        condition: "Requires tool_calling capability.",
+        description: "Whether and which tool to call.",
+    },
+    {
+        name: "response_format",
+        type: "string",
+        condition: "JSON mode or structured output.",
+        description: "Requested output format (text or JSON).",
+    },
+    {
+        name: "stop",
+        type: "string",
+        description: "Stop sequences that end generation.",
+    },
+    {
+        name: "user",
+        type: "string",
+        description: "End-user identifier for abuse tracking.",
+    },
+];
+
+const grok46Parameters: ChatParameter[] = [
+    {
+        name: "temperature",
+        type: "number",
+        min: 0,
+        max: 2,
+        description: "Sampling temperature for output randomness.",
+    },
+    {
+        name: "top_p",
+        type: "number",
+        min: 0,
+        max: 1,
+        description: "Nucleus sampling probability mass.",
+    },
+    {
+        name: "reasoning_effort",
+        type: "string",
+        enum: ["none", "minimal", "low", "medium", "high", "xhigh", "max"],
+        description:
+            "Reasoning depth. Passed through unchanged; the provider chooses the effort.",
+    },
+    {
+        name: "max_tokens",
+        type: "integer",
+        min: 0,
+        description: "Maximum number of output tokens.",
+    },
+    {
+        name: "max_completion_tokens",
+        type: "integer",
+        min: 0,
+        condition: "Converted to max_tokens before reaching the provider.",
+        description: "Alternative way to set the maximum output tokens.",
+    },
+    {
+        name: "stream",
+        type: "boolean",
+        description: "Stream the response.",
+    },
+    {
+        name: "tools",
+        type: "string",
+        condition: "Requires tool_calling capability.",
+        description: "Function tools the model may call.",
+    },
+    {
+        name: "tool_choice",
+        type: "string",
+        enum: ["none", "auto", "required"],
+        condition: "Requires tool_calling capability.",
+        description: "Whether and which tool to call.",
+    },
+    {
+        name: "response_format",
+        type: "string",
+        condition: "JSON mode or structured output.",
+        description: "Requested output format (text or JSON).",
+    },
+    {
+        name: "stop",
+        type: "string",
+        description: "Stop sequences that end generation.",
+    },
+    {
+        name: "seed",
+        type: "integer",
+        min: -1,
+        description: "Seed for reproducible generation.",
+    },
+];
+
+const claudeSonnet5Parameters: ChatParameter[] = [
+    {
+        name: "reasoning_effort",
+        type: "string",
+        enum: ["none", "minimal", "low", "medium", "high", "xhigh"],
+        condition:
+            "Maps to Claude adaptive thinking output_config.effort; xhigh normalizes to high.",
+        description: "Reasoning depth via extended thinking.",
+    },
+    {
+        name: "max_tokens",
+        type: "integer",
+        min: 0,
+        description: "Maximum number of output tokens.",
+    },
+    {
+        name: "max_completion_tokens",
+        type: "integer",
+        min: 0,
+        condition: "Converted to max_tokens before reaching the provider.",
+        description: "Alternative way to set the maximum output tokens.",
+    },
+    {
+        name: "stream",
+        type: "boolean",
+        description: "Stream the response.",
+    },
+    {
+        name: "tools",
+        type: "string",
+        condition: "Requires tool_calling capability.",
+        description: "Function tools the model may call.",
+    },
+    {
+        name: "tool_choice",
+        type: "string",
+        enum: ["none", "auto", "required"],
+        condition: "Requires tool_calling capability.",
+        description: "Whether and which tool to call.",
+    },
+    {
+        name: "response_format",
+        type: "string",
+        condition: "JSON mode or structured output.",
+        description: "Requested output format (text or JSON).",
+    },
+    {
+        name: "stop",
+        type: "string",
+        description: "Stop sequences that end generation.",
+    },
+    {
+        name: "user",
+        type: "string",
+        description: "End-user identifier.",
+    },
+];
 
 const TEXT_BASE_SERVICES = {
     "openai/gpt-5.4-nano": {
@@ -61,6 +254,7 @@ const TEXT_BASE_SERVICES = {
         tools: true,
         contextLength: 400000,
         isSpecialized: false,
+        supportedParameters: gpt5FamilySamplingOmittedParameters,
     },
     "openai/gpt-5-nano": {
         aliases: ["gpt-5-nano", "gpt-5-nano-2025-08-07", "openai-fast"],
@@ -1002,6 +1196,7 @@ const TEXT_BASE_SERVICES = {
         // Azure's Global Standard deployment is capped at 200K context.
         contextLength: 200000,
         isSpecialized: false,
+        supportedParameters: grok46Parameters,
     },
     "google/gemini-2.5-flash-lite:search": {
         aliases: [
@@ -1176,6 +1371,11 @@ const TEXT_BASE_SERVICES = {
         tools: true,
         contextLength: 1000000, // Bedrock Claude Sonnet 5 context window.
         isSpecialized: false,
+        supportedParameters: claudeSonnet5Parameters,
+        // The Bedrock native config injects max_tokens: 64000 when the caller
+        // omits it (modelConfigs.ts "claude-sonnet-5"), so this is a real
+        // gateway-applied default.
+        defaultParameters: { max_tokens: 64000 },
     },
     "anthropic/claude-opus-4.6": {
         aliases: ["claude-opus-4.5", "claude-opus-4.6"],

--- a/shared/schemas/openai.ts
+++ b/shared/schemas/openai.ts
@@ -1,7 +1,10 @@
 // AI generated based on `https://github.com/Portkey-AI/openapi/blob/master/openapi.yaml` and adaped
 
 import { z } from "zod";
-import { MODEL_CATEGORIES } from "../registry/registry.ts";
+import {
+    CHAT_PARAMETER_TYPES,
+    MODEL_CATEGORIES,
+} from "../registry/registry.ts";
 import { AUDIO_VOICES, DEFAULT_TEXT_MODEL } from "../registry/text.ts";
 import { SafeSchema } from "./safety.ts";
 
@@ -302,6 +305,17 @@ const ChatCompletionStreamOptionsSchema = z
     })
     .nullable()
     .optional();
+
+// Shared with the registry ChatParameter shape, exposed on model listings.
+const ChatParameterSchema = z.object({
+    name: z.string(),
+    type: z.enum(CHAT_PARAMETER_TYPES),
+    description: z.string().optional(),
+    min: z.number().optional(),
+    max: z.number().optional(),
+    enum: z.array(z.string()).optional(),
+    condition: z.string().optional(),
+});
 
 export const CreateChatCompletionRequestSchema = z
     .object({
@@ -746,6 +760,13 @@ export const OpenAIModelSchema = z
         reasoning: z.boolean().optional(),
         context_length: z.number().optional(),
         per_user_rpm: z.number().positive().nullable().optional(),
+        supported_parameters: z.array(ChatParameterSchema).optional(),
+        default_parameters: z
+            .record(
+                z.string(),
+                z.union([z.string(), z.number(), z.boolean(), z.null()]),
+            )
+            .optional(),
     })
     .meta({
         description: "OpenAI-compatible model object with capability metadata",


### PR DESCRIPTION
- Adds `supported_parameters` and `default_parameters` to text model listings (`/v1/models/*`, registry-driven) so apps can discover which Chat-completions controls a model accepts and their gateway-applied defaults.
- Exposes on the shared registry `ModelDefinition`, the `ModelInfoSchema`/`OpenAIModelSchema`, the `/models` proxy route, and the SDK `ModelInfo` type. Only text-category models surface these fields.
- Documents accuracy rule: a parameter is listed only if it actually survives the model's gateway transform pipeline (`availableModels.ts`) and reaches the provider.
- Lists `openai/gpt-5.4-nano`, `x-ai/grok-4.6`, and `anthropic/claude-sonnet-5` (with `defaultParameters: { max_tokens: 64000 }`).
- Corrects competing PR #14623: `temperature` and other sampling controls are stripped by `omitOpenAISampling`/`omitClaudeSampling`, not "supported" or "locked to 1" — regression-guarded in tests.
- Adds `chatParameters.test.ts` covering registry round-trips, non-text absence, and the transform-pipeline regression.

Fixes #14599