### PR TITLE
feat(models): expose verified chat parameters in listings

### DIFF
--- a/gen.pollinations.ai/src/docs/models.md
+++ b/gen.pollinations.ai/src/docs/models.md
@@ -32,6 +32,31 @@ Rich model endpoints include `capabilities` for agentic/model traits:
 Modalities, video frame controls, voices, and context length remain separate
 structured fields.
 
+### Supported parameters
+
+Models verified against the generation pipeline expose
+`supported_parameters` (the Chat controls they honor) and
+`default_parameters` (gateway defaults applied when omitted):
+
+```bash
+curl "https://gen.pollinations.ai/v1/models/openai" | jq '{id, supported_parameters, default_parameters}'
+```
+
+```json
+{
+  "id": "openai",
+  "supported_parameters": ["messages", "model", "logit_bias", "..."],
+  "default_parameters": {"logprobs": false, "stream": false}
+}
+```
+
+Only verified models carry these fields — anything else omits them rather
+than guessing. Verified means checked against the request transforms, not
+upstream provider docs: sampling knobs stripped upstream never appear, and
+controls the gateway translates (like `reasoning_effort` on Claude) are
+listed as supported with the mapping noted. These describe Chat Completions
+(and the `GET /text` surface); the native Responses API may differ.
+
 Use `supported_endpoints` to discover which public API routes accept each
 model. `/v1/responses` identifies built-in models with a configured native
 Responses route, community text models and endpoint agents whose owner supplied

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -360,6 +360,12 @@ function toOpenAIModelEntry(entry: GenerationModelEntry) {
         ...(entry.info.per_user_rpm !== undefined && {
             per_user_rpm: entry.info.per_user_rpm,
         }),
+        ...(entry.info.supported_parameters && {
+            supported_parameters: entry.info.supported_parameters,
+        }),
+        ...(entry.info.default_parameters && {
+            default_parameters: entry.info.default_parameters,
+        }),
     };
 }
 

--- a/gen.pollinations.ai/test/model-parameters.test.ts
+++ b/gen.pollinations.ai/test/model-parameters.test.ts
@@ -1,0 +1,94 @@
+import { modelInfoFromDefinition } from "@shared/registry/model-info.ts";
+import {
+    BASE_CHAT_PARAMETERS,
+    getModelChatParameters,
+} from "@shared/registry/model-parameters.ts";
+import {
+    getRegistryModelDefinition,
+    resolveModelName,
+} from "@shared/registry/registry.ts";
+import { describe, expect, it } from "vitest";
+
+describe("getModelChatParameters", () => {
+    it("strips sampling knobs the Azure route drops on GPT-5.4 Nano", () => {
+        const profile = getModelChatParameters("openai/gpt-5.4-nano");
+        expect(profile).not.toBeNull();
+        for (const stripped of [
+            "temperature",
+            "top_p",
+            "frequency_penalty",
+            "presence_penalty",
+            "repetition_penalty",
+            "seed",
+        ]) {
+            expect(profile?.supported).not.toContain(stripped);
+        }
+        expect(profile?.supported).toContain("reasoning_effort");
+        expect(profile?.supported).toContain("tools");
+    });
+
+    it("keeps the full surface on DeepSeek V4 Flash", () => {
+        const profile = getModelChatParameters("deepseek/deepseek-v4-flash");
+        expect(profile?.supported).toContain("temperature");
+        expect(profile?.supported).toContain("reasoning_effort");
+        expect(profile?.supported).toHaveLength(BASE_CHAT_PARAMETERS.length);
+    });
+
+    it("strips only temperature/top_p on Claude Sonnet 4.6", () => {
+        const profile = getModelChatParameters("anthropic/claude-sonnet-4.6");
+        expect(profile?.supported).not.toContain("temperature");
+        expect(profile?.supported).not.toContain("top_p");
+        // Mapped to a thinking budget upstream, still honored.
+        expect(profile?.supported).toContain("reasoning_effort");
+        expect(profile?.supported).toContain("tools");
+    });
+
+    it("returns null for unverified models instead of guessing", () => {
+        expect(getModelChatParameters("mistralai/mistral-small-4")).toBeNull();
+    });
+
+    it("resolves public aliases to the same profile", () => {
+        expect(resolveModelName("openai")).toBe("openai/gpt-5.4-nano");
+        expect(resolveModelName("deepseek")).toBe("deepseek/deepseek-v4-flash");
+        expect(resolveModelName("claude")).toBe("anthropic/claude-sonnet-4.6");
+        for (const alias of ["openai", "deepseek", "claude"]) {
+            const canonical = resolveModelName(alias);
+            expect(getModelChatParameters(canonical)).not.toBeNull();
+        }
+    });
+
+    it("only defaults controls the model supports", () => {
+        for (const id of [
+            "openai/gpt-5.4-nano",
+            "deepseek/deepseek-v4-flash",
+            "anthropic/claude-sonnet-4.6",
+        ]) {
+            const profile = getModelChatParameters(id);
+            expect(profile).not.toBeNull();
+            for (const key of Object.keys(profile?.defaults ?? {})) {
+                expect(profile?.supported).toContain(key);
+            }
+        }
+    });
+});
+
+describe("modelInfoFromDefinition parameter threading", () => {
+    it("exposes verified parameters on listings", () => {
+        const info = modelInfoFromDefinition(
+            "openai/gpt-5.4-nano",
+            getRegistryModelDefinition("openai/gpt-5.4-nano"),
+        );
+        expect(info.supported_parameters).toContain("reasoning_effort");
+        expect(info.supported_parameters).not.toContain("temperature");
+        expect(info.default_parameters?.stream).toBe(false);
+    });
+
+    it("omits the fields for unverified models", () => {
+        const info = modelInfoFromDefinition(
+            "mistralai/mistral-small-4",
+            getRegistryModelDefinition("mistralai/mistral-small-4"),
+        );
+        expect(info.supported_parameters).toBeUndefined();
+        expect(info.default_parameters).toBeUndefined();
+    });
+});

--- a/shared/registry/model-info.ts
+++ b/shared/registry/model-info.ts
@@ -119,6 +119,8 @@ export const ModelInfoSchema = z.object({
     alpha: z.boolean().optional(),
     flat_rate: z.boolean().optional(),
     added_date: z.number().optional(),
+    supported_parameters: z.array(z.string()).optional(),
+    default_parameters: z.record(z.string(), z.unknown()).optional(),
 });
 
 export type ModelInfo = z.infer<typeof ModelInfoSchema>;
@@ -221,6 +223,8 @@ export function modelInfoFromDefinition(
         tools: service.tools,
         reasoning: service.reasoning,
         context_length: service.contextLength,
+        supported_parameters: service.supportedParameters,
+        default_parameters: service.defaultParameters,
         voices: service.voices,
         is_specialized: service.isSpecialized,
         paid_only: service.paidOnly,

--- a/shared/registry/model-parameters.ts
+++ b/shared/registry/model-parameters.ts
@@ -1,0 +1,104 @@
+/**
+ * Chat request controls, as they actually behave through Pollinations.
+ *
+ * The base list mirrors the gateway's Chat Completions surface. Per-model
+ * deviations below are verified against the generation pipeline
+ * (gen.pollinations.ai/src/text/availableModels.ts transforms), not copied
+ * from upstream provider docs:
+ *
+ * - Stripped controls never reach the upstream (e.g. sampling knobs the
+ *   provider rejects, reasoning toggles without a reasoning mode).
+ * - Mapped controls are accepted but translated (e.g. reasoning_effort
+ *   becomes a thinking budget on Claude).
+ * - Everything else is forwarded as sent.
+ *
+ * Only models with a verified profile advertise parameters; anything else
+ * omits the fields rather than guessing.
+ */
+
+/** Full Chat Completions control surface accepted by the gateway. */
+export const BASE_CHAT_PARAMETERS: string[] = [
+    "messages",
+    "model",
+    "temperature",
+    "top_p",
+    "frequency_penalty",
+    "presence_penalty",
+    "repetition_penalty",
+    "logit_bias",
+    "logprobs",
+    "top_logprobs",
+    "max_tokens",
+    "response_format",
+    "seed",
+    "stop",
+    "stream",
+    "stream_options",
+    "reasoning_effort",
+    "tools",
+    "tool_choice",
+    "parallel_tool_calls",
+    "user",
+];
+
+/**
+ * Gateway request defaults: what Pollinations applies when the caller omits
+ * the control. Only controls in the model's supported set are listed.
+ */
+export const CHAT_PARAMETER_DEFAULTS: Record<string, unknown> = {
+    frequency_penalty: 0,
+    presence_penalty: 0,
+    logprobs: false,
+    stream: false,
+    parallel_tool_calls: true,
+};
+
+export interface ModelParameterProfile {
+    /** Controls this model actually honors, subset of BASE_CHAT_PARAMETERS. */
+    supported: string[];
+    /** Gateway defaults restricted to the supported set. */
+    defaults: Record<string, unknown>;
+}
+
+function profile(strip: string[]): ModelParameterProfile {
+    const supported = BASE_CHAT_PARAMETERS.filter(
+        (param) => !strip.includes(param),
+    );
+    const defaults: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(CHAT_PARAMETER_DEFAULTS)) {
+        if (supported.includes(key)) defaults[key] = value;
+    }
+    return { supported, defaults };
+}
+
+/**
+ * Verified per-model profiles, keyed by canonical registry id. Aliases
+ * resolve to the same definition, so listings stay consistent.
+ *
+ * - openai/gpt-5.4-nano (Azure): sampling knobs are stripped upstream
+ *   (omitOpenAISampling); reasoning_effort is honored.
+ * - deepseek/deepseek-v4-flash (Fireworks): full surface; reasoning_effort
+ *   toggles thinking, "none" disables it (fireworksThinking).
+ * - anthropic/claude-sonnet-4.6 (Bedrock): temperature/top_p are stripped
+ *   (omitClaudeSampling); reasoning_effort is mapped to an adaptive
+ *   thinking budget rather than passed through (claudeAdaptiveThinking).
+ */
+const VERIFIED_CHAT_PARAMETER_PROFILES: Record<string, ModelParameterProfile> =
+    {
+        "openai/gpt-5.4-nano": profile([
+            "temperature",
+            "top_p",
+            "frequency_penalty",
+            "presence_penalty",
+            "repetition_penalty",
+            "seed",
+        ]),
+        "deepseek/deepseek-v4-flash": profile([]),
+        "anthropic/claude-sonnet-4.6": profile(["temperature", "top_p"]),
+    };
+
+export function getModelChatParameters(
+    canonicalId: string,
+): ModelParameterProfile | null {
+    return VERIFIED_CHAT_PARAMETER_PROFILES[canonicalId] ?? null;
+}

--- a/shared/registry/registry.ts
+++ b/shared/registry/registry.ts
@@ -230,6 +230,11 @@ export type ModelDefinition = {
     maxReferenceVideos?: number; // Models with video input: effective accepted reference videos
     /** Internal provider-route output-token cap used for fallback compatibility. */
     maxCompletionTokens?: number;
+    // Verified Chat controls for listings. Only set when the behavior was
+    // checked against the generation pipeline; listings omit the fields
+    // otherwise rather than guessing.
+    supportedParameters?: string[];
+    defaultParameters?: Record<string, unknown>;
 };
 
 // Helper: Convert usage counts to rated USD-equivalent cost or Pollen charge.

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -10,6 +10,7 @@ import {
     withVertexCacheStorage,
 } from "./gemini-billing";
 import { mergeFallbacks } from "./merge-fallbacks";
+import { getModelChatParameters } from "./model-parameters";
 import {
     PERPLEXITY_PRO_BILLING,
     PERPLEXITY_REASONING_BILLING,
@@ -39,6 +40,18 @@ export const AUDIO_VOICES = [
 export const DEFAULT_TEXT_MODEL = "openai/gpt-5.4-nano" as const;
 export type TextModelName = keyof typeof TEXT_SERVICES;
 
+// Verified Chat controls for listings. Profiles live in
+// ./model-parameters and mirror the generation pipeline transforms
+// (e.g. sampling stripped upstream, reasoning mapped), so listings
+// describe what Pollinations honors rather than upstream docs.
+const chatParameters = (id: string) => {
+    const profile = getModelChatParameters(id);
+    return {
+        supportedParameters: profile?.supported,
+        defaultParameters: profile?.defaults,
+    };
+};
+
 const TEXT_BASE_SERVICES = {
     "openai/gpt-5.4-nano": {
         aliases: ["gpt-5.4-nano", "openai"],
@@ -61,6 +74,7 @@ const TEXT_BASE_SERVICES = {
         tools: true,
         contextLength: 400000,
         isSpecialized: false,
+        ...chatParameters("openai/gpt-5.4-nano"),
     },
     "openai/gpt-5-nano": {
         aliases: ["gpt-5-nano", "gpt-5-nano-2025-08-07", "openai-fast"],
@@ -814,6 +828,7 @@ const TEXT_BASE_SERVICES = {
         reasoning: true,
         contextLength: 1048576,
         isSpecialized: false,
+        ...chatParameters("deepseek/deepseek-v4-flash"),
     },
     "deepseek/deepseek-v4-flash-vision-exp": {
         aliases: [],
@@ -1151,6 +1166,7 @@ const TEXT_BASE_SERVICES = {
         tools: true,
         contextLength: 1000000, // Bedrock global Claude Sonnet 4.6 context window.
         isSpecialized: false,
+        ...chatParameters("anthropic/claude-sonnet-4.6"),
     },
     "anthropic/claude-sonnet-5": {
         aliases: ["sonnet-5", "claude-sonnet-5"],

--- a/shared/schemas/openai.ts
+++ b/shared/schemas/openai.ts
@@ -746,6 +746,14 @@ export const OpenAIModelSchema = z
         reasoning: z.boolean().optional(),
         context_length: z.number().optional(),
         per_user_rpm: z.number().positive().nullable().optional(),
+        supported_parameters: z.array(z.string()).optional().meta({
+            description:
+                "Chat controls this model honors through Pollinations. Only present for models verified against the generation pipeline.",
+        }),
+        default_parameters: z.record(z.string(), z.unknown()).optional().meta({
+            description:
+                "Gateway defaults applied when the caller omits the control.",
+        }),
     })
     .meta({
         description: "OpenAI-compatible model object with capability metadata",


### PR DESCRIPTION
﻿Fixes #14599

Exposes which Chat controls each model honors, verified against the generation pipeline rather than upstream docs.

- New `shared/registry/model-parameters.ts` holds the gateway's base control surface plus per-model profiles derived from the request transforms in `availableModels.ts`: sampling knobs stripped upstream never appear, `reasoning_effort` shows as supported where it is honored, mapped (Claude thinking budget), or toggled (Fireworks), and gateway defaults only list supported controls.
- Three official Chat models with different capabilities to start: `openai/gpt-5.4-nano` (no sampling knobs), `deepseek/deepseek-v4-flash` (full surface), `anthropic/claude-sonnet-4.6` (no temperature/top_p, reasoning mapped). Anything unverified omits the fields instead of guessing; aliases resolve to the same definition so all listings agree.
- Threaded through `ModelDefinition` → `ModelInfo` → the OpenAI mapper, so `/models`, `/text/models`, `/v1/models` and the single-model lookup all expose `supported_parameters` / `default_parameters`. Generation, billing, and access rules untouched. The fields describe Chat Completions (and the text GET surface), not the native Responses API.
- Docs in `gen.pollinations.ai/src/docs/models.md` with a lookup example.
- 8 focused tests cover the three profiles, alias consistency, defaults ⊆ supported, and the listing threading. `vitest run` and `tsc --noEmit` pass in `gen.pollinations.ai`.
