### PR TITLE
chore: promote main to production

### DIFF
--- a/apps/mcp/worker.test.js
+++ b/apps/mcp/worker.test.js
@@ -200,7 +200,7 @@ test("generateText uses the non-streaming chat completion contract", async (t) =
     await client.close();
 });
 
-test("uploads generated images and returns an MCP resource link", async (t) => {
+test("returns the image API's resource link without downloading or uploading", async (t) => {
     const originalFetch = globalThis.fetch;
     let generationBody;
     t.after(() => {
@@ -219,26 +219,10 @@ test("uploads generated images and returns an MCP resource link", async (t) => {
                 created: 1,
                 data: [
                     {
-                        url: "https://gen.pollinations.ai/image/a%20bee",
+                        url: "https://media.pollinations.ai/generated-image",
+                        media_type: "image/png",
                     },
                 ],
-            });
-        }
-        if (url === "https://gen.pollinations.ai/image/a%20bee") {
-            return new Response(new Uint8Array([1, 2, 3]), {
-                headers: { "Content-Type": "image/png" },
-            });
-        }
-        if (url === "https://media.pollinations.ai/upload") {
-            const file = init.body.get("file");
-            assert.equal(file.type, "image/png");
-            assert.deepEqual(
-                new Uint8Array(await file.arrayBuffer()),
-                new Uint8Array([1, 2, 3]),
-            );
-            assert.equal(init.body.get("tags"), null);
-            return Response.json({
-                url: "https://media.pollinations.ai/generated-image",
             });
         }
         throw new Error(`Unexpected URL: ${url}`);
@@ -261,14 +245,57 @@ test("uploads generated images and returns an MCP resource link", async (t) => {
         prompt: "a bee",
         response_format: "url",
     });
+    assert.deepEqual(JSON.parse(result.content[1].text), {
+        created: 1,
+        data: [
+            {
+                url: "https://media.pollinations.ai/generated-image",
+                media_type: "image/png",
+            },
+        ],
+    });
 
     await client.close();
 });
 
-test("proxies discovery and uploads generated audio, video, and 3D", async (t) => {
+test("reports a missing media link and cancels the body without uploading", async (t) => {
+    const originalFetch = globalThis.fetch;
+    let cancelled = false;
+    let calls = 0;
+    t.after(() => {
+        globalThis.fetch = originalFetch;
+    });
+    globalThis.fetch = async (input) => {
+        calls++;
+        assert.equal(String(input), "https://gen.pollinations.ai/3d/a%20bee");
+        return new Response(
+            new ReadableStream({
+                cancel() {
+                    cancelled = true;
+                },
+            }),
+            { headers: { "Content-Type": "model/gltf-binary" } },
+        );
+    };
+
+    const client = await connectClient({
+        versionNegotiation: { mode: "auto" },
+    });
+    const result = await client.callTool({
+        name: "generate3D",
+        arguments: { prompt: "a bee" },
+    });
+    assert.equal(result.isError, true);
+    assert.match(result.content[0].text, /no public file URL/);
+    assert.equal(cancelled, true);
+    assert.equal(calls, 1);
+    await client.close();
+});
+
+test("proxies discovery and reuses audio, video, and 3D links without uploads", async (t) => {
     const originalFetch = globalThis.fetch;
     const seen = [];
-    const uploadedTypes = [];
+    const cancelled = [];
     t.after(() => {
         globalThis.fetch = originalFetch;
     });
@@ -302,26 +329,49 @@ test("proxies discovery and uploads generated audio, video, and 3D", async (t) =
             });
         }
         if (url.endsWith("/3d/a%20bee")) {
-            return new Response(new Uint8Array([1, 2, 3]), {
-                headers: { "Content-Type": "model/gltf-binary" },
-            });
+            return new Response(
+                new ReadableStream({
+                    cancel() {
+                        cancelled.push("3d");
+                    },
+                }),
+                {
+                    headers: {
+                        "Content-Type": "model/gltf-binary",
+                        Link: '<https://media.pollinations.ai/1>; rel="enclosure"',
+                    },
+                },
+            );
         }
         if (url.endsWith("/video/a%20bee?model=veo")) {
-            return new Response(new Uint8Array([4, 5, 6]), {
-                headers: { "Content-Type": "video/mp4" },
-            });
+            return new Response(
+                new ReadableStream({
+                    cancel() {
+                        cancelled.push("video");
+                    },
+                }),
+                {
+                    headers: {
+                        "Content-Type": "video/mp4",
+                        Link: '<https://media.pollinations.ai/2>; rel="enclosure"',
+                    },
+                },
+            );
         }
         if (url.endsWith("/audio/hello?model=speech-test")) {
-            return new Response(new Uint8Array([7, 8, 9]), {
-                headers: { "Content-Type": "audio/mpeg" },
-            });
-        }
-        if (url === "https://media.pollinations.ai/upload") {
-            const file = init.body.get("file");
-            uploadedTypes.push(file.type);
-            return Response.json({
-                url: `https://media.pollinations.ai/${uploadedTypes.length}`,
-            });
+            return new Response(
+                new ReadableStream({
+                    cancel() {
+                        cancelled.push("audio");
+                    },
+                }),
+                {
+                    headers: {
+                        "Content-Type": "audio/mpeg",
+                        Link: '<https://media.pollinations.ai/3>; rel="enclosure"',
+                    },
+                },
+            );
         }
         throw new Error(`Unexpected URL: ${url}`);
     };
@@ -387,11 +437,7 @@ test("proxies discovery and uploads generated audio, video, and 3D", async (t) =
         name: "Generated audio",
         mimeType: "audio/mpeg",
     });
-    assert.deepEqual(uploadedTypes, [
-        "model/gltf-binary",
-        "video/mp4",
-        "audio/mpeg",
-    ]);
+    assert.deepEqual(cancelled, ["3d", "video", "audio"]);
 
     assert.ok(
         seen.every(({ authorization }) => authorization === `Bearer ${TOKEN}`),

--- a/packages/mcp/AGENTS.md
+++ b/packages/mcp/AGENTS.md
@@ -2,9 +2,9 @@
 
 ## Design Principles
 
-1. **Thin proxy.** API calls go through `gen.pollinations.ai`; generated binary outputs are uploaded unlisted to `media.pollinations.ai` and returned as resource links. Do not call other service hosts directly — use the gateway's rewrites (`/account/*`, `/image/*`, `/text/*`, `/audio/*`, `/v1/*`).
+1. **Thin proxy.** API calls go through `gen.pollinations.ai`; return generated media's existing public URL as a resource link without downloading or re-uploading it. Use the image API's JSON URL or the binary response's enclosure `Link` header. Do not call other service hosts directly — use the gateway's rewrites (`/account/*`, `/image/*`, `/text/*`, `/audio/*`, `/v1/*`).
 2. **No hardcoded model or voice enums.** Validate against the live registry via `utils/models.js`. Tool param schemas should be `z.string()` with a "use listX for the live list" hint.
-3. **Don't transform response data.** Pass through API responses; only reshape when an MCP content block is required (for example, upload generated binary output and return a resource link).
+3. **Don't transform response data.** Pass through API responses; only reshape when an MCP content block is required (for example, return a generated media URL as a resource link).
 4. **Minimal tool surface.** Every tool is extra context for the LLM to reason over and a chance to pick the wrong one. Add only what's genuinely useful inside a host (Claude Desktop, Cursor, etc.).
 5. **Stateless HTTP only.** Read the bearer token from the request context. Do not add process-local state, authentication tools, sessions, or stdio entrypoints.
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -38,9 +38,9 @@ For all Pollinations-hosted MCP servers, see the
 | `getModelStatus` | Inspect recent requests, errors, and latency | `/v1/models/status` |
 | `getBalance` | Check remaining Pollen; requires `account:usage` | `/account/balance` |
 
-Generated media is uploaded unlisted to `media.pollinations.ai` and returned as
-an MCP resource link, so binary data does not consume model context. Anyone
-with the link can access it, and it expires after 30 days.
+Generated media is returned as an MCP resource link using the API's existing
+public Media URL. No download or re-upload is needed, and binary data does not
+consume model context. Anyone with the link can access it; expired files return 404.
 
 Models, voices, capabilities, and pricing come from the live registry. Use
 `listModels` before selecting a model or voice.

--- a/packages/mcp/src/services/audioService.js
+++ b/packages/mcp/src/services/audioService.js
@@ -4,8 +4,8 @@ import {
     buildUrl,
     createMCPResponse,
     createTextContent,
-    fetchAndUploadMedia,
     fetchJsonWithAuth,
+    fetchMediaLink,
 } from "../utils/coreUtils.js";
 
 function publicAudioUrl(source) {
@@ -79,9 +79,8 @@ async function generateAudio(params, context) {
     requireApiKey(context);
 
     const { text, ...options } = params;
-    const { contentType, mediaUrl } = await fetchAndUploadMedia(
+    const { contentType, mediaUrl } = await fetchMediaLink(
         buildUrl(`/audio/${encodeURIComponent(text)}`, options),
-        {},
         context,
     );
     return createMCPResponse([

--- a/packages/mcp/src/services/imageService.js
+++ b/packages/mcp/src/services/imageService.js
@@ -4,8 +4,8 @@ import {
     buildUrl,
     createMCPResponse,
     createTextContent,
-    fetchAndUploadMedia,
     fetchJsonWithAuth,
+    fetchMediaLink,
 } from "../utils/coreUtils.js";
 import { validateImageModel, validateVideoModel } from "../utils/models.js";
 
@@ -47,29 +47,15 @@ async function generateImage(params, context) {
     );
     const image = result.data?.[0];
     if (!image?.url) throw new Error("Image API returned no image URL");
-    const { contentType, mediaUrl } = await fetchAndUploadMedia(
-        image.url,
-        {},
-        context,
-    );
 
     return createMCPResponse([
         {
             type: "resource_link",
-            uri: mediaUrl,
+            uri: image.url,
             name: "Generated image",
-            mimeType: image.media_type || contentType,
+            mimeType: image.media_type,
         },
-        createTextContent(
-            {
-                ...result,
-                data: result.data.map(({ url: _url, ...entry }) => ({
-                    ...entry,
-                    url: mediaUrl,
-                })),
-            },
-            true,
-        ),
+        createTextContent(result, true),
     ]);
 }
 
@@ -114,9 +100,8 @@ async function generateVideo(params, context) {
         params,
         context,
     );
-    const { contentType, mediaUrl } = await fetchAndUploadMedia(
+    const { contentType, mediaUrl } = await fetchMediaLink(
         buildUrl(`/video/${encodedPrompt}`, queryParams),
-        {},
         context,
     );
     return createMCPResponse([
@@ -124,7 +109,7 @@ async function generateVideo(params, context) {
             type: "resource_link",
             uri: mediaUrl,
             name: "Generated video",
-            mimeType: contentType || "video/mp4",
+            mimeType: contentType,
         },
         createTextContent(
             {

--- a/packages/mcp/src/services/model3dService.js
+++ b/packages/mcp/src/services/model3dService.js
@@ -4,7 +4,7 @@ import {
     buildUrl,
     createMCPResponse,
     createTextContent,
-    fetchAndUploadMedia,
+    fetchMediaLink,
 } from "../utils/coreUtils.js";
 import { validateModel3d } from "../utils/models.js";
 
@@ -22,9 +22,8 @@ async function generate3D(params, context) {
     }
 
     const { prompt, ...options } = params;
-    const { contentType, mediaUrl } = await fetchAndUploadMedia(
+    const { contentType, mediaUrl } = await fetchMediaLink(
         buildUrl(`/3d/${encodeURIComponent(prompt)}`, options),
-        {},
         context,
     );
     return createMCPResponse([
@@ -32,7 +31,7 @@ async function generate3D(params, context) {
             type: "resource_link",
             uri: mediaUrl,
             name: "Generated 3D model",
-            mimeType: contentType || "model/gltf-binary",
+            mimeType: contentType,
         },
         createTextContent({ url: mediaUrl, prompt, ...options }, true),
     ]);

--- a/packages/mcp/src/utils/coreUtils.js
+++ b/packages/mcp/src/utils/coreUtils.js
@@ -1,7 +1,6 @@
 import { getAuthHeaders } from "./authUtils.js";
 
 const DEFAULT_API_BASE_URL = "https://gen.pollinations.ai";
-const MEDIA_UPLOAD_URL = "https://media.pollinations.ai/upload";
 const configuredApiBaseUrl =
     typeof process !== "undefined"
         ? process.env?.POLLINATIONS_BASE_URL?.trim()
@@ -142,27 +141,20 @@ export async function postChatCompletion(body, context) {
 
 /**
  * @param {string} url - URL to fetch
- * @param {Object} options - Fetch options
- * @returns {Promise<{contentType: string, mediaUrl: string}>} - Content type and uploaded public URL
+ * @returns {Promise<{contentType: string, mediaUrl: string}>} - Content type and existing public URL
  */
-export async function fetchAndUploadMedia(url, options = {}, context) {
-    const response = await fetchResponseWithAuth(url, options, context);
+export async function fetchMediaLink(url, context) {
+    const response = await fetchResponseWithAuth(url, {}, context);
     const contentType =
         response.headers.get("content-type") || "application/octet-stream";
-    const form = new FormData();
-    form.append(
-        "file",
-        new Blob([await response.arrayBuffer()], { type: contentType }),
-        "generation",
-    );
-    const upload = await fetchResponseWithAuth(
-        MEDIA_UPLOAD_URL,
-        { method: "POST", body: form },
-        context,
-    );
-    const result = await upload.json();
-    if (!result?.url) throw new Error("Media upload returned no URL");
-    return { contentType, mediaUrl: result.url };
+
+    const mediaUrl = response.headers
+        .get("Link")
+        ?.match(/^<([^>]+)>; rel="enclosure"$/)?.[1];
+    await response.body?.cancel();
+    if (!mediaUrl)
+        throw new Error("Media generation returned no public file URL");
+    return { contentType, mediaUrl };
 }
 
 /**


### PR DESCRIPTION
- Promotes the focused MCP media-link simplification
- Reuses generated public URLs instead of downloading and re-uploading binaries
- Keeps the MCP server as a thin proxy

Validated with MCP core and worker tests; upstream PR CI is green.