### PR TITLE
feat(models): filter listings by reliability and expose health metadata

### DIFF
--- a/gen.pollinations.ai/src/docs/models.md
+++ b/gen.pollinations.ai/src/docs/models.md
@@ -27,6 +27,56 @@ Any other value (e.g. `tru`, `yes`, `2`) returns **400 Bad Request**.
 
 Example: `GET /models?community=false`
 
+### Reliability filtering and health metadata
+
+All model discovery endpoints also accept an optional `reliability` query
+parameter:
+
+| Parameter | Values | Behaviour |
+|-----------|--------|-----------|
+| *(omitted)* | | Returns all models (default, backward-compatible) |
+| `reliability=reliable` | `reliable` | Keeps only models with a high recent success rate |
+| `reliability=all` | `all` | Explicit default, same as omitting |
+
+Every entry in `/v1/models`, `/v1/models/:model`, and the rich lists
+carries two extra fields:
+
+- `reliability`: `reliable`, `unreliable`, or `unknown`. A model is
+  `reliable` when at least 20 requests were observed in the last 60 minutes
+  and at least 95% succeeded. Requests rescued by a fallback count as
+  successes; requests the caller broke (4xx) are excluded. No usable data
+  means `unknown` — experimental status is tracked separately and never
+  affects this verdict.
+- `health`: `{success_rate, sample_count, window_minutes, last_request_at}`,
+  or `null` when unknown.
+
+Examples:
+
+```bash
+# Official, reliable models only
+curl "https://gen.pollinations.ai/v1/models?community=false&reliability=reliable"
+
+# Same via headers, for clients that append /models to a base URL
+# and cannot add query strings (Open WebUI, LibreChat, Cline)
+curl https://gen.pollinations.ai/v1/models \
+  -H "X-Model-Source: official" \
+  -H "X-Model-Reliability: reliable"
+```
+
+```python
+import requests
+
+models = requests.get(
+    "https://gen.pollinations.ai/v1/models",
+    params={"reliability": "reliable"},
+).json()["data"]
+print([(m["id"], m["reliability"], m["health"]) for m in models])
+```
+
+Query parameters win when both a query param and its header are present.
+Filtering never changes generation permissions: hidden, permission-filtered,
+and unaffordable models stay hidden exactly as before.
+
 Rich model endpoints include `capabilities` for agentic/model traits:
 `tool_calling`, `reasoning`, `web_search`, and `code_execution`.
 Modalities, video frame controls, voices, and context length remain separate

--- a/gen.pollinations.ai/src/model-health.ts
+++ b/gen.pollinations.ai/src/model-health.ts
@@ -1,0 +1,138 @@
+import {
+    type ModelHealthRow,
+    type ModelHealthSummary,
+    type ModelReliability,
+    modelReliability,
+    summarizeModelHealth,
+} from "@shared/registry/model-health.ts";
+import type { GenerationModelEntry } from "./model-registry.ts";
+
+// Same public pipe as the /v1/models/status endpoint; minutes matches its
+// default window so both surfaces agree.
+const HEALTH_PIPE_URL =
+    "https://api.europe-west2.gcp.tinybird.co/v0/pipes/model_health.json";
+const HEALTH_PIPE_TOKEN =
+    "p.eyJ1IjogImFjYTYzZjc5LThjNTYtNDhlNC05NWJjLWEyYmFjMTY0NmJkMyIsICJpZCI6ICI5ZWZmMGM3Ni1kOTZkLTQwYjgtYWQwOC1mNDFlMmRiYjBmYTIiLCAiaG9zdCI6ICJnY3AtZXVyb3BlLXdlc3QyIn0.6VnVkAQ5h_fkcDZVDUoU38dzTxaw0xo3DnmKkhECbA8";
+const HEALTH_WINDOW_MINUTES = 60;
+const HEALTH_CACHE_TTL_MS = 60_000;
+
+export type ModelsReliabilityFilter = "reliable" | "all";
+
+export interface ModelHealthAttachment {
+    reliability: ModelReliability;
+    health: ModelHealthSummary | null;
+}
+
+const VALID_RELIABILITIES: ModelsReliabilityFilter[] = ["reliable", "all"];
+
+/**
+ * Query params win; the X-Model-Reliability header exists for clients that
+ * append /models to a base URL themselves and cannot add query strings
+ * (Open WebUI, LibreChat, Cline). Throws on invalid values.
+ */
+export function parseReliabilityParam(
+    queryReliability: string | undefined,
+    headerReliability: string | undefined,
+): ModelsReliabilityFilter {
+    const raw = (queryReliability ?? headerReliability ?? "all").toLowerCase();
+    if (!VALID_RELIABILITIES.includes(raw as ModelsReliabilityFilter)) {
+        throw new Error(
+            `reliability must be one of ${VALID_RELIABILITIES.join(", ")}`,
+        );
+    }
+    return raw as ModelsReliabilityFilter;
+}
+
+/**
+ * Header mirror of the ?community= query param, for the same clients.
+ * Returns the community param value to use, or undefined to leave unset.
+ * Throws on invalid values.
+ */
+export function parseSourceHeader(
+    queryCommunity: string | undefined,
+    headerSource: string | undefined,
+): string | undefined {
+    if (queryCommunity !== undefined) return queryCommunity;
+    if (headerSource === undefined) return undefined;
+    const raw = headerSource.toLowerCase();
+    if (raw === "official") return "false";
+    if (raw === "community") return "true";
+    if (raw === "all") return undefined;
+    throw new Error("X-Model-Source must be one of official, community, all");
+}
+
+let cachedRows: ModelHealthRow[] | null = null;
+let cachedAt = 0;
+
+async function getHealthRows(): Promise<ModelHealthRow[]> {
+    const now = Date.now();
+    if (cachedRows && now - cachedAt < HEALTH_CACHE_TTL_MS) return cachedRows;
+    try {
+        const url = new URL(HEALTH_PIPE_URL);
+        url.searchParams.set("token", HEALTH_PIPE_TOKEN);
+        url.searchParams.set("minutes", String(HEALTH_WINDOW_MINUTES));
+        const response = await fetch(url.toString());
+        if (!response.ok) throw new Error(`health feed ${response.status}`);
+        const body = (await response.json()) as { data?: ModelHealthRow[] };
+        cachedRows = Array.isArray(body.data) ? body.data : [];
+        cachedAt = now;
+    } catch {
+        // No usable feed: keep serving the catalog with unknown health rather
+        // than failing discovery. Stale cache (if any) still applies.
+        if (!cachedRows) cachedRows = [];
+    }
+    return cachedRows;
+}
+
+export async function getModelHealthAttachments(
+    modelIds: string[],
+): Promise<Map<string, ModelHealthAttachment>> {
+    const rows = await getHealthRows();
+    const attachments = new Map<string, ModelHealthAttachment>();
+    for (const id of modelIds) {
+        const summary = summarizeModelHealth(rows, id, HEALTH_WINDOW_MINUTES);
+        attachments.set(id, {
+            reliability: modelReliability(summary),
+            health: summary,
+        });
+    }
+    return attachments;
+}
+
+export function attachmentFor(
+    attachments: Map<string, ModelHealthAttachment>,
+    entry: GenerationModelEntry,
+): ModelHealthAttachment | undefined {
+    return (
+        attachments.get(entry.id) ??
+        (entry.info.name !== entry.id
+            ? attachments.get(entry.info.name)
+            : undefined)
+    );
+}
+
+/**
+ * Applies the reliability filter after permission filtering, so access rules
+ * and default listings are untouched. Unknown reliability never matches.
+ */
+export function filterEntriesByReliability(
+    entries: GenerationModelEntry[],
+    reliability: ModelsReliabilityFilter,
+    attachments: Map<string, ModelHealthAttachment>,
+): GenerationModelEntry[] {
+    if (reliability === "all") return entries;
+    return entries.filter(
+        (entry) =>
+            attachmentFor(attachments, entry)?.reliability === "reliable",
+    );
+}
+
+/** Model ids plus display names, so health rows match either key. */
+export function attachmentKeysFor(entries: GenerationModelEntry[]): string[] {
+    const keys = new Set<string>();
+    for (const entry of entries) {
+        keys.add(entry.id);
+        keys.add(entry.info.name);
+    }
+    return [...keys];
+}

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -24,6 +24,16 @@ import {
 } from "../media/response-output.ts";
 import { mediaResponses } from "../media/responses.ts";
 import {
+    attachmentFor,
+    attachmentKeysFor,
+    filterEntriesByReliability,
+    getModelHealthAttachments,
+    type ModelHealthAttachment,
+    type ModelsReliabilityFilter,
+    parseReliabilityParam,
+    parseSourceHeader,
+} from "../model-health.ts";
+import {
     formatOpenAIImageResponse,
     handleImageGeneration,
     prepareOpenAIImageEdit,
@@ -261,9 +271,10 @@ function filterEntriesByCommunityParam(
     );
 }
 
-// Factory for model-list endpoints: validates the community query parameter,
-// filters by API key permissions, paid balance, and community flag,
-// then returns the model list as JSON.
+// Factory for model-list endpoints: validates the community and reliability
+// query parameters, filters by API key permissions, paid balance, community
+// flag, and reliability, then returns the model list as JSON with health
+// metadata attached.
 const modelsListHandler = (
     getEntries: (
         c: Context<Env>,
@@ -272,20 +283,56 @@ const modelsListHandler = (
     [
         validator("query", ModelListQueryParamsSchema),
         async (c: Context<Env>) => {
-            const { community } = c.req.valid(
+            const { community, reliability: reliabilityParam } = c.req.valid(
                 "query" as never,
             ) as ModelListQueryParams;
+            let reliability: ModelsReliabilityFilter;
+            let communityValue = community;
+            try {
+                reliability = parseReliabilityParam(
+                    reliabilityParam,
+                    c.req.header("X-Model-Reliability"),
+                );
+                if (communityValue === undefined) {
+                    communityValue = parseSourceHeader(
+                        undefined,
+                        c.req.header("X-Model-Source"),
+                    ) as typeof communityValue;
+                }
+            } catch (err) {
+                throw new HTTPException(400, {
+                    message:
+                        err instanceof Error ? err.message : "Invalid filter",
+                });
+            }
             const allowedModels = c.var.auth?.apiKey?.permissions?.models;
             const paidBalance = hasPaidBalance(c);
-            return c.json(
+            const visibleEntries = await getEntries(c);
+            const attachments = await getModelHealthAttachments(
+                attachmentKeysFor(visibleEntries),
+            );
+            const entries = filterEntriesByReliability(
                 filterEntriesByCommunityParam(
                     filterEntriesByPermissions(
-                        await getEntries(c),
+                        visibleEntries,
                         allowedModels,
                         paidBalance,
                     ),
-                    community,
-                ).map((entry) => entry.info),
+                    communityValue,
+                ),
+                reliability,
+                attachments,
+            );
+            return c.json(
+                entries.map((entry) => {
+                    const attachment = attachmentFor(attachments, entry);
+                    if (!attachment) return entry.info;
+                    return {
+                        ...entry.info,
+                        reliability: attachment.reliability,
+                        health: attachment.health,
+                    };
+                }),
             );
         },
     ] as const;
@@ -332,7 +379,13 @@ async function getVisibleVideoModelEntries(c: Context<Env>) {
 // /v1/models/:model (retrieve). `created` derives from the registry addedDate
 // so both endpoints return stable timestamps instead of per-request wall-clock
 // values.
-function toOpenAIModelEntry(entry: GenerationModelEntry) {
+function toOpenAIModelEntry(
+    entry: GenerationModelEntry,
+    attachments?: Map<string, ModelHealthAttachment>,
+) {
+    const attachment = attachments
+        ? attachmentFor(attachments, entry)
+        : undefined;
     return {
         id: entry.info.name,
         object: "model" as const,
@@ -359,6 +412,10 @@ function toOpenAIModelEntry(entry: GenerationModelEntry) {
         }),
         ...(entry.info.per_user_rpm !== undefined && {
             per_user_rpm: entry.info.per_user_rpm,
+        }),
+        ...(attachment && {
+            reliability: attachment.reliability,
+            health: attachment.health,
         }),
     };
 }
@@ -403,7 +460,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Models (OpenAI-compatible)",
             description:
-                'Returns available models in the OpenAI-compatible format (`{object: "list", data: [...]}`), with Pollinations pricing and capability extensions. Official models are ordered by modality (text, image, video, 3D, audio, realtime, embedding), with each configured default first, followed by stable and then alpha/preview models from newest to oldest. Community models follow from newest to oldest. Use `/models`, `/text/models`, `/image/models`, `/audio/models`, or `/embeddings/models` for richer metadata. When authenticated: the owner\'s private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.',
+                'Returns available models in the OpenAI-compatible format (`{object: "list", data: [...]}`), with Pollinations pricing and capability extensions. Official models are ordered by modality (text, image, video, 3D, audio, realtime, embedding), with each configured default first, followed by stable and then alpha/preview models from newest to oldest. Community models follow from newest to oldest. Each entry carries `reliability` (`reliable`, `unreliable`, or `unknown` when there is no usable health data) and a minimal `health` object (success rate, sample count, window, freshness). When authenticated: the owner\'s private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models. Pass `?reliability=reliable` to keep only models with a high recent success rate. Clients that append `/models` to a base URL and cannot add query strings can send `X-Model-Source: official|community|all` and `X-Model-Reliability: reliable|all` headers instead (query params win when both are present).',
             responses: {
                 200: {
                     description: "Success",
@@ -418,22 +475,51 @@ export const proxyRoutes = new Hono<Env>()
         }),
         validator("query", ModelListQueryParamsSchema),
         async (c) => {
-            const { community } = c.req.valid(
+            const { community, reliability: reliabilityParam } = c.req.valid(
                 "query" as never,
             ) as ModelListQueryParams;
+            let reliability: ModelsReliabilityFilter;
+            let communityValue = community;
+            try {
+                reliability = parseReliabilityParam(
+                    reliabilityParam,
+                    c.req.header("X-Model-Reliability"),
+                );
+                if (communityValue === undefined) {
+                    communityValue = parseSourceHeader(
+                        undefined,
+                        c.req.header("X-Model-Source"),
+                    ) as typeof communityValue;
+                }
+            } catch (err) {
+                throw new HTTPException(400, {
+                    message:
+                        err instanceof Error ? err.message : "Invalid filter",
+                });
+            }
             const allowedModels = c.var.auth?.apiKey?.permissions?.models;
             const paidBalance = hasPaidBalance(c);
-            const modelEntries = filterEntriesByCommunityParam(
-                filterEntriesByPermissions(
-                    await getVisibleModelEntries(c),
-                    allowedModels,
-                    paidBalance,
+            const visibleEntries = await getVisibleModelEntries(c);
+            const attachments = await getModelHealthAttachments(
+                attachmentKeysFor(visibleEntries),
+            );
+            const modelEntries = filterEntriesByReliability(
+                filterEntriesByCommunityParam(
+                    filterEntriesByPermissions(
+                        visibleEntries,
+                        allowedModels,
+                        paidBalance,
+                    ),
+                    communityValue,
                 ),
-                community,
+                reliability,
+                attachments,
             );
             return c.json({
                 object: "list" as const,
-                data: modelEntries.map(toOpenAIModelEntry),
+                data: modelEntries.map((entry) =>
+                    toOpenAIModelEntry(entry, attachments),
+                ),
             });
         },
     )
@@ -478,7 +564,12 @@ export const proxyRoutes = new Hono<Env>()
                     message: `Model '${modelId}' not found`,
                 });
             }
-            return c.json(toOpenAIModelEntry(entry));
+            return c.json(
+                toOpenAIModelEntry(
+                    entry,
+                    await getModelHealthAttachments(attachmentKeysFor([entry])),
+                ),
+            );
         },
     )
     .get(
@@ -487,7 +578,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Models",
             description:
-                "Returns all available models with pricing, capabilities, and metadata. Official models are ordered by modality (text, image, video, 3D, audio, realtime, embedding), with each configured default first, followed by stable and then alpha/preview models from newest to oldest. Community models follow from newest to oldest. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
+                "Returns all available models with pricing, capabilities, and metadata. Official models are ordered by modality (text, image, video, 3D, audio, realtime, embedding), with each configured default first, followed by stable and then alpha/preview models from newest to oldest. Community models follow from newest to oldest. Each entry carries `reliability` and a minimal `health` object (see `/v1/models`). When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models. Pass `?reliability=reliable` to keep only models with a high recent success rate.",
             responses: {
                 200: {
                     description: "Success",

--- a/gen.pollinations.ai/src/schemas/models.ts
+++ b/gen.pollinations.ai/src/schemas/models.ts
@@ -5,6 +5,10 @@ export const ModelListQueryParamsSchema = z.object({
         description:
             "Filter by community status: `true`/`1` for community-only, `false`/`0` for official-only. Omit for all models.",
     }),
+    reliability: z.enum(["reliable", "all"]).optional().meta({
+        description:
+            "Filter by recent reliability: `reliable` keeps only models with a high success rate on enough recent traffic. Omit for all models.",
+    }),
 });
 
 export type ModelListQueryParams = z.infer<typeof ModelListQueryParamsSchema>;

--- a/gen.pollinations.ai/test/model-health.test.ts
+++ b/gen.pollinations.ai/test/model-health.test.ts
@@ -1,0 +1,166 @@
+import {
+    type ModelHealthRow,
+    modelReliability,
+    summarizeModelHealth,
+} from "@shared/registry/model-health.ts";
+import { describe, expect, it } from "vitest";
+import {
+    filterEntriesByReliability,
+    parseReliabilityParam,
+    parseSourceHeader,
+} from "../src/model-health.ts";
+import type { GenerationModelEntry } from "../src/model-registry.ts";
+
+function row(overrides: Partial<ModelHealthRow> = {}): ModelHealthRow {
+    return {
+        model: "openai",
+        total_requests: 100,
+        status_2xx: 98,
+        errors_4xx: 2,
+        fallback_rescues: 0,
+        last_request_at: "2026-09-09T23:00:00",
+        ...overrides,
+    };
+}
+
+function entry(id: string, communityEndpoint?: unknown): GenerationModelEntry {
+    return {
+        id,
+        info: { name: id },
+        communityEndpoint,
+    } as unknown as GenerationModelEntry;
+}
+
+describe("summarizeModelHealth", () => {
+    it("computes the rate over non-caller-failure traffic", () => {
+        // (98 + 0) / (100 - 2) = 1.0
+        expect(summarizeModelHealth([row()], "openai", 60)).toEqual({
+            success_rate: 1,
+            sample_count: 98,
+            window_minutes: 60,
+            last_request_at: "2026-09-09T23:00:00",
+        });
+    });
+
+    it("counts fallback rescues as successes", () => {
+        // (90 + 5) / (100 - 2) = 0.9694
+        const summary = summarizeModelHealth(
+            [row({ status_2xx: 90, fallback_rescues: 5 })],
+            "openai",
+            60,
+        );
+        expect(summary?.success_rate).toBeCloseTo(0.9694, 4);
+    });
+
+    it("clamps the rate at 1 when rescues overlap 2xx", () => {
+        const summary = summarizeModelHealth(
+            [row({ status_2xx: 98, fallback_rescues: 5 })],
+            "openai",
+            60,
+        );
+        expect(summary?.success_rate).toBe(1);
+    });
+
+    it("returns null with no row or no evaluated traffic", () => {
+        expect(summarizeModelHealth([], "openai", 60)).toBeNull();
+        expect(
+            summarizeModelHealth([row({ model: "other" })], "openai", 60),
+        ).toBeNull();
+        expect(
+            summarizeModelHealth(
+                [row({ total_requests: 5, errors_4xx: 5, status_2xx: 0 })],
+                "openai",
+                60,
+            ),
+        ).toBeNull();
+    });
+});
+
+describe("modelReliability", () => {
+    it("marks high-rate, well-sampled models reliable", () => {
+        expect(
+            modelReliability({
+                success_rate: 0.97,
+                sample_count: 200,
+                window_minutes: 60,
+                last_request_at: null,
+            }),
+        ).toBe("reliable");
+    });
+
+    it("marks low-rate models unreliable", () => {
+        expect(
+            modelReliability({
+                success_rate: 0.75,
+                sample_count: 200,
+                window_minutes: 60,
+                last_request_at: null,
+            }),
+        ).toBe("unreliable");
+    });
+
+    it("reports unknown without data or with thin samples", () => {
+        expect(modelReliability(null)).toBe("unknown");
+        expect(
+            modelReliability({
+                success_rate: 1,
+                sample_count: 5,
+                window_minutes: 60,
+                last_request_at: null,
+            }),
+        ).toBe("unknown");
+    });
+});
+
+describe("parseReliabilityParam", () => {
+    it("defaults to all and lets query win over headers", () => {
+        expect(parseReliabilityParam(undefined, undefined)).toBe("all");
+        expect(parseReliabilityParam("reliable", "all")).toBe("reliable");
+        expect(parseReliabilityParam(undefined, "reliable")).toBe("reliable");
+    });
+
+    it("rejects unknown values", () => {
+        expect(() => parseReliabilityParam("sometimes", undefined)).toThrow(
+            /reliability must be/,
+        );
+    });
+});
+
+describe("parseSourceHeader", () => {
+    it("maps official/community/all onto the community param", () => {
+        expect(parseSourceHeader(undefined, undefined)).toBeUndefined();
+        expect(parseSourceHeader("true", "official")).toBe("true");
+        expect(parseSourceHeader(undefined, "official")).toBe("false");
+        expect(parseSourceHeader(undefined, "community")).toBe("true");
+        expect(parseSourceHeader(undefined, "all")).toBeUndefined();
+    });
+
+    it("rejects unknown values", () => {
+        expect(() => parseSourceHeader(undefined, "private")).toThrow(
+            /X-Model-Source must be/,
+        );
+    });
+});
+
+describe("filterEntriesByReliability", () => {
+    const attachments = new Map([
+        ["good", { reliability: "reliable" as const, health: null }],
+        ["bad", { reliability: "unreliable" as const, health: null }],
+    ]);
+
+    it("keeps everything by default", () => {
+        const entries = [entry("good"), entry("bad"), entry("new")];
+        expect(filterEntriesByReliability(entries, "all", attachments)).toEqual(
+            entries,
+        );
+    });
+
+    it("keeps only reliable models, unknown never matches", () => {
+        const entries = [entry("good"), entry("bad"), entry("new")];
+        expect(
+            filterEntriesByReliability(entries, "reliable", attachments).map(
+                (e) => e.id,
+            ),
+        ).toEqual(["good"]);
+    });
+});

--- a/shared/registry/model-health.ts
+++ b/shared/registry/model-health.ts
@@ -1,0 +1,69 @@
+/**
+ * Minimal reliability math over the public `model_health` feed.
+ *
+ * A model is "reliable" when it has enough recent traffic and almost all of
+ * it succeeded. Requests rescued by a fallback count as successes; requests
+ * the caller broke (4xx) are excluded from the sample instead of dragging
+ * the rate down. A model with no usable data is "unknown", never unreliable.
+ * Experimental status is tracked elsewhere and stays out of this verdict.
+ */
+
+// Share of successful requests required for the "reliable" verdict.
+export const RELIABILITY_MIN_SUCCESS_RATE = 0.95;
+// Requests below this sample size report "unknown" instead of a verdict.
+export const RELIABILITY_MIN_SAMPLES = 20;
+
+/** One row of the public `model_health` pipe, trimmed to what we use. */
+export interface ModelHealthRow {
+    model: string;
+    total_requests: number;
+    status_2xx: number;
+    errors_4xx: number;
+    fallback_rescues: number;
+    last_request_at: string | null;
+}
+
+/** Per-model health attached to catalog responses. */
+export interface ModelHealthSummary {
+    success_rate: number;
+    sample_count: number;
+    window_minutes: number;
+    last_request_at: string | null;
+}
+
+export type ModelReliability = "reliable" | "unreliable" | "unknown";
+
+export function summarizeModelHealth(
+    rows: ModelHealthRow[],
+    modelId: string,
+    windowMinutes: number,
+): ModelHealthSummary | null {
+    const row = rows.find((candidate) => candidate.model === modelId);
+    if (!row) return null;
+
+    const evaluated = row.total_requests - row.errors_4xx;
+    if (evaluated <= 0) return null;
+
+    // Clamp: some pipes already fold rescues into 2xx.
+    const successRate = Math.min(
+        1,
+        (row.status_2xx + row.fallback_rescues) / evaluated,
+    );
+    return {
+        success_rate: Math.round(successRate * 10000) / 10000,
+        sample_count: evaluated,
+        window_minutes: windowMinutes,
+        last_request_at: row.last_request_at,
+    };
+}
+
+export function modelReliability(
+    summary: ModelHealthSummary | null,
+): ModelReliability {
+    if (!summary || summary.sample_count < RELIABILITY_MIN_SAMPLES) {
+        return "unknown";
+    }
+    return summary.success_rate >= RELIABILITY_MIN_SUCCESS_RATE
+        ? "reliable"
+        : "unreliable";
+}

--- a/shared/registry/model-info.ts
+++ b/shared/registry/model-info.ts
@@ -119,6 +119,16 @@ export const ModelInfoSchema = z.object({
     alpha: z.boolean().optional(),
     flat_rate: z.boolean().optional(),
     added_date: z.number().optional(),
+    reliability: z.enum(["reliable", "unreliable", "unknown"]).optional(),
+    health: z
+        .object({
+            success_rate: z.number(),
+            sample_count: z.number(),
+            window_minutes: z.number(),
+            last_request_at: z.string().nullable(),
+        })
+        .nullable()
+        .optional(),
 });
 
 export type ModelInfo = z.infer<typeof ModelInfoSchema>;

--- a/shared/schemas/openai.ts
+++ b/shared/schemas/openai.ts
@@ -746,6 +746,26 @@ export const OpenAIModelSchema = z
         reasoning: z.boolean().optional(),
         context_length: z.number().optional(),
         per_user_rpm: z.number().positive().nullable().optional(),
+        reliability: z
+            .enum(["reliable", "unreliable", "unknown"])
+            .optional()
+            .meta({
+                description:
+                    "Reliability verdict from recent traffic: reliable (high success rate on enough samples), unreliable, or unknown (no usable data). Independent of experimental status.",
+            }),
+        health: z
+            .object({
+                success_rate: z.number(),
+                sample_count: z.number(),
+                window_minutes: z.number(),
+                last_request_at: z.string().nullable(),
+            })
+            .nullable()
+            .optional()
+            .meta({
+                description:
+                    "Minimal health metadata behind the verdict. Null when unknown.",
+            }),
     })
     .meta({
         description: "OpenAI-compatible model object with capability metadata",


### PR DESCRIPTION
﻿Fixes #14535

Adds reliability filtering and minimal health metadata to model discovery, building on the existing `?community=` filter instead of a parallel system.

- `GET /v1/models`, `GET /v1/models/:model` and the rich lists (`/models` and the category lists share one factory) accept `?reliability=reliable`. Clients that append `/models` to a base URL and cannot add query strings (Open WebUI, LibreChat, Cline) can send `X-Model-Source: official|community|all` and `X-Model-Reliability: reliable|all` headers instead; query params win when both are present.
- Every entry carries `reliability` (`reliable` / `unreliable` / `unknown`) and a minimal `health` object (success rate, sample count, window, freshness). A model is reliable at 95%+ success over 20+ recent requests; fallback rescues count as successes, caller-side 4xx is excluded, and missing data means `unknown`. Experimental status is untouched.
- Filtering runs after permission and paid-balance filtering, so access rules and default listings are unchanged. Health comes from the existing cached `model_health` feed (60s TTL, stale fallback); when it is unreachable everything reports unknown rather than failing discovery.
- Docs in `gen.pollinations.ai/src/docs/models.md` with curl, Python, and header-based client examples.
- 13 focused unit tests cover the rate math (including the rescue overlap clamp), thresholds, param/header parsing and precedence, and the filter itself. `vitest run` and `tsc --noEmit` pass in `gen.pollinations.ai`.
