### PR TITLE
feat: probe Responses capability during community endpoint testing

### DIFF
--- a/enter.pollinations.ai/src/routes/community-endpoints/schemas.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints/schemas.ts
@@ -444,6 +444,12 @@ export const CommunityEndpointTestResponseSchema = z
             .describe(
                 "Image tests only: input types detected from generation and edit probes.",
             ),
+        responsesSupported: z
+            .boolean()
+            .optional()
+            .describe(
+                "Text endpoints with api=chat_completions only: whether the upstream also supports /v1/responses, detected by an automatic probe.",
+            ),
     })
     .passthrough();
 export const CommunityEndpointDeleteResponseSchema = z.object({

--- a/enter.pollinations.ai/src/services/community-endpoint-openai.ts
+++ b/enter.pollinations.ai/src/services/community-endpoint-openai.ts
@@ -5,6 +5,7 @@ import {
     communityImageEditsUrl,
     communityImageGenerationsUrl,
     communityOpenAIBaseUrl,
+    communityResponsesUrl,
 } from "@shared/community-endpoint-urls.ts";
 import {
     COMMUNITY_ENDPOINT_TIMEOUT_MS,
@@ -59,6 +60,12 @@ export type CommunityEndpointTestResult = {
     inputModalities?: ModelInputModality[];
     /** Image tests only: editing failed, but generation remains usable. */
     imageEditError?: string;
+    /**
+     * Text endpoints only: when the declared API is `chat_completions`, the
+     * probe also checks whether the upstream responds correctly to a minimal
+     * /v1/responses request. Set when the probe succeeds.
+     */
+    responsesSupported?: boolean;
 };
 
 function authorizationHeaders(bearerToken: string): HeadersInit {
@@ -280,7 +287,67 @@ export async function testCommunityEndpoint({
     parser.feed(`${stream}\n\n`);
     if (!hasUsage)
         throw new Error("Endpoint omitted valid terminal streaming usage");
+    if (api === "chat_completions") {
+        const responsesSupported = await probeResponsesEndpoint(
+            communityOpenAIBaseUrl(url),
+            bearerToken,
+            model,
+        );
+        if (responsesSupported) {
+            result.responsesSupported = true;
+        }
+    }
     return result;
+}
+
+/**
+ * Probe whether an upstream endpoint supports /v1/responses by sending a
+ * minimal request and validating the response shape. Returns TRUE when the
+ * upstream returns a valid terminal Response with usage. Fails silently —
+ * a 400, 404, or timeout means the endpoint does not support Responses.
+ */
+async function probeResponsesEndpoint(
+    baseUrl: string,
+    bearerToken: string,
+    model: string,
+): Promise<boolean> {
+    const url = communityResponsesUrl(baseUrl);
+    let response: Response;
+    try {
+        response = await fetch(url, {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${normalizeCommunityEndpointBearerToken(bearerToken)}`,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                input: "Reply with OK.",
+                model,
+                store: false,
+                stream: false,
+            }),
+            signal: AbortSignal.timeout(COMMUNITY_ENDPOINT_TIMEOUT_MS),
+        });
+    } catch {
+        return false;
+    }
+    if (!response.ok) return false;
+    let body: string;
+    try {
+        body = await response.text();
+    } catch {
+        return false;
+    }
+    try {
+        const parsed = CreateResponseResponseSchema.safeParse(JSON.parse(body));
+        return (
+            parsed.success &&
+            ["completed", "incomplete"].includes(parsed.data.status) &&
+            parsed.data.usage != null
+        );
+    } catch {
+        return false;
+    }
 }
 
 export async function testCommunityImageEndpoint({


### PR DESCRIPTION
## Problem

Owners of community text models with `api: chat_completions` currently have
no way to discover whether their upstream supports `/v1/responses`. The
Responses API is available (#14239 merged), but only endpoints explicitly
declared as `api: "responses"` can use it.

Many chat-compatible upstreams (OpenRouter, Fireworks, Azure, etc.) also
support `/v1/responses` with the same credentials and model — but there is
no discovery path, so owners either never try or have to manually probe the
endpoint and change the API field.

Issue: #14303.

## Changes

**enter.pollinations.ai — test endpoint probe (2 files, +73):**

When testing a `chat_completions` community endpoint, the test now also
sends a minimal non-streaming `/v1/responses` request to the derived
Responses URL. If the upstream returns a valid terminal
`CreateResponseResponse` with usage, the test result includes
`responsesSupported: true`.

The probe is silent on all failures — a 400, 404, malformed JSON, or
timeout simply leaves `responsesSupported` unset. The existing chat test
continues unchanged and is not blocked by the probe.

**Schema:** `CommunityEndpointTestResponseSchema` gains an optional
`responsesSupported: boolean` field.

**No DB changes, no routing changes.** Routing and `/v1/models`
advertising already work when the owner changes `api` to `"responses"`.
This change just gives owners the evidence they need to make that decision.

## How it works

```mermaid
sequenceDiagram
    Owner->>TestEndpoint: POST /v1/models/test { api:chat_completions, url, ... }
    TestEndpoint->>Upstream: POST {url}/chat/completions { messages:..., stream:false }
    Upstream-->>TestEndpoint: ChatCompletion + usage
    TestEndpoint->>Upstream: POST {base}/responses { input:..., stream:false }
    Upstream-->>TestEndpoint: CreateResponseResponse + usage | 400 | timeout
    TestEndpoint-->>Owner: { ok:true, ..., responsesSupported:true|false }
```

If `responsesSupported: true`, the owner can safely change the endpoint's
`api` to `"responses"` — the upstream has been verified to respond
correctly.

## Verification

- TypeScript typecheck passes on the changed packages.
- Follows the exact pattern of the existing chat and responses test flows
  in `community-endpoint-openai.ts`.
- Uses the already-exported `communityResponsesUrl()` helper for URL
  derivation and `CreateResponseResponseSchema` for response validation
  (same imports the existing `api === "responses"` test path uses).

**Automation disclosure:** this pull request's changes and this summary
were prepared with Claude Code. I reviewed the diff and verification
myself before submitting, and I am the person accountable for it.

Closes: https://github.com/pollinations/pollinations/issues/14303