### PR TITLE
fix: honor explicit chat limits and tool settings

### DIFF
--- a/gen.pollinations.ai/scripts/deploy-portkey.sh
+++ b/gen.pollinations.ai/scripts/deploy-portkey.sh
@@ -10,7 +10,7 @@ set -e
 # Vertex explicit context caching, and Perplexity LF/CRLF stream framing
 # PRs: https://github.com/pollinations/gateway/pull/5, https://github.com/pollinations/gateway/pull/8, https://github.com/pollinations/gateway/pull/11
 PORTKEY_REPO="https://github.com/pollinations/gateway.git"
-PORTKEY_COMMIT="${PORTKEY_COMMIT:-9ed9584bb8fcf61172dac8028b48c15957765f5d}"  # Perplexity stream framing fix (#11)
+PORTKEY_COMMIT="${PORTKEY_COMMIT:-0847784b29c4f48ce89d052533ef751f19b47f8f}"  # Preserve explicit chat provider parameters
 CLONE_DIR="/tmp/portkey-gateway-$$"
 ENVIRONMENT="${PORTKEY_ENV:-production}"
 PORTKEY_ACCOUNT_ID="${PORTKEY_ACCOUNT_ID:-b6ec751c0862027ba269faf7029b2501}"

--- a/gen.pollinations.ai/scripts/deploy-portkey.sh
+++ b/gen.pollinations.ai/scripts/deploy-portkey.sh
@@ -10,7 +10,7 @@ set -e
 # Vertex explicit context caching, and Perplexity LF/CRLF stream framing
 # PRs: https://github.com/pollinations/gateway/pull/5, https://github.com/pollinations/gateway/pull/8, https://github.com/pollinations/gateway/pull/11
 PORTKEY_REPO="https://github.com/pollinations/gateway.git"
-PORTKEY_COMMIT="${PORTKEY_COMMIT:-0847784b29c4f48ce89d052533ef751f19b47f8f}"  # Preserve explicit chat provider parameters
+PORTKEY_COMMIT="${PORTKEY_COMMIT:-639928b0af4682e675b0cf0209b79694c01ea330}"  # Preserve explicit chat provider parameters (#12)
 CLONE_DIR="/tmp/portkey-gateway-$$"
 ENVIRONMENT="${PORTKEY_ENV:-production}"
 PORTKEY_ACCOUNT_ID="${PORTKEY_ACCOUNT_ID:-b6ec751c0862027ba269faf7029b2501}"

--- a/gen.pollinations.ai/src/text/generateTextPortkey.ts
+++ b/gen.pollinations.ai/src/text/generateTextPortkey.ts
@@ -100,9 +100,8 @@ export async function generateTextPortkey(
         );
     }
 
-    // These options belong to the Responses adapter, not generic providers.
+    // This internal transport belongs only to the Responses adapter.
     delete state.options.responsesFetcher;
-    delete state.options.parallel_tool_calls;
 
     const completion = await genericOpenAIClient(
         state.messages,

--- a/gen.pollinations.ai/src/text/transforms/parameterProcessor.ts
+++ b/gen.pollinations.ai/src/text/transforms/parameterProcessor.ts
@@ -30,15 +30,15 @@ export function processParameters(
     }
 
     if (config.supportsMaxCompletionTokens === true) {
-        if (updatedOptions.max_tokens !== undefined) {
+        if (updatedOptions.max_tokens != null) {
             log(
                 `Converting max_tokens (${updatedOptions.max_tokens}) to max_completion_tokens`,
             );
             updatedOptions.max_completion_tokens = updatedOptions.max_tokens;
             delete updatedOptions.max_tokens;
         }
-    } else if (updatedOptions.max_completion_tokens !== undefined) {
-        if (updatedOptions.max_tokens === undefined) {
+    } else if (updatedOptions.max_completion_tokens != null) {
+        if (updatedOptions.max_tokens == null) {
             updatedOptions.max_tokens = updatedOptions.max_completion_tokens;
         }
         delete updatedOptions.max_completion_tokens;

--- a/gen.pollinations.ai/src/text/utils/modelResolver.ts
+++ b/gen.pollinations.ai/src/text/utils/modelResolver.ts
@@ -60,11 +60,19 @@ export function resolveModelConfig(
     const definedOptions = Object.fromEntries(
         Object.entries(options).filter(([_, v]) => v !== undefined),
     );
+    const defaults = {
+        ...((config.defaultOptions || {}) as Record<string, unknown>),
+    };
+    // Either caller-supplied token limit must win before alias conversion.
+    if (options.max_tokens != null || options.max_completion_tokens != null) {
+        delete defaults.max_tokens;
+        delete defaults.max_completion_tokens;
+    }
 
     return {
         messages,
         options: {
-            ...((config.defaultOptions || {}) as Record<string, unknown>),
+            ...defaults,
             ...definedOptions,
             model: usedModel,
             modelConfig: config,

--- a/gen.pollinations.ai/test/text/generateTextPortkey.test.ts
+++ b/gen.pollinations.ai/test/text/generateTextPortkey.test.ts
@@ -242,7 +242,11 @@ describe("generateTextPortkey", () => {
         );
     });
 
-    it("sets an owned request deadline below the public gateway limit", async () => {
+    it.each([
+        undefined,
+        false,
+        true,
+    ])("sets the request deadline and preserves explicit parallel_tool_calls (%s)", async (parallel_tool_calls) => {
         const fetcher = vi.fn(
             async (_input: RequestInfo | URL, init?: RequestInit) => {
                 const headers = new Headers(init?.headers);
@@ -250,9 +254,11 @@ describe("generateTextPortkey", () => {
                 expect(headers.get("x-portkey-strict-open-ai-compliance")).toBe(
                     "false",
                 );
-                expect(JSON.parse(String(init?.body))).not.toHaveProperty(
-                    "parallel_tool_calls",
-                );
+                const body = JSON.parse(String(init?.body));
+                expect(body.parallel_tool_calls).toBe(parallel_tool_calls);
+                if (parallel_tool_calls === undefined) {
+                    expect(body).not.toHaveProperty("parallel_tool_calls");
+                }
 
                 return Response.json({
                     model: "provider-model",
@@ -275,7 +281,7 @@ describe("generateTextPortkey", () => {
                     provider: "openai",
                     model: "provider-model",
                 },
-                parallel_tool_calls: false,
+                parallel_tool_calls,
                 portkeyGatewayUrl: "https://portkey.test",
             },
             fetcher,

--- a/gen.pollinations.ai/test/text/requestUtils.test.ts
+++ b/gen.pollinations.ai/test/text/requestUtils.test.ts
@@ -11,6 +11,30 @@ import { SENTINEL_SEED } from "../../src/util.js";
 afterEach(() => vi.restoreAllMocks());
 
 describe("getChatRequestData", () => {
+    it.each([
+        undefined,
+        false,
+        true,
+    ])("does not invent parallel_tool_calls (%s)", (parallel_tool_calls) => {
+        const request = getChatRequestData(
+            CreateChatCompletionRequestSchema.parse({
+                model: "openai/gpt-5.4",
+                messages: [{ role: "user", content: "hello" }],
+                ...(parallel_tool_calls === undefined
+                    ? {}
+                    : { parallel_tool_calls }),
+            }),
+        );
+        expect(request.parallel_tool_calls).toBe(parallel_tool_calls);
+        expect(
+            chatToResponsesRequest(request.messages, request)
+                .parallel_tool_calls,
+        ).toBe(parallel_tool_calls);
+        if (parallel_tool_calls === undefined) {
+            expect(request).not.toHaveProperty("parallel_tool_calls");
+        }
+    });
+
     it("preserves validated OpenAI and provider fields", () => {
         const body = CreateChatCompletionRequestSchema.parse({
             model: "openai/gpt-5-nano",

--- a/gen.pollinations.ai/test/text/transforms/parameterProcessor.test.ts
+++ b/gen.pollinations.ai/test/text/transforms/parameterProcessor.test.ts
@@ -1,6 +1,8 @@
+import { CreateChatCompletionRequestSchema } from "@shared/schemas/openai.ts";
 import { describe, expect, it } from "vitest";
 import { findModelByName } from "../../../src/text/availableModels.js";
 import { portkeyConfig } from "../../../src/text/configs/modelConfigs.js";
+import { getChatRequestData } from "../../../src/text/requestUtils.js";
 import { processParameters } from "../../../src/text/transforms/parameterProcessor.js";
 import {
     omitParameters,
@@ -13,6 +15,39 @@ const messages = [{ role: "user" as const, content: "hello" }];
 const modelDef = { name: "test-model" };
 
 describe("processParameters", () => {
+    it.each([
+        "anthropic/claude-sonnet-4.6",
+        "inception/mercury-2.5-preview",
+        "qwen/qwen3.8-flash",
+        "openai/gpt-5.4",
+        "openai/gpt-6-astra",
+    ])("honors caller token limits before defaults for %s", (model) => {
+        for (const [limits, expected] of [
+            [{ max_completion_tokens: 128 }, 128],
+            [{ max_tokens: 64 }, 64],
+            [{ max_tokens: 64, max_completion_tokens: 128 }, 64],
+            [{ max_tokens: null, max_completion_tokens: 128 }, 128],
+            [{ max_completion_tokens: 0 }, 0],
+        ] as const) {
+            const input = getChatRequestData(
+                CreateChatCompletionRequestSchema.parse({
+                    model,
+                    messages,
+                    ...limits,
+                }),
+            );
+            const original = structuredClone(input);
+            const resolved = resolveModelConfig(messages, input);
+            const { options } = processParameters(messages, resolved.options);
+            const field = resolved.options.modelConfig
+                ?.supportsMaxCompletionTokens
+                ? "max_completion_tokens"
+                : "max_tokens";
+            expect(options[field]).toBe(expected);
+            expect(input).toEqual(original);
+        }
+    });
+
     it("converts max_tokens to max_completion_tokens for Azure OpenAI models", () => {
         const result = processParameters(messages, {
             model: "gpt-5-nano",

--- a/packages/mcp/src/services/textService.js
+++ b/packages/mcp/src/services/textService.js
@@ -346,7 +346,7 @@ const chatParamsSchema = {
     parallel_tool_calls: z
         .boolean()
         .optional()
-        .describe("Allow parallel tool calls (default: true)"),
+        .describe("Allow parallel tool calls when supported by the model"),
     functions: z
         .array(
             z.object({

--- a/shared/schemas/openai.ts
+++ b/shared/schemas/openai.ts
@@ -362,7 +362,7 @@ export const CreateChatCompletionRequestSchema = z
         top_p: z.number().min(0).max(1).nullable().optional(),
         tools: z.array(ChatCompletionToolSchema).optional(),
         tool_choice: ChatCompletionToolChoiceOptionSchema.optional(),
-        parallel_tool_calls: z.boolean().optional().default(true),
+        parallel_tool_calls: z.boolean().optional(),
         user: z.string().optional(),
         prompt_cache_key: z.string().optional(),
         prompt_cache_options: PromptCacheOptionsSchema,


### PR DESCRIPTION
- Honor either caller token limit before model defaults. Preserve existing max_tokens precedence when both limits are explicit; handle nullable aliases correctly.
- Forward explicit parallel_tool_calls without injecting true into every request. Keep intentional sampling restrictions and deprecated thinking-alias removal from #14585 and #12029.
- Pin merged [gateway #12](https://github.com/pollinations/gateway/pull/12), commit 639928b0af4682e675b0cf0209b79694c01ea330, for Azure parallel tools, generic top_k and Claude effort/JSON schema. Its tree matches the live-tested branch exactly.
- Verification: 227 focused tests, Gen typecheck, Biome and MCP tests pass; 590 limit checks across all 118 routes preserve defaults. Sixteen live probes through local Gen + gateway code reach real providers, covering Azure single/parallel/streaming tools, Claude 32-token output/schema/effort, nullable limits and Fireworks/DeepInfra top_k. Unsupported OVH top_k and invalid Claude inputs return provider 400s. These are not public auth/billing end-to-end tests. Full Enter/Gen CI passed before the pin-only update.
- Addresses forwarding bugs found while reviewing #14599. Parameter metadata remains separate. No production deployment or credential changes.