### PR TITLE
fix(polli-cli): refresh harness configs

### DIFF
--- a/packages/polli-cli/package-lock.json
+++ b/packages/polli-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pollinations/cli",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pollinations/cli",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/packages/polli-cli/package.json
+++ b/packages/polli-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollinations/cli",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "The Pollinations CLI — for humans, AI agents, and everything in between",
   "type": "module",
   "bin": {

--- a/packages/polli-cli/src/harnesses/dsh.ts
+++ b/packages/polli-cli/src/harnesses/dsh.ts
@@ -23,7 +23,7 @@ import type {
 const ID = "dsh";
 const LABEL = "DeepSeek Harness";
 const PROVIDER = "pollinations";
-const DEFAULT_MODEL = "deepseek";
+const DEFAULT_MODEL = "deepseek/deepseek-v4-flash";
 const KEY_ENV = "POLLI_DSH_API_KEY";
 const MCP_ID = "mcp-pollinations";
 const MCP_URL = `${BASE_URL}/mcp/pollinations`;

--- a/packages/polli-cli/src/harnesses/openclaw.ts
+++ b/packages/polli-cli/src/harnesses/openclaw.ts
@@ -23,7 +23,7 @@ import type {
 const ID = "openclaw";
 const LABEL = "OpenClaw";
 const PROVIDER = "pollinations";
-const DEFAULT_MODEL = "kimi";
+const DEFAULT_MODEL = "moonshotai/kimi-k2.6";
 // Key is stored once in env.vars and referenced as ${VAR} from the provider,
 // matching OpenClaw's own config-level variable substitution.
 const KEY_ENV = "POLLI_OPENCLAW_API_KEY";

--- a/packages/polli-cli/src/harnesses/opencode.test.ts
+++ b/packages/polli-cli/src/harnesses/opencode.test.ts
@@ -32,6 +32,8 @@ const configDir = () =>
           ? join(home, "Library", "Application Support", "pollinations")
           : join(home, ".config", "pollinations");
 const opencodeFile = () => join(home, ".config", "opencode", "opencode.json");
+const opencodeJsoncFile = () =>
+    join(home, ".config", "opencode", "opencode.jsonc");
 const pluginConfig = () => join(configDir(), "config.json");
 const snapshotFiles = () => {
     const dir = join(home, ".pollinations", "harnesses");
@@ -97,6 +99,40 @@ describe("opencode harness", () => {
             lang: "en",
             apiKey: "sk_test_key",
         });
+    });
+
+    it("uses the highest-precedence existing JSONC config", () => {
+        mkdirSync(join(home, ".config", "opencode"), { recursive: true });
+        const json = '{"autoupdate":false}\n';
+        const jsonc = `{
+            // OpenCode accepts comments and trailing commas.
+            autoupdate: true,
+        }`;
+        writeFileSync(opencodeFile(), json);
+        writeFileSync(opencodeJsoncFile(), jsonc);
+
+        configureOpenCode(ctx, settings);
+
+        expect(read(opencodeFile())).toBe(json);
+        expect(readJsonFile(opencodeJsoncFile())).toMatchObject({
+            autoupdate: true,
+            plugin: ["opencode-pollinations-plugin"],
+            model: "pollinations/enter/openai",
+        });
+
+        disableOpenCode(ctx);
+        expect(read(opencodeJsoncFile())).toBe(jsonc);
+    });
+
+    it("refuses to overwrite an invalid config", () => {
+        mkdirSync(join(home, ".config", "opencode"), { recursive: true });
+        writeFileSync(opencodeFile(), "{");
+
+        expect(() => configureOpenCode(ctx, settings)).toThrow(
+            "Could not parse OpenCode config",
+        );
+        expect(read(opencodeFile())).toBe("{");
+        expect(existsSync(pluginConfig())).toBe(false);
     });
 
     it("uses an existing plugins array instead of plugin", () => {

--- a/packages/polli-cli/src/harnesses/opencode.ts
+++ b/packages/polli-cli/src/harnesses/opencode.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+import JSON5 from "json5";
 import {
     commandExists,
     readTextIfExists,
@@ -13,7 +14,7 @@ import type { HarnessAdapter, HarnessContext, HarnessResult } from "./types.js";
 
 const ID = "opencode";
 const LABEL = "OpenCode";
-const DEFAULT_MODEL = "openai";
+const DEFAULT_MODEL = "openai/gpt-5.4-nano";
 const PLUGIN_SPEC = "opencode-pollinations-plugin";
 
 /**
@@ -44,7 +45,12 @@ const opencodeConfigFile = (ctx: HarnessContext) => {
     const dir = ctx.env.OPENCODE_CONFIG_DIR?.trim()
         ? resolveHomePath(ctx.home, ctx.env.OPENCODE_CONFIG_DIR)
         : join(ctx.home, ".config", "opencode");
-    return join(dir, "opencode.json");
+    return (
+        ["opencode.jsonc", "opencode.json", "config.json"]
+            .map((name) => join(dir, name))
+            .find((path) => readTextIfExists(path) !== null) ??
+        join(dir, "opencode.json")
+    );
 };
 
 const pluginConfigFile = (ctx: HarnessContext) =>
@@ -59,11 +65,16 @@ const readJson = (path: string): Record<string, unknown> | null => {
     const text = readTextIfExists(path);
     if (text === null) return null;
     try {
-        const parsed = JSON.parse(text);
-        return parsed && typeof parsed === "object" ? parsed : null;
-    } catch {
-        return null;
+        const parsed = JSON5.parse(text);
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+            return parsed as Record<string, unknown>;
+        }
+    } catch (error) {
+        throw new Error(`Could not parse OpenCode config at ${path}`, {
+            cause: error,
+        });
     }
+    throw new Error(`OpenCode config at ${path} must contain an object`);
 };
 
 const writeJson = (path: string, data: unknown) =>

--- a/packages/polli-cli/src/harnesses/pi.test.ts
+++ b/packages/polli-cli/src/harnesses/pi.test.ts
@@ -59,9 +59,9 @@ describe("pi harness", () => {
             .pollinations as Record<string, unknown>;
         expect(provider).toMatchObject({
             api: "openai-completions",
-            apiKey: "pollinations",
             baseUrl: "https://gen.pollinations.ai/v1",
         });
+        expect(provider.apiKey).toBeUndefined();
         expect((provider.models as { id: string }[]).map((m) => m.id)).toEqual([
             "deepseek",
             "kimi",
@@ -212,13 +212,13 @@ describe("pi harness", () => {
         expect(pi.status(ctx).configured).toBe(false);
     });
 
-    it("reports unconfigured when the provider API key marker is missing", () => {
+    it("reports unconfigured when the provider config is incomplete", () => {
         configurePi(ctx, settings);
         const data = readJson(modelsFile());
         const provider = (
             data.providers as Record<string, Record<string, unknown>>
         ).pollinations;
-        delete provider.apiKey;
+        delete provider.api;
         writeFileSync(modelsFile(), `${JSON.stringify(data, null, 2)}\n`);
         expect(pi.status(ctx).configured).toBe(false);
     });

--- a/packages/polli-cli/src/harnesses/pi.ts
+++ b/packages/polli-cli/src/harnesses/pi.ts
@@ -21,7 +21,7 @@ import type {
 const ID = "pi";
 const LABEL = "Pi";
 const PROVIDER = "pollinations";
-const DEFAULT_MODEL = "deepseek";
+const DEFAULT_MODEL = "deepseek/deepseek-v4-flash";
 
 export const piAgentDir = (ctx: HarnessContext): string => {
     const configured = ctx.env.PI_CODING_AGENT_DIR;
@@ -66,8 +66,6 @@ const readKey = (ctx: HarnessContext): string | null => {
 const providerConfig = (models: HarnessModel[]) => ({
     baseUrl: `${BASE_URL}/v1`,
     api: "openai-completions",
-    // Pi validates custom providers before resolving their auth.json entry.
-    apiKey: PROVIDER,
     compat: {
         supportsStore: false,
         supportsDeveloperRole: false,
@@ -175,7 +173,9 @@ const result = (ctx: HarnessContext): HarnessResult => {
     const provider = providers?.[PROVIDER] as
         | Record<string, unknown>
         | undefined;
-    const hasProvider = provider?.apiKey === PROVIDER;
+    const hasProvider =
+        provider?.baseUrl === `${BASE_URL}/v1` &&
+        provider?.api === "openai-completions";
 
     const authEntry = authData[PROVIDER] as Record<string, unknown> | undefined;
     const hasKey =

--- a/packages/polli-cli/src/harnesses/prime.ts
+++ b/packages/polli-cli/src/harnesses/prime.ts
@@ -21,7 +21,7 @@ import type {
 const ID = "prime";
 const LABEL = "Prime Agent";
 const PROVIDER = "pollinations";
-const DEFAULT_MODEL = "deepseek";
+const DEFAULT_MODEL = "deepseek/deepseek-v4-flash";
 
 /** Prime Agent resolves its agent dir from this override, tilde included. */
 export const primeAgentDir = (ctx: HarnessContext) => {


### PR DESCRIPTION
- Use canonical model IDs in every harness config
- Support OpenCode JSONC configs without overwriting invalid files
- Align Pi auth config with current Pi and release CLI 0.1.13