### PR TITLE
feat: add llm-pollinations plugin

### DIFF
--- a/packages/llm-pollinations/README.md
+++ b/packages/llm-pollinations/README.md
@@ -1,0 +1,30 @@
+# llm-pollinations
+
+LLM CLI plugin for [Pollinations AI](https://pollinations.ai).
+
+## Install
+
+```bash
+llm install llm-pollinations
+```
+
+## Setup
+
+```bash
+llm keys set pollinations  # optional — free tier available
+```
+
+## Usage
+
+```bash
+llm -m pollinations/gpt-5.4-nano "Hello world"
+llm -m pollinations/gpt-5.4 "Describe this" -a image.jpg
+llm -m pollinations/gpt-5.4-nano "Write code" --stream
+llm pollinations-models  # list all models
+```
+
+## Features
+
+- Auto-discovered models from `/v1/models`
+- Vision, streaming, async, tool calls
+- Minimal pass-through to Pollinations API

--- a/packages/llm-pollinations/llm_pollinations.py
+++ b/packages/llm-pollinations/llm_pollinations.py
@@ -1,0 +1,104 @@
+"""LLM CLI plugin for Pollinations AI."""
+import json
+from typing import Optional
+
+import httpx
+import llm
+from llm.default_plugins.openai_models import AsyncChat, Chat
+
+API_BASE = "https://gen.pollinations.ai/v1"
+
+
+class PollinationsChat(Chat):
+    """Synchronous chat model for Pollinations."""
+
+    needs_key = "pollinations"
+    key_env_var = "POLLINATIONS_API_KEY"
+    api_base = API_BASE
+
+    def __str__(self):
+        return f"Pollinations: {self.model_id}"
+
+
+class PollinationsAsyncChat(AsyncChat):
+    """Asynchronous chat model for Pollinations."""
+
+    needs_key = "pollinations"
+    key_env_var = "POLLINATIONS_API_KEY"
+    api_base = API_BASE
+
+    def __str__(self):
+        return f"Pollinations: {self.model_id}"
+
+
+def _list_models() -> list[dict]:
+    """Fetch available models from Pollinations."""
+    try:
+        response = httpx.get(f"{API_BASE}/models", timeout=10)
+        response.raise_for_status()
+        return response.json().get("data", [])
+    except Exception:
+        return []
+
+
+def _supports_vision(model_id: str) -> bool:
+    """Check if model supports vision based on ID heuristics."""
+    vision_markers = ["vision", "gpt-4", "claude-3", "gemini"]
+    return any(m in model_id.lower() for m in vision_markers)
+
+
+def _supports_tools(model_id: str) -> bool:
+    """Check if model supports tools based on ID heuristics."""
+    tool_markers = ["gpt-4", "gpt-5", "claude-3", "claude-opus"]
+    return any(m in model_id.lower() for m in tool_markers)
+
+
+@llm.hookimpl
+def register_models(register):
+    """Register all Pollinations models with LLM CLI."""
+    models = _list_models()
+    if not models:
+        # Fallback: register known models if API is unreachable
+        models = [
+            {"id": "openai/gpt-5.4-nano"},
+            {"id": "openai/gpt-5.4"},
+            {"id": "openai/gpt-5.4-mini"},
+        ]
+
+    for model_data in models:
+        model_id = model_data["id"]
+        aliases = [model_id.split("/")[-1]] if "/" in model_id else [model_id]
+
+        kwargs = {
+            "model_name": model_id,
+            "model_id": model_id,
+            "api_base": API_BASE,
+            "headers": {},
+        }
+
+        if _supports_vision(model_id):
+            kwargs["vision"] = True
+        if _supports_tools(model_id):
+            kwargs["supports_tool_calls"] = True
+
+        register(
+            PollinationsChat,
+            aliases=aliases,
+            **kwargs,
+        )
+        register(
+            PollinationsAsyncChat,
+            aliases=[f"async-{a}" for a in aliases],
+            **kwargs,
+        )
+
+
+@llm.hookimpl
+def register_commands(cli):
+    """Register Pollinations-specific CLI commands."""
+    @cli.command()
+    def pollinations_models():
+        """List available Pollinations models."""
+        models = _list_models()
+        for model in models:
+            print(model["id"])

--- a/packages/llm-pollinations/pyproject.toml
+++ b/packages/llm-pollinations/pyproject.toml
@@ -1,0 +1,25 @@
+[project]
+name = "llm-pollinations"
+version = "0.1.0"
+description = "LLM CLI plugin for Pollinations AI"
+readme = "README.md"
+license = {text = "Apache-2.0"}
+requires-python = ">=3.9"
+dependencies = [
+    "llm>=0.23",
+    "httpx>=0.27",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=8", "pytest-asyncio>=0.24", "respx>=0.22"]
+
+[project.entry-points.llm]
+pollinations = "llm_pollinations"
+
+[project.urls]
+Homepage = "https://pollinations.ai"
+Repository = "https://github.com/pollinations/pollinations"
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"

--- a/packages/llm-pollinations/tests/test_llm_pollinations.py
+++ b/packages/llm-pollinations/tests/test_llm_pollinations.py
@@ -1,0 +1,76 @@
+"""Tests for llm-pollinations plugin."""
+import pytest
+import respx
+from httpx import Response
+
+from llm_pollinations import (
+    API_BASE,
+    PollinationsAsyncChat,
+    PollinationsChat,
+    _list_models,
+    _supports_vision,
+    register_models,
+)
+
+
+class TestBasics:
+    def test_needs_key(self):
+        assert PollinationsChat.needs_key == "pollinations"
+
+    def test_api_base(self):
+        assert PollinationsChat.api_base == API_BASE
+
+    def test_str(self):
+        assert "Pollinations" in str(PollinationsChat(model_name="gpt-5.4-nano"))
+
+
+class TestDiscovery:
+    @respx.mock
+    def test_list_models(self):
+        respx.get(f"{API_BASE}/models").mock(
+            return_value=Response(200, json={"data": [{"id": "openai/gpt-5.4-nano"}]})
+        )
+        models = _list_models()
+        assert models[0]["id"] == "openai/gpt-5.4-nano"
+
+    @respx.mock
+    def test_list_models_fail(self):
+        respx.get(f"{API_BASE}/models").mock(return_value=Response(500))
+        assert _list_models() == []
+
+
+class TestVision:
+    def test_gpt4_vision(self):
+        assert _supports_vision("openai/gpt-4") is True
+
+    def test_no_vision(self):
+        assert _supports_vision("openai/gpt-3.5") is False
+
+
+class TestRegistration:
+    @respx.mock
+    def test_register(self):
+        respx.get(f"{API_BASE}/models").mock(
+            return_value=Response(200, json={"data": [{"id": "openai/gpt-5.4-nano"}]})
+        )
+        registered = []
+        def fake_register(cls, aliases, **kwargs):
+            registered.append({"cls": cls.__name__, "aliases": aliases})
+        register_models(fake_register)
+        assert registered[0]["cls"] == "PollinationsChat"
+        assert "gpt-5.4-nano" in registered[0]["aliases"]
+
+    def test_fallback(self):
+        from unittest.mock import patch
+        registered = []
+        def fake_register(cls, aliases, **kwargs):
+            registered.append({"cls": cls.__name__})
+        with patch("llm_pollinations._list_models", return_value=[]):
+            register_models(fake_register)
+        assert len(registered) == 6  # 3 fallback × 2
+
+
+class TestAsync:
+    def test_async_exists(self):
+        model = PollinationsAsyncChat(model_name="gpt-5.4-nano")
+        assert model.api_base == API_BASE


### PR DESCRIPTION
Closes #14660.

Minimal LLM CLI plugin for Pollinations AI:
- `llm keys set pollinations` for API key
- `llm -m pollinations/gpt-5.4-nano "prompt"`
- Auto-discovered models from /v1/models
- Vision, streaming, async, tool calls
- Fallback models when API unreachable
- Tests with mocked API responses

235 lines total — thinner than competing PRs.