### PR TITLE
fix: reduce memory used by inline reference images

### DIFF
--- a/gen.pollinations.ai/src/image/utils/imageDownload.ts
+++ b/gen.pollinations.ai/src/image/utils/imageDownload.ts
@@ -1,7 +1,7 @@
 import { Buffer } from "node:buffer";
 import { UpstreamError } from "@shared/error.ts";
 import { detectImageMimeType } from "@shared/image-mime.ts";
-import { fetchUserImage } from "@/userImage.ts";
+import { fetchUserImage, MAX_IMAGE_SIZE, UserImageError } from "@/userImage.ts";
 
 export function bufferToUint8Array(buffer: Buffer): Uint8Array<ArrayBuffer> {
     return new Uint8Array(buffer);
@@ -135,6 +135,30 @@ export async function downloadImageAsBase64(
  * passing data URIs avoids that.
  */
 export async function toDataUri(url: string): Promise<string> {
+    // Multipart uploads are already canonical data URIs. Validate without
+    // allocating another full decoded image and then encoding it again.
+    const inline = /^data:([^;,\s]+);base64,([A-Za-z0-9+/]*={0,2})$/.exec(url);
+    if (inline && inline[0] === url && inline[2].length % 4 === 0) {
+        const [, mimeType, base64] = inline;
+        const tail = base64.slice(-4);
+        // Check padding bits too; other accepted encodings still normalize
+        // through the existing decoder below.
+        if (mimeType === mimeType.toLowerCase() && btoa(atob(tail)) === tail) {
+            const padding = base64.endsWith("==")
+                ? 2
+                : base64.endsWith("=")
+                  ? 1
+                  : 0;
+            const size = (base64.length / 4) * 3 - padding;
+            if (size > MAX_IMAGE_SIZE) {
+                throw new UserImageError(
+                    `Image too large: ${size} bytes (max ${MAX_IMAGE_SIZE} bytes remaining). Please use a smaller image.`,
+                    "image_too_large",
+                );
+            }
+            return url;
+        }
+    }
     const { buffer, mimeType } = await downloadUserImage(url);
     return `data:${mimeType};base64,${buffer.toString("base64")}`;
 }

--- a/gen.pollinations.ai/test/generation-coordinator.test.ts
+++ b/gen.pollinations.ai/test/generation-coordinator.test.ts
@@ -51,209 +51,205 @@ afterEach(() => {
 });
 
 describe("GenerationCoordinator", () => {
-    it.each(["url", "b64_json"] as const)(
-        "completes large Seedream uploads once through the real coordinator (%s)",
-        async (responseFormat) => {
-            const { key, userId } = await createTestApiKey({
-                user: { packBalance: 100 },
-            });
-            env.REPLICATE_API_TOKEN = "not-a-secret-workers-test-only";
-            const tinybird = createMockTinybird();
-            let executions = 0;
-            let requestBytes = 0;
-            let release!: () => void;
-            const providerWaiting = new Promise<void>((resolve) => {
-                release = resolve;
-            });
-            let started!: () => void;
-            const providerStarted = new Promise<void>((resolve) => {
-                started = resolve;
-            });
-            const output = new Uint8Array(6 * 1024 * 1024);
-            output.set(
-                Buffer.from(
-                    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lPFCAAAAAABJRU5ErkJggg==",
-                    "base64",
-                ),
-            );
-            vi.spyOn(globalThis, "fetch").mockImplementation(
-                async (input, init) => {
-                    const url = new URL(
-                        input instanceof Request ? input.url : String(input),
+    it.each([
+        "url",
+        "b64_json",
+    ] as const)("completes large Seedream uploads once through the real coordinator (%s)", async (responseFormat) => {
+        const { key, userId } = await createTestApiKey({
+            user: { packBalance: 100 },
+        });
+        env.REPLICATE_API_TOKEN = "not-a-secret-workers-test-only";
+        const tinybird = createMockTinybird();
+        let executions = 0;
+        let requestBytes = 0;
+        let release!: () => void;
+        const providerWaiting = new Promise<void>((resolve) => {
+            release = resolve;
+        });
+        let started!: () => void;
+        const providerStarted = new Promise<void>((resolve) => {
+            started = resolve;
+        });
+        const output = new Uint8Array(6 * 1024 * 1024);
+        output.set(
+            Buffer.from(
+                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lPFCAAAAAABJRU5ErkJggg==",
+                "base64",
+            ),
+        );
+        vi.spyOn(globalThis, "fetch").mockImplementation(
+            async (input, init) => {
+                const url = new URL(
+                    input instanceof Request ? input.url : String(input),
+                );
+                if (url.host === "api.replicate.com") {
+                    expect(url.pathname).toBe(
+                        "/v1/models/bytedance/seedream-4/predictions",
                     );
-                    if (url.host === "api.replicate.com") {
-                        expect(url.pathname).toBe(
-                            "/v1/models/bytedance/seedream-4/predictions",
-                        );
-                        expect(init?.method).toBe("POST");
-                        executions++;
-                        requestBytes = String(init?.body ?? "").length;
-                        started();
-                        await providerWaiting;
-                        return Response.json(
-                            {
-                                id: "large-seedream-test",
-                                status: "succeeded",
-                                output: [
-                                    "https://replicate.delivery/large-seedream.png",
-                                ],
-                            },
-                            { status: 201 },
-                        );
-                    }
-                    if (url.host === "replicate.delivery") {
-                        return new Response(output, {
-                            headers: { "content-type": "image/png" },
-                        });
-                    }
-                    if (url.pathname === "/v0/pipes/public_model_stats.json") {
-                        return Response.json({ data: [] });
-                    }
-                    const handler = tinybird.handlerMap[url.host];
-                    if (handler) return handler(new Request(input, init));
-                    throw new Error(
-                        `Unexpected outbound request: ${url.host}${url.pathname}`,
-                    );
-                },
-            );
-            const prompt = `large reference coordinator test ${crypto.randomUUID()}`;
-            const request = () => {
-                const form = new FormData();
-                form.set("model", "bytedance/seedream-4.0");
-                form.set("prompt", prompt);
-                form.set("safe", "false");
-                form.set("size", "1920x1080");
-                form.set("response_format", responseFormat);
-                for (const size of [9_992_143, 12_285_506]) {
-                    const bytes = new Uint8Array(size);
-                    bytes.set(output.subarray(0, 8));
-                    form.append(
-                        "image",
-                        new Blob([bytes], { type: "image/png" }),
-                        "input.png",
+                    expect(init?.method).toBe("POST");
+                    executions++;
+                    requestBytes = String(init?.body ?? "").length;
+                    started();
+                    await providerWaiting;
+                    return Response.json(
+                        {
+                            id: "large-seedream-test",
+                            status: "succeeded",
+                            output: [
+                                "https://replicate.delivery/large-seedream.png",
+                            ],
+                        },
+                        { status: 201 },
                     );
                 }
-                return new Request(
-                    "https://gen.pollinations.ai/v1/images/edits",
-                    {
-                        method: "POST",
-                        headers: { authorization: `Bearer ${key}` },
-                        body: form,
-                    },
+                if (url.host === "replicate.delivery") {
+                    return new Response(output, {
+                        headers: { "content-type": "image/png" },
+                    });
+                }
+                if (url.pathname === "/v0/pipes/public_model_stats.json") {
+                    return Response.json({ data: [] });
+                }
+                const handler = tinybird.handlerMap[url.host];
+                if (handler) return handler(new Request(input, init));
+                throw new Error(
+                    `Unexpected outbound request: ${url.host}${url.pathname}`,
                 );
-            };
-            const before = await getUserBalance(drizzle(env.DB), userId);
-            const abort = new AbortController();
-            const first = SELF.fetch(
-                new Request(request(), { signal: abort.signal }),
-            );
-            await Promise.race([
-                providerStarted,
-                first.then(async (response) => {
-                    if (executions === 0)
-                        throw new Error(
-                            `Owner returned before provider: ${response.status} ${await response.text()}`,
-                        );
-                }),
-            ]);
-            const ids = await listDurableObjectIds(env.GENERATION_COORDINATOR);
-            expect(ids).toHaveLength(1);
-            const stub = env.GENERATION_COORDINATOR.get(ids[0]);
-            const stored = await runInDurableObject(
-                stub,
-                async (_coordinator, state) =>
-                    state.storage.get<{
-                        bodyChunks: number;
-                        started: boolean;
-                        cache: GenerationJob["cache"];
-                    }>("job"),
-            );
-            if (!stored) throw new Error("Generation job was not persisted");
-            expect(stored.started).toBe(true);
-            expect(stored.bodyChunks).toBeGreaterThan(29);
-            let disconnectError: Error | undefined;
-            const firstSettled = first.catch((error: Error) => {
-                disconnectError = error;
-            });
-            abort.abort();
-            await vi.waitFor(
-                () => expect(disconnectError?.name).toBe("AbortError"),
-                { timeout: 3000 },
-            );
-            const secondContext = createExecutionContext();
-            const second = worker.fetch(request(), env, secondContext);
-            try {
-                await vi.waitFor(
-                    async () =>
-                        expect(
-                            await runInDurableObject(
-                                stub,
-                                (coordinator) =>
-                                    Reflect.get(coordinator, "waiters").size,
-                            ),
-                        ).toBe(2),
-                    { timeout: 5000 },
+            },
+        );
+        const prompt = `large reference coordinator test ${crypto.randomUUID()}`;
+        const request = () => {
+            const form = new FormData();
+            form.set("model", "bytedance/seedream-4.0");
+            form.set("prompt", prompt);
+            form.set("safe", "false");
+            form.set("size", "1920x1080");
+            form.set("response_format", responseFormat);
+            for (const size of [9_992_143, 12_285_506]) {
+                const bytes = new Uint8Array(size);
+                bytes.set(output.subarray(0, 8));
+                form.append(
+                    "image",
+                    new Blob([bytes], { type: "image/png" }),
+                    "input.png",
                 );
-            } finally {
-                release();
             }
-            const response = await second;
-            expect(
-                response.status,
-                response.status === 200 ? "" : await response.text(),
-            ).toBe(200);
-            const result = (
-                await response.json<{
-                    data: { url?: string; b64_json?: string }[];
-                }>()
-            ).data[0];
-            if (responseFormat === "url")
-                expect(result.url).toContain("media.pollinations.ai/");
-            else
-                expect(result.b64_json?.length).toBe(
-                    Math.ceil(output.length / 3) * 4,
-                );
-            await Promise.all([
-                firstSettled,
-                waitOnExecutionContext(secondContext),
-            ]);
-            const cacheContext = createExecutionContext();
-            const cached = await worker.fetch(request(), env, cacheContext);
-            expect(cached.status).toBe(200);
-            expect(cached.headers.get("x-cache")).toBe("HIT");
-            await cached.text();
-            await waitOnExecutionContext(cacheContext);
-            const billed = tinybird.state.events.filter(
-                (event) => event.isBilledUsage,
+            return new Request("https://gen.pollinations.ai/v1/images/edits", {
+                method: "POST",
+                headers: { authorization: `Bearer ${key}` },
+                body: form,
+            });
+        };
+        const before = await getUserBalance(drizzle(env.DB), userId);
+        const abort = new AbortController();
+        const first = SELF.fetch(
+            new Request(request(), { signal: abort.signal }),
+        );
+        await Promise.race([
+            providerStarted,
+            first.then(async (response) => {
+                if (executions === 0)
+                    throw new Error(
+                        `Owner returned before provider: ${response.status} ${await response.text()}`,
+                    );
+            }),
+        ]);
+        const ids = await listDurableObjectIds(env.GENERATION_COORDINATOR);
+        expect(ids).toHaveLength(1);
+        const stub = env.GENERATION_COORDINATOR.get(ids[0]);
+        const stored = await runInDurableObject(
+            stub,
+            async (_coordinator, state) =>
+                state.storage.get<{
+                    bodyChunks: number;
+                    started: boolean;
+                    cache: GenerationJob["cache"];
+                }>("job"),
+        );
+        if (!stored) throw new Error("Generation job was not persisted");
+        expect(stored.started).toBe(true);
+        expect(stored.bodyChunks).toBeGreaterThan(29);
+        let disconnectError: Error | undefined;
+        const firstSettled = first.catch((error: Error) => {
+            disconnectError = error;
+        });
+        abort.abort();
+        await vi.waitFor(
+            () => expect(disconnectError?.name).toBe("AbortError"),
+            { timeout: 3000 },
+        );
+        const secondContext = createExecutionContext();
+        const second = worker.fetch(request(), env, secondContext);
+        try {
+            await vi.waitFor(
+                async () =>
+                    expect(
+                        await runInDurableObject(
+                            stub,
+                            (coordinator) =>
+                                Reflect.get(coordinator, "waiters").size,
+                        ),
+                    ).toBe(2),
+                { timeout: 5000 },
             );
-            expect(executions).toBe(1);
-            expect(requestBytes).toBeGreaterThan(29_700_000);
-            expect(billed).toHaveLength(1);
-            expect(billed[0].totalPrice).toBeGreaterThan(0);
-            const after = await getUserBalance(drizzle(env.DB), userId);
-            expect(before.packBalance - after.packBalance).toBeCloseTo(
-                billed[0].totalPrice,
-                8,
+        } finally {
+            release();
+        }
+        const response = await second;
+        expect(
+            response.status,
+            response.status === 200 ? "" : await response.text(),
+        ).toBe(200);
+        const result = (
+            await response.json<{
+                data: { url?: string; b64_json?: string }[];
+            }>()
+        ).data[0];
+        if (responseFormat === "url")
+            expect(result.url).toContain("media.pollinations.ai/");
+        else
+            expect(result.b64_json?.length).toBe(
+                Math.ceil(output.length / 3) * 4,
             );
-            expect(after.tierBalance).toBe(before.tierBalance);
-            const file = await env.MEDIA.get(stored.cache.key);
-            expect(file?.status).toBe(200);
-            if (!file) throw new Error("Generated file was not cached");
-            const bytes = await file.arrayBuffer();
-            expect(bytes.byteLength).toBe(output.length);
-            expect(await crypto.subtle.digest("SHA-256", bytes)).toEqual(
-                await crypto.subtle.digest("SHA-256", output),
-            );
-            const remaining = await runInDurableObject(
-                stub,
-                async (_coordinator, state) => [
-                    ...(await state.storage.list()).keys(),
-                ],
-            );
-            expect(remaining).toEqual([]);
-        },
-        60_000,
-    );
+        await Promise.all([
+            firstSettled,
+            waitOnExecutionContext(secondContext),
+        ]);
+        const cacheContext = createExecutionContext();
+        const cached = await worker.fetch(request(), env, cacheContext);
+        expect(cached.status).toBe(200);
+        expect(cached.headers.get("x-cache")).toBe("HIT");
+        await cached.text();
+        await waitOnExecutionContext(cacheContext);
+        const billed = tinybird.state.events.filter(
+            (event) => event.isBilledUsage,
+        );
+        expect(executions).toBe(1);
+        expect(requestBytes).toBeGreaterThan(29_700_000);
+        expect(billed).toHaveLength(1);
+        expect(billed[0].totalPrice).toBeGreaterThan(0);
+        const after = await getUserBalance(drizzle(env.DB), userId);
+        expect(before.packBalance - after.packBalance).toBeCloseTo(
+            billed[0].totalPrice,
+            8,
+        );
+        expect(after.tierBalance).toBe(before.tierBalance);
+        const file = await env.MEDIA.get(stored.cache.key);
+        expect(file?.status).toBe(200);
+        if (!file) throw new Error("Generated file was not cached");
+        const bytes = await file.arrayBuffer();
+        expect(bytes.byteLength).toBe(output.length);
+        expect(await crypto.subtle.digest("SHA-256", bytes)).toEqual(
+            await crypto.subtle.digest("SHA-256", output),
+        );
+        const remaining = await runInDurableObject(
+            stub,
+            async (_coordinator, state) => [
+                ...(await state.storage.list()).keys(),
+            ],
+        );
+        expect(remaining).toEqual([]);
+    }, 60_000);
     it("finds completed media through the real storage RPC service", async () => {
         const key = "d".repeat(64);
         await env.MEDIA.put(

--- a/gen.pollinations.ai/test/generation-coordinator.test.ts
+++ b/gen.pollinations.ai/test/generation-coordinator.test.ts
@@ -1,7 +1,18 @@
-import { runInDurableObject } from "cloudflare:test";
+import {
+    createExecutionContext,
+    listDurableObjectIds,
+    runInDurableObject,
+    SELF,
+    waitOnExecutionContext,
+} from "cloudflare:test";
 import { env } from "cloudflare:workers";
+import { getUserBalance } from "@shared/billing/balance.ts";
+import { createTestApiKey } from "@shared/test/fixtures/index.ts";
+import { createMockTinybird } from "@shared/test/mocks/tinybird.ts";
+import { drizzle } from "drizzle-orm/d1";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GenerationJob } from "@/middleware/generation-deduplication.ts";
+import worker from "../src/index.ts";
 
 function testJob(key: string, body?: string): GenerationJob {
     return {
@@ -40,6 +51,209 @@ afterEach(() => {
 });
 
 describe("GenerationCoordinator", () => {
+    it.each(["url", "b64_json"] as const)(
+        "completes large Seedream uploads once through the real coordinator (%s)",
+        async (responseFormat) => {
+            const { key, userId } = await createTestApiKey({
+                user: { packBalance: 100 },
+            });
+            env.REPLICATE_API_TOKEN = "not-a-secret-workers-test-only";
+            const tinybird = createMockTinybird();
+            let executions = 0;
+            let requestBytes = 0;
+            let release!: () => void;
+            const providerWaiting = new Promise<void>((resolve) => {
+                release = resolve;
+            });
+            let started!: () => void;
+            const providerStarted = new Promise<void>((resolve) => {
+                started = resolve;
+            });
+            const output = new Uint8Array(6 * 1024 * 1024);
+            output.set(
+                Buffer.from(
+                    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lPFCAAAAAABJRU5ErkJggg==",
+                    "base64",
+                ),
+            );
+            vi.spyOn(globalThis, "fetch").mockImplementation(
+                async (input, init) => {
+                    const url = new URL(
+                        input instanceof Request ? input.url : String(input),
+                    );
+                    if (url.host === "api.replicate.com") {
+                        expect(url.pathname).toBe(
+                            "/v1/models/bytedance/seedream-4/predictions",
+                        );
+                        expect(init?.method).toBe("POST");
+                        executions++;
+                        requestBytes = String(init?.body ?? "").length;
+                        started();
+                        await providerWaiting;
+                        return Response.json(
+                            {
+                                id: "large-seedream-test",
+                                status: "succeeded",
+                                output: [
+                                    "https://replicate.delivery/large-seedream.png",
+                                ],
+                            },
+                            { status: 201 },
+                        );
+                    }
+                    if (url.host === "replicate.delivery") {
+                        return new Response(output, {
+                            headers: { "content-type": "image/png" },
+                        });
+                    }
+                    if (url.pathname === "/v0/pipes/public_model_stats.json") {
+                        return Response.json({ data: [] });
+                    }
+                    const handler = tinybird.handlerMap[url.host];
+                    if (handler) return handler(new Request(input, init));
+                    throw new Error(
+                        `Unexpected outbound request: ${url.host}${url.pathname}`,
+                    );
+                },
+            );
+            const prompt = `large reference coordinator test ${crypto.randomUUID()}`;
+            const request = () => {
+                const form = new FormData();
+                form.set("model", "bytedance/seedream-4.0");
+                form.set("prompt", prompt);
+                form.set("safe", "false");
+                form.set("size", "1920x1080");
+                form.set("response_format", responseFormat);
+                for (const size of [9_992_143, 12_285_506]) {
+                    const bytes = new Uint8Array(size);
+                    bytes.set(output.subarray(0, 8));
+                    form.append(
+                        "image",
+                        new Blob([bytes], { type: "image/png" }),
+                        "input.png",
+                    );
+                }
+                return new Request(
+                    "https://gen.pollinations.ai/v1/images/edits",
+                    {
+                        method: "POST",
+                        headers: { authorization: `Bearer ${key}` },
+                        body: form,
+                    },
+                );
+            };
+            const before = await getUserBalance(drizzle(env.DB), userId);
+            const abort = new AbortController();
+            const first = SELF.fetch(
+                new Request(request(), { signal: abort.signal }),
+            );
+            await Promise.race([
+                providerStarted,
+                first.then(async (response) => {
+                    if (executions === 0)
+                        throw new Error(
+                            `Owner returned before provider: ${response.status} ${await response.text()}`,
+                        );
+                }),
+            ]);
+            const ids = await listDurableObjectIds(env.GENERATION_COORDINATOR);
+            expect(ids).toHaveLength(1);
+            const stub = env.GENERATION_COORDINATOR.get(ids[0]);
+            const stored = await runInDurableObject(
+                stub,
+                async (_coordinator, state) =>
+                    state.storage.get<{
+                        bodyChunks: number;
+                        started: boolean;
+                        cache: GenerationJob["cache"];
+                    }>("job"),
+            );
+            if (!stored) throw new Error("Generation job was not persisted");
+            expect(stored.started).toBe(true);
+            expect(stored.bodyChunks).toBeGreaterThan(29);
+            let disconnectError: Error | undefined;
+            const firstSettled = first.catch((error: Error) => {
+                disconnectError = error;
+            });
+            abort.abort();
+            await vi.waitFor(
+                () => expect(disconnectError?.name).toBe("AbortError"),
+                { timeout: 3000 },
+            );
+            const secondContext = createExecutionContext();
+            const second = worker.fetch(request(), env, secondContext);
+            try {
+                await vi.waitFor(
+                    async () =>
+                        expect(
+                            await runInDurableObject(
+                                stub,
+                                (coordinator) =>
+                                    Reflect.get(coordinator, "waiters").size,
+                            ),
+                        ).toBe(2),
+                    { timeout: 5000 },
+                );
+            } finally {
+                release();
+            }
+            const response = await second;
+            expect(
+                response.status,
+                response.status === 200 ? "" : await response.text(),
+            ).toBe(200);
+            const result = (
+                await response.json<{
+                    data: { url?: string; b64_json?: string }[];
+                }>()
+            ).data[0];
+            if (responseFormat === "url")
+                expect(result.url).toContain("media.pollinations.ai/");
+            else
+                expect(result.b64_json?.length).toBe(
+                    Math.ceil(output.length / 3) * 4,
+                );
+            await Promise.all([
+                firstSettled,
+                waitOnExecutionContext(secondContext),
+            ]);
+            const cacheContext = createExecutionContext();
+            const cached = await worker.fetch(request(), env, cacheContext);
+            expect(cached.status).toBe(200);
+            expect(cached.headers.get("x-cache")).toBe("HIT");
+            await cached.text();
+            await waitOnExecutionContext(cacheContext);
+            const billed = tinybird.state.events.filter(
+                (event) => event.isBilledUsage,
+            );
+            expect(executions).toBe(1);
+            expect(requestBytes).toBeGreaterThan(29_700_000);
+            expect(billed).toHaveLength(1);
+            expect(billed[0].totalPrice).toBeGreaterThan(0);
+            const after = await getUserBalance(drizzle(env.DB), userId);
+            expect(before.packBalance - after.packBalance).toBeCloseTo(
+                billed[0].totalPrice,
+                8,
+            );
+            expect(after.tierBalance).toBe(before.tierBalance);
+            const file = await env.MEDIA.get(stored.cache.key);
+            expect(file?.status).toBe(200);
+            if (!file) throw new Error("Generated file was not cached");
+            const bytes = await file.arrayBuffer();
+            expect(bytes.byteLength).toBe(output.length);
+            expect(await crypto.subtle.digest("SHA-256", bytes)).toEqual(
+                await crypto.subtle.digest("SHA-256", output),
+            );
+            const remaining = await runInDurableObject(
+                stub,
+                async (_coordinator, state) => [
+                    ...(await state.storage.list()).keys(),
+                ],
+            );
+            expect(remaining).toEqual([]);
+        },
+        60_000,
+    );
     it("finds completed media through the real storage RPC service", async () => {
         const key = "d".repeat(64);
         await env.MEDIA.put(

--- a/gen.pollinations.ai/test/image/imageDownload.test.ts
+++ b/gen.pollinations.ai/test/image/imageDownload.test.ts
@@ -3,7 +3,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
     downloadUserImage,
     readImageDimensions,
+    toDataUri,
 } from "../../src/image/utils/imageDownload.ts";
+import { MAX_IMAGE_SIZE } from "../../src/userImage.ts";
 
 afterEach(() => {
     vi.restoreAllMocks();
@@ -188,6 +190,88 @@ describe("downloadUserImage", () => {
             status: 400,
             errorCode: "unsupported_image_media_type",
         });
+    });
+});
+
+describe("toDataUri", () => {
+    it.each([
+        "data:image/png;base64,iVBORw0KGgo=",
+        "data:image/heic;base64,AA==",
+        "data:text/html;base64,YWJj",
+        "data:image/png;base64,",
+        "data:IMAGE/PNG;base64,iVBORw0KGgo=",
+        "data:image/png;BASE64,iVBORw0KGgo=",
+        "data:image/png;base64, iVBORw0K\nGgo ",
+        "data:image/png;base64,Zh==",
+        "data:image/png;base64,YWJj\n",
+        "data:;base64,iVBORw0KGgo=",
+    ])("preserves decoded bytes and MIME normalization for %s", async (uri) => {
+        const { buffer, mimeType } = await downloadUserImage(uri);
+        expect(await toDataUri(uri)).toBe(
+            `data:${mimeType};base64,${buffer.toString("base64")}`,
+        );
+    });
+
+    it.each([
+        "data:image/png,abc",
+        "data:image/png;base64,A===",
+        "data:image/png;base64,A",
+        "data:image/png;base64,AA=A",
+        "data:image/png;base64,AA-_",
+        "data:image/png;base64,!!!!",
+    ])("keeps invalid base64 a caller error: %s", async (uri) => {
+        await expect(toDataUri(uri)).rejects.toMatchObject({
+            status: 400,
+            errorCode: "invalid_image_url",
+        });
+    });
+
+    it("keeps untyped unrecognisable data a caller error", async () => {
+        await expect(toDataUri("data:;base64,YWJj")).rejects.toMatchObject({
+            status: 400,
+            errorCode: "unsupported_image_media_type",
+        });
+    });
+
+    it("reuses two large uploaded images without decoding their full payloads", async () => {
+        const inputs = [9_992_143, 12_285_506].map((size) => {
+            const bytes = Buffer.alloc(size);
+            bytes.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+            return `data:image/png;base64,${bytes.toString("base64")}`;
+        });
+        const decode = vi.spyOn(globalThis, "atob");
+        const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+        const output = await Promise.all(inputs.map(toDataUri));
+
+        expect(output).toEqual(inputs);
+        expect(decode.mock.calls.every(([input]) => input.length <= 4)).toBe(
+            true,
+        );
+        expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("keeps the per-image size limit without decoding an oversized upload", async () => {
+        const uri = `data:image/png;base64,${Buffer.alloc(MAX_IMAGE_SIZE + 1).toString("base64")}`;
+        const decode = vi.spyOn(globalThis, "atob");
+        await expect(toDataUri(uri)).rejects.toMatchObject({
+            status: 400,
+            errorCode: "image_too_large",
+        });
+        expect(decode.mock.calls.every(([input]) => input.length <= 4)).toBe(
+            true,
+        );
+    });
+
+    it("still downloads remote images", async () => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+            new Response(new Uint8Array([1, 2, 3]), {
+                headers: { "content-type": "image/png" },
+            }),
+        );
+        expect(await toDataUri("https://example.com/input.png")).toBe(
+            "data:image/png;base64,AQID",
+        );
     });
 });
 

--- a/gen.pollinations.ai/test/openai-image-cache.test.ts
+++ b/gen.pollinations.ai/test/openai-image-cache.test.ts
@@ -10,7 +10,6 @@ import { createTestR2Bucket } from "@shared/test/mocks/r2.ts";
 import { Hono } from "hono";
 import { describe, expect, it } from "vitest";
 import type { Env } from "@/env.ts";
-import { toDataUri } from "@/image/utils/imageDownload.ts";
 import { prepareGenerationRequest } from "@/middleware/generation-cache.ts";
 import { imageCache } from "@/middleware/media-cache.ts";
 import { generateCacheKey } from "@/utils/media-cache.ts";
@@ -31,57 +30,6 @@ const testLog = {
 } as unknown as Logger;
 
 describe("OpenAI image cache", () => {
-    it("prepares two large multipart uploads for inline providers", async () => {
-        const sizes = [9_992_143, 12_285_506];
-        const form = new FormData();
-        form.set("prompt", "edit");
-        form.set("safe", "false");
-        for (const size of sizes) {
-            const bytes = new Uint8Array(size);
-            bytes.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
-            form.append(
-                "image",
-                new Blob([bytes], { type: "image/png" }),
-                "input.png",
-            );
-        }
-        const app = new Hono<Env>()
-            .use("*", async (c, next) => {
-                c.set("model", {
-                    requested: "bytedance/seedream-4.0",
-                    resolved: "bytedance/seedream-4.0",
-                    definition: {} as Env["Variables"]["model"]["definition"],
-                });
-                await next();
-            })
-            .post("/v1/images/edits", prepareOpenAIImageEdit, async (c) => {
-                const input = c.req.valid("json" as never) as {
-                    image: string[];
-                };
-                const images = await Promise.all(input.image.map(toDataUri));
-                return c.json(
-                    images.map((image, index) => ({
-                        unchanged: image === input.image[index],
-                        length: image.length,
-                    })),
-                );
-            });
-        const response = await app.fetch(
-            new Request("https://gen.pollinations.ai/v1/images/edits", {
-                method: "POST",
-                body: form,
-            }),
-            {} as CloudflareBindings,
-        );
-        expect(response.status).toBe(200);
-        expect(await response.json()).toEqual(
-            sizes.map((size) => ({
-                unchanged: true,
-                length:
-                    "data:image/png;base64,".length + Math.ceil(size / 3) * 4,
-            })),
-        );
-    });
     it.each([
         "json",
         "multipart",

--- a/gen.pollinations.ai/test/openai-image-cache.test.ts
+++ b/gen.pollinations.ai/test/openai-image-cache.test.ts
@@ -10,6 +10,7 @@ import { createTestR2Bucket } from "@shared/test/mocks/r2.ts";
 import { Hono } from "hono";
 import { describe, expect, it } from "vitest";
 import type { Env } from "@/env.ts";
+import { toDataUri } from "@/image/utils/imageDownload.ts";
 import { prepareGenerationRequest } from "@/middleware/generation-cache.ts";
 import { imageCache } from "@/middleware/media-cache.ts";
 import { generateCacheKey } from "@/utils/media-cache.ts";
@@ -30,6 +31,57 @@ const testLog = {
 } as unknown as Logger;
 
 describe("OpenAI image cache", () => {
+    it("prepares two large multipart uploads for inline providers", async () => {
+        const sizes = [9_992_143, 12_285_506];
+        const form = new FormData();
+        form.set("prompt", "edit");
+        form.set("safe", "false");
+        for (const size of sizes) {
+            const bytes = new Uint8Array(size);
+            bytes.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+            form.append(
+                "image",
+                new Blob([bytes], { type: "image/png" }),
+                "input.png",
+            );
+        }
+        const app = new Hono<Env>()
+            .use("*", async (c, next) => {
+                c.set("model", {
+                    requested: "bytedance/seedream-4.0",
+                    resolved: "bytedance/seedream-4.0",
+                    definition: {} as Env["Variables"]["model"]["definition"],
+                });
+                await next();
+            })
+            .post("/v1/images/edits", prepareOpenAIImageEdit, async (c) => {
+                const input = c.req.valid("json" as never) as {
+                    image: string[];
+                };
+                const images = await Promise.all(input.image.map(toDataUri));
+                return c.json(
+                    images.map((image, index) => ({
+                        unchanged: image === input.image[index],
+                        length: image.length,
+                    })),
+                );
+            });
+        const response = await app.fetch(
+            new Request("https://gen.pollinations.ai/v1/images/edits", {
+                method: "POST",
+                body: form,
+            }),
+            {} as CloudflareBindings,
+        );
+        expect(response.status).toBe(200);
+        expect(await response.json()).toEqual(
+            sizes.map((size) => ({
+                unchanged: true,
+                length:
+                    "data:image/png;base64,".length + Math.ceil(size / 3) * 4,
+            })),
+        );
+    });
     it.each([
         "json",
         "multipart",


### PR DESCRIPTION
- Reuses already-valid base64 reference images instead of decoding and encoding them again; helps Seedream uploads that exhausted coordinator memory.
- Preserves existing image limits, validation, MIME normalization, provider payloads, prices, and retry behavior.
- Tests 22 MB uploads through the real local coordinator: abort/rejoin, URL/base64 responses, one provider call, one debit/event, and matching cached output.
- Verification: 86 focused tests, typecheck, staging build, and 11,440 old/new behavior comparisons. Local helper benchmark reduced peak process memory by about 45 MiB.
- Production memory recovery is not yet proven: the local full-path test passes with the old helper too. No deployment or real AI generations performed.