### PR TITLE
feat: add llm-pollinations plugin for Simon Willison's LLM

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -24,6 +24,12 @@ A terminal app for using Pollinations without writing any code. Type a prompt, g
 
 **Who it's for:** people comfortable in a terminal — humans testing things quickly, and AI agents driving workflows.
 
+### [llm-pollinations/](./llm-pollinations) — plugin for Simon Willison's `llm`
+
+A native provider plugin that registers Pollinations' text models inside the [`llm`](https://llm.datasette.io/) CLI and Python library, so you can run `llm -m pollinations/<model>` alongside any other provider.
+
+**Who it's for:** developers already using the `llm` CLI/library who want Pollinations models available without leaving that tool.
+
 ### [n8n/](./n8n) — n8n tunnel setup
 
 A small set of helper scripts for exposing a self-hosted [n8n](https://n8n.io) automation instance through a Cloudflare tunnel. Not a Pollinations library — it's infrastructure used by the team to run automation workflows that talk to Pollinations.

--- a/packages/llm-pollinations/README.md
+++ b/packages/llm-pollinations/README.md
@@ -1,0 +1,68 @@
+# llm-pollinations
+
+[LLM](https://llm.datasette.io/) plugin for text models hosted by [Pollinations.ai](https://pollinations.ai).
+
+## Installation
+
+```bash
+llm install llm-pollinations
+```
+
+## Configuration
+
+Set an API key, either as an environment variable:
+
+```bash
+export POLLINATIONS_API_KEY=sk_...
+```
+
+or stored in LLM's key store:
+
+```bash
+llm keys set pollinations
+```
+
+Get a key at [enter.pollinations.ai/keys](https://enter.pollinations.ai/keys), or create a dedicated one with the [Polli CLI](https://github.com/pollinations/pollinations/tree/main/packages/polli-cli):
+
+```bash
+polli keys create --name llm-pollinations --budget 5
+```
+
+## Usage
+
+Models are loaded from Pollinations' live catalog and registered as `pollinations/<model-id>`:
+
+```bash
+llm models list | grep pollinations
+llm -m pollinations/openai/gpt-5.4-nano "Explain pollination in one sentence"
+```
+
+Vision, tool calling, and reasoning options are only available on models the catalog advertises support for:
+
+```bash
+llm -m pollinations/openai/gpt-6-astra -a photo.jpg "What's in this image?"
+llm -m pollinations/openai/gpt-6-astra --functions 'def multiply(x: int, y: int) -> int: return x * y' "What is 12 times 7?"
+```
+
+The catalog is cached for an hour under LLM's user directory and falls back to the last cached copy if Pollinations is unreachable.
+
+## Python API
+
+```python
+import llm
+
+model = llm.get_model("pollinations/openai/gpt-5.4-nano")
+response = model.prompt("Explain pollination in one sentence")
+print(response.text())
+```
+
+## Scope
+
+This plugin only covers Pollinations' OpenAI-compatible chat models via LLM's built-in `Chat`/`AsyncChat` classes — no image generation, embeddings, or a custom auth flow. Streaming, conversations, tools, and attachments are all handled by LLM's OpenAI-compatible base classes.
+
+## Development
+
+```bash
+pip install -e . pytest
+python -m pytest
+```

--- a/packages/llm-pollinations/llm_pollinations.py
+++ b/packages/llm-pollinations/llm_pollinations.py
@@ -1,0 +1,103 @@
+import json
+import time
+from pathlib import Path
+
+import httpx
+import llm
+from llm.default_plugins.openai_models import AsyncChat, Chat
+
+API_BASE = "https://gen.pollinations.ai/v1"
+MODELS_URL = f"{API_BASE}/models"
+CACHE_PATH = llm.user_dir() / "pollinations_models.json"
+CACHE_TIMEOUT = 3600
+
+
+class DownloadError(Exception):
+    pass
+
+
+def fetch_cached_json(url, path, cache_timeout, headers=None):
+    path = Path(path)
+    if path.is_file():
+        mod_time = path.stat().st_mtime
+        if time.time() - mod_time < cache_timeout:
+            with open(path, "r") as fp:
+                return json.load(fp)
+    try:
+        response = httpx.get(url, headers=headers, timeout=10, follow_redirects=True)
+        response.raise_for_status()
+        data = response.json()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w") as fp:
+            json.dump(data, fp)
+        return data
+    except httpx.HTTPError:
+        if path.is_file():
+            with open(path, "r") as fp:
+                return json.load(fp)
+        raise DownloadError(f"Failed to fetch {url} and no cache is available at {path}")
+
+
+def get_pollinations_models(key):
+    data = fetch_cached_json(
+        url=MODELS_URL,
+        path=CACHE_PATH,
+        cache_timeout=CACHE_TIMEOUT,
+        headers={"Authorization": f"Bearer {key}"},
+    )
+    return data["data"]
+
+
+def is_chat_model(model_definition):
+    return model_definition.get("category") == "text" and "/v1/chat/completions" in (
+        model_definition.get("supported_endpoints") or []
+    )
+
+
+def supports_images(model_definition):
+    return "image" in (model_definition.get("input_modalities") or [])
+
+
+class _PollinationsMixin:
+    needs_key = "pollinations"
+    key_env_var = "POLLINATIONS_API_KEY"
+
+    def __str__(self):
+        return f"Pollinations Chat: {self.model_id}"
+
+
+class PollinationsChat(_PollinationsMixin, Chat):
+    pass
+
+
+class PollinationsAsyncChat(_PollinationsMixin, AsyncChat):
+    pass
+
+
+@llm.hookimpl
+def register_models(register):
+    key = llm.get_key("", "pollinations", "POLLINATIONS_API_KEY")
+    if not key:
+        return
+    try:
+        models = get_pollinations_models(key)
+    except DownloadError:
+        return
+    seen_ids = set()
+    for model_definition in models:
+        model_id = model_definition.get("id")
+        if not model_id or model_id in seen_ids or not is_chat_model(model_definition):
+            continue
+        seen_ids.add(model_id)
+        kwargs = dict(
+            model_id=f"pollinations/{model_id}",
+            model_name=model_id,
+            api_base=API_BASE,
+            vision=supports_images(model_definition),
+            reasoning=bool(model_definition.get("reasoning")),
+            supports_tools=bool(model_definition.get("tools")),
+        )
+        register(
+            PollinationsChat(**kwargs),
+            PollinationsAsyncChat(**kwargs),
+        )

--- a/packages/llm-pollinations/pyproject.toml
+++ b/packages/llm-pollinations/pyproject.toml
@@ -1,0 +1,26 @@
+[project]
+name = "llm-pollinations"
+version = "0.1.0"
+description = "LLM plugin for models hosted by Pollinations.ai"
+readme = "README.md"
+authors = [{name = "pollinations.ai"}]
+license = "MIT"
+requires-python = ">=3.10"
+dependencies = [
+    "llm>=0.35",
+    "httpx",
+]
+
+[project.urls]
+Homepage = "https://github.com/pollinations/pollinations/tree/main/packages/llm-pollinations"
+Issues = "https://github.com/pollinations/pollinations/issues"
+
+[project.entry-points.llm]
+pollinations = "llm_pollinations"
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[dependency-groups]
+dev = ["pytest"]

--- a/packages/llm-pollinations/tests/test_llm_pollinations.py
+++ b/packages/llm-pollinations/tests/test_llm_pollinations.py
@@ -1,0 +1,130 @@
+import json
+import time
+
+import httpx
+import llm
+import pytest
+
+import llm_pollinations as mod
+
+TEXT_MODEL = {
+    "id": "openai/gpt-5.4-nano",
+    "category": "text",
+    "supported_endpoints": ["/v1/chat/completions", "/text"],
+    "input_modalities": ["text", "image"],
+    "tools": True,
+    "reasoning": False,
+}
+NON_CHAT_TEXT_MODEL = {
+    "id": "some/embedding-model",
+    "category": "text",
+    "supported_endpoints": ["/v1/embeddings"],
+}
+IMAGE_MODEL = {
+    "id": "black-forest-labs/flux",
+    "category": "image",
+    "supported_endpoints": ["/v1/chat/completions", "/v1/images/generations"],
+}
+
+
+def test_is_chat_model():
+    assert mod.is_chat_model(TEXT_MODEL) is True
+    assert mod.is_chat_model(NON_CHAT_TEXT_MODEL) is False
+    assert mod.is_chat_model(IMAGE_MODEL) is False
+
+
+def test_supports_images():
+    assert mod.supports_images(TEXT_MODEL) is True
+    assert mod.supports_images(NON_CHAT_TEXT_MODEL) is False
+
+
+def test_fetch_cached_json_writes_and_reuses_cache(tmp_path, monkeypatch):
+    calls = []
+
+    def fake_get(url, headers=None, timeout=None, follow_redirects=None):
+        calls.append(url)
+        return httpx.Response(200, json={"data": [TEXT_MODEL]}, request=httpx.Request("GET", url))
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+    path = tmp_path / "models.json"
+
+    first = mod.fetch_cached_json(mod.MODELS_URL, path, cache_timeout=3600)
+    second = mod.fetch_cached_json(mod.MODELS_URL, path, cache_timeout=3600)
+
+    assert first == second == {"data": [TEXT_MODEL]}
+    assert len(calls) == 1
+
+
+def test_fetch_cached_json_falls_back_to_stale_cache_on_error(tmp_path, monkeypatch):
+    path = tmp_path / "models.json"
+    path.write_text(json.dumps({"data": [TEXT_MODEL]}))
+    old_time = time.time() - 10000
+    import os
+
+    os.utime(path, (old_time, old_time))
+
+    def failing_get(url, headers=None, timeout=None, follow_redirects=None):
+        raise httpx.ConnectError("boom", request=httpx.Request("GET", url))
+
+    monkeypatch.setattr(httpx, "get", failing_get)
+
+    result = mod.fetch_cached_json(mod.MODELS_URL, path, cache_timeout=3600)
+    assert result == {"data": [TEXT_MODEL]}
+
+
+def test_fetch_cached_json_raises_without_cache_or_network(tmp_path, monkeypatch):
+    path = tmp_path / "models.json"
+
+    def failing_get(url, headers=None, timeout=None, follow_redirects=None):
+        raise httpx.ConnectError("boom", request=httpx.Request("GET", url))
+
+    monkeypatch.setattr(httpx, "get", failing_get)
+
+    with pytest.raises(mod.DownloadError):
+        mod.fetch_cached_json(mod.MODELS_URL, path, cache_timeout=3600)
+
+
+def test_register_models_skips_when_no_key(monkeypatch):
+    monkeypatch.setattr(llm, "get_key", lambda *a, **k: None)
+    registered = []
+    mod.register_models(lambda *models: registered.extend(models))
+    assert registered == []
+
+
+def test_register_models_registers_chat_models_only(monkeypatch, tmp_path):
+    monkeypatch.setattr(llm, "get_key", lambda *a, **k: "sk_test")
+    monkeypatch.setattr(mod, "CACHE_PATH", tmp_path / "models.json")
+    monkeypatch.setattr(
+        mod,
+        "get_pollinations_models",
+        lambda key: [TEXT_MODEL, NON_CHAT_TEXT_MODEL, IMAGE_MODEL],
+    )
+
+    registered = []
+    mod.register_models(lambda *models: registered.extend(models))
+
+    assert len(registered) == 2
+    chat_model, async_chat_model = registered
+    assert isinstance(chat_model, mod.PollinationsChat)
+    assert isinstance(async_chat_model, mod.PollinationsAsyncChat)
+    assert chat_model.model_id == "pollinations/openai/gpt-5.4-nano"
+    assert chat_model.model_name == "openai/gpt-5.4-nano"
+    assert chat_model.vision is True
+    assert chat_model.supports_tools is True
+    assert chat_model.needs_key == "pollinations"
+    assert chat_model.key_env_var == "POLLINATIONS_API_KEY"
+
+
+def test_register_models_deduplicates_ids(monkeypatch, tmp_path):
+    monkeypatch.setattr(llm, "get_key", lambda *a, **k: "sk_test")
+    monkeypatch.setattr(mod, "CACHE_PATH", tmp_path / "models.json")
+    monkeypatch.setattr(
+        mod,
+        "get_pollinations_models",
+        lambda key: [TEXT_MODEL, dict(TEXT_MODEL)],
+    )
+
+    registered = []
+    mod.register_models(lambda *models: registered.extend(models))
+
+    assert len(registered) == 2


### PR DESCRIPTION
Fixes #14660

Adds `packages/llm-pollinations`, a native provider plugin for Simon Willison's `llm` CLI/library.

- Registers Pollinations' text models as `pollinations/<model-id>`, loaded live from `gen.pollinations.ai/v1/models` (no hardcoded list).
- Reuses `llm`'s built-in `Chat`/`AsyncChat` OpenAI-compatible base classes — streaming, conversations, tool calling, and attachments are handled by `llm`, not reimplemented.
- Vision, tool calling, and reasoning are only enabled per-model when the catalog advertises them (`input_modalities`, `tools`, `reasoning`).
- Catalog fetch is gated on a configured key (`llm keys set pollinations` or `POLLINATIONS_API_KEY`) and cached for an hour with stale-cache fallback on network errors.
- README covers install, key setup (direct + via `polli keys create`), CLI and Python usage.

**Testing:**
- `python -m pytest` — 8 unit tests covering model filtering, capability detection, cache read/write/stale-fallback, and `register_models` behavior (no key → no-op, dedup, correct kwargs).
- Verified live against `gen.pollinations.ai/v1/models` (public, no key required to list): confirms real catalog shape and that filtering to `category == "text"` + `/v1/chat/completions` support yields 282 unique, non-colliding model IDs with correct vision/tools/reasoning flags.
- No live Pollinations API key with balance was available in this environment to run real chat completions, so request/response wiring (non-streaming, streaming, multi-turn conversation, image attachment, tool-calling loop, and the async Python API) was verified end-to-end against a local OpenAI-compatible mock server through the actual `PollinationsChat`/`PollinationsAsyncChat` classes — all passed.