### PR TITLE
feat: add tgpt Pollinations harness

### DIFF
--- a/CODING_HARNESSES.md
+++ b/CODING_HARNESSES.md
@@ -53,7 +53,7 @@ tgpt "Hello"
 
 tgpt already includes a Pollinations provider. `on` selects it for text generation and writes a dedicated key and model to `~/.config/tgpt/config.conf`, making tgpt use the authenticated `gen.pollinations.ai` endpoint. Choose another model with `--model <id>`; `off` restores the previous file or removes only the Pollinations values if the file changed later.
 
-The default model is `openai/gpt-5.4-nano`. Polli writes tgpt's `AI_API_KEY` setting because it takes precedence over provider-specific keys. Exported environment variables, a local `config.conf`, or `--config` can override this user-level setup. `off` does not revoke the account key.
+The default model is `openai/gpt-5.4-nano`. Polli clears any generic `AI_API_KEY` from this file so it cannot override the dedicated `POLLINATIONS_API_KEY`; the original file is backed up. Exported environment variables, a local `config.conf`, or `--config` can override this user-level setup. `off` does not revoke the account key.
 
 ## DeepSeek Harness
 

--- a/CODING_HARNESSES.md
+++ b/CODING_HARNESSES.md
@@ -2,7 +2,7 @@
 
 Use `polli harness` to connect a supported coding harness to Pollinations. It handles Polli login, a dedicated API key, model setup, and any Pollinations capabilities supported by that harness.
 
-> **Available now:** Bloom CLI, DeepSeek Harness, OpenCode, OpenClaw, Pi, and Prime Agent are integrated `polli harness` profiles.
+> **Available now:** Bloom CLI, DeepSeek Harness, OpenCode, OpenClaw, Pi, Prime Agent, and tgpt are integrated `polli harness` profiles.
 
 ## Use a harness
 
@@ -31,6 +31,7 @@ If a harness cannot be launched, `on` stops before login, key creation, or confi
 | [OpenClaw](https://github.com/openclaw/openclaw) | **Available now** — `polli harness openclaw on` | Adds the Pollinations provider, a dedicated key, and the Polli skill, pulling models from the live catalog. Defaults to `kimi`. |
 | [Pi](https://github.com/earendil-works/pi) | **Available now** — `polli harness pi on` | Uses Pi's native provider support and the Polli skill. Pi intentionally has no built-in MCP support. Defaults to `deepseek`. |
 | [Prime Agent](https://github.com/PrimeIntellect-ai/prime-agent) | **Available now** — `polli harness prime on` | Uses native provider support and the Polli skill while preserving memories, sessions, and unrelated configuration. |
+| [tgpt](https://github.com/aandrew-me/tgpt) | **Available now** — `polli harness tgpt on` | Configures tgpt's existing Pollinations provider with a dedicated key and authenticated text model. |
 
 ## Bloom CLI
 
@@ -41,6 +42,16 @@ bloom
 ```
 
 Bloom already uses Pollinations for its models. `on` creates a dedicated key and stores it in `~/.bloom/.env` (or `$BLOOM_HOME/.env`); `off` restores the previous file or removes only that key if the file changed later.
+
+## tgpt
+
+```bash
+brew install tgpt # or use another official installation method
+polli harness tgpt on
+tgpt "Hello"
+```
+
+tgpt already includes a Pollinations provider. `on` selects it for text generation and writes a dedicated key and model to `~/.config/tgpt/config.conf`, making tgpt use the authenticated `gen.pollinations.ai` endpoint. Choose another model with `--model <id>`; `off` restores the previous file or removes only the Pollinations values if the file changed later.
 
 ## DeepSeek Harness
 

--- a/CODING_HARNESSES.md
+++ b/CODING_HARNESSES.md
@@ -53,6 +53,8 @@ tgpt "Hello"
 
 tgpt already includes a Pollinations provider. `on` selects it for text generation and writes a dedicated key and model to `~/.config/tgpt/config.conf`, making tgpt use the authenticated `gen.pollinations.ai` endpoint. Choose another model with `--model <id>`; `off` restores the previous file or removes only the Pollinations values if the file changed later.
 
+The default model is `openai/gpt-5.4-nano`. Polli writes tgpt's `AI_API_KEY` setting because it takes precedence over provider-specific keys. Exported environment variables, a local `config.conf`, or `--config` can override this user-level setup. `off` does not revoke the account key.
+
 ## DeepSeek Harness
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ See [Publish an Agent](./BUILD_YOUR_OWN_AGENT.md) for setup and billing behavior
 
 ## 🛠️ Coding Harnesses
 
-Run agentic coding tools such as Bloom CLI, DeepSeek Harness, OpenCode, Pi, and Prime Agent on Pollinations models. `polli harness` edits the harness's own config so it calls `gen.pollinations.ai/v1` with a dedicated key, and restores it on `off`.
+Run tools such as Bloom CLI, DeepSeek Harness, OpenCode, Pi, Prime Agent, and tgpt on Pollinations models. `polli harness` edits the tool's own config so it calls Pollinations with a dedicated key, and restores it on `off`.
 
 ```bash
 npx @pollinations/cli harness dsh on

--- a/packages/polli-cli/README.md
+++ b/packages/polli-cli/README.md
@@ -138,11 +138,13 @@ polli harness opencode on         # enables the Pollinations OpenCode plugin + d
 polli harness openclaw on         # adds the Pollinations provider + Polli skill to OpenClaw
 polli harness pi on               # native provider, key, startup model, and Polli skill
 polli harness prime on            # native Prime Agent provider support
+polli harness tgpt on             # authenticated Pollinations text models in tgpt
 polli harness <harness> status
 polli harness <harness> off
 ```
 
 Bloom stores its dedicated key in `$BLOOM_HOME/.env` (default `~/.bloom/.env`).
+tgpt stores its provider, dedicated key, and model in `~/.config/tgpt/config.conf`.
 The DSH adapter configures the Pollinations provider, hosted Pollinations MCP,
 and Polli CLI skill globally under `$DSH_HOME` (default `~/.dsh`). OpenCode uses
 its official plugin; OpenClaw uses `openclaw.json`, while Pi and Prime Agent use

--- a/packages/polli-cli/SKILL.md
+++ b/packages/polli-cli/SKILL.md
@@ -43,7 +43,7 @@ If `polli` is not installed, run `npm i -g @pollinations/cli@latest` (provides t
 | List your quests + claim state | `polli quests` (filters: `--open --claimable --claimed --coming-soon`) |
 | Manage prompt agents | `polli agents list` |
 | Manage invite-only community models | `polli my-models list` |
-| Connect a coding harness to Pollinations | `polli harness <bloom\|dsh\|opencode\|openclaw\|pi\|prime> on` (available adapters: `polli harness --help`) |
+| Connect a coding harness to Pollinations | `polli harness <bloom\|dsh\|opencode\|openclaw\|pi\|prime\|tgpt> on` (available adapters: `polli harness --help`) |
 | Machine-readable output | append `--json` to any command |
 
 ## Setup
@@ -220,10 +220,12 @@ polli harness pi on --model kimi    # any tool-calling text model from `polli mo
 polli harness pi off                # restore the Pi config backed up before "on"
 polli harness openclaw on           # login if needed, mint key "polli-harness-openclaw", add provider + Polli skill
 polli harness openclaw off          # remove the Pollinations provider, key, and skill
+polli harness tgpt on               # use tgpt's Pollinations provider with a dedicated key
+polli harness tgpt off              # restore tgpt's previous configuration
 ```
-Each adapter checks that its harness can be launched before login, key creation, or configuration. DSH's official launch uses `npx`, so its adapter checks for `npx`; Bloom, OpenCode, OpenClaw, and Pi require their installed commands.
+Each adapter checks that its harness can be launched before login, key creation, or configuration. DSH's official launch uses `npx`, so its adapter checks for `npx`; Bloom, OpenCode, OpenClaw, Pi, and tgpt require their installed commands.
 
-Bloom already uses Pollinations and only needs a dedicated key in `$BLOOM_HOME/.env` (default `~/.bloom/.env`). The DSH adapter globally configures the Pollinations provider, hosted Pollinations MCP, and this skill under `$DSH_HOME` (default `~/.dsh`). OpenCode enables the existing Pollinations plugin and stores its dedicated key in the plugin config. OpenClaw adds a `pollinations` provider to `~/.openclaw/openclaw.json`, stores a dedicated key in `env.vars`, and installs this skill under `~/.openclaw/skills/polli/`. Pi writes `~/.pi/agent/models.json`, `auth.json`, and `settings.json`, and installs this skill under `~/.pi/agent/skills/polli/`. Guide: `polli docs` section "Coding Harnesses".
+Bloom already uses Pollinations and only needs a dedicated key in `$BLOOM_HOME/.env` (default `~/.bloom/.env`). tgpt's existing Pollinations provider is selected in `~/.config/tgpt/config.conf` with a dedicated key and model. The DSH adapter globally configures the Pollinations provider, hosted Pollinations MCP, and this skill under `$DSH_HOME` (default `~/.dsh`). OpenCode enables the existing Pollinations plugin and stores its dedicated key in the plugin config. OpenClaw adds a `pollinations` provider to `~/.openclaw/openclaw.json`, stores a dedicated key in `env.vars`, and installs this skill under `~/.openclaw/skills/polli/`. Pi writes `~/.pi/agent/models.json`, `auth.json`, and `settings.json`, and installs this skill under `~/.pi/agent/skills/polli/`. Guide: `polli docs` section "Coding Harnesses".
 
 ### Read API docs
 ```bash

--- a/packages/polli-cli/package-lock.json
+++ b/packages/polli-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pollinations/cli",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pollinations/cli",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/packages/polli-cli/package.json
+++ b/packages/polli-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pollinations/cli",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "The Pollinations CLI — for humans, AI agents, and everything in between",
   "type": "module",
   "bin": {

--- a/packages/polli-cli/src/harnesses/index.ts
+++ b/packages/polli-cli/src/harnesses/index.ts
@@ -4,6 +4,7 @@ import { openclaw } from "./openclaw.js";
 import { opencode } from "./opencode.js";
 import { pi } from "./pi.js";
 import { prime } from "./prime.js";
+import { tgpt } from "./tgpt.js";
 import type { HarnessAdapter } from "./types.js";
 
 export const HARNESSES: HarnessAdapter[] = [
@@ -13,4 +14,5 @@ export const HARNESSES: HarnessAdapter[] = [
     openclaw,
     pi,
     prime,
+    tgpt,
 ];

--- a/packages/polli-cli/src/harnesses/tgpt.test.ts
+++ b/packages/polli-cli/src/harnesses/tgpt.test.ts
@@ -1,0 +1,80 @@
+import {
+    existsSync,
+    mkdirSync,
+    mkdtempSync,
+    readFileSync,
+    rmSync,
+    statSync,
+    writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseEnv } from "node:util";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { configureTgpt, disableTgpt, tgpt } from "./tgpt.js";
+import type { HarnessContext } from "./types.js";
+
+let home: string;
+let ctx: HarnessContext;
+
+beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "polli-tgpt-harness-"));
+    ctx = { home, env: {} };
+});
+
+afterEach(() => rmSync(home, { recursive: true, force: true }));
+
+const configFile = () => join(home, ".config", "tgpt", "config.conf");
+const read = () => readFileSync(configFile(), "utf-8");
+
+describe("tgpt harness", () => {
+    it("configures authenticated Pollinations text requests", () => {
+        expect(configureTgpt(ctx, "sk_test_key")).toMatchObject({
+            harness: "tgpt",
+            configured: true,
+            model: "openai",
+        });
+        expect(parseEnv(read())).toMatchObject({
+            AI_PROVIDER: "pollinations",
+            POLLINATIONS_API_KEY: "sk_test_key",
+            POLLINATIONS_MODEL: "openai",
+        });
+        expect(statSync(configFile()).mode & 0o777).toBe(0o600);
+    });
+
+    it("preserves unrelated configuration and replaces managed values", () => {
+        mkdirSync(join(home, ".config", "tgpt"), { recursive: true });
+        writeFileSync(
+            configFile(),
+            "OTHER_KEY=keep\nAI_PROVIDER=groq\nPOLLINATIONS_MODEL=old\n",
+        );
+        configureTgpt(ctx, "sk_test_key", "deepseek");
+        expect(parseEnv(read())).toMatchObject({
+            OTHER_KEY: "keep",
+            AI_PROVIDER: "pollinations",
+            POLLINATIONS_API_KEY: "sk_test_key",
+            POLLINATIONS_MODEL: "deepseek",
+        });
+    });
+
+    it("restores the original file on off", () => {
+        mkdirSync(join(home, ".config", "tgpt"), { recursive: true });
+        const original = "AI_PROVIDER=groq\nOTHER_KEY=keep\n";
+        writeFileSync(configFile(), original);
+        configureTgpt(ctx, "sk_test_key");
+        expect(disableTgpt(ctx).outcome).toBe("restored");
+        expect(read()).toBe(original);
+    });
+
+    it("removes only managed values when the file changed after on", () => {
+        configureTgpt(ctx, "sk_test_key");
+        writeFileSync(configFile(), `${read()}LATER=keep\n`);
+        expect(disableTgpt(ctx).outcome).toBe("stripped");
+        expect(read()).toBe("LATER=keep\n");
+    });
+
+    it("stops before configuration when tgpt is unavailable", async () => {
+        await expect(tgpt.on(ctx, {})).rejects.toThrow("tgpt was not found");
+        expect(existsSync(configFile())).toBe(false);
+    });
+});

--- a/packages/polli-cli/src/harnesses/tgpt.test.ts
+++ b/packages/polli-cli/src/harnesses/tgpt.test.ts
@@ -36,7 +36,7 @@ describe("tgpt harness", () => {
         });
         expect(parseEnv(read())).toMatchObject({
             AI_PROVIDER: "pollinations",
-            AI_API_KEY: "sk_test_key",
+            POLLINATIONS_API_KEY: "sk_test_key",
             POLLINATIONS_MODEL: "openai/gpt-5.4-nano",
         });
         expect(statSync(configFile()).mode & 0o777).toBe(0o600);
@@ -52,15 +52,16 @@ describe("tgpt harness", () => {
         expect(parseEnv(read())).toMatchObject({
             OTHER_KEY: "keep",
             AI_PROVIDER: "pollinations",
-            AI_API_KEY: "sk_test_key",
-            POLLINATIONS_API_KEY: "older-pollinations-key",
+            POLLINATIONS_API_KEY: "sk_test_key",
             POLLINATIONS_MODEL: "deepseek",
         });
+        expect(parseEnv(read()).AI_API_KEY).toBeUndefined();
     });
 
     it("restores the original file on off", () => {
         mkdirSync(join(home, ".config", "tgpt"), { recursive: true });
-        const original = "AI_PROVIDER=groq\nOTHER_KEY=keep\n";
+        const original =
+            "AI_PROVIDER=groq\nAI_API_KEY=old-provider-key\nOTHER_KEY=keep\n";
         writeFileSync(configFile(), original);
         configureTgpt(ctx, "sk_test_key");
         expect(disableTgpt(ctx).outcome).toBe("restored");

--- a/packages/polli-cli/src/harnesses/tgpt.test.ts
+++ b/packages/polli-cli/src/harnesses/tgpt.test.ts
@@ -32,12 +32,12 @@ describe("tgpt harness", () => {
         expect(configureTgpt(ctx, "sk_test_key")).toMatchObject({
             harness: "tgpt",
             configured: true,
-            model: "openai",
+            model: "openai/gpt-5.4-nano",
         });
         expect(parseEnv(read())).toMatchObject({
             AI_PROVIDER: "pollinations",
-            POLLINATIONS_API_KEY: "sk_test_key",
-            POLLINATIONS_MODEL: "openai",
+            AI_API_KEY: "sk_test_key",
+            POLLINATIONS_MODEL: "openai/gpt-5.4-nano",
         });
         expect(statSync(configFile()).mode & 0o777).toBe(0o600);
     });
@@ -46,13 +46,14 @@ describe("tgpt harness", () => {
         mkdirSync(join(home, ".config", "tgpt"), { recursive: true });
         writeFileSync(
             configFile(),
-            "OTHER_KEY=keep\nAI_PROVIDER=groq\nPOLLINATIONS_MODEL=old\n",
+            "OTHER_KEY=keep\nAI_PROVIDER=groq\nAI_API_KEY=old-provider-key\nPOLLINATIONS_API_KEY=older-pollinations-key\nPOLLINATIONS_MODEL=old\n",
         );
         configureTgpt(ctx, "sk_test_key", "deepseek");
         expect(parseEnv(read())).toMatchObject({
             OTHER_KEY: "keep",
             AI_PROVIDER: "pollinations",
-            POLLINATIONS_API_KEY: "sk_test_key",
+            AI_API_KEY: "sk_test_key",
+            POLLINATIONS_API_KEY: "older-pollinations-key",
             POLLINATIONS_MODEL: "deepseek",
         });
     });
@@ -76,5 +77,18 @@ describe("tgpt harness", () => {
     it("stops before configuration when tgpt is unavailable", async () => {
         await expect(tgpt.on(ctx, {})).rejects.toThrow("tgpt was not found");
         expect(existsSync(configFile())).toBe(false);
+    });
+
+    it("keeps a different provider selected after on", () => {
+        configureTgpt(ctx, "sk_test_key");
+        writeFileSync(
+            configFile(),
+            read().replace(
+                'AI_PROVIDER="pollinations"',
+                'AI_PROVIDER="ollama"',
+            ),
+        );
+        expect(disableTgpt(ctx).outcome).toBe("stripped");
+        expect(parseEnv(read())).toEqual({ AI_PROVIDER: "ollama" });
     });
 });

--- a/packages/polli-cli/src/harnesses/tgpt.ts
+++ b/packages/polli-cli/src/harnesses/tgpt.ts
@@ -1,0 +1,114 @@
+import { join } from "node:path";
+import { parseEnv } from "node:util";
+import {
+    commandExists,
+    readTextIfExists,
+    writeTextAtomic,
+} from "./fs.js";
+import { resolveHarnessKey } from "./keys.js";
+import { applyWithSnapshot, restoreOrStrip } from "./snapshot.js";
+import type { HarnessAdapter, HarnessContext, HarnessResult } from "./types.js";
+
+const ID = "tgpt";
+const LABEL = "tgpt";
+const DEFAULT_MODEL = "openai";
+const MANAGED_KEYS = [
+    "AI_PROVIDER",
+    "POLLINATIONS_API_KEY",
+    "POLLINATIONS_MODEL",
+] as const;
+
+const configPath = (ctx: HarnessContext) =>
+    join(ctx.home, ".config", "tgpt", "config.conf");
+const files = (ctx: HarnessContext) => [configPath(ctx)];
+const managedLine = new RegExp(
+    `^\\s*(?:${MANAGED_KEYS.join("|")})\\s*=`,
+    "u",
+);
+
+const readConfig = (ctx: HarnessContext) => {
+    const text = readTextIfExists(configPath(ctx));
+    return text === null ? {} : parseEnv(text);
+};
+
+const writeConfig = (ctx: HarnessContext, apiKey: string, model: string) => {
+    const lines = (readTextIfExists(configPath(ctx)) ?? "")
+        .split("\n")
+        .filter((line) => !managedLine.test(line));
+    const insertAt = lines.at(-1) === "" ? lines.length - 1 : lines.length;
+    lines.splice(
+        insertAt,
+        0,
+        'AI_PROVIDER="pollinations"',
+        `POLLINATIONS_API_KEY=${JSON.stringify(apiKey)}`,
+        `POLLINATIONS_MODEL=${JSON.stringify(model)}`,
+    );
+    writeTextAtomic(configPath(ctx), lines.join("\n"), 0o600);
+};
+
+const stripConfig = (ctx: HarnessContext) => {
+    const text = readTextIfExists(configPath(ctx));
+    if (text === null) return false;
+    const lines = text.split("\n");
+    const filtered = lines.filter((line) => !managedLine.test(line));
+    if (filtered.length === lines.length) return false;
+    writeTextAtomic(configPath(ctx), filtered.join("\n"), 0o600);
+    return true;
+};
+
+const result = (ctx: HarnessContext): HarnessResult => {
+    const config = readConfig(ctx);
+    const model = config.POLLINATIONS_MODEL || undefined;
+    return {
+        harness: ID,
+        label: LABEL,
+        configured:
+            config.AI_PROVIDER === "pollinations" &&
+            Boolean(config.POLLINATIONS_API_KEY) &&
+            Boolean(model),
+        model,
+        files: files(ctx),
+    };
+};
+
+export const configureTgpt = (
+    ctx: HarnessContext,
+    apiKey: string,
+    model = DEFAULT_MODEL,
+) => {
+    applyWithSnapshot(ctx, ID, files(ctx), () =>
+        writeConfig(ctx, apiKey, model),
+    );
+    return result(ctx);
+};
+
+export const disableTgpt = (ctx: HarnessContext): HarnessResult => {
+    const outcome = restoreOrStrip(ctx, ID, files(ctx), () =>
+        stripConfig(ctx),
+    );
+    return { ...result(ctx), configured: false, outcome };
+};
+
+export const tgpt: HarnessAdapter = {
+    id: ID,
+    label: LABEL,
+    description: "Configure tgpt to use authenticated Pollinations text models",
+    restartHint: "Changes apply on the next tgpt session.",
+
+    async on(ctx, options) {
+        if (!commandExists("tgpt", ctx.env)) {
+            throw new Error(
+                "tgpt was not found. Install it first: https://github.com/aandrew-me/tgpt#installation",
+            );
+        }
+        const existingKey = readConfig(ctx).POLLINATIONS_API_KEY || null;
+        const apiKey = await resolveHarnessKey(
+            { id: ID, label: LABEL, existingKey },
+            { browser: options.browser },
+        );
+        return configureTgpt(ctx, apiKey, options.model ?? DEFAULT_MODEL);
+    },
+
+    off: disableTgpt,
+    status: result,
+};

--- a/packages/polli-cli/src/harnesses/tgpt.ts
+++ b/packages/polli-cli/src/harnesses/tgpt.ts
@@ -10,7 +10,7 @@ const LABEL = "tgpt";
 const DEFAULT_MODEL = "openai/gpt-5.4-nano";
 const MANAGED_KEYS = [
     "AI_PROVIDER",
-    "AI_API_KEY",
+    "POLLINATIONS_API_KEY",
     "POLLINATIONS_MODEL",
 ] as const;
 
@@ -27,13 +27,17 @@ const readConfig = (ctx: HarnessContext) => {
 const writeConfig = (ctx: HarnessContext, apiKey: string, model: string) => {
     const lines = (readTextIfExists(configPath(ctx)) ?? "")
         .split("\n")
-        .filter((line) => !managedLine.test(line));
+        // tgpt prioritizes AI_API_KEY over its provider-specific key.
+        .filter(
+            (line) =>
+                !managedLine.test(line) && !/^\s*AI_API_KEY\s*=/u.test(line),
+        );
     const insertAt = lines.at(-1) === "" ? lines.length - 1 : lines.length;
     lines.splice(
         insertAt,
         0,
         'AI_PROVIDER="pollinations"',
-        `AI_API_KEY=${JSON.stringify(apiKey)}`,
+        `POLLINATIONS_API_KEY=${JSON.stringify(apiKey)}`,
         `POLLINATIONS_MODEL=${JSON.stringify(model)}`,
     );
     writeTextAtomic(configPath(ctx), lines.join("\n"), 0o600);
@@ -62,7 +66,7 @@ const result = (ctx: HarnessContext): HarnessResult => {
         label: LABEL,
         configured:
             config.AI_PROVIDER === "pollinations" &&
-            Boolean(config.AI_API_KEY) &&
+            Boolean(config.POLLINATIONS_API_KEY) &&
             Boolean(model),
         model,
         files: files(ctx),
@@ -97,7 +101,7 @@ export const tgpt: HarnessAdapter = {
                 "tgpt was not found. Install it first: https://github.com/aandrew-me/tgpt#installation",
             );
         }
-        const existingKey = readConfig(ctx).AI_API_KEY || null;
+        const existingKey = readConfig(ctx).POLLINATIONS_API_KEY || null;
         const apiKey = await resolveHarnessKey(
             { id: ID, label: LABEL, existingKey },
             { browser: options.browser },

--- a/packages/polli-cli/src/harnesses/tgpt.ts
+++ b/packages/polli-cli/src/harnesses/tgpt.ts
@@ -1,30 +1,23 @@
 import { join } from "node:path";
 import { parseEnv } from "node:util";
-import {
-    commandExists,
-    readTextIfExists,
-    writeTextAtomic,
-} from "./fs.js";
+import { commandExists, readTextIfExists, writeTextAtomic } from "./fs.js";
 import { resolveHarnessKey } from "./keys.js";
 import { applyWithSnapshot, restoreOrStrip } from "./snapshot.js";
 import type { HarnessAdapter, HarnessContext, HarnessResult } from "./types.js";
 
 const ID = "tgpt";
 const LABEL = "tgpt";
-const DEFAULT_MODEL = "openai";
+const DEFAULT_MODEL = "openai/gpt-5.4-nano";
 const MANAGED_KEYS = [
     "AI_PROVIDER",
-    "POLLINATIONS_API_KEY",
+    "AI_API_KEY",
     "POLLINATIONS_MODEL",
 ] as const;
 
 const configPath = (ctx: HarnessContext) =>
     join(ctx.home, ".config", "tgpt", "config.conf");
 const files = (ctx: HarnessContext) => [configPath(ctx)];
-const managedLine = new RegExp(
-    `^\\s*(?:${MANAGED_KEYS.join("|")})\\s*=`,
-    "u",
-);
+const managedLine = new RegExp(`^\\s*(?:${MANAGED_KEYS.join("|")})\\s*=`, "u");
 
 const readConfig = (ctx: HarnessContext) => {
     const text = readTextIfExists(configPath(ctx));
@@ -40,7 +33,7 @@ const writeConfig = (ctx: HarnessContext, apiKey: string, model: string) => {
         insertAt,
         0,
         'AI_PROVIDER="pollinations"',
-        `POLLINATIONS_API_KEY=${JSON.stringify(apiKey)}`,
+        `AI_API_KEY=${JSON.stringify(apiKey)}`,
         `POLLINATIONS_MODEL=${JSON.stringify(model)}`,
     );
     writeTextAtomic(configPath(ctx), lines.join("\n"), 0o600);
@@ -50,7 +43,12 @@ const stripConfig = (ctx: HarnessContext) => {
     const text = readTextIfExists(configPath(ctx));
     if (text === null) return false;
     const lines = text.split("\n");
-    const filtered = lines.filter((line) => !managedLine.test(line));
+    const provider = readConfig(ctx).AI_PROVIDER;
+    const filtered = lines.filter(
+        (line) =>
+            !managedLine.test(line) ||
+            (/^\s*AI_PROVIDER\s*=/u.test(line) && provider !== "pollinations"),
+    );
     if (filtered.length === lines.length) return false;
     writeTextAtomic(configPath(ctx), filtered.join("\n"), 0o600);
     return true;
@@ -64,7 +62,7 @@ const result = (ctx: HarnessContext): HarnessResult => {
         label: LABEL,
         configured:
             config.AI_PROVIDER === "pollinations" &&
-            Boolean(config.POLLINATIONS_API_KEY) &&
+            Boolean(config.AI_API_KEY) &&
             Boolean(model),
         model,
         files: files(ctx),
@@ -83,9 +81,7 @@ export const configureTgpt = (
 };
 
 export const disableTgpt = (ctx: HarnessContext): HarnessResult => {
-    const outcome = restoreOrStrip(ctx, ID, files(ctx), () =>
-        stripConfig(ctx),
-    );
+    const outcome = restoreOrStrip(ctx, ID, files(ctx), () => stripConfig(ctx));
     return { ...result(ctx), configured: false, outcome };
 };
 
@@ -101,7 +97,7 @@ export const tgpt: HarnessAdapter = {
                 "tgpt was not found. Install it first: https://github.com/aandrew-me/tgpt#installation",
             );
         }
-        const existingKey = readConfig(ctx).POLLINATIONS_API_KEY || null;
+        const existingKey = readConfig(ctx).AI_API_KEY || null;
         const apiKey = await resolveHarnessKey(
             { id: ID, label: LABEL, existingKey },
             { browser: options.browser },


### PR DESCRIPTION
- Adds `polli harness tgpt on|status|off`, using tgpt's existing authenticated Pollinations text provider.
- Clears a conflicting generic `AI_API_KEY` from tgpt's config so the dedicated provider-specific key takes effect; defaults to `openai/gpt-5.4-nano`.
- Restores the previous configuration on `off`, preserves a subsequently selected provider, and documents config overrides.
- Bumps Polli CLI to `0.1.14` so the integration can publish on merge.

Validation: 116 CLI tests, package build, Biome, and missing-install/option-parsing checks passed. The original implementation was tested through real `on → tgpt request → status → off`; the key-precedence follow-up is covered by the configuration regression test and upstream source inspection.
