### PR TITLE
fix: link staging models to staging OpenWebUI

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/open-webui-link.tsx
+++ b/enter.pollinations.ai/frontend/src/components/models/open-webui-link.tsx
@@ -1,6 +1,9 @@
 import { ExternalLinkIcon, Tooltip } from "@pollinations/ui";
 
-export const OPEN_WEBUI_URL = "https://openwebui.pollinations.ai";
+export const OPEN_WEBUI_URL =
+    import.meta.env.MODE === "staging"
+        ? "https://openwebui-staging.elliot-b6e.workers.dev"
+        : "https://openwebui.pollinations.ai";
 
 /**
  * Open WebUI signs in with Pollinations OAuth and fetches its model list with


### PR DESCRIPTION
- Opens staging model test links in the staging OpenWebUI deployment.
- Keeps development and production links on the production deployment.
- Split from #14622.