### PR TITLE
chore: promote main to production

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/news-faq/news-banner.tsx
+++ b/enter.pollinations.ai/frontend/src/components/news-faq/news-banner.tsx
@@ -25,6 +25,15 @@ interface Highlight {
  */
 const PINNED_NEWS: Highlight[] = [
     {
+        date: "2026-09-11",
+        dateLabel: "Planned for September 11",
+        emoji: "🧩",
+        title: "Community model IDs get a clearer prefix",
+        description:
+            "Community models and agents will be listed as community/username/model instead of username/model.",
+        details: ["Your existing model IDs will keep working."],
+    },
+    {
         date: "2026-08-15",
         dateLabel: "Alpha",
         emoji: "🤖",

--- a/enter.pollinations.ai/src/routes/api-keys.ts
+++ b/enter.pollinations.ai/src/routes/api-keys.ts
@@ -7,9 +7,9 @@ import { sanitizeAuthorizeAccountPermissions } from "@shared/auth/authorize-conf
 import * as schema from "@shared/db/better-auth.ts";
 import { validator } from "@shared/middleware/validator.ts";
 import {
-    canonicalizeModelPermissionIds,
     filterPermissionsToVisibleModels,
     getVisibleModelIdsForUser,
+    validateModelPermissionIds,
 } from "@shared/registry/visible-model-ids.ts";
 import { and, eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
@@ -44,13 +44,7 @@ function buildUpdatedPermissions(
         return undefined;
     }
     const updated = { ...existing };
-    applyPermissionField(
-        updated,
-        "models",
-        Array.isArray(allowedModels)
-            ? canonicalizeModelPermissionIds(allowedModels)
-            : allowedModels,
-    );
+    applyPermissionField(updated, "models", allowedModels);
     applyPermissionField(updated, "account", accountPermissions);
     return updated;
 }
@@ -123,7 +117,7 @@ async function updateKeyMetadata(
  * Uses better-auth's server API which supports server-only fields like permissions.
  *
  * Permissions format: { models?: string[], account?: string[] }
- * - models: ["flux", "openai"] = restrict to specific models
+ * - models: canonical IDs from /models = restrict to specific models
  * - account: ["profile", "usage", "keys"] = allow access to account endpoints
  */
 const UpdateApiKeySchema = z.object({
@@ -132,7 +126,9 @@ const UpdateApiKeySchema = z.object({
         .array(z.string())
         .nullable()
         .optional()
-        .describe("Model IDs this key can access. null = all models allowed"),
+        .describe(
+            "Canonical model IDs from /models. null = all models allowed",
+        ),
     pollenBudget: z
         .number()
         .nullable()
@@ -172,7 +168,9 @@ const CreateApiKeySchema = z.object({
         .array(z.string())
         .nullable()
         .optional()
-        .describe("Model IDs this key can access. null = all models allowed"),
+        .describe(
+            "Canonical model IDs from /models. null = all models allowed",
+        ),
     pollenBudget: z
         .number()
         .nullable()
@@ -352,7 +350,9 @@ export const apiKeysRoutes = new Hono<Env>()
 
             const updatedPermissions = buildUpdatedPermissions(
                 existingPermissions,
-                allowedModels,
+                Array.isArray(allowedModels)
+                    ? await validateModelPermissionIds(c.env.DB, allowedModels)
+                    : allowedModels,
                 sanitizedAccountPerms,
             );
 

--- a/enter.pollinations.ai/test/account-key.test.ts
+++ b/enter.pollinations.ai/test/account-key.test.ts
@@ -135,8 +135,16 @@ test(
         await mocks.enable("tinybird");
         const created = await createApiKeyViaApi(sessionToken, {
             name: "current-key-with-retired-model",
-            allowedModels: ["openai/gpt-5-nano", "retired-model"],
+            allowedModels: ["openai/gpt-5-nano"],
         });
+        await env.DB.prepare("UPDATE apikey SET permissions = ? WHERE id = ?")
+            .bind(
+                JSON.stringify({
+                    models: ["openai/gpt-5-nano", "retired-model"],
+                }),
+                created.id,
+            )
+            .run();
 
         const response = await SELF.fetch(`http://localhost:3000${endpoint}`, {
             headers: {

--- a/enter.pollinations.ai/test/integration/account-keys.test.ts
+++ b/enter.pollinations.ai/test/integration/account-keys.test.ts
@@ -1,4 +1,4 @@
-import { SELF } from "cloudflare:test";
+import { env, SELF } from "cloudflare:test";
 import { describe, expect } from "vitest";
 import { createApiKeyViaApi, test } from "../fixtures.ts";
 
@@ -346,15 +346,26 @@ describe("Account Key Management API", () => {
                     },
                     body: JSON.stringify({
                         name: "account-key-with-retired-model",
-                        allowedModels: [
-                            "black-forest-labs/flux.1-schnell",
-                            "retired-model",
-                        ],
+                        allowedModels: ["black-forest-labs/flux.1-schnell"],
                     }),
                 },
             );
             expect(createResponse.status).toBe(200);
             const created = await createResponse.json();
+
+            await env.DB.prepare(
+                "UPDATE apikey SET permissions = ? WHERE id = ?",
+            )
+                .bind(
+                    JSON.stringify({
+                        models: [
+                            "black-forest-labs/flux.1-schnell",
+                            "retired-model",
+                        ],
+                    }),
+                    created.id,
+                )
+                .run();
 
             const response = await SELF.fetch(
                 "http://localhost:3000/api/account/keys",

--- a/enter.pollinations.ai/test/integration/api-keys.test.ts
+++ b/enter.pollinations.ai/test/integration/api-keys.test.ts
@@ -1,4 +1,8 @@
 import { env, SELF } from "cloudflare:test";
+import {
+    communityModelId,
+    legacyCommunityModelId,
+} from "@shared/community-endpoints.ts";
 import * as schema from "@shared/db/better-auth.ts";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
@@ -915,46 +919,47 @@ describe("API Key Management", () => {
             expect(response.headers.get("pragma")).toBe("no-cache");
         });
 
-        test("should canonicalize model aliases while preserving unknown permissions", async ({
+        test("rejects aliases and unknown IDs on key create and update without changing permissions", async ({
             sessionToken,
         }) => {
+            const canonical = "black-forest-labs/flux.1-schnell";
             const created = await createApiKeyViaApi(sessionToken, {
-                name: "key-with-alias-and-unknown-model",
-                allowedModels: [
-                    "flux",
-                    "nanobanana2",
-                    "gpt-realtime-2",
-                    "retired-model",
-                ],
+                name: "canonical-only-permissions",
+                allowedModels: [canonical],
             });
-
-            const response = await SELF.fetch(
-                "http://localhost:3000/api/api-keys",
-                {
-                    headers: {
-                        Cookie: `better-auth.session_token=${sessionToken}`,
-                    },
-                },
-            );
-
-            expect(response.status).toBe(200);
-            const body = (await response.json()) as ApiKeyListResponse;
-            const listed = body.data.find((key) => key.id === created.id);
-            expect(listed?.permissions?.models).toEqual([
-                "black-forest-labs/flux.1-schnell",
-                "google/gemini-3.1-flash-image",
-                "openai/gpt-realtime-2.1",
-            ]);
-
+            const headers = {
+                "Content-Type": "application/json",
+                Cookie: `better-auth.session_token=${sessionToken}`,
+            };
+            for (const model of ["flux", "nanobanana2", "retired-model"]) {
+                for (const path of [
+                    "/api/api-keys",
+                    `/api/api-keys/${created.id}/update`,
+                ]) {
+                    const response = await SELF.fetch(
+                        `http://localhost:3000${path}`,
+                        {
+                            method: "POST",
+                            headers,
+                            body: JSON.stringify({
+                                name: "invalid-model",
+                                type: "secret",
+                                allowedModels: [model],
+                            }),
+                        },
+                    );
+                    expect(response.status).toBe(400);
+                    expect(JSON.stringify(await response.json())).toContain(
+                        "not a canonical model ID",
+                    );
+                }
+            }
             const db = drizzle(env.DB, { schema });
             const stored = await db.query.apikey.findFirst({
                 where: (apikey, { eq }) => eq(apikey.id, created.id),
             });
             expect(JSON.parse(stored?.permissions ?? "{}").models).toEqual([
-                "black-forest-labs/flux.1-schnell",
-                "google/gemini-3.1-flash-image",
-                "openai/gpt-realtime-2.1",
-                "retired-model",
+                canonical,
             ]);
         });
 
@@ -963,10 +968,6 @@ describe("API Key Management", () => {
         }) => {
             const created = await createApiKeyViaApi(sessionToken, {
                 name: "key-with-private-community-models",
-                allowedModels: [
-                    "model-owner/private-model",
-                    "other-owner/private-model",
-                ],
             });
             const db = drizzle(env.DB, { schema });
             const key = await db.query.apikey.findFirst({
@@ -1030,6 +1031,41 @@ describe("API Key Management", () => {
                     completionTextPrice: 0,
                 },
             ]);
+
+            const headers = {
+                "Content-Type": "application/json",
+                Cookie: `better-auth.session_token=${sessionToken}`,
+            };
+            const update = await SELF.fetch(
+                `http://localhost:3000/api/api-keys/${created.id}/update`,
+                {
+                    method: "POST",
+                    headers,
+                    body: JSON.stringify({
+                        allowedModels: [
+                            communityModelId("model-owner", "private-model"),
+                            communityModelId("other-owner", "private-model"),
+                        ],
+                    }),
+                },
+            );
+            expect(update.status).toBe(200);
+            const aliasUpdate = await SELF.fetch(
+                `http://localhost:3000/api/api-keys/${created.id}/update`,
+                {
+                    method: "POST",
+                    headers,
+                    body: JSON.stringify({
+                        allowedModels: [
+                            legacyCommunityModelId(
+                                "model-owner",
+                                "private-model",
+                            ),
+                        ],
+                    }),
+                },
+            );
+            expect(aliasUpdate.status).toBe(400);
 
             const response = await SELF.fetch(
                 "http://localhost:3000/api/api-keys",
@@ -1126,7 +1162,11 @@ describe("API Key Management", () => {
                         Cookie: `better-auth.session_token=${sessionToken}`,
                     },
                     body: JSON.stringify({
-                        allowedModels: ["flux", "nanobanana2", "nanobanana-2"],
+                        allowedModels: [
+                            "black-forest-labs/flux.1-schnell",
+                            "google/gemini-3.1-flash-image",
+                            "google/gemini-3.1-flash-image",
+                        ],
                         accountPermissions: ["profile", "usage"],
                     }),
                 },
@@ -1172,7 +1212,7 @@ describe("API Key Management", () => {
                         Cookie: `better-auth.session_token=${sessionToken}`,
                     },
                     body: JSON.stringify({
-                        allowedModels: ["flux"],
+                        allowedModels: ["black-forest-labs/flux.1-schnell"],
                     }),
                 },
             );
@@ -1311,9 +1351,16 @@ describe("API Key Management", () => {
             // Create a new key
             const createdKey = await createApiKeyViaApi(sessionToken, {
                 name: "budget-test",
-                allowedModels: ["flux", "retired-model"],
             });
             const keyId = createdKey.id;
+            await drizzle(env.DB)
+                .update(schema.apikey)
+                .set({
+                    permissions: JSON.stringify({
+                        models: ["flux", "retired-model"],
+                    }),
+                })
+                .where(eq(schema.apikey.id, keyId));
 
             // Set budget to 50
             const updateResponse = await SELF.fetch(
@@ -1416,7 +1463,7 @@ describe("API Key Management", () => {
                         Cookie: `better-auth.session_token=${sessionToken}`,
                     },
                     body: JSON.stringify({
-                        allowedModels: ["flux"],
+                        allowedModels: ["black-forest-labs/flux.1-schnell"],
                         accountPermissions: ["usage"],
                     }),
                 },
@@ -1536,7 +1583,7 @@ describe("API Key Management", () => {
                         Cookie: `better-auth.session_token=${sessionToken}`,
                     },
                     body: JSON.stringify({
-                        allowedModels: ["openai"],
+                        allowedModels: ["openai/gpt-5.4-nano"],
                     }),
                 },
             );

--- a/gen.pollinations.ai/src/model3d/models/inferenceportClient.ts
+++ b/gen.pollinations.ai/src/model3d/models/inferenceportClient.ts
@@ -170,6 +170,13 @@ async function inferenceportFetch<T>(
         );
     }
 
+    // A failed status check does not mean the generation failed. Never resubmit.
+    if (method === "GET" && response.status >= 500) {
+        await response.body?.cancel();
+        await sleep(Math.min(POLL_INTERVAL_MS, remainingTime(deadline)));
+        return inferenceportFetch<T>(token, method, path, deadline);
+    }
+
     if (!response.ok) {
         const text = await response.text().catch(() => "<no body>");
         throw new InferenceportError(

--- a/gen.pollinations.ai/test/community-endpoints.test.ts
+++ b/gen.pollinations.ai/test/community-endpoints.test.ts
@@ -4455,8 +4455,8 @@ fixtureTest(
 );
 
 fixtureTest(
-    "routes direct calls to a hidden community model",
-    async ({ apiKey }) => {
+    "routes canonical and aliased calls to a hidden community model with a canonical-only key",
+    async () => {
         const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;
         const modelName = `disabled-call-${crypto.randomUUID().slice(0, 8)}`;
         const modelId = communityModelId(ownerGithubUsername, modelName);
@@ -4487,6 +4487,10 @@ fixtureTest(
             hiddenBy: "monitor",
             createdAt: new Date(),
             updatedAt: new Date(),
+        });
+        const { key: apiKey } = await createTestApiKey({
+            allowedModels: [modelId],
+            user: { packBalance: 100 },
         });
 
         const fetchMock = vi.fn(async (input, init) => {

--- a/gen.pollinations.ai/test/model-permissions.test.ts
+++ b/gen.pollinations.ai/test/model-permissions.test.ts
@@ -61,7 +61,7 @@ test("permission readback canonicalizes aliases without exposing hidden or unkno
 
 test("legacy stored allowlists still filter catalogs after canonical promotion", async () => {
     const { key, id } = await createTestApiKey({
-        allowedModels: ["nanobanana2"],
+        allowedModels: ["google/gemini-3.1-flash-image"],
         user: { packBalance: 100 },
     });
     // Simulate an old Enter writer after the one-time migration has run.
@@ -157,7 +157,7 @@ test("permission readback resolves future names against the current registry", (
 
 test("future-name stored allowlists filter catalogs without rewriting the database", async () => {
     const { key, id } = await createTestApiKey({
-        allowedModels: ["flux"],
+        allowedModels: ["black-forest-labs/flux.1-schnell"],
         user: { packBalance: 100 },
     });
     const permissions = { models: ["black-forest-labs/flux.1-schnell"] };
@@ -267,20 +267,13 @@ test("filters image model list by API key permissions", async ({
     expect(modelNames).toContain(RESTRICTED_IMAGE_TEST_MODEL);
 });
 
-test("canonicalizes aliases in new model permissions", async () => {
-    const { key } = await createTestApiKey({
-        allowedModels: ["nanobanana2"],
-        user: { packBalance: 100 },
-    });
-    const response = await fetchWorker("/image/models", {
-        headers: { Authorization: `Bearer ${key}` },
-    });
-
-    expect(response.status).toBe(200);
-    const body = (await response.json()) as { name: string }[];
-    expect(body.map((model) => model.name)).toEqual([
-        "google/gemini-3.1-flash-image",
-    ]);
+test("rejects aliases in new model permissions", async () => {
+    await expect(
+        createTestApiKey({
+            allowedModels: ["nanobanana2"],
+            user: { packBalance: 100 },
+        }),
+    ).rejects.toThrow("not a canonical model ID");
 });
 
 test("empty model permissions deny access and return an empty catalog", async () => {
@@ -306,7 +299,7 @@ test("empty model permissions deny access and return an empty catalog", async ()
 
 test("media routes own their endpoint-specific model defaults", async () => {
     const { key } = await createTestApiKey({
-        allowedModels: ["zimage"],
+        allowedModels: ["tongyi-mai/z-image-turbo"],
         user: { packBalance: 100 },
     });
 

--- a/gen.pollinations.ai/test/model3d/inferenceportClient.test.ts
+++ b/gen.pollinations.ai/test/model3d/inferenceportClient.test.ts
@@ -91,6 +91,69 @@ describe("runInferenceport", () => {
         expect(jobInit.body).toBeUndefined();
     });
 
+    it("retries a 524 status check for the same job without resubmitting", async () => {
+        const fetchSpy = vi
+            .spyOn(globalThis, "fetch")
+            .mockResolvedValueOnce(submitResponse())
+            .mockResolvedValueOnce(new Response("Timed out", { status: 524 }))
+            .mockResolvedValueOnce(
+                jobResponse("completed", {
+                    data: [{ model_ply_b64_bytes: "Zm9v" }],
+                }),
+            );
+
+        const result = await runInferenceport({
+            model: "asset-harvester",
+            imageUrls: ["https://example.com/a.jpg"],
+        });
+
+        expect(result.plyBase64).toBe("Zm9v");
+        expect(
+            fetchSpy.mock.calls.map(([url, init]) => [url, init?.method]),
+        ).toEqual([
+            [SUBMIT_URL, "POST"],
+            [JOB_URL, "GET"],
+            [JOB_URL, "GET"],
+        ]);
+    }, 10_000);
+
+    it.each([
+        ["submission", 524, 1],
+        ["poll", 401, 2],
+    ] as const)("does not retry a %s HTTP %i error", async (_stage, status, calls) => {
+        const fetchSpy = vi.spyOn(globalThis, "fetch");
+        if (calls === 2) fetchSpy.mockResolvedValueOnce(submitResponse());
+        fetchSpy.mockResolvedValue(new Response("Failed", { status }));
+
+        await expect(
+            runInferenceport({
+                model: "asset-harvester",
+                imageUrls: ["https://example.com/a.jpg"],
+            }),
+        ).rejects.toBeInstanceOf(InferenceportError);
+        expect(fetchSpy).toHaveBeenCalledTimes(calls);
+    });
+
+    it("does not extend the deadline after a polling error", async () => {
+        let now = 0;
+        vi.spyOn(Date, "now").mockImplementation(() => now);
+        const fetchSpy = vi
+            .spyOn(globalThis, "fetch")
+            .mockResolvedValueOnce(submitResponse())
+            .mockImplementationOnce(async () => {
+                now = 300_000;
+                return new Response("Timed out", { status: 524 });
+            });
+
+        await expect(
+            runInferenceport({
+                model: "asset-harvester",
+                imageUrls: ["https://example.com/a.jpg"],
+            }),
+        ).rejects.toMatchObject({ status: 504 });
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
     it("throws when submission has no job ID", async () => {
         vi.spyOn(globalThis, "fetch").mockResolvedValue(
             Response.json({ status: "pending" }, { status: 202 }),

--- a/shared/auth/api-key-creation.ts
+++ b/shared/auth/api-key-creation.ts
@@ -2,7 +2,7 @@ import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import { HTTPException } from "hono/http-exception";
 import * as schema from "../db/better-auth.ts";
-import { canonicalizeModelPermissionIds } from "../registry/visible-model-ids.ts";
+import { validateModelPermissionIds } from "../registry/visible-model-ids.ts";
 import { getRedirectUris, parseMetadata } from "./api-key-metadata.ts";
 import { sanitizeAuthorizeAccountPermissions } from "./authorize-config.ts";
 import {
@@ -247,7 +247,10 @@ export async function createApiKeyForUser({
 
     const permissions: Record<string, string[]> = {};
     if (allowedModels) {
-        permissions.models = canonicalizeModelPermissionIds(allowedModels);
+        permissions.models = await validateModelPermissionIds(
+            dbBinding,
+            allowedModels,
+        );
     }
     if (safeAccountPerms && safeAccountPerms.length > 0) {
         permissions.account = safeAccountPerms;

--- a/shared/registry/visible-model-ids.ts
+++ b/shared/registry/visible-model-ids.ts
@@ -1,5 +1,6 @@
 import { and, eq, isNotNull, isNull } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
+import { HTTPException } from "hono/http-exception";
 import {
     communityModelId,
     effectiveCommunityEndpointVisibility,
@@ -11,6 +12,40 @@ import {
     isVisibleModelDefinition,
     resolveModelName,
 } from "./registry.ts";
+
+/** Key writes validate canonical-ID membership without resolving names. */
+export async function validateModelPermissionIds(
+    dbBinding: D1Database,
+    modelIds: readonly string[],
+): Promise<string[]> {
+    if (modelIds.length === 0) return [];
+    const canonicalIds = new Set<string>(
+        getModels().filter(
+            (id) => getRegistryModelDefinition(id).fallbackOnly !== true,
+        ),
+    );
+    const rows = await drizzle(dbBinding)
+        .select({
+            owner: schema.user.githubUsername,
+            name: schema.communityEndpoint.name,
+        })
+        .from(schema.communityEndpoint)
+        .innerJoin(
+            schema.user,
+            eq(schema.communityEndpoint.ownerUserId, schema.user.id),
+        );
+    for (const row of rows) {
+        if (row.owner) canonicalIds.add(communityModelId(row.owner, row.name));
+    }
+    for (const id of modelIds) {
+        if (!canonicalIds.has(id)) {
+            throw new HTTPException(400, {
+                message: `Model permission '${id}' is not a canonical model ID. Use IDs from /models.`,
+            });
+        }
+    }
+    return [...new Set(modelIds)];
+}
 
 export function canonicalizeModelPermissionIds(
     modelIds: readonly string[],


### PR DESCRIPTION
- Promotes canonical model-permission validation and the community namespace announcement
- Keeps existing stored aliases readable while requiring canonical IDs on new key writes
- Retries only InferencePort job-status GETs on upstream 5xx responses; never resubmits generation

Validated with focused Enter (63 tests), Gen permission/community (157 tests), and InferencePort (16 tests) suites.