### PR TITLE
fix: run community monitor with Fable 5.1

### DIFF
--- a/operations/community-monitor/README.md
+++ b/operations/community-monitor/README.md
@@ -19,15 +19,13 @@ Committed (source of truth — edit here, then deploy):
   or better in the freshest 24h/48h window with at least 20 requests are
   protected from a delayed hide after a fix or new fallback.
 - `community-monitor.service` + `loop.sh` — the deployed systemd path. Each
-  cycle gets a fresh Fable 5.1 process (`claude-fable-5-1`, medium effort), and
-  systemd starts the next one 60 minutes after completion. Headless cycles
-  cannot be remote-controlled; a separate
+  cycle gets a fresh Claude process and systemd starts the next one 60 minutes
+  after completion. Headless cycles cannot be remote-controlled; a separate
   persistent `claude --remote-control community-monitor` session runs alongside
   as a phone-accessible console.
 - `.claude/settings.json` — project-scoped Claude Code settings. It fixes the
   auto-compaction calculation window at 300,000 tokens for both headless cycles
-  and the remote-control session launched from the monitor directory. Claude
-  compacts before that window fills to reserve room for output and the summary.
+  and the remote-control session launched from the monitor directory.
 - `update-from-repo.sh` — before each cycle, fetches `origin/main` and atomically
   refreshes only the committed prompt/runtime files. It does not activate until
   the updater itself exists on `main`, so deploying an open PR cannot downgrade
@@ -183,7 +181,7 @@ message limits, health thresholds, and cooldowns remain unchanged.
 
 ## Model/effort
 
-The deployed agent is pinned to `claude-opus-4-8` at medium effort in
+The deployed agent is pinned to `claude-fable-5-1` at medium effort in
 `loop.sh`. Every cycle starts with a fresh context containing the complete
 current `CYCLE.md`. Medium effort is intentional: routine checks are
 mechanical, but owner replies and billing diagnostics require controlled
@@ -191,14 +189,15 @@ comparisons and careful interpretation.
 
 `CLAUDE_CODE_AUTO_COMPACT_WINDOW=300000` is committed in
 `.claude/settings.json`. This is Claude Code's effective context capacity for
-auto-compaction calculations, not a model output-token limit. Project scope is
+auto-compaction calculations, not a model output-token limit. Claude compacts
+before that window fills to reserve room for output and the summary. Project scope is
 intentional: it applies reproducibly to the headless service and the persistent
 remote-control session without modifying the machine's personal settings.
 
 Codex 5.6 Sol at medium effort is the preferred replacement once the EC2 box
 has its own non-personal Codex authentication. Do not copy a maintainer's local
 Codex credentials onto the shared server. Until that service credential is
-available, keep the Opus medium-effort runtime rather than silently leaving the
+available, keep the Fable medium-effort runtime rather than silently leaving the
 monitor offline.
 
 ## Authority split

--- a/operations/community-monitor/README.md
+++ b/operations/community-monitor/README.md
@@ -19,13 +19,15 @@ Committed (source of truth — edit here, then deploy):
   or better in the freshest 24h/48h window with at least 20 requests are
   protected from a delayed hide after a fix or new fallback.
 - `community-monitor.service` + `loop.sh` — the deployed systemd path. Each
-  cycle gets a fresh Claude process and systemd starts the next one 60 minutes
-  after completion. Headless cycles cannot be remote-controlled; a separate
+  cycle gets a fresh Fable 5.1 process (`claude-fable-5-1`, medium effort), and
+  systemd starts the next one 60 minutes after completion. Headless cycles
+  cannot be remote-controlled; a separate
   persistent `claude --remote-control community-monitor` session runs alongside
   as a phone-accessible console.
 - `.claude/settings.json` — project-scoped Claude Code settings. It fixes the
   auto-compaction calculation window at 300,000 tokens for both headless cycles
-  and the remote-control session launched from the monitor directory.
+  and the remote-control session launched from the monitor directory. Claude
+  compacts before that window fills to reserve room for output and the summary.
 - `update-from-repo.sh` — before each cycle, fetches `origin/main` and atomically
   refreshes only the committed prompt/runtime files. It does not activate until
   the updater itself exists on `main`, so deploying an open PR cannot downgrade
@@ -54,8 +56,9 @@ Every new instance gets a persisted swapfile at least the size of RAM.
 
 Use a monitor-specific SSH key and the infrastructure secret manager; do not
 commit private keys or host credentials to this repository, even encrypted.
-Install Node and the `claude` CLI, clone/copy this directory, populate `.env`
-(see `.env.example`), install `community-monitor.service`, then run
+Install Node and Claude Code 2.1.257 or newer (required for Fable 5.1),
+clone/copy this directory, populate `.env` (see `.env.example`),
+install `community-monitor.service`, then run
 `systemctl enable --now community-monitor`.
 
 Moving credentials requires the separate, scoped approval in AGENTS.md's

--- a/operations/community-monitor/loop.sh
+++ b/operations/community-monitor/loop.sh
@@ -11,7 +11,7 @@ LOG=/home/ubuntu/monitor/loop.log
 
 echo "=== cycle start $(date -u +%FT%TZ) ===" | tee -a "$LOG"
 claude -p "$(cat CYCLE.md)" \
-    --model claude-opus-4-8 --effort medium \
+    --model claude-fable-5-1 --effort medium \
     --dangerously-skip-permissions \
     --allowedTools "Bash,Read,Write,mcp__discord__discord_read_messages,mcp__discord__discord_send" \
     2>&1 | tee -a "$LOG"


### PR DESCRIPTION
- Pins the hourly monitor to `claude-fable-5-1`, keeping medium effort and the existing cadence.
- Keeps the existing 300,000-token auto-compaction window; documents its output/summary reserve and the required Claude Code version.
- Verified on EC2 with Claude Code 2.1.267 and a successful tool-disabled Fable 5.1 request using the existing login.
- Validation: shell syntax, diff checks, and all 11 monitor tests pass. Biome does not process these shell/Markdown files.