### PR TITLE
feat: add llm-pollinations plugin

### DIFF
--- a/packages/llm-pollinations/README.md
+++ b/packages/llm-pollinations/README.md
@@ -1,0 +1,55 @@
+# llm-pollinations
+
+[Pollinations](https://pollinations.ai) models for [Simon Willison's llm](https://llm.datasette.io/).
+
+Text models are loaded from the [Pollinations catalog](https://gen.pollinations.ai/v1/models) and registered as `pollinations/<model-id>` — no hardcoded model list. The catalog is cached for an hour in the llm user directory and falls back to a stale copy when Pollinations is unreachable.
+
+Image input, tool calling, reasoning and structured outputs are enabled only when the catalog advertises them for a model.
+
+## Installation
+
+```bash
+llm install llm-pollinations
+```
+
+## API keys
+
+```bash
+llm keys set pollinations
+# or: export POLLINATIONS_API_KEY=...
+```
+
+Get a key at [enter.pollinations.ai/keys](https://enter.pollinations.ai/keys), or create a dedicated key with the [Polli CLI](https://github.com/pollinations/pollinations/tree/main/packages/polli-cli):
+
+```bash
+npx @pollinations/cli auth login
+npx @pollinations/cli keys create --name llm
+```
+
+## Usage
+
+```bash
+# Pick a model from llm models list (they look like pollinations/openai/gpt-5.4-nano)
+llm -m pollinations/openai/gpt-5.4-nano "Say hi in Russian"
+
+# Streaming, chat, vision and tools where the model advertises them
+llm -s -m pollinations/openai/gpt-5.4-nano "Tell a joke"
+llm chat -m pollinations/openai/gpt-5.4-nano
+llm -m pollinations/<vision-model> -a photo.jpg "Describe this photo"
+llm -T llm_get_time -m pollinations/<tool-model> "What time is it?"
+```
+
+Python API:
+
+```python
+import llm
+
+model = llm.get_model("pollinations/openai/gpt-5.4-nano")
+print(model.prompt("Say hi in Russian").text())
+```
+
+## Development
+
+```bash
+python -m pytest
+```

--- a/packages/llm-pollinations/README.md
+++ b/packages/llm-pollinations/README.md
@@ -35,8 +35,8 @@ llm -m pollinations/openai/gpt-5.4-nano "Say hi in Russian"
 # Streaming, chat, vision and tools where the model advertises them
 llm -s -m pollinations/openai/gpt-5.4-nano "Tell a joke"
 llm chat -m pollinations/openai/gpt-5.4-nano
-llm -m pollinations/<vision-model> -a photo.jpg "Describe this photo"
-llm -T llm_get_time -m pollinations/<tool-model> "What time is it?"
+llm -m "pollinations/<vision-model>" -a photo.jpg "Describe this photo"
+llm -T llm_get_time -m "pollinations/<tool-model>" "What time is it?"
 ```
 
 Python API:

--- a/packages/llm-pollinations/llm_pollinations.py
+++ b/packages/llm-pollinations/llm_pollinations.py
@@ -39,13 +39,25 @@ def fetch_catalog(skip_cache=False):
         response = httpx.get(CATALOG_URL, headers=headers, timeout=10, follow_redirects=True)
         response.raise_for_status()
         payload = response.json()
-    except httpx.HTTPError:
+    except (httpx.HTTPError, ValueError):
+        # ValueError covers malformed JSON in otherwise-successful responses.
         if stale is not None:
             return stale
         raise
     catalog = payload.get("data") if isinstance(payload, dict) else payload
-    CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
-    CACHE_PATH.write_text(json.dumps(catalog, indent=2))
+    if not isinstance(catalog, list):
+        # The catalog must be a list of model dicts; anything else means an
+        # unexpected response shape, so the stale cache is safer.
+        if stale is not None:
+            return stale
+        raise ValueError("Unexpected Pollinations catalog response")
+    try:
+        CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        CACHE_PATH.write_text(json.dumps(catalog, indent=2))
+    except OSError:
+        # Cache persistence is best-effort; the in-memory catalog is still
+        # valid for this run.
+        pass
     return catalog
 
 

--- a/packages/llm-pollinations/llm_pollinations.py
+++ b/packages/llm-pollinations/llm_pollinations.py
@@ -1,0 +1,119 @@
+"""
+llm-pollinations: Pollinations models for Simon Willison's llm.
+
+Registers text models from the Pollinations catalog as
+``pollinations/<model-id>`` — the catalog is fetched from
+https://gen.pollinations.ai/v1/models, cached for an hour in the llm user
+directory, and falls back to a stale copy when Pollinations is unreachable.
+
+https://github.com/pollinations/pollinations/tree/main/packages/llm-pollinations
+"""
+
+import json
+import time
+
+import httpx
+import llm
+from llm.default_plugins.openai_models import AsyncChat, Chat
+
+BASE_URL = "https://gen.pollinations.ai/v1"
+CATALOG_URL = BASE_URL + "/models"
+CACHE_PATH = llm.user_dir() / "pollinations_models.json"
+CACHE_TIMEOUT = 3600  # one hour
+
+
+def fetch_catalog(skip_cache=False):
+    """
+    Return the Pollinations model catalog as a list of dicts.
+
+    The catalog is cached in the llm user directory for CACHE_TIMEOUT
+    seconds. If it cannot be fetched, a stale cached copy is returned
+    when one exists.
+    """
+    stale = _read_cache()
+    if stale is not None and not skip_cache and _cache_age() < CACHE_TIMEOUT:
+        return stale
+    key = llm.get_key("", "pollinations", "POLLINATIONS_API_KEY")
+    headers = {"Authorization": "Bearer {}".format(key)} if key else None
+    try:
+        response = httpx.get(CATALOG_URL, headers=headers, timeout=10, follow_redirects=True)
+        response.raise_for_status()
+        payload = response.json()
+    except httpx.HTTPError:
+        if stale is not None:
+            return stale
+        raise
+    catalog = payload.get("data") if isinstance(payload, dict) else payload
+    CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    CACHE_PATH.write_text(json.dumps(catalog, indent=2))
+    return catalog
+
+
+def _read_cache():
+    try:
+        return json.loads(CACHE_PATH.read_text())
+    except (OSError, ValueError):
+        return None
+
+
+def _cache_age():
+    try:
+        return time.time() - CACHE_PATH.stat().st_mtime
+    except OSError:
+        return float("inf")
+
+
+def chat_models(catalog):
+    """Yield catalog entries for models that chat and reply with text."""
+    for model in catalog:
+        if "/v1/chat/completions" not in (model.get("supported_endpoints") or []):
+            continue
+        if "text" not in (model.get("output_modalities") or []):
+            continue
+        yield model
+
+
+def model_kwargs(model):
+    """Build Chat constructor arguments from a catalog entry.
+
+    Image input, tool calling, reasoning and structured outputs are only
+    enabled when the catalog advertises them.
+    """
+    capabilities = model.get("capabilities") or []
+    return dict(
+        model_id="pollinations/{}".format(model["id"]),
+        model_name=model["id"],
+        vision="image" in (model.get("input_modalities") or []),
+        reasoning="reasoning" in capabilities,
+        supports_tools="tool_calling" in capabilities,
+        supports_schema="structured_outputs" in capabilities,
+        can_stream=True,
+        api_base=BASE_URL,
+    )
+
+
+class PollinationsChat(Chat):
+    needs_key = "pollinations"
+    key_env_var = "POLLINATIONS_API_KEY"
+
+    def __str__(self):
+        return "Pollinations: {}".format(self.model_id)
+
+
+class PollinationsAsyncChat(AsyncChat):
+    needs_key = "pollinations"
+    key_env_var = "POLLINATIONS_API_KEY"
+
+    def __str__(self):
+        return "Pollinations: {}".format(self.model_id)
+
+
+@llm.hookimpl
+def register_models(register):
+    # Only hit the catalog when a key is configured, so llm startup stays
+    # fast for users who are not using this plugin.
+    if not llm.get_key("", "pollinations", "POLLINATIONS_API_KEY"):
+        return
+    for model in chat_models(fetch_catalog()):
+        kwargs = model_kwargs(model)
+        register(PollinationsChat(**kwargs), PollinationsAsyncChat(**kwargs))

--- a/packages/llm-pollinations/pyproject.toml
+++ b/packages/llm-pollinations/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "llm-pollinations"
+version = "0.1.0"
+description = "Pollinations models for Simon Willison's llm"
+readme = "README.md"
+requires-python = ">=3.10"
+license = "Apache-2.0"
+dependencies = ["llm>=0.24", "httpx"]
+
+[project.urls]
+Homepage = "https://github.com/pollinations/pollinations/tree/main/packages/llm-pollinations"
+Issues = "https://github.com/pollinations/pollinations/issues"
+
+[project.entry-points.llm]
+pollinations = "llm_pollinations"
+
+[tool.setuptools]
+py-modules = ["llm_pollinations"]

--- a/packages/llm-pollinations/tests/test_llm_pollinations.py
+++ b/packages/llm-pollinations/tests/test_llm_pollinations.py
@@ -1,0 +1,174 @@
+import json
+import os
+import time
+
+import httpx
+import llm
+import pytest
+
+from llm_pollinations import (
+    PollinationsAsyncChat,
+    PollinationsChat,
+    chat_models,
+    fetch_catalog,
+    model_kwargs,
+    register_models,
+)
+
+CATALOG = [
+    {
+        "id": "acme/alpha",
+        "output_modalities": ["text"],
+        "input_modalities": ["text"],
+        "supported_endpoints": ["/v1/chat/completions"],
+        "capabilities": ["tool_calling"],
+    },
+    {
+        "id": "acme/beta",
+        "output_modalities": ["text"],
+        "input_modalities": ["text", "image"],
+        "supported_endpoints": ["/v1/chat/completions"],
+        "capabilities": ["tool_calling", "reasoning"],
+    },
+    {
+        # Audio model: no chat completions endpoint, no text output
+        "id": "acme/voice",
+        "output_modalities": ["audio"],
+        "input_modalities": ["text"],
+        "supported_endpoints": ["/v1/audio/speech"],
+        "capabilities": [],
+    },
+    {
+        # Text model that cannot chat
+        "id": "acme/notchat",
+        "output_modalities": ["text"],
+        "input_modalities": ["text"],
+        "supported_endpoints": ["/text"],
+        "capabilities": [],
+    },
+]
+
+
+def test_chat_models_keeps_only_chat_models():
+    assert [m["id"] for m in chat_models(CATALOG)] == ["acme/alpha", "acme/beta"]
+
+
+def test_model_kwargs_advertises_only_catalog_capabilities():
+    assert model_kwargs(CATALOG[1]) == {
+        "model_id": "pollinations/acme/beta",
+        "model_name": "acme/beta",
+        "vision": True,
+        "reasoning": True,
+        "supports_tools": True,
+        "supports_schema": False,
+        "can_stream": True,
+        "api_base": "https://gen.pollinations.ai/v1",
+    }
+    plain = model_kwargs(CATALOG[0])
+    assert not plain["vision"]
+    assert not plain["reasoning"]
+    assert plain["supports_tools"]
+    assert not plain["supports_schema"]
+
+
+def test_register_models_registers_sync_and_async(monkeypatch):
+    monkeypatch.setattr(llm, "get_key", lambda *args, **kwargs: "test-key")
+    monkeypatch.setattr(
+        "llm_pollinations.fetch_catalog", lambda skip_cache=False: CATALOG
+    )
+    registered = []
+
+    register_models(lambda *models: registered.extend(models))
+
+    sync = {m.model_id: m for m in registered if isinstance(m, PollinationsChat)}
+    async_ = {
+        m.model_id: m for m in registered if isinstance(m, PollinationsAsyncChat)
+    }
+    assert set(sync) == {"pollinations/acme/alpha", "pollinations/acme/beta"}
+    assert set(async_) == set(sync)
+    assert len(registered) == 2 * len(sync)  # sync + async for each model
+    beta = sync["pollinations/acme/beta"]
+    assert beta.needs_key == "pollinations"
+    assert beta.key_env_var == "POLLINATIONS_API_KEY"
+    assert str(beta) == "Pollinations: pollinations/acme/beta"
+
+
+def test_register_models_without_key_registers_nothing(monkeypatch):
+    monkeypatch.setattr(llm, "get_key", lambda *args, **kwargs: "")
+
+    def fail(*args, **kwargs):
+        raise AssertionError("catalog should not be fetched without a key")
+
+    monkeypatch.setattr("llm_pollinations.fetch_catalog", fail)
+    registered = []
+    register_models(lambda *models: registered.extend(models))
+    assert registered == []
+
+
+@pytest.fixture
+def cache_path(tmp_path, monkeypatch):
+    path = tmp_path / "pollinations_models.json"
+    monkeypatch.setattr("llm_pollinations.CACHE_PATH", path)
+    return path
+
+
+def test_fetch_catalog_uses_fresh_cache(cache_path, monkeypatch):
+    cache_path.write_text(json.dumps(CATALOG))
+
+    def explode(*args, **kwargs):
+        raise AssertionError("a fresh cache should not be refetched")
+
+    monkeypatch.setattr(httpx, "get", explode)
+    assert fetch_catalog() == CATALOG
+
+
+def test_fetch_catalog_ignores_fresh_cache_with_skip_cache(cache_path, monkeypatch):
+    cache_path.write_text(json.dumps([{"id": "cached/one"}]))
+    monkeypatch.setattr(llm, "get_key", lambda *args, **kwargs: "k")
+
+    class Response:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"data": CATALOG}
+
+    monkeypatch.setattr(httpx, "get", lambda *args, **kwargs: Response())
+    assert fetch_catalog(skip_cache=True) == CATALOG
+
+
+def test_fetch_catalog_falls_back_to_stale(cache_path, monkeypatch):
+    cache_path.write_text(json.dumps(CATALOG))
+    old = time.time() - 7200
+    os.utime(cache_path, (old, old))
+    monkeypatch.setattr(llm, "get_key", lambda *args, **kwargs: "")
+
+    def fail(*args, **kwargs):
+        raise httpx.ConnectError("no network")
+
+    monkeypatch.setattr(httpx, "get", fail)
+    assert fetch_catalog() == CATALOG
+
+
+def test_fetch_catalog_fetches_and_caches(cache_path, monkeypatch):
+    monkeypatch.setattr(llm, "get_key", lambda *args, **kwargs: "secret")
+
+    class Response:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"data": CATALOG}
+
+    seen = {}
+
+    def fake_get(url, headers=None, **kwargs):
+        seen["url"] = url
+        seen["headers"] = headers
+        return Response()
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+    assert fetch_catalog() == CATALOG
+    assert json.loads(cache_path.read_text()) == CATALOG
+    assert seen["url"] == "https://gen.pollinations.ai/v1/models"
+    assert seen["headers"] == {"Authorization": "Bearer secret"}


### PR DESCRIPTION
Adds a native Pollinations provider plugin for Simon Willison's [llm](https://llm.datasette.io/) CLI and Python library.

Fixes #14660

## What it does

- `llm-pollinations` is an installable, focused Python package at `packages/llm-pollinations/`
- Reuses LLM's OpenAI-compatible `Chat`/`AsyncChat` classes against `https://gen.pollinations.ai/v1` — no recreated streaming, conversations, tools, or attachment handling
- Authentication via `llm keys set pollinations` or the `POLLINATIONS_API_KEY` environment variable
- Compatible text models are loaded dynamically from the authenticated `/v1/models` catalog and registered as `pollinations/<model-id>` — no hardcoded model list, no provider-name collisions
- Image input, tool calling, reasoning, and structured outputs are enabled only when the catalog advertises them
- Catalog loading uses a small time-limited cache (1 hour) in the llm user directory with stale-cache fallback when Pollinations is unreachable
- Documentation includes direct key setup and creating a dedicated key through Polli CLI

## Verified against current llm (0.35)

- Normal prompts, streaming, `llm chat`, an image attachment, tool calling (`llm.Tool.function` + `response.reply()`), and the LLM Python API — 174 models registered dynamically from the live catalog
- 8 focused unit tests: catalog filtering, capability flags, sync+async registration, key gating, cache freshness / skip_cache / stale-fallback / fetch-and-cache

## Notes

- `httpx` is declared explicitly: current llm ships an internal `httpx2`, so plugins importing `httpx` need their own dependency (caught by tests)
- Out of scope per the issue: image generation, embeddings, a custom device-auth flow, a configuration UI, and a new Polli CLI integration command
