### PR TITLE
feat: ban accounts using Stripe fraud signals

### DIFF
--- a/.github/workflows/billing-check-fraud.yml
+++ b/.github/workflows/billing-check-fraud.yml
@@ -1,0 +1,41 @@
+name: Billing / Check fraud bans
+
+on:
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: billing-fraud-bans
+  cancel-in-progress: false
+
+jobs:
+  check:
+    # Enable this repository variable only after the ban guards are deployed.
+    # Manual runs are always read-only. No activation as a side effect of merging.
+    if: github.repository == 'pollinations/pollinations' && (github.event_name == 'workflow_dispatch' || vars.FRAUD_BAN_ENABLED == 'true')
+    runs-on: ubuntu-latest
+    timeout-minutes: 55
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: production
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+          cache: npm
+      - run: npm ci
+      - uses: nhedger/setup-sops@v3
+      - name: Scan full Stripe history and apply the approved policy
+        env:
+          SOPS_AGE_KEY: ${{ secrets.SOPS_AGE_KEY }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN_MYCELI }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID_MYCELI }}
+          FRAUD_BAN_APPLY: ${{ github.event_name == 'schedule' && vars.FRAUD_BAN_ENABLED == 'true' }}
+          FRAUD_BAN_EXCLUDED_USER_IDS: ${{ vars.FRAUD_BAN_EXCLUDED_USER_IDS }}
+        run: >-
+          sops exec-file --no-fifo enter.pollinations.ai/secrets/prod.vars.json
+          'node enter.pollinations.ai/scripts/check-fraud-bans.mjs --secrets-file {}'

--- a/enter.pollinations.ai/frontend/src/routes/error.tsx
+++ b/enter.pollinations.ai/frontend/src/routes/error.tsx
@@ -1,4 +1,5 @@
 import { Button, Surface } from "@pollinations/ui";
+import { isBannedLoginError } from "@shared/auth/ban.ts";
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/error")({
@@ -10,7 +11,7 @@ export const Route = createFileRoute("/error")({
 
 function ErrorPage() {
     const { error } = Route.useSearch();
-    const isBanned = error === "banned";
+    const isBanned = isBannedLoginError(error);
     const isStagingInviteOnly = error === "staging_is_invite-only";
 
     const title = isBanned
@@ -19,7 +20,7 @@ function ErrorPage() {
           ? "Staging is invite-only"
           : "Something went wrong";
     const message = isBanned
-        ? "Your account has been deactivated. This might be a mistake — reach out and we'll sort it out together."
+        ? "Your account has been deactivated. If you think this is a mistake, contact billing."
         : isStagingInviteOnly
           ? "This is the staging environment and access is limited to the Pollinations team. Head to pollinations.ai to use the production app."
           : "An unexpected error occurred. Please try again or open a GitHub issue if this keeps happening.";
@@ -30,6 +31,14 @@ function ErrorPage() {
                 variant="card"
                 className="w-full max-w-md p-8 text-center shadow-lg"
             >
+                {isBanned && (
+                    <a
+                        href="https://pollinations.ai/"
+                        className="block mb-6 font-heading"
+                    >
+                        Pollinations
+                    </a>
+                )}
                 <h1 className="font-heading text-3xl mb-3">{title}</h1>
 
                 <p className="font-body text-theme-text-base mb-6 leading-relaxed">
@@ -37,25 +46,28 @@ function ErrorPage() {
                 </p>
 
                 <div className="flex flex-col gap-3">
+                    <Button as="a" size="lg" href="/" className="mt-2">
+                        Go to Home →
+                    </Button>
                     {isBanned && (
                         <Button
                             as="a"
                             size="lg"
-                            href="https://github.com/pollinations/pollinations/issues/new?title=Account+deactivated&body=Hi%2C+my+account+has+been+deactivated+and+I+believe+this+may+be+a+mistake.+Could+you+please+review+it%3F"
-                            target="_blank"
-                            rel="noopener noreferrer"
+                            href="mailto:billing@pollinations.ai"
                         >
-                            Create a GitHub Issue
+                            Contact billing
                         </Button>
                     )}
-
-                    <Button as="a" size="lg" href="/" className="mt-2">
-                        Go to Home →
-                    </Button>
                 </div>
 
                 <div className="mt-8 text-sm text-theme-text-soft">
-                    pollinations.ai
+                    {isBanned ? (
+                        <a href="https://pollinations.ai/terms">
+                            Terms &amp; Conditions
+                        </a>
+                    ) : (
+                        "pollinations.ai"
+                    )}
                 </div>
             </Surface>
         </div>

--- a/enter.pollinations.ai/frontend/src/routes/error.tsx
+++ b/enter.pollinations.ai/frontend/src/routes/error.tsx
@@ -1,4 +1,5 @@
-import { Button, Surface } from "@pollinations/ui";
+import { Button, Heading, Surface } from "@pollinations/ui";
+import logoWordmarkUrl from "@pollinations/ui/brand/lockup-horizontal.svg";
 import { isBannedLoginError } from "@shared/auth/ban.ts";
 import { createFileRoute } from "@tanstack/react-router";
 
@@ -15,12 +16,12 @@ function ErrorPage() {
     const isStagingInviteOnly = error === "staging_is_invite-only";
 
     const title = isBanned
-        ? "Account Deactivated"
+        ? "Account Suspended"
         : isStagingInviteOnly
           ? "Staging is invite-only"
           : "Something went wrong";
     const message = isBanned
-        ? "Your account has been deactivated. If you think this is a mistake, contact billing."
+        ? "Your account has been suspended. If you think this is a mistake, contact billing."
         : isStagingInviteOnly
           ? "This is the staging environment and access is limited to the Pollinations team. Head to pollinations.ai to use the production app."
           : "An unexpected error occurred. Please try again or open a GitHub issue if this keeps happening.";
@@ -34,12 +35,23 @@ function ErrorPage() {
                 {isBanned && (
                     <a
                         href="https://pollinations.ai/"
-                        className="block mb-6 font-heading"
+                        className="inline-flex mb-6 text-theme-text-strong"
+                        aria-label="Pollinations"
                     >
-                        Pollinations
+                        <span className="sr-only">Pollinations</span>
+                        <span
+                            aria-hidden="true"
+                            className="block h-6 w-[195px] bg-current"
+                            style={{
+                                WebkitMask: `url(${logoWordmarkUrl}) center / contain no-repeat`,
+                                mask: `url(${logoWordmarkUrl}) center / contain no-repeat`,
+                            }}
+                        />
                     </a>
                 )}
-                <h1 className="font-heading text-3xl mb-3">{title}</h1>
+                <Heading as="h1" size="section" className="mb-3">
+                    {title}
+                </Heading>
 
                 <p className="font-body text-theme-text-base mb-6 leading-relaxed">
                     {message}

--- a/enter.pollinations.ai/scripts/check-fraud-bans.mjs
+++ b/enter.pollinations.ai/scripts/check-fraud-bans.mjs
@@ -1,0 +1,70 @@
+import { readFile } from "node:fs/promises";
+import Stripe from "stripe";
+import { runFraudBanCheck } from "../src/utils/stripe-fraud-ban.ts";
+
+// Production-only job. These identities match Enter's production bindings.
+const D1_DATABASE_ID = "fc771b05-4e24-48bf-980c-d09f21279bd1";
+const CF_ACCOUNT_ID = "b6ec751c0862027ba269faf7029b2501";
+
+async function main() {
+    const secretPath = process.argv[process.argv.indexOf("--secrets-file") + 1];
+    if (!process.argv.includes("--secrets-file") || !secretPath)
+        throw new Error("--secrets-file is required");
+    if (
+        !process.env.CLOUDFLARE_API_TOKEN ||
+        process.env.CLOUDFLARE_ACCOUNT_ID !== CF_ACCOUNT_ID
+    )
+        throw new Error("Expected production Cloudflare credentials");
+    const { STRIPE_SECRET_KEY } = JSON.parse(
+        await readFile(secretPath, "utf8"),
+    );
+    if (!STRIPE_SECRET_KEY) throw new Error("STRIPE_SECRET_KEY is required");
+    const stripe = new Stripe(STRIPE_SECRET_KEY, {
+        apiVersion: "2025-12-15.clover",
+        maxNetworkRetries: 3,
+        timeout: 30000,
+    });
+    async function query(body) {
+        const response = await fetch(
+            `https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/d1/database/${D1_DATABASE_ID}/query`,
+            {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${process.env.CLOUDFLARE_API_TOKEN}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify(body),
+                signal: AbortSignal.timeout(60000),
+            },
+        );
+        if (!response.ok)
+            throw new Error(`D1 query failed: HTTP ${response.status}`);
+        const data = await response.json();
+        if (
+            !data.success ||
+            !Array.isArray(data.result) ||
+            data.result.length !== (body.batch?.length ?? 1) ||
+            data.result.some((page) => !page.success)
+        )
+            throw new Error("D1 query failed");
+        return data.result;
+    }
+    await runFraudBanCheck(stripe, query, {
+        apply: process.env.FRAUD_BAN_APPLY === "true",
+        // Add manually restored accounts here before lifting their bans.
+        excludedUserIds: (process.env.FRAUD_BAN_EXCLUDED_USER_IDS ?? "")
+            .split(",")
+            .map((id) => id.trim())
+            .filter(Boolean),
+    });
+}
+
+if (import.meta.main) {
+    main().catch(() => {
+        // Provider errors can contain payment data. Keep public logs aggregate-only.
+        console.error(
+            "Fraud check failed. No further accounts will be processed; investigate before retrying.",
+        );
+        process.exitCode = 1;
+    });
+}

--- a/enter.pollinations.ai/scripts/check-fraud-bans.mjs
+++ b/enter.pollinations.ai/scripts/check-fraud-bans.mjs
@@ -1,6 +1,25 @@
 import { readFile } from "node:fs/promises";
 import Stripe from "stripe";
 import { runFraudBanCheck } from "../src/utils/stripe-fraud-ban.ts";
+import { FraudCheckError } from "../src/utils/stripe-fraud-score.ts";
+
+export function fraudCheckErrorMessage(error) {
+    if (error instanceof FraudCheckError) return error.message;
+    if (error instanceof Stripe.errors.StripeError) {
+        const status = Number.isInteger(error.statusCode)
+            ? ` (HTTP ${error.statusCode})`
+            : "";
+        return `Stripe request failed${status}. Check Stripe request logs; response details hidden.`;
+    }
+    if (error instanceof SyntaxError)
+        return "Invalid JSON in credentials or D1 response; contents hidden.";
+    if (error?.code === "ENOENT") return "Credentials file not found.";
+    if (error?.code === "EACCES" || error?.code === "EPERM")
+        return "Credentials file cannot be read: permission denied.";
+    if (error?.name === "TimeoutError" || error?.name === "AbortError")
+        return "Request timed out or was aborted.";
+    return "Unexpected failure; details hidden to protect credentials and payment data.";
+}
 
 // Production-only job. These identities match Enter's production bindings.
 const D1_DATABASE_ID = "fc771b05-4e24-48bf-980c-d09f21279bd1";
@@ -9,16 +28,17 @@ const CF_ACCOUNT_ID = "b6ec751c0862027ba269faf7029b2501";
 async function main() {
     const secretPath = process.argv[process.argv.indexOf("--secrets-file") + 1];
     if (!process.argv.includes("--secrets-file") || !secretPath)
-        throw new Error("--secrets-file is required");
+        throw new FraudCheckError("--secrets-file is required");
     if (
         !process.env.CLOUDFLARE_API_TOKEN ||
         process.env.CLOUDFLARE_ACCOUNT_ID !== CF_ACCOUNT_ID
     )
-        throw new Error("Expected production Cloudflare credentials");
+        throw new FraudCheckError("Expected production Cloudflare credentials");
     const { STRIPE_SECRET_KEY } = JSON.parse(
         await readFile(secretPath, "utf8"),
     );
-    if (!STRIPE_SECRET_KEY) throw new Error("STRIPE_SECRET_KEY is required");
+    if (!STRIPE_SECRET_KEY)
+        throw new FraudCheckError("STRIPE_SECRET_KEY is required");
     const stripe = new Stripe(STRIPE_SECRET_KEY, {
         apiVersion: "2025-12-15.clover",
         maxNetworkRetries: 3,
@@ -38,7 +58,9 @@ async function main() {
             },
         );
         if (!response.ok)
-            throw new Error(`D1 query failed: HTTP ${response.status}`);
+            throw new FraudCheckError(
+                `D1 query failed: HTTP ${response.status}`,
+            );
         const data = await response.json();
         if (
             !data.success ||
@@ -46,7 +68,7 @@ async function main() {
             data.result.length !== (body.batch?.length ?? 1) ||
             data.result.some((page) => !page.success)
         )
-            throw new Error("D1 query failed");
+            throw new FraudCheckError("D1 query failed");
         return data.result;
     }
     await runFraudBanCheck(stripe, query, {
@@ -60,10 +82,10 @@ async function main() {
 }
 
 if (import.meta.main) {
-    main().catch(() => {
+    main().catch((error) => {
         // Provider errors can contain payment data. Keep public logs aggregate-only.
         console.error(
-            "Fraud check failed. No further accounts will be processed; investigate before retrying.",
+            `Fraud check failed: ${fraudCheckErrorMessage(error)} No further accounts will be processed.`,
         );
         process.exitCode = 1;
     });

--- a/enter.pollinations.ai/scripts/check-fraud-bans.test.mjs
+++ b/enter.pollinations.ai/scripts/check-fraud-bans.test.mjs
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import Stripe from "stripe";
+import { FraudCheckError } from "../src/utils/stripe-fraud-score.ts";
+import { fraudCheckErrorMessage } from "./check-fraud-bans.mjs";
+
+test("missing CLI arguments produce an actionable error and nonzero exit", () => {
+    const result = spawnSync(
+        process.execPath,
+        [
+            "--experimental-strip-types",
+            fileURLToPath(new URL("./check-fraud-bans.mjs", import.meta.url)),
+        ],
+        { encoding: "utf8" },
+    );
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /--secrets-file is required/);
+});
+
+test("application-authored diagnostics are preserved", () => {
+    assert.equal(
+        fraudCheckErrorMessage(new FraudCheckError("Invalid D1 user page")),
+        "Invalid D1 user page",
+    );
+    assert.equal(
+        fraudCheckErrorMessage(
+            new FraudCheckError("D1 query failed: HTTP 403"),
+        ),
+        "D1 query failed: HTTP 403",
+    );
+});
+
+test("Stripe errors expose HTTP status but not response contents", () => {
+    const error = new Stripe.errors.StripeAuthenticationError({
+        message: "PRIVATE_CONTENT",
+        statusCode: 401,
+    });
+    const message = fraudCheckErrorMessage(error);
+    assert.match(message, /Stripe request failed.*HTTP 401/);
+    assert.doesNotMatch(message, /PRIVATE_CONTENT/);
+});
+
+test("parser, filesystem, and unknown errors never expose raw contents", () => {
+    for (const error of [
+        new SyntaxError("PRIVATE_CONTENT"),
+        new Error("PRIVATE_CONTENT"),
+        "PRIVATE_CONTENT",
+    ]) {
+        assert.doesNotMatch(fraudCheckErrorMessage(error), /PRIVATE_CONTENT/);
+    }
+    assert.match(
+        fraudCheckErrorMessage(new SyntaxError("PRIVATE_CONTENT")),
+        /Invalid JSON/,
+    );
+    assert.match(
+        fraudCheckErrorMessage({ code: "ENOENT", message: "PRIVATE_CONTENT" }),
+        /file not found/,
+    );
+    assert.match(
+        fraudCheckErrorMessage({ code: "EACCES", message: "PRIVATE_CONTENT" }),
+        /permission denied/,
+    );
+    assert.match(
+        fraudCheckErrorMessage({
+            name: "TimeoutError",
+            message: "PRIVATE_CONTENT",
+        }),
+        /timed out/,
+    );
+});

--- a/enter.pollinations.ai/src/auth.ts
+++ b/enter.pollinations.ai/src/auth.ts
@@ -5,6 +5,7 @@ import {
     createApiKeyPlugin,
     StagingAccessDeniedError,
 } from "@shared/auth/api-key.ts";
+import { ACCOUNT_RESTRICTED_MESSAGE } from "@shared/auth/ban.ts";
 import * as betterAuthSchema from "@shared/db/better-auth.ts";
 import {
     account as accountTable,
@@ -76,7 +77,10 @@ export function createAuth(env: Cloudflare.Env, ctx?: ExecutionContext) {
             message: "Only one Discord account can be connected.",
         });
 
-    const adminPlugin = admin({ adminUserIds: ADMIN_USER_IDS });
+    const adminPlugin = admin({
+        adminUserIds: ADMIN_USER_IDS,
+        bannedUserMessage: ACCOUNT_RESTRICTED_MESSAGE,
+    });
 
     const oauthProviderPlugin = oauthProvider({
         loginPage: "/app/sign-in",

--- a/enter.pollinations.ai/src/routes/app-lookup.ts
+++ b/enter.pollinations.ai/src/routes/app-lookup.ts
@@ -2,6 +2,7 @@ import {
     getRedirectUris,
     parseMetadata,
 } from "@shared/auth/api-key-metadata.ts";
+import { isUserBanned } from "@shared/auth/ban.ts";
 import * as schema from "@shared/db/better-auth.ts";
 import { validator } from "@shared/middleware/validator.ts";
 import { eq } from "drizzle-orm";
@@ -22,6 +23,7 @@ async function resolveAttribution(
         where: eq(schema.user.id, keyRow.referenceId),
     });
     const redirectUris = getRedirectUris(meta);
+    if (!user || isUserBanned(user)) return { found: false as const };
     return {
         found: true as const,
         clientId: keyRow.id,

--- a/enter.pollinations.ai/src/routes/stripe-webhooks.ts
+++ b/enter.pollinations.ai/src/routes/stripe-webhooks.ts
@@ -7,11 +7,19 @@ import { Hono } from "hono";
 import type Stripe from "stripe";
 import type { Env } from "../env.ts";
 import { createStripeClient, verifyWebhookSignature } from "../utils/stripe.ts";
+import { getStripeId } from "../utils/stripe-billing/customer.ts";
 import {
     creditAutoTopUpInvoice,
     markAutoTopUpInvoiceFailed,
 } from "../utils/stripe-billing/index.ts";
-import { recordStripeCardFingerprintAttempt } from "../utils/stripe-card-gate.ts";
+import {
+    getStripeNewCardGateStatus,
+    recordStripeCardFingerprintAttempt,
+} from "../utils/stripe-card-gate.ts";
+import {
+    banFraudAccount,
+    expireOpenStripeCheckoutSessions,
+} from "../utils/stripe-fraud-ban.ts";
 
 interface StripeEventData {
     eventType: string;
@@ -123,6 +131,20 @@ async function recordFailedCardFingerprintFromCharge({
             cardFingerprint: snapshot.cardFingerprint,
             createdAt: event.created ? event.created * 1000 : Date.now(),
         });
+        const gate = await getStripeNewCardGateStatus(
+            env.DB,
+            userId,
+            event.created ? event.created * 1000 : Date.now(),
+        );
+        if (!gate.shouldBanAccount) return;
+        await banFraudAccount(env.DB, userId);
+        const customerId = getStripeId(charge.customer);
+        if (customerId) {
+            await expireOpenStripeCheckoutSessions(
+                createStripeClient(env),
+                customerId,
+            );
+        }
     } catch (err) {
         console.error(
             `Failed to record Stripe failed-card fingerprint for event ${event.id}:`,

--- a/enter.pollinations.ai/src/routes/stripe-webhooks.ts
+++ b/enter.pollinations.ai/src/routes/stripe-webhooks.ts
@@ -7,19 +7,11 @@ import { Hono } from "hono";
 import type Stripe from "stripe";
 import type { Env } from "../env.ts";
 import { createStripeClient, verifyWebhookSignature } from "../utils/stripe.ts";
-import { getStripeId } from "../utils/stripe-billing/customer.ts";
 import {
     creditAutoTopUpInvoice,
     markAutoTopUpInvoiceFailed,
 } from "../utils/stripe-billing/index.ts";
-import {
-    getStripeNewCardGateStatus,
-    recordStripeCardFingerprintAttempt,
-} from "../utils/stripe-card-gate.ts";
-import {
-    banFraudAccount,
-    expireOpenStripeCheckoutSessions,
-} from "../utils/stripe-fraud-ban.ts";
+import { recordStripeCardFingerprintAttempt } from "../utils/stripe-card-gate.ts";
 
 interface StripeEventData {
     eventType: string;
@@ -131,20 +123,6 @@ async function recordFailedCardFingerprintFromCharge({
             cardFingerprint: snapshot.cardFingerprint,
             createdAt: event.created ? event.created * 1000 : Date.now(),
         });
-        const gate = await getStripeNewCardGateStatus(
-            env.DB,
-            userId,
-            event.created ? event.created * 1000 : Date.now(),
-        );
-        if (!gate.shouldBanAccount) return;
-        await banFraudAccount(env.DB, userId);
-        const customerId = getStripeId(charge.customer);
-        if (customerId) {
-            await expireOpenStripeCheckoutSessions(
-                createStripeClient(env),
-                customerId,
-            );
-        }
     } catch (err) {
         console.error(
             `Failed to record Stripe failed-card fingerprint for event ${event.id}:`,

--- a/enter.pollinations.ai/src/routes/stripe.ts
+++ b/enter.pollinations.ai/src/routes/stripe.ts
@@ -1,3 +1,4 @@
+import { ACCOUNT_RESTRICTED_MESSAGE, isUserBanned } from "@shared/auth/ban.ts";
 import {
     calculateServiceFeeCents,
     describePollenPack,
@@ -14,6 +15,7 @@ import { createAuth } from "../auth.ts";
 import type { Env } from "../env.ts";
 import { getCohortFromCountry } from "../utils/currency-router.ts";
 import { createStripeClient } from "../utils/stripe.ts";
+import { getUserStripeBillingRow } from "../utils/stripe-billing/customer.ts";
 import {
     createBillingPortalSession,
     getBillingOverview,
@@ -25,6 +27,7 @@ import {
     getStripeNewCardGateStatus,
     stripeNewCardGateMetadata,
 } from "../utils/stripe-card-gate.ts";
+import { expireOpenStripeCheckoutSessions } from "../utils/stripe-fraud-ban.ts";
 
 /**
  * Stripe pack configuration
@@ -68,6 +71,16 @@ export const stripeRoutes = new Hono<Env>()
 
         // Create Stripe client
         const stripe = createStripeClient(c.env);
+
+        const buyer = await getUserStripeBillingRow(c.env.DB, userId);
+        if (isUserBanned(buyer)) {
+            if (buyer.stripeCustomerId)
+                await expireOpenStripeCheckoutSessions(
+                    stripe,
+                    buyer.stripeCustomerId,
+                );
+            return c.json({ error: ACCOUNT_RESTRICTED_MESSAGE }, 403);
+        }
 
         // Return checkout sessions to the Pollen page for this environment.
         const baseUrl =
@@ -176,6 +189,13 @@ export const stripeRoutes = new Hono<Env>()
             });
 
             // Redirect to Stripe Checkout (will use checkout.pollinations.ai custom domain)
+            if (isUserBanned(await getUserStripeBillingRow(c.env.DB, userId))) {
+                await expireOpenStripeCheckoutSessions(
+                    stripe,
+                    stripeCustomerId,
+                );
+                return c.json({ error: ACCOUNT_RESTRICTED_MESSAGE }, 403);
+            }
             if (checkoutSession.url) {
                 return c.redirect(checkoutSession.url);
             }

--- a/enter.pollinations.ai/src/utils/stripe-billing/auto-top-up.ts
+++ b/enter.pollinations.ai/src/utils/stripe-billing/auto-top-up.ts
@@ -1,3 +1,4 @@
+import { ACCOUNT_RESTRICTED_MESSAGE, isUserBanned } from "@shared/auth/ban.ts";
 import {
     AUTO_TOP_UP_PACK_MAX_USD,
     AUTO_TOP_UP_PACK_MIN_USD,
@@ -45,7 +46,7 @@ export async function updateAutoTopUpSettings(
     input: AutoTopUpInput,
 ): Promise<
     | { ok: true; overview: BillingOverview }
-    | { ok: false; status: 400; error: string }
+    | { ok: false; status: 400 | 403; error: string }
 > {
     if (!input.enabled) {
         await env.DB.prepare(
@@ -57,6 +58,10 @@ export async function updateAutoTopUpSettings(
             .run();
 
         return { ok: true, overview: await getBillingOverview(env, userId) };
+    }
+
+    if (isUserBanned(await getUserStripeBillingRow(env.DB, userId))) {
+        return { ok: false, status: 403, error: ACCOUNT_RESTRICTED_MESSAGE };
     }
 
     const pack =
@@ -105,14 +110,18 @@ export async function updateAutoTopUpSettings(
         };
     }
 
-    await env.DB.prepare(
+    const updated = await env.DB.prepare(
         `UPDATE user
             SET auto_top_up_enabled = 1,
                 auto_top_up_amount_usd = ?
-            WHERE id = ?`,
+            WHERE id = ? AND (COALESCE(banned, 0) = 0 OR ban_expires <= unixepoch())`,
     )
         .bind(packAmountUsd, userId)
         .run();
+
+    if (!updated.meta.changes) {
+        return { ok: false, status: 403, error: ACCOUNT_RESTRICTED_MESSAGE };
+    }
 
     return { ok: true, overview: await getBillingOverview(env, userId) };
 }
@@ -122,6 +131,10 @@ export async function processAutoTopUpForUser(
     userId: string,
 ): Promise<AutoTopUpProcessResult> {
     const user = await getUserStripeBillingRow(env.DB, userId);
+
+    if (isUserBanned(user)) {
+        return { status: "skipped", reason: "account restricted" };
+    }
 
     if (!user.autoTopUpEnabled) {
         return { status: "skipped", reason: "auto top-up disabled" };
@@ -581,6 +594,7 @@ async function claimAutoTopUpAttempt(
                 FROM user
                 WHERE id = ?
                     AND auto_top_up_enabled = 1
+                    AND (COALESCE(banned, 0) = 0 OR ban_expires <= unixepoch())
                     AND auto_top_up_amount_usd IS NOT NULL
                     AND COALESCE(pack_balance, 0) <= ?
             )

--- a/enter.pollinations.ai/src/utils/stripe-billing/customer.ts
+++ b/enter.pollinations.ai/src/utils/stripe-billing/customer.ts
@@ -48,6 +48,8 @@ export async function getUserStripeBillingRow(
     const [user] = await drizzle(db)
         .select({
             id: userTable.id,
+            banned: userTable.banned,
+            banExpires: userTable.banExpires,
             name: userTable.name,
             email: userTable.email,
             packBalance: userTable.packBalance,

--- a/enter.pollinations.ai/src/utils/stripe-billing/types.ts
+++ b/enter.pollinations.ai/src/utils/stripe-billing/types.ts
@@ -1,4 +1,6 @@
 export type UserStripeBillingRow = {
+    banned: boolean | null;
+    banExpires: Date | null;
     id: string;
     name: string;
     email: string;

--- a/enter.pollinations.ai/src/utils/stripe-card-gate.ts
+++ b/enter.pollinations.ai/src/utils/stripe-card-gate.ts
@@ -36,19 +36,15 @@ export async function getStripeNewCardGateStatus(
     const windowStart = now - STRIPE_NEW_CARD_WINDOW_MS;
     const row = await db
         .prepare(
-            `SELECT
-                COUNT(DISTINCT card_fingerprint) AS distinct_count
+            `SELECT COUNT(DISTINCT card_fingerprint) AS count
             FROM stripe_card_fingerprint_attempt
             WHERE user_id = ?
-                AND created_at >= ?
-                AND created_at <= ?`,
+                AND created_at >= ?`,
         )
-        .bind(userId, windowStart, now)
-        .first<{
-            distinct_count: number | null;
-        }>();
+        .bind(userId, windowStart)
+        .first<{ count: number | null }>();
 
-    const distinctFailedCardCount24h = Number(row?.distinct_count ?? 0);
+    const distinctFailedCardCount24h = Number(row?.count ?? 0);
 
     return {
         gate:
@@ -96,5 +92,6 @@ export async function recordStripeCardFingerprintAttempt(
             input.createdAt ?? Date.now(),
         )
         .run();
+
     return (result.meta.changes ?? 0) > 0;
 }

--- a/enter.pollinations.ai/src/utils/stripe-card-gate.ts
+++ b/enter.pollinations.ai/src/utils/stripe-card-gate.ts
@@ -1,6 +1,4 @@
 export const STRIPE_NEW_CARD_LIMIT = 4;
-export const STRIPE_ACCOUNT_BAN_CARD_LIMIT = 8;
-export const STRIPE_FAILED_CARD_ATTEMPT_LIMIT = 50;
 export const STRIPE_NEW_CARD_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 export const STRIPE_NEW_CARD_GATE_METADATA = {
@@ -11,7 +9,6 @@ export const STRIPE_NEW_CARD_GATE_METADATA = {
 
 export type StripeNewCardGateStatus = {
     gate: "ok" | "locked";
-    shouldBanAccount: boolean;
     distinctFailedCardCount24h: number;
     limit: number;
 };
@@ -31,7 +28,6 @@ export async function getStripeNewCardGateStatus(
     if (!userId) {
         return {
             gate: "ok",
-            shouldBanAccount: false,
             distinctFailedCardCount24h: 0,
             limit: STRIPE_NEW_CARD_LIMIT,
         };
@@ -41,8 +37,7 @@ export async function getStripeNewCardGateStatus(
     const row = await db
         .prepare(
             `SELECT
-                COUNT(DISTINCT card_fingerprint) AS distinct_count,
-                COUNT(*) AS attempt_count
+                COUNT(DISTINCT card_fingerprint) AS distinct_count
             FROM stripe_card_fingerprint_attempt
             WHERE user_id = ?
                 AND created_at >= ?
@@ -51,20 +46,15 @@ export async function getStripeNewCardGateStatus(
         .bind(userId, windowStart, now)
         .first<{
             distinct_count: number | null;
-            attempt_count: number | null;
         }>();
 
     const distinctFailedCardCount24h = Number(row?.distinct_count ?? 0);
-    const failedCardAttemptCount24h = Number(row?.attempt_count ?? 0);
 
     return {
         gate:
             distinctFailedCardCount24h >= STRIPE_NEW_CARD_LIMIT
                 ? "locked"
                 : "ok",
-        shouldBanAccount:
-            distinctFailedCardCount24h >= STRIPE_ACCOUNT_BAN_CARD_LIMIT ||
-            failedCardAttemptCount24h >= STRIPE_FAILED_CARD_ATTEMPT_LIMIT,
         distinctFailedCardCount24h,
         limit: STRIPE_NEW_CARD_LIMIT,
     };

--- a/enter.pollinations.ai/src/utils/stripe-card-gate.ts
+++ b/enter.pollinations.ai/src/utils/stripe-card-gate.ts
@@ -1,4 +1,6 @@
 export const STRIPE_NEW_CARD_LIMIT = 4;
+export const STRIPE_ACCOUNT_BAN_CARD_LIMIT = 8;
+export const STRIPE_FAILED_CARD_ATTEMPT_LIMIT = 50;
 export const STRIPE_NEW_CARD_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 export const STRIPE_NEW_CARD_GATE_METADATA = {
@@ -9,6 +11,7 @@ export const STRIPE_NEW_CARD_GATE_METADATA = {
 
 export type StripeNewCardGateStatus = {
     gate: "ok" | "locked";
+    shouldBanAccount: boolean;
     distinctFailedCardCount24h: number;
     limit: number;
 };
@@ -28,6 +31,7 @@ export async function getStripeNewCardGateStatus(
     if (!userId) {
         return {
             gate: "ok",
+            shouldBanAccount: false,
             distinctFailedCardCount24h: 0,
             limit: STRIPE_NEW_CARD_LIMIT,
         };
@@ -36,21 +40,31 @@ export async function getStripeNewCardGateStatus(
     const windowStart = now - STRIPE_NEW_CARD_WINDOW_MS;
     const row = await db
         .prepare(
-            `SELECT COUNT(DISTINCT card_fingerprint) AS count
+            `SELECT
+                COUNT(DISTINCT card_fingerprint) AS distinct_count,
+                COUNT(*) AS attempt_count
             FROM stripe_card_fingerprint_attempt
             WHERE user_id = ?
-                AND created_at >= ?`,
+                AND created_at >= ?
+                AND created_at <= ?`,
         )
-        .bind(userId, windowStart)
-        .first<{ count: number | null }>();
+        .bind(userId, windowStart, now)
+        .first<{
+            distinct_count: number | null;
+            attempt_count: number | null;
+        }>();
 
-    const distinctFailedCardCount24h = Number(row?.count ?? 0);
+    const distinctFailedCardCount24h = Number(row?.distinct_count ?? 0);
+    const failedCardAttemptCount24h = Number(row?.attempt_count ?? 0);
 
     return {
         gate:
             distinctFailedCardCount24h >= STRIPE_NEW_CARD_LIMIT
                 ? "locked"
                 : "ok",
+        shouldBanAccount:
+            distinctFailedCardCount24h >= STRIPE_ACCOUNT_BAN_CARD_LIMIT ||
+            failedCardAttemptCount24h >= STRIPE_FAILED_CARD_ATTEMPT_LIMIT,
         distinctFailedCardCount24h,
         limit: STRIPE_NEW_CARD_LIMIT,
     };
@@ -92,6 +106,5 @@ export async function recordStripeCardFingerprintAttempt(
             input.createdAt ?? Date.now(),
         )
         .run();
-
     return (result.meta.changes ?? 0) > 0;
 }

--- a/enter.pollinations.ai/src/utils/stripe-fraud-ban.ts
+++ b/enter.pollinations.ai/src/utils/stripe-fraud-ban.ts
@@ -1,20 +1,108 @@
 import type Stripe from "stripe";
+import {
+    collectStripeFraudScores,
+    FRAUD_BAN_EXCLUDED_USER_ID,
+    FRAUD_BAN_THRESHOLD,
+    type FraudUser,
+} from "./stripe-fraud-score.ts";
+
+type FraudQuery = { sql: string; params: string[] };
+type QueryRunner = (
+    body: FraudQuery | { batch: FraudQuery[] },
+) => Promise<{ results?: unknown[] }[]>;
+
+/** All-history hourly check. Callers must explicitly enable writes. */
+export async function runFraudBanCheck(
+    stripe: Stripe,
+    query: QueryRunner,
+    {
+        apply = false,
+        excludedUserIds = [],
+    }: { apply?: boolean; excludedUserIds?: string[] } = {},
+) {
+    const account = await stripe.accounts.retrieve();
+    if (account.id !== "acct_1SrY3q7rcjS3l7tr")
+        throw new Error("Unexpected Stripe account");
+    const users: FraudUser[] = [];
+    let cursor = "";
+    for (;;) {
+        const [page] = await query({
+            sql: "SELECT id, stripe_customer_id FROM user WHERE id > ? ORDER BY id LIMIT 5000",
+            params: [cursor],
+        });
+        if (!Array.isArray(page?.results))
+            throw new Error("Invalid D1 user page");
+        const rows = page.results as FraudUser[];
+        if (
+            rows.some(
+                (user) =>
+                    typeof user.id !== "string" ||
+                    (user.stripe_customer_id !== null &&
+                        typeof user.stripe_customer_id !== "string"),
+            )
+        )
+            throw new Error("Invalid D1 user identity");
+        users.push(...rows);
+        if (rows.length < 5000) break;
+        const next = rows.at(-1)?.id;
+        if (!next || next <= cursor) throw new Error("Invalid D1 pagination");
+        cursor = next;
+    }
+    if (!users.length) throw new Error("No D1 users; refusing to continue");
+    const result = await collectStripeFraudScores(stripe, users);
+    const excluded = new Set([FRAUD_BAN_EXCLUDED_USER_ID, ...excludedUserIds]);
+    const candidates = users.filter(
+        (user) =>
+            !excluded.has(user.id) &&
+            (result.scores.get(user.id) ?? 0) >= FRAUD_BAN_THRESHOLD,
+    );
+    // Public Actions logs contain aggregate counts only.
+    console.log(
+        JSON.stringify({
+            apply,
+            charges: result.charges,
+            unmapped: result.unmapped,
+            conflicting: result.conflicting,
+            candidates: candidates.length,
+        }),
+    );
+    if (apply) {
+        for (const user of candidates) {
+            await query({ batch: fraudBanQueries(user.id) });
+            // Retry expiry even when the ban already exists.
+            for (const customer of result.customers.get(user.id) ?? []) {
+                await expireOpenStripeCheckoutSessions(stripe, customer, () => {
+                    console.error(
+                        "Checkout expiry failed; the next hourly run will retry.",
+                    );
+                });
+            }
+        }
+    }
+    return {
+        candidates: candidates.length,
+        applied: apply ? candidates.length : 0,
+    };
+}
+
+export function fraudBanQueries(userId: string) {
+    if (userId === FRAUD_BAN_EXCLUDED_USER_ID) return [];
+    return [
+        "UPDATE user SET banned = 1, ban_reason = 'Payment abuse', ban_expires = NULL, auto_top_up_enabled = 0 WHERE id = ? AND (COALESCE(banned, 0) = 0 OR ban_expires <= unixepoch())",
+        "UPDATE user SET auto_top_up_enabled = 0 WHERE id = ?",
+        "DELETE FROM session WHERE user_id = ?",
+    ].map((sql) => ({ sql, params: [userId] }));
+}
 
 export async function banFraudAccount(
     db: D1Database,
     userId: string,
 ): Promise<void> {
-    await db.batch([
-        db
-            .prepare(
-                `UPDATE user SET banned = 1, ban_reason = 'Payment abuse', ban_expires = NULL, auto_top_up_enabled = 0 WHERE id = ? AND (COALESCE(banned, 0) = 0 OR ban_expires <= unixepoch())`,
-            )
-            .bind(userId),
-        db
-            .prepare("UPDATE user SET auto_top_up_enabled = 0 WHERE id = ?")
-            .bind(userId),
-        db.prepare("DELETE FROM session WHERE user_id = ?").bind(userId),
-    ]);
+    const queries = fraudBanQueries(userId);
+    if (queries.length)
+        await db.batch(
+            queries.map(({ sql, params }) => db.prepare(sql).bind(...params)),
+        );
 }
 
 /**
@@ -25,6 +113,7 @@ export async function banFraudAccount(
 export async function expireOpenStripeCheckoutSessions(
     stripe: Stripe,
     customerId: string,
+    logError: (...args: unknown[]) => void = console.error,
 ): Promise<void> {
     const sessions: Stripe.Checkout.Session[] = [];
     try {
@@ -36,7 +125,7 @@ export async function expireOpenStripeCheckoutSessions(
             sessions.push(session);
         }
     } catch (error) {
-        console.error(
+        logError(
             `Failed to list open Stripe Checkout sessions for customer ${customerId}:`,
             error,
         );
@@ -48,7 +137,7 @@ export async function expireOpenStripeCheckoutSessions(
     );
     results.forEach((result, index) => {
         if (result.status !== "rejected") return;
-        console.error(
+        logError(
             `Failed to expire Stripe Checkout session ${sessions[index]?.id} for customer ${customerId}:`,
             result.reason,
         );

--- a/enter.pollinations.ai/src/utils/stripe-fraud-ban.ts
+++ b/enter.pollinations.ai/src/utils/stripe-fraud-ban.ts
@@ -3,6 +3,7 @@ import {
     collectStripeFraudScores,
     FRAUD_BAN_EXCLUDED_USER_ID,
     FRAUD_BAN_THRESHOLD,
+    FraudCheckError,
     type FraudUser,
 } from "./stripe-fraud-score.ts";
 
@@ -22,7 +23,7 @@ export async function runFraudBanCheck(
 ) {
     const account = await stripe.accounts.retrieve();
     if (account.id !== "acct_1SrY3q7rcjS3l7tr")
-        throw new Error("Unexpected Stripe account");
+        throw new FraudCheckError("Unexpected Stripe account");
     const users: FraudUser[] = [];
     let cursor = "";
     for (;;) {
@@ -31,7 +32,7 @@ export async function runFraudBanCheck(
             params: [cursor],
         });
         if (!Array.isArray(page?.results))
-            throw new Error("Invalid D1 user page");
+            throw new FraudCheckError("Invalid D1 user page");
         const rows = page.results as FraudUser[];
         if (
             rows.some(
@@ -41,14 +42,16 @@ export async function runFraudBanCheck(
                         typeof user.stripe_customer_id !== "string"),
             )
         )
-            throw new Error("Invalid D1 user identity");
+            throw new FraudCheckError("Invalid D1 user identity");
         users.push(...rows);
         if (rows.length < 5000) break;
         const next = rows.at(-1)?.id;
-        if (!next || next <= cursor) throw new Error("Invalid D1 pagination");
+        if (!next || next <= cursor)
+            throw new FraudCheckError("Invalid D1 pagination");
         cursor = next;
     }
-    if (!users.length) throw new Error("No D1 users; refusing to continue");
+    if (!users.length)
+        throw new FraudCheckError("No D1 users; refusing to continue");
     const result = await collectStripeFraudScores(stripe, users);
     const excluded = new Set([FRAUD_BAN_EXCLUDED_USER_ID, ...excludedUserIds]);
     const candidates = users.filter(
@@ -92,17 +95,6 @@ export function fraudBanQueries(userId: string) {
         "UPDATE user SET auto_top_up_enabled = 0 WHERE id = ?",
         "DELETE FROM session WHERE user_id = ?",
     ].map((sql) => ({ sql, params: [userId] }));
-}
-
-export async function banFraudAccount(
-    db: D1Database,
-    userId: string,
-): Promise<void> {
-    const queries = fraudBanQueries(userId);
-    if (queries.length)
-        await db.batch(
-            queries.map(({ sql, params }) => db.prepare(sql).bind(...params)),
-        );
 }
 
 /**

--- a/enter.pollinations.ai/src/utils/stripe-fraud-ban.ts
+++ b/enter.pollinations.ai/src/utils/stripe-fraud-ban.ts
@@ -1,0 +1,56 @@
+import type Stripe from "stripe";
+
+export async function banFraudAccount(
+    db: D1Database,
+    userId: string,
+): Promise<void> {
+    await db.batch([
+        db
+            .prepare(
+                `UPDATE user SET banned = 1, ban_reason = 'Payment abuse', ban_expires = NULL, auto_top_up_enabled = 0 WHERE id = ? AND (COALESCE(banned, 0) = 0 OR ban_expires <= unixepoch())`,
+            )
+            .bind(userId),
+        db
+            .prepare("UPDATE user SET auto_top_up_enabled = 0 WHERE id = ?")
+            .bind(userId),
+        db.prepare("DELETE FROM session WHERE user_id = ?").bind(userId),
+    ]);
+}
+
+/**
+ * Expires every open Checkout session of a customer across all list pages.
+ * Failures are logged rather than thrown because the restriction is already
+ * stored and future checkout attempts remain blocked.
+ */
+export async function expireOpenStripeCheckoutSessions(
+    stripe: Stripe,
+    customerId: string,
+): Promise<void> {
+    const sessions: Stripe.Checkout.Session[] = [];
+    try {
+        for await (const session of stripe.checkout.sessions.list({
+            customer: customerId,
+            status: "open",
+            limit: 100,
+        })) {
+            sessions.push(session);
+        }
+    } catch (error) {
+        console.error(
+            `Failed to list open Stripe Checkout sessions for customer ${customerId}:`,
+            error,
+        );
+        return;
+    }
+
+    const results = await Promise.allSettled(
+        sessions.map((session) => stripe.checkout.sessions.expire(session.id)),
+    );
+    results.forEach((result, index) => {
+        if (result.status !== "rejected") return;
+        console.error(
+            `Failed to expire Stripe Checkout session ${sessions[index]?.id} for customer ${customerId}:`,
+            result.reason,
+        );
+    });
+}

--- a/enter.pollinations.ai/src/utils/stripe-fraud-score.ts
+++ b/enter.pollinations.ai/src/utils/stripe-fraud-score.ts
@@ -1,0 +1,170 @@
+import type Stripe from "stripe";
+
+export const FRAUD_BAN_THRESHOLD = 0.75;
+// Manually settled account: never automatically ban it.
+export const FRAUD_BAN_EXCLUDED_USER_ID = "GcN1eNVQXW58eLIppqxlgvI6a1w9Scic";
+const WEIGHTS = { fd: 5, ew: 2, fraud: 3, hr: 1, rb: 0 } as const;
+type Signal = keyof typeof WEIGHTS;
+const SIGNALS = Object.keys(WEIGHTS) as Signal[];
+export type FraudPayment = { chargeId: string } & Partial<
+    Record<Signal, boolean>
+>;
+
+/** Simulator parity: deduplicate charges, strongest signal wins, sum capped contributions. */
+export function cappedFraudScore(payments: Iterable<FraudPayment>): number {
+    const charges = new Map<string, Set<Signal>>();
+    for (const payment of payments) {
+        if (!/^(ch|py)_.+/.test(payment.chargeId))
+            throw new Error("Missing Stripe charge identity");
+        const flags = charges.get(payment.chargeId) ?? new Set<Signal>();
+        for (const signal of SIGNALS) if (payment[signal]) flags.add(signal);
+        charges.set(payment.chargeId, flags);
+    }
+    const counts = { fd: 0, ew: 0, fraud: 0, hr: 0, rb: 0 };
+    for (const flags of charges.values()) {
+        let winner: Signal | undefined;
+        for (const signal of SIGNALS) {
+            if (
+                flags.has(signal) &&
+                WEIGHTS[signal] > (winner ? WEIGHTS[winner] : 0)
+            )
+                winner = signal;
+        }
+        if (winner) counts[winner]++;
+    }
+    const score = SIGNALS.reduce(
+        (sum, signal) =>
+            sum +
+            WEIGHTS[signal] *
+                Math.min(
+                    1,
+                    0.1 *
+                        (counts[signal] / 2) ** (Math.log(10) / Math.log(500)),
+                ),
+        0,
+    );
+    return Number(score.toFixed(2));
+}
+
+export type FraudUser = { id: string; stripe_customer_id: string | null };
+
+/** Fail the whole scan before any writes if a source cannot be fully read. */
+export async function collectStripeFraudScores(
+    stripe: Stripe,
+    users: FraudUser[],
+    until = Math.floor(Date.now() / 1000),
+) {
+    const userIds = new Set(users.map((user) => user.id));
+    const customerUsers = new Map<string, Set<string>>();
+    for (const user of users) {
+        if (!user.stripe_customer_id) continue;
+        const ids =
+            customerUsers.get(user.stripe_customer_id) ?? new Set<string>();
+        ids.add(user.id);
+        customerUsers.set(user.stripe_customer_id, ids);
+    }
+    const payments = new Map<
+        string,
+        { userId: string | null; payment: FraudPayment }
+    >();
+    const customers = new Map<string, Set<string>>();
+    for (const [customerId, ids] of customerUsers) {
+        if (ids.size === 1) {
+            const [id] = ids;
+            const linked = customers.get(id) ?? new Set<string>();
+            linked.add(customerId);
+            customers.set(id, linked);
+        }
+    }
+    let unmapped = 0;
+    let conflicting = 0;
+    for await (const charge of stripe.charges.list({
+        limit: 100,
+        created: { lte: until },
+    })) {
+        if (!charge.livemode) throw new Error("Expected live Stripe charges");
+        const customerId =
+            typeof charge.customer === "string"
+                ? charge.customer
+                : charge.customer?.id;
+        const ids = new Set(customerId ? customerUsers.get(customerId) : []);
+        // Billing/receipt email is buyer-controlled, not proof of account identity.
+        for (const id of [
+            charge.metadata?.userId,
+            charge.metadata?.pollinations_user_id,
+        ])
+            if (id) ids.add(id);
+        const [candidate] = ids;
+        const userId =
+            ids.size === 1 && userIds.has(candidate) ? candidate : null;
+        if (!userId) unmapped++;
+        if (ids.size > 1) conflicting++;
+        if (userId && customerId) {
+            const linked = customers.get(userId) ?? new Set<string>();
+            linked.add(customerId);
+            customers.set(userId, linked);
+        }
+        payments.set(charge.id, {
+            userId,
+            payment: {
+                chargeId: charge.id,
+                fraud:
+                    charge.fraud_details?.stripe_report === "fraudulent" ||
+                    charge.fraud_details?.user_report === "fraudulent",
+                hr: charge.outcome?.risk_level === "highest",
+                rb: charge.outcome?.type === "blocked",
+            },
+        });
+    }
+    function paymentFor(value: string | Stripe.Charge) {
+        const payment = payments.get(
+            typeof value === "string" ? value : value.id,
+        );
+        if (!payment) throw new Error("Incomplete Stripe charge coverage");
+        return payment.payment;
+    }
+    for await (const dispute of stripe.disputes.list({
+        limit: 100,
+        created: { lte: until },
+    })) {
+        if (!dispute.livemode) throw new Error("Expected live Stripe disputes");
+        if (dispute.reason === "fraudulent")
+            paymentFor(dispute.charge).fd = true;
+    }
+    for await (const warning of stripe.radar.earlyFraudWarnings.list({
+        limit: 100,
+        created: { lte: until },
+    })) {
+        if (!warning.livemode) throw new Error("Expected live Stripe warnings");
+        paymentFor(warning.charge).ew = true;
+    }
+    // Never expire another account's checkout on an ambiguously shared customer.
+    const customerOwners = new Map<string, Set<string>>();
+    for (const [id, linked] of customers) {
+        for (const customerId of linked) {
+            const owners = customerOwners.get(customerId) ?? new Set<string>();
+            owners.add(id);
+            customerOwners.set(customerId, owners);
+        }
+    }
+    for (const [customerId, owners] of customerOwners) {
+        if (owners.size > 1)
+            for (const id of owners) customers.get(id)?.delete(customerId);
+    }
+    const byUser = new Map<string, FraudPayment[]>();
+    for (const { userId, payment } of payments.values()) {
+        if (!userId) continue;
+        const list = byUser.get(userId) ?? [];
+        list.push(payment);
+        byUser.set(userId, list);
+    }
+    return {
+        scores: new Map(
+            [...byUser].map(([id, list]) => [id, cappedFraudScore(list)]),
+        ),
+        customers,
+        charges: payments.size,
+        unmapped,
+        conflicting,
+    };
+}

--- a/enter.pollinations.ai/src/utils/stripe-fraud-score.ts
+++ b/enter.pollinations.ai/src/utils/stripe-fraud-score.ts
@@ -1,5 +1,8 @@
 import type Stripe from "stripe";
 
+/** Only use with application-authored messages, never provider/file contents. */
+export class FraudCheckError extends Error {}
+
 export const FRAUD_BAN_THRESHOLD = 0.75;
 // Manually settled account: never automatically ban it.
 export const FRAUD_BAN_EXCLUDED_USER_ID = "GcN1eNVQXW58eLIppqxlgvI6a1w9Scic";
@@ -15,7 +18,7 @@ export function cappedFraudScore(payments: Iterable<FraudPayment>): number {
     const charges = new Map<string, Set<Signal>>();
     for (const payment of payments) {
         if (!/^(ch|py)_.+/.test(payment.chargeId))
-            throw new Error("Missing Stripe charge identity");
+            throw new FraudCheckError("Missing Stripe charge identity");
         const flags = charges.get(payment.chargeId) ?? new Set<Signal>();
         for (const signal of SIGNALS) if (payment[signal]) flags.add(signal);
         charges.set(payment.chargeId, flags);
@@ -82,7 +85,8 @@ export async function collectStripeFraudScores(
         limit: 100,
         created: { lte: until },
     })) {
-        if (!charge.livemode) throw new Error("Expected live Stripe charges");
+        if (!charge.livemode)
+            throw new FraudCheckError("Expected live Stripe charges");
         const customerId =
             typeof charge.customer === "string"
                 ? charge.customer
@@ -120,14 +124,16 @@ export async function collectStripeFraudScores(
         const payment = payments.get(
             typeof value === "string" ? value : value.id,
         );
-        if (!payment) throw new Error("Incomplete Stripe charge coverage");
+        if (!payment)
+            throw new FraudCheckError("Incomplete Stripe charge coverage");
         return payment.payment;
     }
     for await (const dispute of stripe.disputes.list({
         limit: 100,
         created: { lte: until },
     })) {
-        if (!dispute.livemode) throw new Error("Expected live Stripe disputes");
+        if (!dispute.livemode)
+            throw new FraudCheckError("Expected live Stripe disputes");
         if (dispute.reason === "fraudulent")
             paymentFor(dispute.charge).fd = true;
     }
@@ -135,7 +141,8 @@ export async function collectStripeFraudScores(
         limit: 100,
         created: { lte: until },
     })) {
-        if (!warning.livemode) throw new Error("Expected live Stripe warnings");
+        if (!warning.livemode)
+            throw new FraudCheckError("Expected live Stripe warnings");
         paymentFor(warning.charge).ew = true;
     }
     // Never expire another account's checkout on an ambiguously shared customer.

--- a/enter.pollinations.ai/test/fraud-ban.test.ts
+++ b/enter.pollinations.ai/test/fraud-ban.test.ts
@@ -1,0 +1,195 @@
+import { env, SELF } from "cloudflare:test";
+import { isBannedLoginError } from "@shared/auth/ban.ts";
+import * as schema from "@shared/db/better-auth.ts";
+import { admin } from "better-auth/plugins";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+import { expect } from "vitest";
+import {
+    processAutoTopUpForUser,
+    updateAutoTopUpSettings,
+} from "../src/utils/stripe-billing/auto-top-up.ts";
+import {
+    getStripeNewCardGateStatus,
+    recordStripeCardFingerprintAttempt,
+} from "../src/utils/stripe-card-gate.ts";
+import { banFraudAccount } from "../src/utils/stripe-fraud-ban.ts";
+import { test } from "./fixtures.ts";
+
+test("checkout created during a ban is expired instead of redirected", async ({
+    sessionToken,
+    mocks,
+}) => {
+    await mocks.enable("stripe", "tinybird");
+    const db = drizzle(env.DB, { schema });
+    const user = await db.query.user.findFirst();
+    if (!user) throw Error("Missing fixture user");
+    mocks.stripe.state.onCheckoutSessionCreated = () =>
+        banFraudAccount(env.DB, user.id);
+    const response = await SELF.fetch(
+        "http://localhost:3000/api/stripe/checkout/p10",
+        {
+            headers: { Cookie: `better-auth.session_token=${sessionToken}` },
+            redirect: "manual",
+        },
+    );
+    expect(response.status).toBe(403);
+    expect(mocks.stripe.state.checkoutSessions).toHaveLength(1);
+    expect(mocks.stripe.state.checkoutSessions[0].status).toBe("expired");
+});
+
+test("ban page recognizes the installed library error code", () => {
+    expect(isBannedLoginError(admin().$ERROR_CODES.BANNED_USER.code)).toBe(
+        true,
+    );
+    expect(isBannedLoginError("banned")).toBe(true);
+    expect(isBannedLoginError("unknown")).toBe(false);
+});
+
+test("fraud thresholds keep four-card Radar and eight-card OR fifty-attempt bans", async ({
+    sessionToken,
+}) => {
+    expect(sessionToken).toBeTruthy();
+    const db = drizzle(env.DB, { schema });
+    const user = await db.query.user.findFirst();
+    if (!user) throw Error("Missing fixture user");
+    const now = Date.now();
+    for (let i = 0; i < 50; i++) {
+        await recordStripeCardFingerprintAttempt(env.DB, {
+            userId: user.id,
+            eventId: `evt_${i}`,
+            cardFingerprint: `fp_${i % 7}`,
+            createdAt: now,
+        });
+        if (i === 3)
+            expect(
+                await getStripeNewCardGateStatus(env.DB, user.id, now),
+            ).toMatchObject({ gate: "locked", shouldBanAccount: false });
+        if (i === 48)
+            expect(
+                (await getStripeNewCardGateStatus(env.DB, user.id, now))
+                    .shouldBanAccount,
+            ).toBe(false);
+    }
+    expect(
+        (await getStripeNewCardGateStatus(env.DB, user.id, now))
+            .shouldBanAccount,
+    ).toBe(true);
+    expect(
+        (await getStripeNewCardGateStatus(env.DB, user.id, now - 1))
+            .shouldBanAccount,
+    ).toBe(false);
+    expect(
+        (await getStripeNewCardGateStatus(env.DB, user.id, now + 86400001))
+            .shouldBanAccount,
+    ).toBe(false);
+    await db.delete(schema.stripeCardFingerprintAttempt);
+    for (let i = 0; i < 8; i++)
+        await recordStripeCardFingerprintAttempt(env.DB, {
+            userId: user.id,
+            eventId: `card_${i}`,
+            cardFingerprint: `card_${i}`,
+            createdAt: now,
+        });
+    expect(
+        (await getStripeNewCardGateStatus(env.DB, user.id, now))
+            .shouldBanAccount,
+    ).toBe(true);
+});
+
+test("fraud ban revokes sessions, stops automatic payments, and rejects existing keys", async ({
+    sessionToken,
+    apiKey,
+    pubApiKey,
+}) => {
+    const db = drizzle(env.DB, { schema });
+    const user = await db.query.user.findFirst();
+    if (!user) throw Error("Missing fixture user");
+    await db
+        .update(schema.user)
+        .set({ autoTopUpEnabled: true })
+        .where(eq(schema.user.id, user.id));
+    await banFraudAccount(env.DB, user.id);
+    await banFraudAccount(env.DB, user.id);
+    expect(await db.query.user.findFirst()).toMatchObject({
+        banned: true,
+        banExpires: null,
+        autoTopUpEnabled: false,
+    });
+    expect(
+        await db.query.session.findMany({
+            where: eq(schema.session.userId, user.id),
+        }),
+    ).toHaveLength(0);
+    expect(await processAutoTopUpForUser(env, user.id)).toEqual({
+        status: "skipped",
+        reason: "account restricted",
+    });
+    expect(
+        await updateAutoTopUpSettings(env, user.id, {
+            enabled: true,
+            packAmountUsd: 10,
+        }),
+    ).toMatchObject({ ok: false, status: 403 });
+    for (const key of [apiKey, pubApiKey]) {
+        const result = await SELF.fetch(
+            "http://localhost:3000/api/account/profile",
+            { headers: { Authorization: `Bearer ${key}` } },
+        );
+        expect(result.status).toBe(403);
+    }
+    const lookup = await SELF.fetch(
+        `http://localhost:3000/api/app-lookup?app_key=${encodeURIComponent(pubApiKey)}`,
+    );
+    expect(await lookup.json()).toMatchObject({ found: false });
+    const checkout = await SELF.fetch(
+        "http://localhost:3000/api/stripe/checkout/p10",
+        {
+            headers: { Cookie: `better-auth.session_token=${sessionToken}` },
+            redirect: "manual",
+        },
+    );
+    expect(checkout.status).toBe(401);
+});
+
+test("banned login reaches the restricted error screen", async ({
+    sessionToken,
+    mocks,
+}) => {
+    await mocks.enable("github");
+    expect(sessionToken).toBeTruthy();
+    const db = drizzle(env.DB, { schema });
+    const user = await db.query.user.findFirst();
+    if (!user) throw Error("Missing fixture user");
+    await banFraudAccount(env.DB, user.id);
+    const start = await SELF.fetch(
+        "http://localhost:3000/api/auth/sign-in/social",
+        {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ provider: "github" }),
+        },
+    );
+    const data = (await start.json()) as { url: string };
+    const state = new URL(data.url).searchParams.get("state");
+    const result = await SELF.fetch(
+        `http://localhost:3000/api/auth/callback/github?code=test-code&state=${state}`,
+        {
+            headers: {
+                Cookie: start.headers.get("Set-Cookie") ?? "",
+                Accept: "text/html",
+            },
+            redirect: "manual",
+        },
+    );
+    expect(result.status).toBe(302);
+    const location = new URL(
+        result.headers.get("Location") ?? "",
+        "http://localhost:3000",
+    );
+    expect(location.pathname).toBe("/error");
+    expect(location.searchParams.get("error")).toBe("BANNED_USER");
+    expect(isBannedLoginError(location.searchParams.get("error") ?? "")).toBe(
+        true,
+    );
+});

--- a/enter.pollinations.ai/test/fraud-ban.test.ts
+++ b/enter.pollinations.ai/test/fraud-ban.test.ts
@@ -13,8 +13,16 @@ import {
     getStripeNewCardGateStatus,
     recordStripeCardFingerprintAttempt,
 } from "../src/utils/stripe-card-gate.ts";
-import { banFraudAccount } from "../src/utils/stripe-fraud-ban.ts";
+import { fraudBanQueries } from "../src/utils/stripe-fraud-ban.ts";
 import { test } from "./fixtures.ts";
+
+async function banFraudAccount(db: D1Database, userId: string): Promise<void> {
+    const queries = fraudBanQueries(userId);
+    if (queries.length)
+        await db.batch(
+            queries.map(({ sql, params }) => db.prepare(sql).bind(...params)),
+        );
+}
 
 test("checkout created during a ban is expired instead of redirected", async ({
     sessionToken,
@@ -69,9 +77,6 @@ test("four-card Radar stays independent from account bans", async ({
     expect((await getStripeNewCardGateStatus(env.DB, user.id, now)).gate).toBe(
         "locked",
     );
-    expect(
-        (await getStripeNewCardGateStatus(env.DB, user.id, now - 1)).gate,
-    ).toBe("ok");
     expect(
         (await getStripeNewCardGateStatus(env.DB, user.id, now + 86400001))
             .gate,

--- a/enter.pollinations.ai/test/fraud-ban.test.ts
+++ b/enter.pollinations.ai/test/fraud-ban.test.ts
@@ -46,7 +46,7 @@ test("ban page recognizes the installed library error code", () => {
     expect(isBannedLoginError("unknown")).toBe(false);
 });
 
-test("fraud thresholds keep four-card Radar and eight-card OR fifty-attempt bans", async ({
+test("four-card Radar stays independent from account bans", async ({
     sessionToken,
 }) => {
     expect(sessionToken).toBeTruthy();
@@ -64,25 +64,18 @@ test("fraud thresholds keep four-card Radar and eight-card OR fifty-attempt bans
         if (i === 3)
             expect(
                 await getStripeNewCardGateStatus(env.DB, user.id, now),
-            ).toMatchObject({ gate: "locked", shouldBanAccount: false });
-        if (i === 48)
-            expect(
-                (await getStripeNewCardGateStatus(env.DB, user.id, now))
-                    .shouldBanAccount,
-            ).toBe(false);
+            ).toMatchObject({ gate: "locked" });
     }
+    expect((await getStripeNewCardGateStatus(env.DB, user.id, now)).gate).toBe(
+        "locked",
+    );
     expect(
-        (await getStripeNewCardGateStatus(env.DB, user.id, now))
-            .shouldBanAccount,
-    ).toBe(true);
-    expect(
-        (await getStripeNewCardGateStatus(env.DB, user.id, now - 1))
-            .shouldBanAccount,
-    ).toBe(false);
+        (await getStripeNewCardGateStatus(env.DB, user.id, now - 1)).gate,
+    ).toBe("ok");
     expect(
         (await getStripeNewCardGateStatus(env.DB, user.id, now + 86400001))
-            .shouldBanAccount,
-    ).toBe(false);
+            .gate,
+    ).toBe("ok");
     await db.delete(schema.stripeCardFingerprintAttempt);
     for (let i = 0; i < 8; i++)
         await recordStripeCardFingerprintAttempt(env.DB, {
@@ -91,10 +84,10 @@ test("fraud thresholds keep four-card Radar and eight-card OR fifty-attempt bans
             cardFingerprint: `card_${i}`,
             createdAt: now,
         });
-    expect(
-        (await getStripeNewCardGateStatus(env.DB, user.id, now))
-            .shouldBanAccount,
-    ).toBe(true);
+    expect((await getStripeNewCardGateStatus(env.DB, user.id, now)).gate).toBe(
+        "locked",
+    );
+    expect((await db.query.user.findFirst())?.banned).not.toBe(true);
 });
 
 test("fraud ban revokes sessions, stops automatic payments, and rejects existing keys", async ({

--- a/enter.pollinations.ai/test/integration/stripe.test.ts
+++ b/enter.pollinations.ai/test/integration/stripe.test.ts
@@ -1,4 +1,4 @@
-test("eight failed cards ban the account and expire its open checkouts", async ({
+test("eight failed cards are recorded without a webhook account ban", async ({
     sessionToken,
     mocks,
 }) => {
@@ -70,22 +70,19 @@ test("eight failed cards ban the account and expire its open checkouts", async (
 
     await expect
         .poll(async () => {
-            const [row] = await drizzle(env.DB)
+            const rows = await drizzle(env.DB)
                 .select()
-                .from(userTable)
-                .where(eq(userTable.id, userId));
-            return row.banned;
+                .from(stripeCardFingerprintAttemptTable)
+                .where(eq(stripeCardFingerprintAttemptTable.userId, userId));
+            return rows.length;
         })
-        .toBe(true);
+        .toBe(8);
     const [user] = await drizzle(env.DB)
         .select()
         .from(userTable)
         .where(eq(userTable.id, userId));
-    expect(user.banned).toBe(true);
-    expect(user.autoTopUpEnabled).toBe(false);
-    await expect
-        .poll(() => mocks.stripe.state.checkoutSessions[0].status)
-        .toBe("expired");
+    expect(user.banned).not.toBe(true);
+    expect(mocks.stripe.state.checkoutSessions[0].status).toBe("open");
     expect(
         (
             await SELF.fetch(`${base}/checkout/p10`, {
@@ -95,7 +92,7 @@ test("eight failed cards ban the account and expire its open checkouts", async (
                 redirect: "manual",
             })
         ).status,
-    ).toBe(401);
+    ).toBe(302);
 });
 
 import { env, SELF } from "cloudflare:test";

--- a/enter.pollinations.ai/test/integration/stripe.test.ts
+++ b/enter.pollinations.ai/test/integration/stripe.test.ts
@@ -1,3 +1,103 @@
+test("eight failed cards ban the account and expire its open checkouts", async ({
+    sessionToken,
+    mocks,
+}) => {
+    await mocks.enable("stripe", "tinybird");
+    const userId = await getSeededUserId();
+
+    const customer = mockCustomer("cus_test_card_gate");
+    mocks.stripe.state.customers.push(customer);
+    mocks.stripe.state.checkoutSessions.push({
+        id: "cs_fraud",
+        object: "checkout.session",
+        mode: "payment",
+        customer: customer.id,
+        status: "open",
+        url: "https://checkout.stripe.test/fraud",
+    });
+    for (const fingerprint of [
+        "fp_gate_1",
+        "fp_gate_2",
+        "fp_gate_3",
+        "fp_gate_4",
+        "fp_gate_5",
+        "fp_gate_6",
+        "fp_gate_7",
+        "fp_gate_8",
+    ]) {
+        const paymentIntentId = `pi_${fingerprint}`;
+        mocks.stripe.state.paymentIntents.push({
+            id: paymentIntentId,
+            object: "payment_intent",
+            status: "requires_payment_method",
+            amount: 1000,
+            currency: "usd",
+            metadata: { userId },
+            payment_method_types: ["card"],
+            receipt_email: "buyer@example.com",
+            latest_charge: {
+                id: `ch_${fingerprint}`,
+                object: "charge",
+                amount: 1000,
+                currency: "usd",
+                status: "failed",
+                customer: "cus_test_card_gate",
+                payment_intent: paymentIntentId,
+                metadata: { userId },
+                billing_details: { email: "buyer@example.com" },
+                payment_method_details: {
+                    type: "card",
+                    card: {
+                        fingerprint,
+                        brand: "visa",
+                        country: "US",
+                        network: "visa",
+                    },
+                },
+                outcome: { risk_level: "elevated", risk_score: 61 },
+            },
+        });
+
+        const response = await postSignedStripeWebhook(
+            createCardPaymentFailedEvent({
+                eventId: `evt_${fingerprint}`,
+                paymentIntentId,
+                userId,
+            }),
+        );
+        expect(response.status).toBe(200);
+    }
+
+    await expect
+        .poll(async () => {
+            const [row] = await drizzle(env.DB)
+                .select()
+                .from(userTable)
+                .where(eq(userTable.id, userId));
+            return row.banned;
+        })
+        .toBe(true);
+    const [user] = await drizzle(env.DB)
+        .select()
+        .from(userTable)
+        .where(eq(userTable.id, userId));
+    expect(user.banned).toBe(true);
+    expect(user.autoTopUpEnabled).toBe(false);
+    await expect
+        .poll(() => mocks.stripe.state.checkoutSessions[0].status)
+        .toBe("expired");
+    expect(
+        (
+            await SELF.fetch(`${base}/checkout/p10`, {
+                headers: {
+                    Cookie: `better-auth.session_token=${sessionToken}`,
+                },
+                redirect: "manual",
+            })
+        ).status,
+    ).toBe(401);
+});
+
 import { env, SELF } from "cloudflare:test";
 import { createHmac } from "node:crypto";
 import {

--- a/enter.pollinations.ai/test/mocks/stripe.ts
+++ b/enter.pollinations.ai/test/mocks/stripe.ts
@@ -55,7 +55,8 @@ type StripeCheckoutSession = {
     object: "checkout.session";
     mode: string;
     customer: string | null;
-    url: string;
+    url: string | null;
+    status?: "open" | "complete" | "expired";
 };
 
 type StripePortalSession = {
@@ -167,6 +168,7 @@ export type MockStripeState = {
     invoicePayments: StripeInvoicePayment[];
     paymentIntents: StripePaymentIntent[];
     requests: StripeRequest[];
+    onCheckoutSessionCreated: (() => Promise<void>) | null;
     customerCreateByIdempotencyKey: Record<string, string>;
     /**
      * Per-invoice override for the `/v1/invoices/:id/pay` mock response.
@@ -264,8 +266,36 @@ export function createMockStripe(): MockAPI<MockStripeState> {
                 mode: form.get("mode") ?? "payment",
                 customer: form.get("customer"),
                 url: `https://checkout.stripe.test/${state.checkoutSessions.length + 1}`,
+                status: "open",
             };
             state.checkoutSessions.push(session);
+            await state.onCheckoutSessionCreated?.();
+            return c.json(session);
+        })
+        .get("/v1/checkout/sessions", (c) => {
+            recordRequest(c, state);
+            const customer = c.req.query("customer");
+            const status = c.req.query("status");
+            const data = state.checkoutSessions.filter(
+                (session) =>
+                    (!customer || session.customer === customer) &&
+                    (!status || session.status === status),
+            );
+            return c.json({
+                object: "list",
+                url: "/v1/checkout/sessions",
+                has_more: false,
+                data,
+            });
+        })
+        .post("/v1/checkout/sessions/:id/expire", (c) => {
+            recordRequest(c, state);
+            const session = state.checkoutSessions.find(
+                (item) => item.id === c.req.param("id"),
+            );
+            if (!session) return stripeNotFound(c);
+            session.status = "expired";
+            session.url = null;
             return c.json(session);
         })
         .post("/v1/billing_portal/sessions", async (c) => {
@@ -555,6 +585,7 @@ function createInitialState(): MockStripeState {
         invoicePayments: [],
         paymentIntents: [],
         requests: [],
+        onCheckoutSessionCreated: null,
         customerCreateByIdempotencyKey: {},
         payBehavior: {},
     };

--- a/enter.pollinations.ai/test/mocks/stripe.ts
+++ b/enter.pollinations.ai/test/mocks/stripe.ts
@@ -167,6 +167,10 @@ export type MockStripeState = {
     invoiceItems: StripeInvoiceLineItem[];
     invoicePayments: StripeInvoicePayment[];
     paymentIntents: StripePaymentIntent[];
+    fraudCharges: Record<string, unknown>[];
+    fraudDisputes: Record<string, unknown>[];
+    fraudWarnings: Record<string, unknown>[];
+    failFraudWarnings: boolean;
     requests: StripeRequest[];
     onCheckoutSessionCreated: (() => Promise<void>) | null;
     customerCreateByIdempotencyKey: Record<string, string>;
@@ -193,7 +197,40 @@ export type MockStripeState = {
 export function createMockStripe(): MockAPI<MockStripeState> {
     const state: MockStripeState = createInitialState();
 
+    function fraudPage(c: Context, rows: Record<string, unknown>[]) {
+        recordRequest(c, state);
+        const cursor = c.req.query("starting_after");
+        const start = cursor
+            ? rows.findIndex((row) => row.id === cursor) + 1
+            : 0;
+        const limit = Number(c.req.query("limit") ?? 100);
+        const data = rows.slice(start, start + limit);
+        return c.json({
+            object: "list",
+            data,
+            has_more: start + limit < rows.length,
+            url: c.req.path,
+        });
+    }
     const stripeAPI = new Hono()
+        .get("/v1/account", (c) =>
+            c.json({ id: "acct_1SrY3q7rcjS3l7tr", object: "account" }),
+        )
+        .get("/v1/charges", (c) => fraudPage(c, state.fraudCharges))
+        .get("/v1/disputes", (c) => fraudPage(c, state.fraudDisputes))
+        .get("/v1/radar/early_fraud_warnings", (c) =>
+            state.failFraudWarnings
+                ? c.json(
+                      {
+                          error: {
+                              type: "invalid_request_error",
+                              message: "Unavailable",
+                          },
+                      },
+                      403,
+                  )
+                : fraudPage(c, state.fraudWarnings),
+        )
         .post("/v1/customers", async (c) => {
             const form = await parseForm(c.req.raw);
             recordRequest(c, state, form);
@@ -584,6 +621,10 @@ function createInitialState(): MockStripeState {
         invoiceItems: [],
         invoicePayments: [],
         paymentIntents: [],
+        fraudCharges: [],
+        fraudDisputes: [],
+        fraudWarnings: [],
+        failFraudWarnings: false,
         requests: [],
         onCheckoutSessionCreated: null,
         customerCreateByIdempotencyKey: {},

--- a/enter.pollinations.ai/test/stripe-fraud-score.test.ts
+++ b/enter.pollinations.ai/test/stripe-fraud-score.test.ts
@@ -1,0 +1,259 @@
+import { env } from "cloudflare:test";
+import Stripe from "stripe";
+import { expect } from "vitest";
+import {
+    fraudBanQueries,
+    runFraudBanCheck,
+} from "../src/utils/stripe-fraud-ban.ts";
+import {
+    cappedFraudScore,
+    collectStripeFraudScores,
+    FRAUD_BAN_EXCLUDED_USER_ID,
+} from "../src/utils/stripe-fraud-score.ts";
+import { test } from "./fixtures.ts";
+
+const payments = (count: number, flags: Record<string, boolean>) =>
+    Array.from({ length: count }, (_, i) => ({
+        chargeId: `ch_${i}`,
+        ...flags,
+    }));
+
+test("capped score matches the simulator weights, curve, and rounding", () => {
+    expect(cappedFraudScore([])).toBe(0);
+    expect(cappedFraudScore(payments(2, { fd: true }))).toBe(0.5);
+    expect(cappedFraudScore(payments(6, { fd: true }))).toBe(0.75);
+    expect(cappedFraudScore(payments(9, { fd: true }))).toBe(0.87);
+    expect(cappedFraudScore(payments(1000, { fd: true }))).toBe(5);
+    expect(cappedFraudScore(payments(2000, { hr: true }))).toBe(1);
+    expect(cappedFraudScore(payments(1000, { rb: true }))).toBe(0);
+    expect(cappedFraudScore([{ chargeId: "py_noncard", fd: true }])).toBe(0.39);
+    expect(() => cappedFraudScore([{ chargeId: "", fd: true }])).toThrow();
+});
+
+test("overlapping signals and duplicate events count once per payment", () => {
+    const overlapping = [
+        ...payments(2, { ew: true, hr: true }),
+        ...payments(2, { fraud: true }),
+        ...payments(2, { fd: true }),
+    ];
+    expect(cappedFraudScore(overlapping)).toBe(0.5);
+    expect(
+        cappedFraudScore([
+            ...payments(2, { fraud: true }),
+            { chargeId: "py_other", ew: true },
+        ]),
+    ).toBe(0.45);
+    expect(fraudBanQueries(FRAUD_BAN_EXCLUDED_USER_ID)).toEqual([]);
+});
+
+type Query = { sql: string; params?: string[] };
+async function queryD1(body: Query | { batch: Query[] }) {
+    const queries = "batch" in body ? body.batch : [body];
+    return env.DB.batch(
+        queries.map(({ sql, params }) =>
+            env.DB.prepare(sql).bind(...(params ?? [])),
+        ),
+    );
+}
+const client = () => new Stripe("sk_test_mock", { maxNetworkRetries: 0 });
+
+test("hourly scan reads every page; dry run is read-only; apply bans and expires checkouts", async ({
+    sessionToken,
+    mocks,
+}) => {
+    expect(sessionToken).toBeTruthy();
+    await mocks.enable("stripe");
+    const user = await env.DB.prepare("SELECT id FROM user LIMIT 1").first<{
+        id: string;
+    }>();
+    if (!user) throw Error("Missing user");
+    mocks.stripe.state.fraudCharges.push(
+        ...Array.from({ length: 106 }, (_, i) => ({
+            id: `ch_${i}`,
+            object: "charge",
+            livemode: true,
+            customer: "cus_fraud",
+            metadata: { userId: user.id },
+        })),
+    );
+    mocks.stripe.state.fraudDisputes.push(
+        ...Array.from({ length: 106 }, (_, i) => ({
+            id: `dp_${i}`,
+            object: "dispute",
+            livemode: true,
+            reason: "fraudulent",
+            charge: `ch_${i % 6}`,
+        })),
+    );
+    mocks.stripe.state.fraudWarnings.push(
+        ...Array.from({ length: 101 }, (_, i) => ({
+            id: `issfr_${i}`,
+            livemode: true,
+            charge: "ch_0",
+        })),
+    );
+    mocks.stripe.state.checkoutSessions.push({
+        id: "cs_open",
+        object: "checkout.session",
+        mode: "payment",
+        customer: "cus_fraud",
+        status: "open",
+        url: null,
+    });
+    const stripe = client();
+    expect(await runFraudBanCheck(stripe, queryD1)).toEqual({
+        candidates: 1,
+        applied: 0,
+    });
+    expect(
+        mocks.stripe.state.requests.filter(
+            (request) => request.path === "/v1/charges",
+        ),
+    ).toHaveLength(2);
+    for (const path of ["/v1/disputes", "/v1/radar/early_fraud_warnings"]) {
+        expect(
+            mocks.stripe.state.requests.filter(
+                (request) => request.path === path,
+            ),
+        ).toHaveLength(2);
+    }
+    expect(
+        (
+            await env.DB.prepare("SELECT banned FROM user WHERE id = ?")
+                .bind(user.id)
+                .first()
+        )?.banned,
+    ).not.toBe(1);
+    expect(
+        await runFraudBanCheck(stripe, queryD1, {
+            apply: true,
+            excludedUserIds: [user.id],
+        }),
+    ).toEqual({ candidates: 0, applied: 0 });
+    expect(mocks.stripe.state.checkoutSessions[0].status).toBe("open");
+    expect(await runFraudBanCheck(stripe, queryD1, { apply: true })).toEqual({
+        candidates: 1,
+        applied: 1,
+    });
+    expect(
+        await env.DB.prepare(
+            "SELECT banned, auto_top_up_enabled FROM user WHERE id = ?",
+        )
+            .bind(user.id)
+            .first(),
+    ).toMatchObject({ banned: 1, auto_top_up_enabled: 0 });
+    expect(
+        (
+            await env.DB.prepare(
+                "SELECT COUNT(*) AS n FROM session WHERE user_id = ?",
+            )
+                .bind(user.id)
+                .first()
+        )?.n,
+    ).toBe(0);
+    expect(mocks.stripe.state.checkoutSessions[0].status).toBe("expired");
+});
+
+test("incomplete Stripe scans cannot apply any bans", async ({
+    sessionToken,
+    mocks,
+}) => {
+    expect(sessionToken).toBeTruthy();
+    await mocks.enable("stripe");
+    const user = await env.DB.prepare("SELECT id FROM user LIMIT 1").first<{
+        id: string;
+    }>();
+    if (!user) throw Error("Missing user");
+    mocks.stripe.state.fraudCharges.push(
+        ...Array.from({ length: 6 }, (_, i) => ({
+            id: `ch_${i}`,
+            livemode: true,
+            metadata: { userId: user.id },
+        })),
+    );
+    mocks.stripe.state.fraudDisputes.push(
+        ...Array.from({ length: 6 }, (_, i) => ({
+            id: `dp_${i}`,
+            livemode: true,
+            reason: "fraudulent",
+            charge: `ch_${i}`,
+        })),
+    );
+    mocks.stripe.state.failFraudWarnings = true;
+    await expect(
+        runFraudBanCheck(client(), queryD1, { apply: true }),
+    ).rejects.toThrow();
+    expect(
+        (
+            await env.DB.prepare(
+                "SELECT COUNT(*) AS n FROM user WHERE banned = 1",
+            ).first()
+        )?.n,
+    ).toBe(0);
+    mocks.stripe.state.failFraudWarnings = false;
+    mocks.stripe.state.fraudWarnings.push({
+        id: "issfr_missing",
+        livemode: true,
+        charge: "ch_missing",
+    });
+    await expect(
+        runFraudBanCheck(client(), queryD1, { apply: true }),
+    ).rejects.toThrow("Incomplete Stripe charge coverage");
+});
+
+test("identity conflicts and email-only charges are not attributed", async ({
+    mocks,
+}) => {
+    await mocks.enable("stripe");
+    mocks.stripe.state.fraudCharges.push(
+        {
+            id: "ch_conflict",
+            livemode: true,
+            customer: "cus_a",
+            metadata: { userId: "b" },
+            outcome: { risk_level: "highest" },
+        },
+        {
+            id: "ch_email",
+            livemode: true,
+            billing_details: { email: "a@example.com" },
+            outcome: { risk_level: "highest" },
+        },
+        {
+            id: "py_valid",
+            livemode: true,
+            customer: "cus_a",
+            outcome: { risk_level: "highest" },
+        },
+    );
+    const result = await collectStripeFraudScores(client(), [
+        { id: "a", stripe_customer_id: "cus_a" },
+        { id: "b", stripe_customer_id: null },
+    ]);
+    expect(result.unmapped).toBe(2);
+    expect(result.conflicting).toBe(1);
+    expect(result.scores.get("a")).toBe(0.08);
+    expect(result.scores.has("b")).toBe(false);
+});
+
+test("shared customer checkouts are not expired for another account", async ({
+    mocks,
+}) => {
+    await mocks.enable("stripe");
+    mocks.stripe.state.fraudCharges.push(
+        ...["a", "b"].map((id) => ({
+            id: `ch_${id}`,
+            livemode: true,
+            customer: "cus_shared",
+            metadata: { userId: id },
+            outcome: { risk_level: "highest" },
+        })),
+    );
+    const result = await collectStripeFraudScores(
+        client(),
+        ["a", "b"].map((id) => ({ id, stripe_customer_id: null })),
+    );
+    expect(result.scores.size).toBe(2);
+    expect(result.customers.get("a")?.size).toBe(0);
+    expect(result.customers.get("b")?.size).toBe(0);
+});

--- a/gen.pollinations.ai/src/community-models.ts
+++ b/gen.pollinations.ai/src/community-models.ts
@@ -1,3 +1,4 @@
+import { isUserBanned } from "@shared/auth/ban.ts";
 import { communityResponsesUrl } from "@shared/community-endpoint-urls.ts";
 import {
     type CommunityEndpointRuntime,
@@ -40,6 +41,8 @@ export async function getCommunityModelRegistryEntries(
         .select({
             id: schema.communityEndpoint.id,
             ownerUserId: schema.communityEndpoint.ownerUserId,
+            banned: schema.user.banned,
+            banExpires: schema.user.banExpires,
             ownerGithubUsername: schema.user.githubUsername,
             providerName: schema.user.communityProviderName,
             providerUrl: schema.user.communityProviderUrl,
@@ -68,7 +71,7 @@ export async function getCommunityModelRegistryEntries(
         .where(isNotNull(schema.user.githubUsername));
 
     return rows.flatMap((row): CommunityModelRegistryEntry[] => {
-        if (!row.ownerGithubUsername) return [];
+        if (!row.ownerGithubUsername || isUserBanned(row)) return [];
         const baseUrl = row.baseUrl;
         if (!baseUrl || !row.upstreamModel) return [];
         const modelId = communityModelId(row.ownerGithubUsername, row.name);

--- a/gen.pollinations.ai/test/community-endpoints.test.ts
+++ b/gen.pollinations.ai/test/community-endpoints.test.ts
@@ -59,6 +59,7 @@ import {
 import {
     communityEndpoint as communityEndpointTable,
     session as sessionTable,
+    user as userTable,
 } from "@shared/db/better-auth.ts";
 import { handleError } from "@shared/error.ts";
 import { IMMUTABLE_CACHE_CONTROL } from "@shared/http/cache-control.ts";
@@ -107,6 +108,69 @@ import { communityEndpointGatewayContext } from "../src/text/communityEndpoint.t
 import { withInlineGenerationCoordinator } from "./helpers/inline-generation-coordinator.ts";
 
 const db = drizzle(env.DB);
+
+fixtureTest(
+    "banned owners' public models and agents leave the registry",
+    async () => {
+        const ownerUserId = await createTestUser({
+            githubId: nextAllowedGithubId(),
+            githubUsername: "banned-owner",
+        });
+        await insertCommunityEndpoints({
+            id: "ban-model",
+            ownerUserId,
+            name: "model",
+            description: "Test",
+            type: "proxy",
+            visibility: "public",
+            baseUrl: "https://api.example.com/v1",
+            upstreamModel: "test",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+        await insertCommunityEndpoints({
+            id: "ban-agent",
+            ownerUserId,
+            name: "agent",
+            description: "Test",
+            type: "prompt_agent",
+            visibility: "public",
+            baseUrl: PROMPT_AGENT_BASE_URL_PLACEHOLDER,
+            upstreamModel: "ban-agent",
+            payload: JSON.stringify({
+                prompt: "Test",
+                baseModel: DEFAULT_TEXT_MODEL,
+                mcpServers: [],
+            }),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        });
+        const before = await getCommunityModelRegistryEntries(env);
+        expect(
+            before.filter(
+                (row) => row.communityEndpoint.ownerUserId === ownerUserId,
+            ),
+        ).toHaveLength(2);
+        await db
+            .update(userTable)
+            .set({ banned: true })
+            .where(eq(userTable.id, ownerUserId));
+        expect(
+            (await getCommunityModelRegistryEntries(env)).filter(
+                (row) => row.communityEndpoint.ownerUserId === ownerUserId,
+            ),
+        ).toHaveLength(0);
+        await db
+            .update(userTable)
+            .set({ banned: false })
+            .where(eq(userTable.id, ownerUserId));
+        expect(
+            (await getCommunityModelRegistryEntries(env)).filter(
+                (row) => row.communityEndpoint.ownerUserId === ownerUserId,
+            ),
+        ).toHaveLength(2);
+    },
+);
 
 type CommunityEndpointInsert = typeof communityEndpointTable.$inferInsert;
 type CommunityEndpointFixture = Omit<CommunityEndpointInsert, "title"> &

--- a/gen.pollinations.ai/test/model-permissions.test.ts
+++ b/gen.pollinations.ai/test/model-permissions.test.ts
@@ -1,5 +1,5 @@
 import { env, SELF } from "cloudflare:test";
-import { apikey } from "@shared/db/better-auth.ts";
+import { apikey, user as userTable } from "@shared/db/better-auth.ts";
 import { getAudioModelsInfo } from "@shared/registry/model-info.ts";
 import {
     getRegistryModelDefinition,
@@ -23,6 +23,40 @@ import { type AuthEnv, authFromSnapshot } from "../src/middleware/auth.ts";
 async function fetchWorker(path: string, init: RequestInit = {}) {
     return SELF.fetch(new Request(`https://gen.pollinations.ai${path}`, init));
 }
+
+test("banned app owners block direct keys and existing BYOP keys", async () => {
+    const owner = await createTestApiKey();
+    const caller = await createTestApiKey();
+    const db = drizzle(env.DB);
+    await db
+        .update(apikey)
+        .set({ byopClientKeyId: owner.id })
+        .where(eq(apikey.id, caller.id));
+    await db
+        .update(userTable)
+        .set({ banned: true })
+        .where(eq(userTable.id, owner.userId));
+    for (const key of [owner.key, caller.key]) {
+        expect(
+            (
+                await fetchWorker("/v1/models", {
+                    headers: { Authorization: `Bearer ${key}` },
+                })
+            ).status,
+        ).toBe(403);
+    }
+    await db
+        .update(userTable)
+        .set({ banned: false })
+        .where(eq(userTable.id, owner.userId));
+    expect(
+        (
+            await fetchWorker("/v1/models", {
+                headers: { Authorization: `Bearer ${caller.key}` },
+            })
+        ).status,
+    ).toBe(200);
+});
 
 test("catalog metadata exposes publisher rather than author or brand", async () => {
     const response = await fetchWorker("/models");

--- a/shared/auth/api-key-creation.ts
+++ b/shared/auth/api-key-creation.ts
@@ -5,6 +5,7 @@ import * as schema from "../db/better-auth.ts";
 import { validateModelPermissionIds } from "../registry/visible-model-ids.ts";
 import { getRedirectUris, parseMetadata } from "./api-key-metadata.ts";
 import { sanitizeAuthorizeAccountPermissions } from "./authorize-config.ts";
+import { isUserBanned } from "./ban.ts";
 import {
     isAllowedRedirectUrl,
     redirectUriMatchesAllowlist,
@@ -162,6 +163,10 @@ async function validateClientRedirectBinding(
     if (!clientKey || clientKey.prefix !== "pk") {
         rejectInvalidClientId();
     }
+    const owner = await db.query.user.findFirst({
+        where: eq(schema.user.id, clientKey.referenceId),
+    });
+    if (!owner || isUserBanned(owner)) rejectInvalidClientId();
     const attribution = {
         clientId: clientKey.id,
     };

--- a/shared/auth/api-key.ts
+++ b/shared/auth/api-key.ts
@@ -12,6 +12,7 @@ import {
     verifyAgentRunToken,
 } from "./agent-run-token.ts";
 import { parseMetadata } from "./api-key-metadata.ts";
+import { isUserBanned } from "./ban.ts";
 import { parseGithubIdList } from "./github-id-list.ts";
 
 const PUBLISHABLE_KEY_PREFIX = "pk";
@@ -203,8 +204,7 @@ export function assertNotBanned(user: {
     banExpires?: Date | string | null;
     banReason?: string | null;
 }): void {
-    if (user.banned !== true) return;
-    if (user.banExpires && new Date(user.banExpires) <= new Date()) return;
+    if (!isUserBanned(user)) return;
     throw new BannedAccountError(
         user.banReason ? `Account banned: ${user.banReason}` : "Account banned",
     );
@@ -289,11 +289,16 @@ async function loadActiveApiKeyAuthResult(opts: {
 }): Promise<ApiKeyAuthResult | null> {
     const db = drizzle(opts.env.DB, { schema });
     const byopClientKey = alias(schema.apikey, "byop_client_key");
+    const byopOwner = alias(schema.user, "byop_owner");
     const row = await db
         .select({
             apiKey: getTableColumns(schema.apikey),
             user: getTableColumns(schema.user),
             byopClientName: byopClientKey.name,
+            byopOwner: {
+                banned: byopOwner.banned,
+                banExpires: byopOwner.banExpires,
+            },
             byopClientUserId: byopClientKey.referenceId,
             byopClientPrefix: byopClientKey.prefix,
             byopClientEnabled: byopClientKey.enabled,
@@ -307,6 +312,7 @@ async function loadActiveApiKeyAuthResult(opts: {
             eq(byopClientKey.id, schema.apikey.byopClientKeyId),
         )
         .where(eq(schema.apikey.id, opts.apiKeyId))
+        .leftJoin(byopOwner, eq(byopOwner.id, byopClientKey.referenceId))
         .get();
 
     if (
@@ -318,6 +324,7 @@ async function loadActiveApiKeyAuthResult(opts: {
     }
 
     assertNotBanned(row.user);
+    if (row.byopOwner) assertNotBanned(row.byopOwner);
     assertStagingAccess(opts.env, row.user);
 
     return {

--- a/shared/auth/ban.ts
+++ b/shared/auth/ban.ts
@@ -1,0 +1,16 @@
+export const ACCOUNT_RESTRICTED_MESSAGE =
+    "Account restricted. Contact billing@pollinations.ai";
+
+export function isUserBanned(user: {
+    banned?: boolean | null;
+    banExpires?: Date | string | null;
+}): boolean {
+    return (
+        user.banned === true &&
+        (!user.banExpires || !(new Date(user.banExpires) <= new Date()))
+    );
+}
+
+export function isBannedLoginError(error: string): boolean {
+    return error === "BANNED_USER" || error === "banned";
+}


### PR DESCRIPTION
Adds account-level protection alongside the existing, unchanged Stripe new-card gate.

- **Rules:** Hourly checks; capped score ≥ **0.75**. Weights: fraud dispute **5**, fraud report **3**, early fraud warning **2**, highest risk **1**, blocked payment **0**. Each payment counts toward its strongest signal only. Contributions grow with frequency, capped at each weight, then sum and round to two decimals. A blocked payment can still contribute through its highest-risk flag.
- **Effect:** Bans stop sign-in, API/app-key usage, purchases and auto-top-up. Sessions are revoked, open checkouts expire, and community models/agents become unavailable.
- **Safeguards:** No migration. Incomplete scans and email-only matches cannot trigger bans. The settled account stays excluded. Merchant fraud reports and fraudulent disputes of any outcome currently count; restored accounts need an exclusion.
- **Backfill:** The first enabled run scans **all available history**, as do subsequent runs. A three-month simulator preview (June 4–September 4, 2026) finds **7 candidates** with dispute weight 5 or the experimental 8. This is a historical estimate, not a validated production ban list. Neither weight 8 nor a three-month cutoff is implemented here.
- **Rollout:** Deploy, run a read-only manual check, validate candidates, then explicitly enable hourly enforcement. CI is green.