### PR TITLE
feat: add llm-pollinations plugin for Simon Willison's LLM

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -24,6 +24,12 @@ A terminal app for using Pollinations without writing any code. Type a prompt, g
 
 **Who it's for:** people comfortable in a terminal — humans testing things quickly, and AI agents driving workflows.
 
+### [llm-pollinations/](./llm-pollinations) — plugin for Simon Willison's `llm`
+
+A native provider plugin that registers Pollinations text models inside the [`llm`](https://llm.datasette.io/) CLI and Python library, so you can run `llm -m pollinations/<model>` alongside any other provider.
+
+**Who it's for:** developers already using the `llm` CLI/library who want Pollinations models available without leaving that tool.
+
 ### [n8n/](./n8n) — n8n tunnel setup
 
 A small set of helper scripts for exposing a self-hosted [n8n](https://n8n.io) automation instance through a Cloudflare tunnel. Not a Pollinations library — it's infrastructure used by the team to run automation workflows that talk to Pollinations.
@@ -34,6 +40,7 @@ A small set of helper scripts for exposing a self-hosted [n8n](https://n8n.io) a
 
 - **SDK** and **CLI** are two different doorways into the same Pollinations API — one for code, one for terminals.
 - **MCP** is a third doorway, designed for AI assistants rather than people.
+- **llm-pollinations** plugs the same API into Simon Willison's `llm` CLI for prompt-driven workflows.
 - **n8n** is operational tooling, not something end users install.
 
 If you're new and just want to try Pollinations, the fastest paths are the [CLI](./polli-cli) (no code) or the [SDK](./sdk) (a few lines of code).

--- a/packages/llm-pollinations/README.md
+++ b/packages/llm-pollinations/README.md
@@ -1,0 +1,76 @@
+# llm-pollinations
+
+Pollinations.ai models for [Simon Willison's `llm` CLI](https://llm.datasette.io/) and Python library.
+
+## Installation
+
+```bash
+llm install llm-pollinations
+```
+
+## Authentication
+
+Set a key using one of the following:
+
+```bash
+# Store the key with llm (recommended)
+llm keys set pollinations
+# Paste: sk_...
+
+# Or export an environment variable
+export POLLINATIONS_API_KEY=sk_...
+```
+
+To create a dedicated key through the Polli CLI:
+
+```bash
+polli keys create --name llm-plugin
+# Then run: llm keys set pollinations and paste the sk_... value
+```
+
+Keys are managed at https://enter.pollinations.ai/keys.
+
+## Usage
+
+List available models (registered as `pollinations/<model-id>` from the live catalog):
+
+```bash
+llm models | grep pollinations
+```
+
+Run a prompt:
+
+```bash
+llm -m pollinations/openai/gpt-5-nano 'Reply with exactly one word: banana'
+```
+
+Python API:
+
+```python
+import llm
+
+model = llm.get_model("pollinations/openai/gpt-5-nano")
+response = model.prompt("Reply with exactly one word: banana")
+print(response.text())
+```
+
+Streaming, conversations, tool calling and image attachments are provided by `llm` itself:
+
+```bash
+# Image attachment (vision models only)
+llm -m pollinations/openai/gpt-5-nano -a image.png 'Describe this image'
+```
+
+## Notes
+
+- Models are discovered live from `https://gen.pollinations.ai/v1/models`; there is no hardcoded model list.
+- Image input, tool calling and reasoning are advertised per model only when the catalog lists them.
+- The catalog is cached on disk for one hour (`llm pollinations models --skip-cache` bypasses the cache). If the network fetch fails, the stale cache is used.
+- Models are registered only when a key is configured.
+
+## Development
+
+```bash
+pip install -e '.[dev]' || pip install -e . pytest
+python -m pytest
+```

--- a/packages/llm-pollinations/llm_pollinations.py
+++ b/packages/llm-pollinations/llm_pollinations.py
@@ -1,0 +1,141 @@
+"""Pollinations provider plugin for Simon Willison's LLM.
+
+Registers text models from the Pollinations catalog (https://gen.pollinations.ai)
+as ``pollinations/<model-id>`` and serves them through LLM's OpenAI-compatible
+Chat classes pointed at https://gen.pollinations.ai/v1.
+
+Auth: `llm keys set pollinations` or the POLLINATIONS_API_KEY environment
+variable. Models are only registered when a key is present.
+
+Capabilities (vision, tools, reasoning) are derived live from the catalog and
+only advertised when the catalog advertises them. The catalog is cached on
+disk for an hour, with stale-cache fallback when the network is unreachable.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any, Optional
+
+import click
+import httpx
+import llm
+from llm.default_plugins.openai_models import AsyncChat, Chat
+
+CATALOG_URL = "https://gen.pollinations.ai/v1/models"
+API_BASE = "https://gen.pollinations.ai/v1"
+CACHE_TIMEOUT = 3600
+
+
+class CatalogError(Exception):
+    """Raised when the model catalog cannot be loaded."""
+
+
+def _is_text_model(model: dict[str, Any]) -> bool:
+    """Chat-capable text models only: excludes image/audio/transcription models."""
+    outputs = model.get("output_modalities") or []
+    if "text" not in outputs and model.get("category") != "text":
+        return False
+    return "/v1/chat/completions" in (model.get("supported_endpoints") or [])
+
+
+def _has_capability(model: dict[str, Any], capability: str) -> bool:
+    capabilities = model.get("capabilities") or []
+    if capability in capabilities:
+        return True
+    # Some catalog entries also carry a top-level boolean flag.
+    return bool(model.get(capability))
+
+
+def _supports_images(model: dict[str, Any]) -> bool:
+    return "image" in (model.get("input_modalities") or [])
+
+
+def get_catalog(key: Optional[str] = None, skip_cache: bool = False) -> list[dict[str, Any]]:
+    """Return the Pollinations text-model catalog.
+
+    Fetches https://gen.pollinations.ai/v1/models (authenticated when a key is
+    provided), filters it to chat-capable text models and caches the result at
+    <user_dir>/pollinations_models.json for CACHE_TIMEOUT seconds. Falls back
+    to the stale cache if the network fetch fails.
+    """
+    path = llm.user_dir() / "pollinations_models.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not skip_cache and path.is_file():
+        if time.time() - path.stat().st_mtime < CACHE_TIMEOUT:
+            return json.loads(path.read_text())
+    headers = {"Authorization": "Bearer {}".format(key)} if key else None
+    try:
+        response = httpx.get(CATALOG_URL, headers=headers, timeout=30, follow_redirects=True)
+        response.raise_for_status()
+        payload = response.json()
+    except (httpx.HTTPError, ValueError) as ex:
+        if path.is_file():
+            return json.loads(path.read_text())
+        raise CatalogError(
+            "Failed to download the Pollinations catalog and no cache exists "
+            "at {}".format(path)
+        ) from ex
+    models = payload.get("data", payload) if isinstance(payload, dict) else payload
+    models = [m for m in models if _is_text_model(m)]
+    path.write_text(json.dumps(models))
+    return models
+
+
+class PollinationsChat(Chat):
+    needs_key = "pollinations"
+    key_env_var = "POLLINATIONS_API_KEY"
+
+    def __str__(self):
+        return "Pollinations: {}".format(self.model_id)
+
+
+class PollinationsAsyncChat(AsyncChat):
+    needs_key = "pollinations"
+    key_env_var = "POLLINATIONS_API_KEY"
+
+    def __str__(self):
+        return "Pollinations: {}".format(self.model_id)
+
+
+@llm.hookimpl
+def register_models(register):
+    key = llm.get_key("", "pollinations", "POLLINATIONS_API_KEY")
+    if not key:
+        return
+    seen: set[str] = set()
+    for definition in get_catalog(key):
+        if not _is_text_model(definition):
+            continue
+        model_id = definition.get("id")
+        if not model_id or model_id in seen:
+            continue
+        seen.add(model_id)
+        kwargs = dict(
+            model_id="pollinations/{}".format(model_id),
+            model_name=model_id,
+            vision=_supports_images(definition),
+            reasoning=_has_capability(definition, "reasoning"),
+            supports_tools=_has_capability(definition, "tool_calling"),
+            api_base=API_BASE,
+        )
+        register(
+            PollinationsChat(**kwargs),
+            PollinationsAsyncChat(**kwargs),
+        )
+
+
+@llm.hookimpl
+def register_commands(cli):
+    @cli.group()
+    def pollinations():
+        """Commands for working with the Pollinations provider"""
+
+    @pollinations.command()
+    @click.option("--skip-cache", is_flag=True, help="Bypass the 1-hour cache")
+    def models(skip_cache):
+        """Show text models currently advertised by Pollinations"""
+        key = llm.get_key("", "pollinations", "POLLINATIONS_API_KEY")
+        for definition in get_catalog(key, skip_cache=skip_cache):
+            click.echo(definition["id"])

--- a/packages/llm-pollinations/pyproject.toml
+++ b/packages/llm-pollinations/pyproject.toml
@@ -1,0 +1,26 @@
+[project]
+name = "llm-pollinations"
+version = "0.1.0"
+description = "Pollinations.ai models for Simon Willison's llm CLI and Python library"
+readme = "README.md"
+authors = [{name = "Pollinations contributors"}]
+license = "MIT"
+requires-python = ">=3.10"
+dependencies = [
+    "llm>=0.35",
+    "httpx",
+]
+
+[project.urls]
+Homepage = "https://github.com/pollinations/pollinations/tree/main/packages/llm-pollinations"
+Issues = "https://github.com/pollinations/pollinations/issues"
+
+[project.entry-points.llm]
+pollinations = "llm_pollinations"
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[dependency-groups]
+dev = ["pytest"]

--- a/packages/llm-pollinations/tests/test_llm_pollinations.py
+++ b/packages/llm-pollinations/tests/test_llm_pollinations.py
@@ -1,0 +1,146 @@
+import json
+import os
+import time
+
+import httpx
+import llm
+import pytest
+
+import llm_pollinations as lp
+
+
+def make_model(**overrides):
+    model = {
+        "id": "openai/gpt-5-nano",
+        "category": "text",
+        "output_modalities": ["text"],
+        "input_modalities": ["text"],
+        "supported_endpoints": ["/v1/chat/completions"],
+        "capabilities": ["tool_calling"],
+    }
+    model.update(overrides)
+    return model
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+def test_text_model_requires_chat_completions():
+    assert lp._is_text_model(make_model())
+    # Transcription/realtime models without the chat endpoint are excluded
+    assert not lp._is_text_model(
+        make_model(id="x/whisper", supported_endpoints=["/v1/audio/transcriptions"])
+    )
+
+
+def test_non_text_models_excluded():
+    assert not lp._is_text_model(make_model(category="image", output_modalities=["image"]))
+    assert not lp._is_text_model(make_model(output_modalities=["image"], category=None))
+
+
+def test_capability_from_capabilities_list():
+    assert lp._has_capability(make_model(capabilities=["tool_calling", "reasoning"]), "reasoning")
+    assert lp._has_capability(make_model(capabilities=["tool_calling"]), "tool_calling")
+    assert not lp._has_capability(make_model(capabilities=[]), "tool_calling")
+
+
+def test_capability_from_top_level_flag():
+    assert lp._has_capability(make_model(reasoning=True), "reasoning")
+    assert not lp._has_capability(make_model(reasoning=False), "reasoning")
+
+
+def test_vision_from_input_modalities():
+    assert lp._supports_images(make_model(input_modalities=["text", "image"]))
+    assert not lp._supports_images(make_model(input_modalities=["text"]))
+
+
+def test_register_models_registers_sync_and_async(monkeypatch):
+    monkeypatch.setattr(llm, "get_key", lambda *args, **kwargs: "sk_test")
+    monkeypatch.setattr(
+        lp,
+        "get_catalog",
+        lambda key, skip_cache=False: [
+            make_model(),
+            make_model(),  # duplicate id
+            make_model(id="x/vision", input_modalities=["text", "image"], reasoning=True),
+        ],
+    )
+    registered = []
+    lp.register_models(lambda *ms: registered.extend(ms))
+    ids = {m.model_id for m in registered}
+    assert ids == {"pollinations/openai/gpt-5-nano", "pollinations/x/vision"}
+    # sync + async pair for every model, duplicates skipped
+    assert len(registered) == 4
+    types = {(m.model_id, type(m).__name__) for m in registered}
+    assert ("pollinations/openai/gpt-5-nano", "PollinationsChat") in types
+    assert ("pollinations/openai/gpt-5-nano", "PollinationsAsyncChat") in types
+    vision = next(m for m in registered if m.model_id == "pollinations/x/vision")
+    assert vision.vision is True
+    # reasoning via top-level flag yields a reasoning_effort option
+    assert "reasoning_effort" in vision.Options.model_fields
+
+
+def test_no_key_registers_nothing(monkeypatch):
+    monkeypatch.setattr(llm, "get_key", lambda *args, **kwargs: "")
+    registered = []
+    lp.register_models(lambda *ms: registered.extend(ms))
+    assert registered == []
+
+
+def test_get_catalog_filters_and_caches(monkeypatch, tmp_path):
+    monkeypatch.setattr(lp.llm, "user_dir", lambda: tmp_path)
+
+    payload = {"data": [make_model(), make_model(id="x/image-only", category="image", output_modalities=["image"])]}
+    calls = {}
+
+    def fake_get(url, headers=None, **kwargs):
+        calls["url"] = url
+        calls["headers"] = headers
+        return FakeResponse(payload)
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+    models = lp.get_catalog("sk_test", skip_cache=True)
+    assert [m["id"] for m in models] == ["openai/gpt-5-nano"]
+    assert calls["url"] == lp.CATALOG_URL
+    assert calls["headers"] == {"Authorization": "Bearer sk_test"}
+    assert (tmp_path / "pollinations_models.json").is_file()
+
+    # Within the cache window the network is not hit again
+    def exploding_get(*args, **kwargs):
+        raise AssertionError("network should not be hit")
+
+    monkeypatch.setattr(httpx, "get", exploding_get)
+    assert lp.get_catalog("sk_test") == models
+
+
+def test_get_catalog_stale_cache_fallback(monkeypatch, tmp_path):
+    monkeypatch.setattr(lp.llm, "user_dir", lambda: tmp_path)
+    cache = tmp_path / "pollinations_models.json"
+    cache.write_text(json.dumps([make_model(id="x/stale")]))
+    old = time.time() - lp.CACHE_TIMEOUT - 10
+    os.utime(cache, (old, old))
+
+    def failing_get(*args, **kwargs):
+        raise httpx.ConnectError("network down")
+
+    monkeypatch.setattr(httpx, "get", failing_get)
+    assert [m["id"] for m in lp.get_catalog("sk_test")] == ["x/stale"]
+
+
+def test_get_catalog_error_without_cache(monkeypatch, tmp_path):
+    monkeypatch.setattr(lp.llm, "user_dir", lambda: tmp_path)
+
+    def failing_get(*args, **kwargs):
+        raise httpx.ConnectError("network down")
+
+    monkeypatch.setattr(httpx, "get", failing_get)
+    with pytest.raises(lp.CatalogError):
+        lp.get_catalog("sk_test", skip_cache=True)


### PR DESCRIPTION
Fixes #14660

Adds `packages/llm-pollinations`, a native provider plugin for Simon Willison's `llm` CLI/library.

- Registers Pollinations text models as `pollinations/<model-id>`, loaded live from the authenticated `gen.pollinations.ai/v1/models` catalog (no hardcoded list). Only models exposing `/v1/chat/completions` are registered, so image/audio/transcription endpoints are excluded.
- Reuses `llm`'s built-in `Chat`/`AsyncChat` OpenAI-compatible base classes — streaming, conversations, tool calling and attachments are handled by `llm`, not reimplemented.
- Vision, tool calling and reasoning are enabled per model only when the catalog advertises them (`input_modalities`, `capabilities`, top-level flags).
- Catalog fetch uses the configured key, is cached for an hour on disk, and falls back to the stale cache on network errors. `llm pollinations models --skip-cache` bypasses the cache.
- README covers install, key setup (direct + via `polli keys create`), CLI and Python usage.

**Testing:**
- `python -m pytest` — 10 unit tests covering model filtering, capability detection (capabilities list + top-level flags), cache read/write/stale-fallback, and `register_models` behavior (no key → no-op, dedupe, sync+async pairs, reasoning → `reasoning_effort` option).
- Verified live against a funded Pollinations key with llm 0.35: normal prompts, streaming, `--no-stream`, interactive `llm chat`, image attachment (1×1 png → "pink"), tool calling (23×42 via a `multiply` tool → 966), multi-turn conversation memory, the async Python API, and catalog-driven registration (179 chat-capable models registered from the authenticated catalog, 95 of them with reasoning).