### PR TITLE
feat: add OpenRouter fallbacks for Perplexity Sonar models

### DIFF
--- a/.claude/skills/model-management/references/operating-policy.md
+++ b/.claude/skills/model-management/references/operating-policy.md
@@ -5,8 +5,7 @@ These are strategic defaults. The user's explicit, confirmed contract for a spec
 ## Route selection
 
 - Prefer managed serverless inference.
-- For equivalent routes, prefer **Azure**, then **Fireworks**, then **OpenRouter** because of Pollinations' credit position and effective economics.
-- Treat **DeepInfra** as a parallel funded-balance lane. Use it when it is the best eligible route, but do not move a healthy Azure or Fireworks route there merely to consume balance.
+- For equivalent primary and fallback routes, prefer **Azure**, then **Fireworks**.
 - Before choosing a route, enumerate the exact model across the preferred providers, the current provider, and other already-integrated providers. Compare current posted price, credit eligibility, availability, quotas, capabilities, latency, and maturity.
 - Do not route to a provider solely because an old model name matches. Verify the exact canonical checkpoint, capabilities, limits, latency, and pricing.
 - Direct providers remain valid when the preferred platforms lack an equivalent route or the direct API has a material capability advantage.

--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -2065,6 +2065,16 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "promptTextTokens": 0.000003,
     },
   },
+  "perplexity/sonar-pro:openrouter:perplexity": {
+    "cost": {
+      "completionTextTokens": 0.000015,
+      "promptTextTokens": 0.000003,
+    },
+    "price": {
+      "completionTextTokens": 0.000015,
+      "promptTextTokens": 0.000003,
+    },
+  },
   "perplexity/sonar-reasoning-pro": {
     "cost": {
       "completionTextTokens": 0.000008,
@@ -2073,6 +2083,26 @@ exports[`effective cost and price per model — snapshot 1`] = `
     "price": {
       "completionTextTokens": 0.000008,
       "promptTextTokens": 0.000002,
+    },
+  },
+  "perplexity/sonar-reasoning-pro:openrouter:perplexity": {
+    "cost": {
+      "completionTextTokens": 0.000008,
+      "promptTextTokens": 0.000002,
+    },
+    "price": {
+      "completionTextTokens": 0.000008,
+      "promptTextTokens": 0.000002,
+    },
+  },
+  "perplexity/sonar:openrouter:perplexity": {
+    "cost": {
+      "completionTextTokens": 0.000001,
+      "promptTextTokens": 0.000001,
+    },
+    "price": {
+      "completionTextTokens": 0.000001,
+      "promptTextTokens": 0.000001,
     },
   },
   "pollinations/midijourney": {

--- a/gen.pollinations.ai/src/text/availableModels.ts
+++ b/gen.pollinations.ai/src/text/availableModels.ts
@@ -516,12 +516,24 @@ const models: ModelDefinition[] = [
         config: portkeyConfig["sonar"],
     },
     {
+        name: "perplexity/sonar:openrouter:perplexity",
+        config: portkeyConfig["perplexity/sonar"],
+    },
+    {
         name: "perplexity/sonar-pro",
         config: portkeyConfig["sonar-pro"],
     },
     {
+        name: "perplexity/sonar-pro:openrouter:perplexity",
+        config: portkeyConfig["perplexity/sonar-pro"],
+    },
+    {
         name: "perplexity/sonar-reasoning-pro",
         config: portkeyConfig["sonar-reasoning-pro"],
+    },
+    {
+        name: "perplexity/sonar-reasoning-pro:openrouter:perplexity",
+        config: portkeyConfig["perplexity/sonar-reasoning-pro"],
     },
     {
         name: "moonshotai/kimi-k2.6",

--- a/gen.pollinations.ai/src/text/configs/modelConfigs.ts
+++ b/gen.pollinations.ai/src/text/configs/modelConfigs.ts
@@ -628,6 +628,18 @@ export const portkeyConfig: PortkeyConfigMap = {
     "sonar-pro": () => createPerplexityModelConfig({ model: "sonar-pro" }),
     "sonar-reasoning-pro": () =>
         createPerplexityModelConfig({ model: "sonar-reasoning-pro" }),
+    "perplexity/sonar": createPinnedOpenRouterConfig(
+        "perplexity/sonar",
+        "perplexity",
+    ),
+    "perplexity/sonar-pro": createPinnedOpenRouterConfig(
+        "perplexity/sonar-pro",
+        "perplexity",
+    ),
+    "perplexity/sonar-reasoning-pro": createPinnedOpenRouterConfig(
+        "perplexity/sonar-reasoning-pro",
+        "perplexity",
+    ),
 
     "accounts/fireworks/models/glm-5p2": () =>
         createFireworksModelConfig({

--- a/gen.pollinations.ai/test/static-provider-fallbacks.test.ts
+++ b/gen.pollinations.ai/test/static-provider-fallbacks.test.ts
@@ -19,6 +19,21 @@ import { supportsTextFallbackRequest } from "../src/text/fallbackCompatibility.t
 
 const OPENROUTER_ROUTES = [
     [
+        "perplexity/sonar:openrouter:perplexity",
+        "perplexity/sonar",
+        "perplexity",
+    ],
+    [
+        "perplexity/sonar-pro:openrouter:perplexity",
+        "perplexity/sonar-pro",
+        "perplexity",
+    ],
+    [
+        "perplexity/sonar-reasoning-pro:openrouter:perplexity",
+        "perplexity/sonar-reasoning-pro",
+        "perplexity",
+    ],
+    [
         "qwen/qwen3.8-27b:openrouter:akashml-fp8",
         "qwen/qwen3.8-27b",
         "akashml/fp8",
@@ -148,6 +163,63 @@ function expectInheritedRoute(
 }
 
 describe("static provider fallbacks", () => {
+    it.each([
+        "sonar",
+        "sonar-pro",
+        "sonar-reasoning-pro",
+    ] as const)("keeps %s on direct Perplexity with an OpenRouter fallback", (upstream) => {
+        const model = `perplexity/${upstream}` as const;
+        const primary: ModelDefinition = TEXT_SERVICES[model];
+        expect(primary).toMatchObject({
+            provider: "perplexity",
+            priceMultiplier: 1,
+            fallbacks: [`${model}:openrouter:perplexity`],
+        });
+        expect(primary.paidOnly).not.toBe(true);
+        expect(findModelByName(model)?.config()).toMatchObject({
+            provider: "perplexity-ai",
+            model: upstream,
+        });
+    });
+
+    it.each([
+        ["perplexity/sonar", "low", 0.005],
+        ["perplexity/sonar", "high", 0.012],
+        ["perplexity/sonar-pro", "high", 0.014],
+        ["perplexity/sonar-reasoning-pro", "high", 0.014],
+    ] as const)("bills %s %s search once when OpenRouter reports a total cost", (model, searchContextSize, searchFee) => {
+        const primary = TEXT_SERVICES[model];
+        const fallback = TEXT_SERVICES[`${model}:openrouter:perplexity`];
+        const usage = { promptTextTokens: 100, completionTextTokens: 20 };
+        const expected =
+            100 * primary.cost.promptTextTokens +
+            20 * primary.cost.completionTextTokens +
+            searchFee;
+        // OpenRouter's numeric cost already includes token and search costs.
+        const completion = { usage: { cost: expected } };
+        for (const output of [
+            completion,
+            { streamEvents: [{ choices: [] }, completion] },
+        ]) {
+            const billed = calculateUsageBilling({
+                model,
+                usage,
+                servedBy: fallback,
+                quotedBy: primary,
+                output,
+                input: { searchContextSize },
+            });
+            expect(billed.cost.totalCost).toBeCloseTo(expected, 12);
+            expect(billed.price.totalPrice).toBeCloseTo(expected, 12);
+            expect(billed.adjustments).toHaveLength(1);
+            expect(billed.adjustments[0]).toMatchObject({
+                kind: "search_request",
+                units: 1,
+                cost: searchFee,
+            });
+        }
+    });
+
     it("preserves the Astra quote while recording Data Zone costs", () => {
         const primary = TEXT_SERVICES["openai/gpt-6-astra"];
         const fallback = TEXT_SERVICES["openai/gpt-6-astra:azure:datazone"];

--- a/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
+++ b/gen.pollinations.ai/test/text/utils/modelResolver.test.ts
@@ -565,6 +565,29 @@ describe("resolveModelConfig", () => {
     });
 
     it.each([
+        ["perplexity/sonar", "low"],
+        ["perplexity/sonar", "high"],
+        ["perplexity/sonar-pro", "high"],
+        ["perplexity/sonar-reasoning-pro", "high"],
+    ] as const)("preserves %s %s search context on OpenRouter", (model, searchContextSize) => {
+        const result = resolveModelConfig(messages, {
+            model: `${model}:openrouter:perplexity`,
+            web_search_options: { search_context_size: searchContextSize },
+        });
+        expect(result.options.model).toBe(model);
+        expect(result.options.web_search_options).toEqual({
+            search_context_size: searchContextSize,
+        });
+        expect(result.options.modelConfig).toMatchObject({
+            directEndpoint: "https://openrouter.ai/api/v1/chat/completions",
+        });
+        expect(result.options.provider).toEqual({
+            only: ["perplexity"],
+            allow_fallbacks: false,
+        });
+    });
+
+    it.each([
         "perplexity-high",
         "perplexity-deep",
         "sonar-deep",

--- a/shared/registry/perplexity-billing.ts
+++ b/shared/registry/perplexity-billing.ts
@@ -2,9 +2,7 @@ import type { BillingRules } from "./registry";
 
 type PerplexityCostOutput = {
     usage?: {
-        cost?: {
-            request_cost?: unknown;
-        };
+        cost?: number | { request_cost?: unknown };
         search_context_size?: unknown;
     };
     streamEvents?: unknown[];
@@ -17,6 +15,7 @@ const PROVIDER_COST_CLAMP_FACTOR = 10;
 // object present but request_cost malformed" (should alert louder).
 type ProviderRequestCostRead =
     | { status: "absent" }
+    | { status: "total" }
     | { status: "malformed"; raw: unknown }
     | { status: "ok"; value: number };
 
@@ -24,6 +23,11 @@ type ProviderRequestCostRead =
 function readProviderRequestCost(event: unknown): ProviderRequestCostRead {
     const cost = (event as PerplexityCostOutput | undefined)?.usage?.cost;
     if (cost == null) return { status: "absent" };
+    // OpenRouter reports the total charge here, including tokens. Its native
+    // Sonar search fees use the same context-tier rates as direct Perplexity.
+    if (typeof cost === "number" && Number.isFinite(cost) && cost >= 0) {
+        return { status: "total" };
+    }
     if (typeof cost !== "object") return { status: "malformed", raw: cost };
     if (!("request_cost" in cost)) return { status: "absent" };
     const value = cost.request_cost;
@@ -57,6 +61,7 @@ function getReportedSearchContextSize(output: unknown): string | undefined {
 }
 
 // Resolve the per-request cost via clamp-and-alert (never throws):
+//  - OpenRouter total cost      → static search fee (tokens billed separately)
 //  - absent provider cost       → static fee + WARN (Perplexity-regression signal)
 //  - malformed provider cost    → static fee + ERROR
 //  - provider cost > 10× static → clamp to static fee + ERROR
@@ -82,6 +87,7 @@ function resolvePerplexityRequestCost(args: {
     }
 
     const read = getPerplexityReportedRequestCost(output);
+    if (read.status === "total") return staticFee;
     if (read.status === "absent") {
         // Expected for non-stream Perplexity until the gateway cost-preserving
         // fix deploys. WARN so a persistent absence is visible without paging.

--- a/shared/registry/text-fallbacks.ts
+++ b/shared/registry/text-fallbacks.ts
@@ -9,6 +9,21 @@ import { perMillion } from "./price-helpers";
 
 /** Exact-checkpoint provider routes used when a text model's primary fails. */
 export const TEXT_FALLBACKS = {
+    "perplexity/sonar": {
+        "perplexity/sonar:openrouter:perplexity": {
+            provider: "openrouter",
+        },
+    },
+    "perplexity/sonar-pro": {
+        "perplexity/sonar-pro:openrouter:perplexity": {
+            provider: "openrouter",
+        },
+    },
+    "perplexity/sonar-reasoning-pro": {
+        "perplexity/sonar-reasoning-pro:openrouter:perplexity": {
+            provider: "openrouter",
+        },
+    },
     "openai/gpt-6-astra": {
         "openai/gpt-6-astra:azure:datazone": {
             provider: "azure",


### PR DESCRIPTION
- Adds hidden, exact-model OpenRouter fallbacks for `perplexity/sonar`, `perplexity/sonar-pro`, and `perplexity/sonar-reasoning-pro`. Direct Perplexity stays primary through Portkey, using the unprefixed upstream IDs. Fallbacks use OpenRouter `/api/v1/chat/completions`, the canonical upstream IDs, and `provider.only=["perplexity"]` with provider fallback disabled. Azure, Fireworks, and DeepInfra lack equivalent Sonar routes; both configured routes ultimately depend on Perplexity.
- Preserves multiplier **1**, Quest Pollen access, text/search capabilities, reasoning support, and aliases: `sonar`, `perplexity-high`, `perplexity-deep`, `sonar-deep`, `perplexity-fast`; `sonar-pro`, `perplexity-pro`, `perplexity`; `sonar-reasoning`, `sonar-reasoning-pro`, `perplexity-reasoning`. No Pollinations GPU or public API changes.
- Handles OpenRouter's numeric total cost separately from the search fee, preserving existing token and search-tier rates. Sources: [OpenRouter search billing](https://openrouter.ai/docs/guides/features/plugins/web-search), [Perplexity pricing](https://docs.perplexity.ai/docs/getting-started/pricing).
- Updates equivalent-route preference to Azure, then Fireworks. Secret synchronization shipped separately in #14641; Agent API migration remains separate.
- Validation: **151 focused tests**, including the updated fallback pricing snapshot, Gen/Enter type checks, Biome, and diff checks pass. **11 live OpenRouter requests** pass across all three models, streaming, terminal usage, and search tiers. **Draft gate:** forced-fallback gateway, billing/Tinybird reconciliation, cache, permissions, and burst verification remain; the available staging gateway credential returns **401**.
