### PR TITLE
feat(llm): add Pollinations provider plugin for Simon Willison's llm

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -24,6 +24,12 @@ A terminal app for using Pollinations without writing any code. Type a prompt, g
 
 **Who it's for:** people comfortable in a terminal — humans testing things quickly, and AI agents driving workflows.
 
+### [llm-pollinations/](./llm-pollinations) — the `llm` CLI plugin
+
+Pollinations text models inside [Simon Willison's `llm`](https://llm.datasette.io/) as `pollinations/<model-id>`, read live from your `/v1/models` catalog. No hardcoded model list.
+
+**Who it's for:** anyone already using `llm` who wants Pollinations as one more provider.
+
 ### [n8n/](./n8n) — n8n tunnel setup
 
 A small set of helper scripts for exposing a self-hosted [n8n](https://n8n.io) automation instance through a Cloudflare tunnel. Not a Pollinations library — it's infrastructure used by the team to run automation workflows that talk to Pollinations.

--- a/packages/llm-pollinations/README.md
+++ b/packages/llm-pollinations/README.md
@@ -1,0 +1,65 @@
+# llm-pollinations
+
+Pollinations models inside [Simon Willison's `llm`](https://llm.datasette.io/) CLI and Python library.
+
+## Install
+
+```bash
+pip install llm-pollinations
+```
+
+Requires `llm` 0.24 or newer (it installs automatically).
+
+## Connect a key
+
+Either store a key with llm itself:
+
+```bash
+llm keys set pollinations
+# paste your key from https://enter.pollinations.ai/keys
+```
+
+or export it for one session:
+
+```bash
+export POLLINATIONS_API_KEY="sk_..."
+```
+
+Prefer a dedicated key? Mint one with the Polli CLI:
+
+```bash
+polli keys create --name "llm" --type secret
+```
+
+## Use it
+
+```bash
+llm -m pollinations/openai "explain quorums in one sentence"
+llm -m pollinations/openai "summarise this file" -f README.md
+llm chat -m pollinations/openai
+```
+
+Models come live from your `/v1/models` catalog as `pollinations/<model-id>` — text models you can call, including community models. Vision, tool calling, and reasoning flags follow whatever the catalog advertises for each model. The catalog is cached for an hour with stale-cache fallback, so a network blip never breaks `llm models`.
+
+```bash
+llm models | grep pollinations
+```
+
+Python API:
+
+```python
+import llm
+model = llm.get_model("pollinations/openai")
+print(model.prompt("explain quorums in one sentence").text())
+```
+
+## For maintainers
+
+```bash
+pip install -e ".[test]"  # from packages/llm-pollinations
+pytest
+```
+
+## Publishing
+
+Standard PyPI flow (`python -m build`, `twine upload dist/*`), then submit the repo URL to the [upstream plugin directory](https://llm.datasette.io/en/stable/plugins/directory.html) with a one-line description.

--- a/packages/llm-pollinations/llm_pollinations.py
+++ b/packages/llm-pollinations/llm_pollinations.py
@@ -1,0 +1,138 @@
+"""Pollinations provider for Simon Willison's llm.
+
+Registers Pollinations text models as ``pollinations/<model-id>`` by reading
+the live ``/v1/models`` catalog — no hardcoded model list. Built on llm's own
+OpenAI-compatible Chat/AsyncChat classes, so streaming, conversations, tools,
+and attachments all come from llm itself.
+"""
+
+import json
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import httpx
+import llm
+from llm.default_plugins.openai_models import AsyncChat, Chat
+
+API_BASE = "https://gen.pollinations.ai/v1"
+MODELS_URL = "https://gen.pollinations.ai/v1/models"
+CACHE_TIMEOUT = 3600
+
+
+def _cache_path() -> Path:
+    return llm.user_dir() / "pollinations_models.json"
+
+
+def _read_cache(path: Path) -> Optional[List[Dict[str, Any]]]:
+    try:
+        cached = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(cached.get("models"), list):
+            return cached["models"]
+    except (OSError, ValueError):
+        pass
+    return None
+
+
+def _cache_fresh(path: Path, timeout: int) -> bool:
+    try:
+        return time.time() - path.stat().st_mtime < timeout
+    except OSError:
+        return False
+
+
+def fetch_models(key: str, skip_cache: bool = False) -> List[Dict[str, Any]]:
+    """Load the model catalog with the caller's key.
+
+    Uses a small time-limited cache file, falling back to stale cache when
+    the network fails so a blip never breaks model listing.
+    """
+    path = _cache_path()
+    if not skip_cache and _cache_fresh(path, CACHE_TIMEOUT):
+        cached = _read_cache(path)
+        if cached is not None:
+            return cached
+    try:
+        response = httpx.get(
+            MODELS_URL,
+            headers={"Authorization": f"Bearer {key}"},
+            timeout=30,
+        )
+        response.raise_for_status()
+        body = response.json()
+        models = body.get("data", body)
+        if not isinstance(models, list):
+            raise ValueError("unexpected catalog shape")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"models": models}), encoding="utf-8")
+        return models
+    except Exception:
+        cached = _read_cache(path)
+        if cached is not None:
+            return cached
+        raise
+
+
+def is_chat_model(entry: Dict[str, Any]) -> bool:
+    """Text-in, text-out models only — image/audio models go elsewhere."""
+    if entry.get("category") != "text":
+        return False
+    return "text" in (entry.get("output_modalities") or ["text"])
+
+
+def supports_vision(entry: Dict[str, Any]) -> bool:
+    return "image" in (entry.get("input_modalities") or [])
+
+
+def supports_tools(entry: Dict[str, Any]) -> bool:
+    return entry.get("tools") is True
+
+
+def supports_reasoning(entry: Dict[str, Any]) -> bool:
+    return entry.get("reasoning") is True
+
+
+class PollinationsChat(Chat):
+    needs_key = "pollinations"
+    key_env_var = "POLLINATIONS_API_KEY"
+
+
+class PollinationsAsyncChat(AsyncChat):
+    needs_key = "pollinations"
+    key_env_var = "POLLINATIONS_API_KEY"
+
+
+@llm.hookimpl
+def register_models(register):
+    # Only register when the user has a key — same pattern as other providers.
+    key = llm.get_key("", "pollinations", "POLLINATIONS_API_KEY")
+    if not key:
+        return
+    seen: set = set()
+    for entry in fetch_models(key):
+        if not isinstance(entry, dict):
+            continue
+        model_id = entry.get("id") or entry.get("name")
+        if not model_id or model_id in seen:
+            continue
+        if not is_chat_model(entry):
+            continue
+        seen.add(model_id)
+        aliases = [
+            f"pollinations/{alias}"
+            for alias in entry.get("aliases", [])
+            if isinstance(alias, str) and alias and alias != model_id
+        ]
+        kwargs = dict(
+            model_id=f"pollinations/{model_id}",
+            model_name=model_id,
+            vision=supports_vision(entry),
+            reasoning=supports_reasoning(entry),
+            supports_tools=supports_tools(entry),
+            api_base=API_BASE,
+        )
+        register(
+            PollinationsChat(**kwargs),
+            PollinationsAsyncChat(**kwargs),
+            aliases=aliases,
+        )

--- a/packages/llm-pollinations/pyproject.toml
+++ b/packages/llm-pollinations/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "llm-pollinations"
+version = "0.1.0"
+description = "Pollinations models for Simon Willison's llm CLI and Python library"
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "MIT" }
+dependencies = [
+    "llm>=0.24",
+    "httpx>=0.27",
+]
+
+[project.optional-dependencies]
+test = ["pytest"]
+
+[project.entry-points.llm]
+llm-pollinations = "llm_pollinations"
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+py-modules = ["llm_pollinations"]

--- a/packages/llm-pollinations/tests/test_llm_pollinations.py
+++ b/packages/llm-pollinations/tests/test_llm_pollinations.py
@@ -1,0 +1,127 @@
+import json
+
+import pytest
+
+import llm_pollinations as plugin
+
+
+def entry(model_id, **overrides):
+    base = {
+        "id": model_id,
+        "category": "text",
+        "input_modalities": ["text"],
+        "output_modalities": ["text"],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_chat_model_filtering():
+    assert plugin.is_chat_model(entry("a")) is True
+    assert plugin.is_chat_model(entry("b", category="image")) is False
+    assert (
+        plugin.is_chat_model(entry("c", output_modalities=["audio"]))
+        is False
+    )
+    # Missing category cannot be confirmed as chat — excluded, not guessed.
+    assert plugin.is_chat_model({"id": "d"}) is False
+
+
+def test_capability_flags_come_from_catalog():
+    vision = entry("v", input_modalities=["text", "image"])
+    assert plugin.supports_vision(vision) is True
+    assert plugin.supports_vision(entry("t")) is False
+    assert plugin.supports_tools(entry("x", tools=True)) is True
+    assert plugin.supports_tools(entry("x")) is False
+    assert plugin.supports_reasoning(entry("x", reasoning=True)) is True
+    assert plugin.supports_reasoning(entry("x")) is False
+
+
+def test_fetch_models_uses_fresh_cache(tmp_path, monkeypatch):
+    cache = tmp_path / "models.json"
+    cache.write_text(
+        json.dumps({"models": [entry("cached-model")]}), encoding="utf-8"
+    )
+    monkeypatch.setattr(plugin, "_cache_path", lambda: cache)
+
+    def boom(*args, **kwargs):
+        raise AssertionError("network should not be touched")
+
+    monkeypatch.setattr(plugin.httpx, "get", boom)
+    assert plugin.fetch_models("sk_test") == [entry("cached-model")]
+
+
+def test_fetch_models_stale_fallback(tmp_path, monkeypatch):
+    import time
+
+    cache = tmp_path / "models.json"
+    cache.write_text(
+        json.dumps({"models": [entry("old-model")]}), encoding="utf-8"
+    )
+    old = time.time() - plugin.CACHE_TIMEOUT - 10
+    import os
+
+    os.utime(cache, (old, old))
+    monkeypatch.setattr(plugin, "_cache_path", lambda: cache)
+
+    def fail(*args, **kwargs):
+        raise ConnectionError("offline")
+
+    monkeypatch.setattr(plugin.httpx, "get", fail)
+    assert plugin.fetch_models("sk_test") == [entry("old-model")]
+
+
+def test_fetch_models_raises_without_cache(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        plugin, "_cache_path", lambda: tmp_path / "missing.json"
+    )
+
+    def fail(*args, **kwargs):
+        raise ConnectionError("offline")
+
+    monkeypatch.setattr(plugin.httpx, "get", fail)
+    with pytest.raises(ConnectionError):
+        plugin.fetch_models("sk_test")
+
+
+def test_register_models_skips_duplicates_and_non_chat(monkeypatch):
+    catalog = [
+        entry("openai", **{"aliases": ["gpt-5.4-nano"]}),
+        entry("openai"),
+        entry("img", category="image"),
+        {"id": "", "category": "text"},
+        "not-a-dict",
+    ]
+    monkeypatch.setattr(plugin, "fetch_models", lambda key: catalog)
+    monkeypatch.setattr(
+        plugin.llm, "get_key", lambda *args, **kwargs: "sk_test"
+    )
+    registered = []
+    seen_aliases = []
+
+    def collect(model, async_model=None, aliases=None):
+        registered.extend([model, async_model])
+        seen_aliases.extend(aliases or [])
+
+    plugin.register_models(collect)
+    assert len(registered) == 2  # Chat + AsyncChat for one model
+    assert registered[0].model_id == "pollinations/openai"
+    assert isinstance(registered[0], plugin.PollinationsChat)
+    assert isinstance(registered[1], plugin.PollinationsAsyncChat)
+    assert "pollinations/gpt-5.4-nano" in seen_aliases
+
+
+def test_register_models_needs_key(monkeypatch):
+    monkeypatch.setattr(plugin.llm, "get_key", lambda *args, **kwargs: "")
+    registered = []
+    plugin.register_models(registered.append)
+    assert registered == []
+
+
+def test_model_classes_point_at_pollinations():
+    chat = plugin.PollinationsChat(
+        "pollinations/openai", api_base=plugin.API_BASE
+    )
+    assert chat.api_base == "https://gen.pollinations.ai/v1"
+    assert chat.needs_key == "pollinations"
+    assert chat.key_env_var == "POLLINATIONS_API_KEY"


### PR DESCRIPTION
﻿Fixes #14660

Adds `llm-pollinations`: Pollinations text models inside Simon Willison's `llm` as `pollinations/<model-id>` (plus catalog aliases like `pollinations/openai`).

- Built on llm's own OpenAI-compatible `Chat`/`AsyncChat` against `https://gen.pollinations.ai/v1` — no reimplementation of streaming, conversations, tools, or attachments.
- Auth via `llm keys set pollinations` or `POLLINATIONS_API_KEY`; README documents minting a dedicated key with `polli keys create`.
- Models load live from the authenticated `/v1/models` catalog (community models included), cached for an hour with stale-cache fallback. No hardcoded list, `pollinations/` prefix avoids collisions.
- Vision, tool-calling, and reasoning flags follow whatever the catalog advertises per model.
- Verified end to end against the real API with llm 0.35 on a funded key: plain prompt, streaming, multi-turn chat (remembers context), image attachment, tool-calling loop (21+21 via tool = 42), and the async Python API.
- 8 unit tests cover filtering, capability flags, aliases, cache/fallback behavior, and registration. Docs cover install, key setup, usage, and PyPI + upstream directory submission.
