### PR TITLE
fix: preserve KPI secrets during application deployments

### DIFF
--- a/operations/kpi/deploy.json
+++ b/operations/kpi/deploy.json
@@ -1,9 +1,9 @@
 {
   "target": "script",
   "credentials": "myceli",
-  "sops": "default",
+  "sops": "none",
   "install": "npm ci --prefix ../.. && npm ci",
-  "deploy": "npm run deploy && sops exec-file --no-fifo secrets/env.json 'npx wrangler secret bulk {}'",
+  "deploy": "npm run deploy",
   "verify": [
     "https://kpi.pollinations.ai/"
   ],


### PR DESCRIPTION
- Removes unconditional secret synchronization from KPI deployments so application rollouts preserve the existing Worker credentials.
- Stops requesting SOPS access for the KPI deploy job; separately approved credential changes remain separate operations.
- Validated the deployment manifest and application-discovery tests.
