### PR TITLE
chore: promote Perplexity gateway deployment pin

### DIFF
--- a/APIDOCS.md
+++ b/APIDOCS.md
@@ -285,7 +285,7 @@ Managed prompt agents accept `reasoning.effort` (Responses) and `reasoning_effor
 
 ### Media models in conversations
 
-Image, video, audio and 3D models that advertise these endpoints in [`/models`](/models) accept a text prompt. Only the last user message's text (or a string Responses `input`) is used; history, instructions and text-generation settings are ignored. Attachments return HTTP 400. Use the native media endpoints for edits and generation settings.
+Image, video, audio and 3D models that advertise these endpoints in [`/models`](/models) accept a text prompt. Only the last user message is used; history, instructions and text-generation settings are ignored. Its text parts (or a string Responses `input`) form the prompt. Image parts (`image_url` in Chat, `input_image` in Responses, as URLs or data URIs) are the source images of image models and the start frame of video models that list `image` under `input_modalities`, exactly as `/v1/images/edits` does; other models, including 3D, return HTTP 400 for them, and any other attachment type returns HTTP 400. Use the native media endpoints for generation settings.
 
 Empty prompts, malformed Unicode and prompts consisting only of `.` or `..` return HTTP 400. Reference-required models return their normal missing-input error.
 

--- a/gen.pollinations.ai/scripts/deploy-portkey.sh
+++ b/gen.pollinations.ai/scripts/deploy-portkey.sh
@@ -7,10 +7,10 @@ set -e
 # Configuration
 # Using pollinations fork with upstream v1.15.2 merged + our custom patches
 # Includes: upstream vulnerability fixes, forward-header loop prevention, Gemini/Vertex additions,
-# and Vertex explicit context caching via cache_control markers
-# PRs: https://github.com/pollinations/gateway/pull/5, https://github.com/pollinations/gateway/pull/8
+# Vertex explicit context caching, and Perplexity LF/CRLF stream framing
+# PRs: https://github.com/pollinations/gateway/pull/5, https://github.com/pollinations/gateway/pull/8, https://github.com/pollinations/gateway/pull/11
 PORTKEY_REPO="https://github.com/pollinations/gateway.git"
-PORTKEY_COMMIT="${PORTKEY_COMMIT:-c187bd5898e191dec8a98dd78fad6b643fb86ba4}"  # v1.15.2 sync + vertex explicit caching (#8)
+PORTKEY_COMMIT="${PORTKEY_COMMIT:-9ed9584bb8fcf61172dac8028b48c15957765f5d}"  # Perplexity stream framing fix (#11)
 CLONE_DIR="/tmp/portkey-gateway-$$"
 ENVIRONMENT="${PORTKEY_ENV:-production}"
 PORTKEY_ACCOUNT_ID="${PORTKEY_ACCOUNT_ID:-b6ec751c0862027ba269faf7029b2501}"


### PR DESCRIPTION
- Pins future gateway deployments to the already-verified Perplexity streaming repair (#14657).
- Includes the generated API documentation update (#14659).
- No model routes, prices, credentials, or generation behavior change.