### PR TITLE
FOR [Quest] filter model catalogs by source and reliability #14535

### DIFF
--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -23,6 +23,7 @@ import {
     mediaResponseDescription,
 } from "../media/response-output.ts";
 import { mediaResponses } from "../media/responses.ts";
+import { fetchModelHealthMap } from "../utils/model-health.ts";
 import {
     formatOpenAIImageResponse,
     handleImageGeneration,
@@ -226,6 +227,79 @@ const responsesHandlers = factory.createHandlers(
     generateCreateResponse,
 );
 
+async function attachHealthToEntries(
+    entries: GenerationModelEntry[],
+): Promise<GenerationModelEntry[]> {
+    const healthMap = await fetchModelHealthMap();
+    return entries.map((entry) => {
+        const h = healthMap.get(entry.info.name) ?? {
+            success_rate: null,
+            sample_count: 0,
+            window_minutes: 60,
+            freshness: null,
+        };
+        return {
+            ...entry,
+            info: {
+                ...entry.info,
+                health: h,
+            },
+        };
+    });
+}
+
+function filterEntriesByFilterParams(
+    c: Context<Env>,
+    entries: GenerationModelEntry[],
+    query: ModelListQueryParams,
+): GenerationModelEntry[] {
+    const headerFilter = c.req.header("x-pollinations-model-filter");
+    const filterStr = query.filter || headerFilter;
+
+    let wantOfficial: boolean | undefined;
+    let wantReliable: boolean | undefined;
+    let wantCommunity: boolean | undefined;
+
+    if (query.community !== undefined) {
+        wantCommunity = query.community === "true" || query.community === "1";
+    }
+    if (query.official !== undefined) {
+        wantOfficial = query.official === "true" || query.official === "1";
+    }
+    if (query.reliable !== undefined) {
+        wantReliable = query.reliable === "true" || query.reliable === "1";
+    }
+
+    if (filterStr) {
+        const parts = filterStr.split(",").map((s) => s.trim().toLowerCase());
+        if (parts.includes("official")) wantOfficial = true;
+        if (parts.includes("reliable")) wantReliable = true;
+        if (parts.includes("community")) wantCommunity = true;
+    }
+
+    return entries.filter((entry) => {
+        if (wantOfficial === true && entry.info.community) return false;
+        if (wantOfficial === false && !entry.info.community) return false;
+
+        if (wantCommunity === true && !entry.info.community) return false;
+        if (wantCommunity === false && entry.info.community) return false;
+
+        if (wantReliable === true) {
+            const h = entry.info.health;
+            if (!h || h.success_rate === null || h.success_rate < 0.7) {
+                return false;
+            }
+        } else if (wantReliable === false) {
+            const h = entry.info.health;
+            if (h && h.success_rate !== null && h.success_rate >= 0.7) {
+                return false;
+            }
+        }
+
+        return true;
+    });
+}
+
 // Helper to filter models by API key permissions and paid balance.
 function filterEntriesByPermissions(
     entries: GenerationModelEntry[],
@@ -250,7 +324,7 @@ function hasPaidBalance(c: any): boolean | undefined {
 }
 
 // Optionally filter entries by the validated `?community` query parameter.
-function filterEntriesByCommunityParam(
+function _filterEntriesByCommunityParam(
     entries: GenerationModelEntry[],
     communityParam: string | undefined,
 ): GenerationModelEntry[] {
@@ -272,21 +346,25 @@ const modelsListHandler = (
     [
         validator("query", ModelListQueryParamsSchema),
         async (c: Context<Env>) => {
-            const { community } = c.req.valid(
+            const queryParams = c.req.valid(
                 "query" as never,
             ) as ModelListQueryParams;
             const allowedModels = c.var.auth?.apiKey?.permissions?.models;
             const paidBalance = hasPaidBalance(c);
-            return c.json(
-                filterEntriesByCommunityParam(
-                    filterEntriesByPermissions(
-                        await getEntries(c),
-                        allowedModels,
-                        paidBalance,
-                    ),
-                    community,
-                ).map((entry) => entry.info),
+            const entriesWithHealth = await attachHealthToEntries(
+                await getEntries(c),
             );
+            const filteredByPermissions = filterEntriesByPermissions(
+                entriesWithHealth,
+                allowedModels,
+                paidBalance,
+            );
+            const filtered = filterEntriesByFilterParams(
+                c,
+                filteredByPermissions,
+                queryParams,
+            );
+            return c.json(filtered.map((entry) => entry.info));
         },
     ] as const;
 
@@ -351,6 +429,7 @@ function toOpenAIModelEntry(entry: GenerationModelEntry) {
             base_model: entry.info.base_model,
         }),
         pricing: entry.info.pricing,
+        health: entry.info.health,
         capabilities: entry.info.capabilities,
         ...(entry.info.tools && { tools: entry.info.tools }),
         ...(entry.info.reasoning && { reasoning: entry.info.reasoning }),
@@ -418,18 +497,23 @@ export const proxyRoutes = new Hono<Env>()
         }),
         validator("query", ModelListQueryParamsSchema),
         async (c) => {
-            const { community } = c.req.valid(
+            const queryParams = c.req.valid(
                 "query" as never,
             ) as ModelListQueryParams;
             const allowedModels = c.var.auth?.apiKey?.permissions?.models;
             const paidBalance = hasPaidBalance(c);
-            const modelEntries = filterEntriesByCommunityParam(
-                filterEntriesByPermissions(
-                    await getVisibleModelEntries(c),
-                    allowedModels,
-                    paidBalance,
-                ),
-                community,
+            const entriesWithHealth = await attachHealthToEntries(
+                await getVisibleModelEntries(c),
+            );
+            const filteredByPermissions = filterEntriesByPermissions(
+                entriesWithHealth,
+                allowedModels,
+                paidBalance,
+            );
+            const modelEntries = filterEntriesByFilterParams(
+                c,
+                filteredByPermissions,
+                queryParams,
             );
             return c.json({
                 object: "list" as const,
@@ -478,7 +562,8 @@ export const proxyRoutes = new Hono<Env>()
                     message: `Model '${modelId}' not found`,
                 });
             }
-            return c.json(toOpenAIModelEntry(entry));
+            const [withHealth] = await attachHealthToEntries([entry]);
+            return c.json(toOpenAIModelEntry(withHealth));
         },
     )
     .get(

--- a/gen.pollinations.ai/src/schemas/models.ts
+++ b/gen.pollinations.ai/src/schemas/models.ts
@@ -5,6 +5,18 @@ export const ModelListQueryParamsSchema = z.object({
         description:
             "Filter by community status: `true`/`1` for community-only, `false`/`0` for official-only. Omit for all models.",
     }),
+    official: z.enum(["true", "false", "1", "0"]).optional().meta({
+        description:
+            "Filter by official status: `true`/`1` for official-only, `false`/`0` for community-only.",
+    }),
+    reliable: z.enum(["true", "false", "1", "0"]).optional().meta({
+        description:
+            "Filter by reliability: `true`/`1` for reliable models (success_rate >= 0.70).",
+    }),
+    filter: z.string().optional().meta({
+        description:
+            "Filter string or comma-separated filters: `official`, `reliable`, `community`. Supports `x-pollinations-model-filter` header equivalent.",
+    }),
 });
 
 export type ModelListQueryParams = z.infer<typeof ModelListQueryParamsSchema>;

--- a/gen.pollinations.ai/src/utils/model-health.ts
+++ b/gen.pollinations.ai/src/utils/model-health.ts
@@ -1,0 +1,114 @@
+import type { ModelHealth } from "@shared/schemas/openai.ts";
+import debug from "debug";
+
+const log = debug("pollinations:model-health");
+
+const TINYBIRD_HOST = "https://api.europe-west2.gcp.tinybird.co";
+const TINYBIRD_PUBLIC_TOKEN =
+    "p.eyJ1IjogImFjYTYzZjc5LThjNTYtNDhlNC05NWJjLWEyYmFjMTY0NmJkMyIsICJpZCI6ICI5ZWZmMGM3Ni1kOTZkLTQwYjgtYWQwOC1mNDFlMmRiYjBmYTIiLCAiaG9zdCI6ICJnY3AtZXVyb3BlLXdlc3QyIn0.6VnVkAQ5h_fkcDZVDUoU38dzTxaw0xo3DnmKkhECbA8";
+
+const CACHE_TTL_MS = 60_000;
+const DEFAULT_WINDOW_MINUTES = 60;
+
+export type RawHealthRow = {
+    model: string;
+    total_requests: number;
+    status_2xx: number;
+    errors_4xx: number;
+    errors_5xx: number;
+    last_request_at?: string;
+    last_error_at?: string;
+};
+
+type CachedHealthData = {
+    healthMap: Map<string, ModelHealth>;
+    timestamp: number;
+};
+
+let cachedHealth: CachedHealthData | null = null;
+
+export async function fetchModelHealthMap(
+    minutes: number = DEFAULT_WINDOW_MINUTES,
+    fetchFn: typeof fetch = fetch,
+): Promise<Map<string, ModelHealth>> {
+    const now = Date.now();
+    if (cachedHealth && now - cachedHealth.timestamp < CACHE_TTL_MS) {
+        return cachedHealth.healthMap;
+    }
+
+    const healthMap = new Map<string, ModelHealth>();
+
+    try {
+        const url = new URL("/v0/pipes/model_health.json", TINYBIRD_HOST);
+        url.searchParams.set("token", TINYBIRD_PUBLIC_TOKEN);
+        url.searchParams.set("minutes", String(minutes));
+
+        const res = await fetchFn(url.toString());
+        if (res.ok) {
+            const body = (await res.json()) as { data?: RawHealthRow[] };
+            if (Array.isArray(body.data)) {
+                processHealthRows(body.data, minutes, healthMap);
+            }
+        }
+    } catch (err) {
+        log("Failed to fetch model health from Tinybird: %O", err);
+    }
+
+    cachedHealth = { healthMap, timestamp: now };
+    return healthMap;
+}
+
+export function processHealthRows(
+    rows: RawHealthRow[],
+    windowMinutes: number,
+    outMap: Map<string, ModelHealth>,
+): void {
+    // Group rows by model
+    const aggregated = new Map<
+        string,
+        {
+            status_2xx: number;
+            errors_5xx: number;
+            last_request_at: string | null;
+        }
+    >();
+
+    for (const row of rows) {
+        if (!row.model) continue;
+        const existing = aggregated.get(row.model) || {
+            status_2xx: 0,
+            errors_5xx: 0,
+            last_request_at: null,
+        };
+
+        existing.status_2xx += row.status_2xx ?? 0;
+        existing.errors_5xx += row.errors_5xx ?? 0;
+
+        if (row.last_request_at) {
+            if (
+                !existing.last_request_at ||
+                row.last_request_at > existing.last_request_at
+            ) {
+                existing.last_request_at = row.last_request_at;
+            }
+        }
+
+        aggregated.set(row.model, existing);
+    }
+
+    for (const [modelId, stats] of aggregated.entries()) {
+        const sampleCount = stats.status_2xx + stats.errors_5xx;
+        const successRate =
+            sampleCount > 0 ? stats.status_2xx / sampleCount : null;
+
+        outMap.set(modelId, {
+            success_rate:
+                successRate !== null
+                    ? Math.round(successRate * 10000) / 10000
+                    : null,
+            sample_count: sampleCount,
+            window_minutes: windowMinutes,
+            freshness: stats.last_request_at,
+        });
+    }
+}

--- a/gen.pollinations.ai/test/model-health.test.ts
+++ b/gen.pollinations.ai/test/model-health.test.ts
@@ -1,0 +1,64 @@
+import type { ModelHealth } from "@shared/schemas/openai.ts";
+import { describe, expect, it } from "vitest";
+import { processHealthRows } from "../src/utils/model-health.ts";
+
+describe("processHealthRows", () => {
+    it("calculates success_rate excluding 4xx and including fallback_rescues in 2xx", () => {
+        const rows = [
+            {
+                model: "openai/gpt-4o",
+                total_requests: 120,
+                status_2xx: 90, // Includes fallback rescues
+                errors_4xx: 20, // Caller errors (excluded)
+                errors_5xx: 10,
+                last_request_at: "2026-03-31T12:00:00Z",
+            },
+        ];
+
+        const outMap = new Map<string, ModelHealth>();
+        processHealthRows(rows, 60, outMap);
+
+        const health = outMap.get("openai/gpt-4o");
+        expect(health).toBeDefined();
+        // sample_count = 90 + 10 = 100
+        // success_rate = 90 / 100 = 0.9
+        expect(health?.sample_count).toBe(100);
+        expect(health?.success_rate).toBe(0.9);
+        expect(health?.window_minutes).toBe(60);
+        expect(health?.freshness).toBe("2026-03-31T12:00:00Z");
+    });
+
+    it("aggregates multiple rows for the same model across event_types", () => {
+        const rows = [
+            {
+                model: "my-model",
+                total_requests: 10,
+                status_2xx: 8,
+                errors_4xx: 2,
+                errors_5xx: 2,
+                last_request_at: "2026-03-31T11:00:00Z",
+            },
+            {
+                model: "my-model",
+                total_requests: 20,
+                status_2xx: 18,
+                errors_4xx: 5,
+                errors_5xx: 2,
+                last_request_at: "2026-03-31T12:00:00Z",
+            },
+        ];
+
+        const outMap = new Map<string, ModelHealth>();
+        processHealthRows(rows, 60, outMap);
+
+        const health = outMap.get("my-model");
+        expect(health).toBeDefined();
+        // 2xx = 8 + 18 = 26
+        // 5xx = 2 + 2 = 4
+        // sample_count = 30
+        // success_rate = 26/30 ~ 0.8667
+        expect(health?.sample_count).toBe(30);
+        expect(health?.success_rate).toBeCloseTo(0.8667, 3);
+        expect(health?.freshness).toBe("2026-03-31T12:00:00Z");
+    });
+});

--- a/gen.pollinations.ai/test/models-retrieve.test.ts
+++ b/gen.pollinations.ai/test/models-retrieve.test.ts
@@ -152,3 +152,38 @@ test("applies the same 404 rule to aliases of hidden models", async ({
     });
     expect(response.status).toBe(404);
 });
+
+test("returns health metadata on /v1/models and filters by official/reliable params and header", async () => {
+    const listResponse = await fetchWorker("/v1/models");
+    expect(listResponse.status).toBe(200);
+    const listJson = (await listResponse.json()) as {
+        data: Record<string, unknown>[];
+    };
+    expect(Array.isArray(listJson.data)).toBe(true);
+    if (listJson.data.length > 0) {
+        const first = listJson.data[0];
+        expect(first.health).toBeDefined();
+        expect(first.health).toHaveProperty("success_rate");
+        expect(first.health).toHaveProperty("sample_count");
+        expect(first.health).toHaveProperty("window_minutes");
+        expect(first.health).toHaveProperty("freshness");
+    }
+
+    // Filter official=true
+    const officialResponse = await fetchWorker("/v1/models?official=true");
+    expect(officialResponse.status).toBe(200);
+    const officialJson = (await officialResponse.json()) as {
+        data: Record<string, unknown>[];
+    };
+    expect(officialJson.data.every((m) => m.community === false)).toBe(true);
+
+    // Filter via header x-pollinations-model-filter: official
+    const headerResponse = await fetchWorker("/v1/models", {
+        headers: { "x-pollinations-model-filter": "official" },
+    });
+    expect(headerResponse.status).toBe(200);
+    const headerJson = (await headerResponse.json()) as {
+        data: Record<string, unknown>[];
+    };
+    expect(headerJson.data.every((m) => m.community === false)).toBe(true);
+});

--- a/shared/registry/model-info.ts
+++ b/shared/registry/model-info.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { ModelHealthSchema } from "../schemas/health.ts";
 import { SAFETY_FEATURES } from "../schemas/safety.ts";
 import { publicPriceInfo, toFixedPoint } from "./public-pricing";
 import {
@@ -119,6 +120,7 @@ export const ModelInfoSchema = z.object({
     alpha: z.boolean().optional(),
     flat_rate: z.boolean().optional(),
     added_date: z.number().optional(),
+    health: ModelHealthSchema.optional(),
 });
 
 export type ModelInfo = z.infer<typeof ModelInfoSchema>;

--- a/shared/schemas/health.ts
+++ b/shared/schemas/health.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+export const ModelHealthSchema = z
+    .object({
+        success_rate: z.number().min(0).max(1).nullable(),
+        sample_count: z.number().int().nonnegative(),
+        window_minutes: z.number().int().positive(),
+        freshness: z.string().nullable(),
+    })
+    .meta({
+        description: "Minimal health metadata derived from operational metrics",
+    });
+
+export type ModelHealth = z.infer<typeof ModelHealthSchema>;

--- a/shared/schemas/openai.ts
+++ b/shared/schemas/openai.ts
@@ -1,3 +1,6 @@
+import { type ModelHealth, ModelHealthSchema } from "./health.ts";
+export { type ModelHealth, ModelHealthSchema };
+
 // AI generated based on `https://github.com/Portkey-AI/openapi/blob/master/openapi.yaml` and adaped
 
 import { z } from "zod";
@@ -746,6 +749,7 @@ export const OpenAIModelSchema = z
         reasoning: z.boolean().optional(),
         context_length: z.number().optional(),
         per_user_rpm: z.number().positive().nullable().optional(),
+        health: ModelHealthSchema.optional(),
     })
     .meta({
         description: "OpenAI-compatible model object with capability metadata",


### PR DESCRIPTION
## FOR [Quest] filter model catalogs by source and reliability #14535 
- Exposes operational health metadata (`success_rate`, `sample_count`, `window_minutes`, `freshness`) on `/v1/models` and model list endpoints.
- Supports model discovery filtering (`official`, `reliable`, `community`) via query parameters (`?official=true`, `?reliable=true`, `?filter=reliable`) and optional header `x-pollinations-model-filter`.
- Preserves access permissions and generation behavior while adding comprehensive unit and integration tests.

## Files Touched ( 8 files touched with 350 additions and 20 deletions )
- gen.pollinations.ai/src/routes/proxy.ts
- gen.pollinations.ai/src/schemas/models.ts
- gen.pollinations.ai/src/utils/model-health.ts
- gen.pollinations.ai/test/model-health.test.ts
- gen.pollinations.ai/test/models-retrieve.test.ts
- shared/registry/model-info.ts
- shared/schemas/health.ts
- shared/schemas/openai.ts

### THANK YOU POLLINATION AI
@voodoohop Please Review Whenever You Are Free!