### PR TITLE
feat: accept image parts for media models on Chat and Responses

### DIFF
--- a/gen.pollinations.ai/src/docs/text-generation.md
+++ b/gen.pollinations.ai/src/docs/text-generation.md
@@ -37,7 +37,7 @@ Managed prompt agents accept `reasoning.effort` (Responses) and `reasoning_effor
 
 ### Media models in conversations
 
-Image, video, audio and 3D models that advertise these endpoints in [`/models`](/models) accept a text prompt. Only the last user message is used; history, instructions and text-generation settings are ignored. Its text parts (or a string Responses `input`) form the prompt. Image parts (`image_url` in Chat, `input_image` in Responses, as URLs or data URIs) are source images for models that list `image` under `input_modalities`; other models return HTTP 400 for them, and any other attachment type returns HTTP 400. Use the native media endpoints for generation settings.
+Image, video, audio and 3D models that advertise these endpoints in [`/models`](/models) accept a text prompt. Only the last user message is used; history, instructions and text-generation settings are ignored. Its text parts (or a string Responses `input`) form the prompt. Image parts (`image_url` in Chat, `input_image` in Responses, as URLs or data URIs) are the source images of image models and the start frame of video models that list `image` under `input_modalities`, exactly as `/v1/images/edits` does; other models, including 3D, return HTTP 400 for them, and any other attachment type returns HTTP 400. Use the native media endpoints for generation settings.
 
 Empty prompts, malformed Unicode and prompts consisting only of `.` or `..` return HTTP 400. Reference-required models return their normal missing-input error.
 

--- a/gen.pollinations.ai/src/docs/text-generation.md
+++ b/gen.pollinations.ai/src/docs/text-generation.md
@@ -37,7 +37,7 @@ Managed prompt agents accept `reasoning.effort` (Responses) and `reasoning_effor
 
 ### Media models in conversations
 
-Image, video, audio and 3D models that advertise these endpoints in [`/models`](/models) accept a text prompt. Only the last user message's text (or a string Responses `input`) is used; history, instructions and text-generation settings are ignored. Attachments return HTTP 400. Use the native media endpoints for edits and generation settings.
+Image, video, audio and 3D models that advertise these endpoints in [`/models`](/models) accept a text prompt. Only the last user message is used; history, instructions and text-generation settings are ignored. Its text parts (or a string Responses `input`) form the prompt. Image parts (`image_url` in Chat, `input_image` in Responses, as URLs or data URIs) are source images for models that list `image` under `input_modalities`; other models return HTTP 400 for them, and any other attachment type returns HTTP 400. Use the native media endpoints for generation settings.
 
 Empty prompts, malformed Unicode and prompts consisting only of `.` or `..` return HTTP 400. Reference-required models return their normal missing-input error.
 

--- a/gen.pollinations.ai/src/media/responses.ts
+++ b/gen.pollinations.ai/src/media/responses.ts
@@ -3,7 +3,6 @@ import { every } from "hono/combine";
 import { createMiddleware } from "hono/factory";
 import { HTTPException } from "hono/http-exception";
 import type { Env } from "@/env.ts";
-import { normalizedJsonBody } from "@/middleware/generation-cache.ts";
 import { deduplicateGeneration } from "@/middleware/generation-deduplication.ts";
 import {
     audioCache,
@@ -11,7 +10,6 @@ import {
     model3dCache,
 } from "@/middleware/media-cache.ts";
 import { resolveModel } from "@/middleware/model.ts";
-import { applySafetyToInput } from "@/middleware/safety.ts";
 import { track } from "@/middleware/track.ts";
 import {
     responsesToChatCompletion,
@@ -19,6 +17,7 @@ import {
 } from "@/text/responses/chatResponse.ts";
 import { generationAccess } from "@/utils/generation-access.ts";
 import { getGenerationModelRegistry } from "../model-registry.ts";
+import { prepareImageEditRequest } from "../routes/images.ts";
 import { mediaPromptRoute } from "./prompt-route.ts";
 import { createMediaResponse, mediaResponseStream } from "./response-output.ts";
 
@@ -124,27 +123,21 @@ export function mediaResponses(protocol: MediaProtocol) {
                     ctx.set("generationRequestMethod", "GET");
                     return proceed();
                 }
+                // The edits executor runs image and video (start frame)
+                // models; 3D has its own handler.
                 if (
-                    entry.definition.category !== "image" ||
+                    route !== "/image/" ||
                     !entry.definition.inputModalities?.includes("image")
                 )
                     throw new HTTPException(400, {
-                        message: `Model "${entry.id}" does not accept image input.`,
+                        message: `Model "${entry.id}" does not accept image input on this endpoint.`,
                     });
-                // Replay the JSON edits contract: the executor parses it as
-                // already-safe, and data URIs are hashed into the cache key.
-                const safe = body.safe as SafeValue;
-                const edit = normalizedJsonBody(
-                    JSON.stringify({
-                        prompt: await applySafetyToInput(ctx, prompt, safe),
-                        model: entry.id,
-                        image: images.map((image_url) => ({ image_url })),
-                        ...(safe !== undefined && { safe }),
-                    }),
-                );
-                ctx.set("generationRequestBody", edit);
-                ctx.set("generationCacheBody", edit);
-                ctx.set("generationRequestContentType", "application/json");
+                await prepareImageEditRequest(ctx, {
+                    prompt,
+                    imageUrls: images,
+                    safe: body.safe as SafeValue,
+                    extra: {},
+                });
                 ctx.set(
                     "generationRequestUrl",
                     new URL("/v1/images/edits", ctx.req.url),

--- a/gen.pollinations.ai/src/media/responses.ts
+++ b/gen.pollinations.ai/src/media/responses.ts
@@ -1,9 +1,9 @@
+import type { SafeValue } from "@shared/schemas/safety.ts";
 import { every } from "hono/combine";
 import { createMiddleware } from "hono/factory";
 import { HTTPException } from "hono/http-exception";
-import type { SafeValue } from "@shared/schemas/safety.ts";
 import type { Env } from "@/env.ts";
-import { prepareGenerationRequest } from "@/middleware/generation-cache.ts";
+import { normalizedJsonBody } from "@/middleware/generation-cache.ts";
 import { deduplicateGeneration } from "@/middleware/generation-deduplication.ts";
 import {
     audioCache,
@@ -134,8 +134,7 @@ export function mediaResponses(protocol: MediaProtocol) {
                 // Replay the JSON edits contract: the executor parses it as
                 // already-safe, and data URIs are hashed into the cache key.
                 const safe = body.safe as SafeValue;
-                ctx.set(
-                    "generationRequestBody",
+                const edit = normalizedJsonBody(
                     JSON.stringify({
                         prompt: await applySafetyToInput(ctx, prompt, safe),
                         model: entry.id,
@@ -143,13 +142,15 @@ export function mediaResponses(protocol: MediaProtocol) {
                         ...(safe !== undefined && { safe }),
                     }),
                 );
+                ctx.set("generationRequestBody", edit);
+                ctx.set("generationCacheBody", edit);
                 ctx.set("generationRequestContentType", "application/json");
                 ctx.set(
                     "generationRequestUrl",
                     new URL("/v1/images/edits", ctx.req.url),
                 );
                 ctx.set("generationRequestMethod", "POST");
-                await prepareGenerationRequest(ctx, proceed);
+                await proceed();
             }),
             cache,
             generationAccess,

--- a/gen.pollinations.ai/src/media/responses.ts
+++ b/gen.pollinations.ai/src/media/responses.ts
@@ -1,7 +1,9 @@
 import { every } from "hono/combine";
 import { createMiddleware } from "hono/factory";
 import { HTTPException } from "hono/http-exception";
+import type { SafeValue } from "@shared/schemas/safety.ts";
 import type { Env } from "@/env.ts";
+import { prepareGenerationRequest } from "@/middleware/generation-cache.ts";
 import { deduplicateGeneration } from "@/middleware/generation-deduplication.ts";
 import {
     audioCache,
@@ -9,6 +11,7 @@ import {
     model3dCache,
 } from "@/middleware/media-cache.ts";
 import { resolveModel } from "@/middleware/model.ts";
+import { applySafetyToInput } from "@/middleware/safety.ts";
 import { track } from "@/middleware/track.ts";
 import {
     responsesToChatCompletion,
@@ -21,27 +24,45 @@ import { createMediaResponse, mediaResponseStream } from "./response-output.ts";
 
 type MediaProtocol = "responses" | "chat/completions";
 
+type MediaInput = { prompt: string; images: string[] };
+
+/** Chat `image_url` and Responses `input_image` parts, as URLs or data URIs. */
+function imagePart(part: { type?: unknown; image_url?: unknown }) {
+    if (part.type !== "image_url" && part.type !== "input_image") return;
+    const url =
+        typeof part.image_url === "string"
+            ? part.image_url
+            : (part.image_url as { url?: unknown } | undefined)?.url;
+    return typeof url === "string" ? url : undefined;
+}
+
 /** Earlier conversation is context for text models, not a media prompt. */
-export function mediaPrompt(input: unknown): string {
+export function mediaPrompt(input: unknown): MediaInput {
     let content: unknown = input;
+    const images: string[] = [];
     if (Array.isArray(input)) {
         content = input.findLast((item) => item?.role === "user")?.content;
     }
     if (Array.isArray(content)) {
-        if (
-            content.some(
-                (part) =>
-                    !part ||
-                    !["text", "input_text"].includes(part.type) ||
-                    typeof part.text !== "string",
-            )
-        ) {
-            throw new HTTPException(400, {
-                message:
-                    "Media generation accepts text only; use the native media endpoints for attachments.",
-            });
+        const texts: string[] = [];
+        for (const part of content) {
+            const image = part && imagePart(part);
+            if (image) {
+                images.push(image);
+            } else if (
+                part &&
+                ["text", "input_text"].includes(part.type) &&
+                typeof part.text === "string"
+            ) {
+                texts.push(part.text);
+            } else {
+                throw new HTTPException(400, {
+                    message:
+                        "Media generation accepts text and image parts only; use the native media endpoints for other attachments.",
+                });
+            }
         }
-        content = content.map((part) => part.text).join("\n");
+        content = texts.join("\n");
     }
     if (typeof content !== "string" || !content.trim()) {
         throw new HTTPException(400, {
@@ -59,7 +80,7 @@ export function mediaPrompt(input: unknown): string {
             message: "Media prompt cannot be only '.' or '..'.",
         });
     }
-    return content;
+    return { prompt: content, images };
 }
 
 /** Generate through the native durable pipeline, then only change presentation. */
@@ -86,21 +107,49 @@ export function mediaResponses(protocol: MediaProtocol) {
             }),
             track(entry.eventType),
             createMiddleware<Env>(async (ctx, proceed) => {
-                const prompt = mediaPrompt(
+                const { prompt, images } = mediaPrompt(
                     protocol === "responses" ? body.input : body.messages,
                 );
-                const url = new URL(
-                    `${route}${encodeURIComponent(prompt)}`,
-                    ctx.req.url,
-                );
-                url.searchParams.set("model", entry.id);
-                if (body.safe !== undefined)
-                    url.searchParams.set("safe", String(body.safe));
-                ctx.set("generationRequestUrl", url);
-                ctx.set("generationRequestMethod", "GET");
                 // The provider is not a text stream; only the final wrapper is.
                 ctx.var.track.streamRequested = false;
-                await proceed();
+                if (images.length === 0) {
+                    const url = new URL(
+                        `${route}${encodeURIComponent(prompt)}`,
+                        ctx.req.url,
+                    );
+                    url.searchParams.set("model", entry.id);
+                    if (body.safe !== undefined)
+                        url.searchParams.set("safe", String(body.safe));
+                    ctx.set("generationRequestUrl", url);
+                    ctx.set("generationRequestMethod", "GET");
+                    return proceed();
+                }
+                if (
+                    entry.definition.category !== "image" ||
+                    !entry.definition.inputModalities?.includes("image")
+                )
+                    throw new HTTPException(400, {
+                        message: `Model "${entry.id}" does not accept image input.`,
+                    });
+                // Replay the JSON edits contract: the executor parses it as
+                // already-safe, and data URIs are hashed into the cache key.
+                const safe = body.safe as SafeValue;
+                ctx.set(
+                    "generationRequestBody",
+                    JSON.stringify({
+                        prompt: await applySafetyToInput(ctx, prompt, safe),
+                        model: entry.id,
+                        image: images.map((image_url) => ({ image_url })),
+                        ...(safe !== undefined && { safe }),
+                    }),
+                );
+                ctx.set("generationRequestContentType", "application/json");
+                ctx.set(
+                    "generationRequestUrl",
+                    new URL("/v1/images/edits", ctx.req.url),
+                );
+                ctx.set("generationRequestMethod", "POST");
+                await prepareGenerationRequest(ctx, proceed);
             }),
             cache,
             generationAccess,

--- a/gen.pollinations.ai/src/middleware/generation-cache.ts
+++ b/gen.pollinations.ai/src/middleware/generation-cache.ts
@@ -65,7 +65,8 @@ export type GenerationCacheAdapter = {
     ) => { response: Response; write: Promise<void> };
 };
 
-function normalizedJsonBody(body: string): string {
+/** One stable identity per JSON body: key order and the `key` credential do not matter. */
+export function normalizedJsonBody(body: string): string {
     try {
         const parsed = JSON.parse(body);
         if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {

--- a/gen.pollinations.ai/src/routes/images.ts
+++ b/gen.pollinations.ai/src/routes/images.ts
@@ -27,6 +27,7 @@ import type { Context } from "hono";
 import { createMiddleware } from "hono/factory";
 import type { Env } from "@/env.ts";
 import { generateImageOrVideoResponse } from "@/image/handler.ts";
+import { normalizedJsonBody } from "@/middleware/generation-cache.ts";
 import { applySafetyToInput, withSafetyHeaders } from "@/middleware/safety.ts";
 import { arrayBufferToBase64 } from "@/util.ts";
 
@@ -232,10 +233,20 @@ async function parseEditInput(c: Context): Promise<{
 
 // --- Exported handlers ---
 
-/** Normalize edit inputs once per request; only file-producing inputs identify the cache. */
-export const prepareOpenAIImageEdit = createMiddleware<Env>(async (c, next) => {
-    const { imageUrls, extra, response_format, ...input } =
-        await parseEditInput(c);
+type EditInput = Omit<
+    Awaited<ReturnType<typeof parseEditInput>>,
+    "response_format"
+>;
+
+/**
+ * Build the JSON edits body the coordinator replays. Every entry point
+ * (native edits, Chat, Responses) hashes this same normalized body, so
+ * identical edits share one cache key and one generation.
+ */
+export async function prepareImageEditRequest(
+    c: Context<Env>,
+    { imageUrls, extra, ...input }: EditInput,
+) {
     const body = {
         ...extra,
         ...input,
@@ -247,14 +258,23 @@ export const prepareOpenAIImageEdit = createMiddleware<Env>(async (c, next) => {
     };
     // Replay the JSON edits contract even when the caller uploaded multipart files.
     // Leave random seed selection to execution so retries without a seed still join.
-    c.set("generationRequestBody", JSON.stringify(body));
+    const identity = normalizedJsonBody(JSON.stringify(body));
+    c.set("generationRequestBody", identity);
+    c.set("generationCacheBody", identity);
     c.set("generationRequestContentType", "application/json");
+    if (c.var.track) c.var.track.streamRequested = false;
+    return body;
+}
+
+/** Normalize edit inputs once per request; only file-producing inputs identify the cache. */
+export const prepareOpenAIImageEdit = createMiddleware<Env>(async (c, next) => {
+    const { response_format, ...input } = await parseEditInput(c);
+    const body = await prepareImageEditRequest(c, input);
     c.req.addValidatedData("json", {
         ...body,
-        image: imageUrls,
+        image: input.imageUrls,
         response_format,
     });
-    if (c.var.track) c.var.track.streamRequested = false;
     await next();
 });
 

--- a/gen.pollinations.ai/test/generation-vcr.test.ts
+++ b/gen.pollinations.ai/test/generation-vcr.test.ts
@@ -909,7 +909,10 @@ test("media text protocols route image parts through the edits contract", async 
                                 },
                                 protocol === "responses"
                                     ? { type: "input_image", image_url: image }
-                                    : { type: "image_url", image_url: { url: image } },
+                                    : {
+                                          type: "image_url",
+                                          image_url: { url: image },
+                                      },
                             ],
                         },
                     ],

--- a/gen.pollinations.ai/test/generation-vcr.test.ts
+++ b/gen.pollinations.ai/test/generation-vcr.test.ts
@@ -877,7 +877,7 @@ test("media text protocols reject invalid prompts and attachments before generat
     ).toBe(false);
 });
 
-test("media text protocols route image parts through the edits contract", async ({
+test("media text protocols share one edit generation with native edits", async ({
     mocks,
 }) => {
     await mocks.enable("tinybird", "deepInfra");
@@ -885,6 +885,27 @@ test("media text protocols route image parts through the edits contract", async 
     const image = `data:image/png;base64,${png1x1Base64}`;
     const prompt = `edit wrapper ${crypto.randomUUID()}`;
     const bindings = withInlineGenerationCoordinator(env);
+    const native = await fetchWorker(
+        "/v1/images/edits",
+        {
+            method: "POST",
+            headers: {
+                authorization: `Bearer ${key}`,
+                "content-type": "application/json",
+            },
+            body: JSON.stringify({
+                model: "prunaai/p-image-edit",
+                prompt,
+                image,
+            }),
+        },
+        bindings,
+    );
+    expect(native.response.status, await native.response.clone().text()).toBe(
+        200,
+    );
+    await native.wait();
+    expect(mocks.deepInfra.state.requests).toHaveLength(1);
     const request = (protocol: string, model: string) =>
         fetchWorker(
             `/v1/${protocol}`,
@@ -934,7 +955,8 @@ test("media text protocols route image parts through the edits contract", async 
         /^!\[Image\]\(https:\/\/media\./,
     );
     await Promise.all(results.map(({ wait }) => wait()));
-    // Both protocols share one edit generation, keyed on the hashed body.
+    // All three entry points hash the same edit body, so the native
+    // generation serves both text protocols from the cache.
     expect(mocks.deepInfra.state.requests).toHaveLength(1);
     expect(mocks.deepInfra.state.requests[0]).toMatchObject({
         prompt,

--- a/gen.pollinations.ai/test/generation-vcr.test.ts
+++ b/gen.pollinations.ai/test/generation-vcr.test.ts
@@ -877,6 +877,81 @@ test("media text protocols reject invalid prompts and attachments before generat
     ).toBe(false);
 });
 
+test("media text protocols route image parts through the edits contract", async ({
+    mocks,
+}) => {
+    await mocks.enable("tinybird", "deepInfra");
+    const { key } = await createTestApiKey({ user: { packBalance: 100 } });
+    const image = `data:image/png;base64,${png1x1Base64}`;
+    const prompt = `edit wrapper ${crypto.randomUUID()}`;
+    const bindings = withInlineGenerationCoordinator(env);
+    const request = (protocol: string, model: string) =>
+        fetchWorker(
+            `/v1/${protocol}`,
+            {
+                method: "POST",
+                headers: {
+                    authorization: `Bearer ${key}`,
+                    "content-type": "application/json",
+                },
+                body: JSON.stringify({
+                    model,
+                    [protocol === "responses" ? "input" : "messages"]: [
+                        {
+                            role: "user",
+                            content: [
+                                {
+                                    type:
+                                        protocol === "responses"
+                                            ? "input_text"
+                                            : "text",
+                                    text: prompt,
+                                },
+                                protocol === "responses"
+                                    ? { type: "input_image", image_url: image }
+                                    : { type: "image_url", image_url: { url: image } },
+                            ],
+                        },
+                    ],
+                }),
+            },
+            bindings,
+        );
+    const results = await Promise.all(
+        ["responses", "chat/completions"].map((protocol) =>
+            request(protocol, "prunaai/p-image-edit"),
+        ),
+    );
+    for (const { response } of results)
+        expect(response.status, await response.clone().text()).toBe(200);
+    const chat = (await results[1].response.json()) as {
+        choices: { message: { content: string } }[];
+    };
+    expect(chat.choices[0].message.content).toMatch(
+        /^!\[Image\]\(https:\/\/media\./,
+    );
+    await Promise.all(results.map(({ wait }) => wait()));
+    // Both protocols share one edit generation, keyed on the hashed body.
+    expect(mocks.deepInfra.state.requests).toHaveLength(1);
+    expect(mocks.deepInfra.state.requests[0]).toMatchObject({
+        prompt,
+        images: [image],
+    });
+    expect(
+        mocks.tinybird.state.events.filter((event) => event.isBilledUsage),
+    ).toHaveLength(1);
+    expect(
+        mocks.tinybird.state.events.find((event) => event.isBilledUsage),
+    ).toMatchObject({ modelRequested: "prunaai/p-image-edit" });
+
+    // A text-input-only media model rejects images before any generation.
+    const { response, wait } = await request("chat/completions", "flux");
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain("does not accept image input");
+    await wait();
+    expect(mocks.deepInfra.state.requests).toHaveLength(1);
+});
+
 test("media Responses rejects invalid string input before generation", async ({
     mocks,
 }) => {

--- a/gen.pollinations.ai/test/media-responses.test.ts
+++ b/gen.pollinations.ai/test/media-responses.test.ts
@@ -32,10 +32,27 @@ describe("media text protocols", () => {
                 },
                 { role: "assistant", content: "not the prompt" },
             ]),
-        ).toBe("a cat\nin space");
-        expect(mediaPrompt(" literal prompt ")).toBe(" literal prompt ");
-        expect(mediaPrompt("猫 🚀 ... %2F")).toBe("猫 🚀 ... %2F");
-        expect(mediaPrompt(" . ")).toBe(" . ");
+        ).toEqual({ prompt: "a cat\nin space", images: [] });
+        expect(mediaPrompt(" literal prompt ").prompt).toBe(" literal prompt ");
+        expect(mediaPrompt("猫 🚀 ... %2F").prompt).toBe("猫 🚀 ... %2F");
+        expect(mediaPrompt(" . ").prompt).toBe(" . ");
+    });
+
+    it("collects Chat image_url and Responses input_image parts in order", () => {
+        const data = "data:image/png;base64,AAAA";
+        expect(
+            mediaPrompt([
+                {
+                    role: "user",
+                    content: [
+                        { type: "image_url", image_url: { url: url } },
+                        { type: "text", text: "make it night" },
+                        { type: "input_image", image_url: data },
+                        { type: "input_image", image_url: { url: url } },
+                    ],
+                },
+            ]),
+        ).toEqual({ prompt: "make it night", images: [url, data, url] });
     });
 
     it.each([
@@ -48,7 +65,25 @@ describe("media text protocols", () => {
         "\udc00",
         [{ role: "assistant", content: "hello" }],
         [{ role: "user", content: [{ type: "input_image", image_url: url }] }],
-    ])("rejects absent text and attachments: %j", (input) => {
+        [
+            {
+                role: "user",
+                content: [
+                    { type: "text", text: "summarise" },
+                    { type: "input_file", file_data: "AAAA" },
+                ],
+            },
+        ],
+        [
+            {
+                role: "user",
+                content: [
+                    { type: "text", text: "listen" },
+                    { type: "input_audio", input_audio: { data: "AAAA" } },
+                ],
+            },
+        ],
+    ])("rejects absent text and non-image attachments: %j", (input) => {
         expect(() => mediaPrompt(input)).toThrow();
     });
 


### PR DESCRIPTION
- Adds image input to media models on `/v1/chat/completions` and `/v1/responses`: `image_url` (Chat) and `input_image` (Responses) parts in the last user message, as URLs or data URIs.
- Routes prompts with images through the existing `/v1/images/edits` replay contract via a shared `prepareImageEditRequest`, so native edits, Chat and Responses hash one normalized body (quality default, safe, model) and share one cache key, one generation and one billed event. Text-only prompts keep the `GET /image/{prompt}` path unchanged.
- Image models take the parts as source images; video models take them as the start frame (same edits executor). 3D models and models without `image` in `input_modalities` return 400, as does any other attachment type.
- Motivation: since #14618, every media error from Open WebUI users (7/7 in the first 6.5 h, 4 users) was a photo attached to an image-edit model (kontext-pro, nova-canvas, mai-image-2.5-flash). Open WebUI sends attachments exactly as `image_url` data URIs.
- Tests: part extraction and rejection cases in `media-responses.test.ts`; VCR test proves a native edit followed by both text protocols shares one mocked generation and one billed event, and that a text-input-only model rejects images before generation. Staging-verified for image edits (chat 200, responses and streaming cache hits, billing once); video start frames not live-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mNrP6DkRQmm3YStNjfFv3
