### PR TITLE
Fixes #14535: Filter model catalogs by source and reliability

### DIFF
--- a/gen.pollinations.ai/src/docs/models.md
+++ b/gen.pollinations.ai/src/docs/models.md
@@ -42,6 +42,29 @@ Supported media models also advertise both endpoints and return generated-file
 links as assistant text. Reference-required models return their normal missing-input
 error; use their native endpoint until attachments are supported here.
 
+Chat model listings also expose `supported_parameters` — the OpenAI-compatible
+Chat Completions request parameters a model accepts through Pollinations — and
+`default_parameters`, which lists only the defaults the gateway itself applies
+(unset parameters use the upstream model's own defaults). These fields describe
+the Chat Completions and `/text` routes, not the native Responses API.
+
+Model lists also accept two discovery filters: `?source=official|community`
+picks built-in or community models, and `?reliable=true` keeps only models
+whose health window shows a success rate of at least 0.9. A matching
+`X-Pollinations-Model-Source` header works for clients whose fixed base URLs
+cannot carry query strings (the query parameter wins when both are set).
+Rich listings also expose minimal `health` metadata — `success_rate` (0-1;
+fallback rescues count as successes, caller-side 4xx failures are excluded),
+`samples`, `window_minutes` (60), and the `as_of` freshness timestamp. Models
+without health data carry no `health` field; experimental (`alpha`) status
+stays separate from reliability.
+
+```bash
+curl "https://gen.pollinations.ai/v1/models?source=official"
+curl "https://gen.pollinations.ai/v1/models?reliable=true"
+curl -H "X-Pollinations-Model-Source: official" "https://gen.pollinations.ai/v1/models"
+```
+
 ## Community Models
 
 Community models use an `owner/model` id and appear in the same discovery responses as Pollinations-operated models. Use `community=true` to return only community models or `community=false` to exclude them.

--- a/gen.pollinations.ai/src/routes/model-status.ts
+++ b/gen.pollinations.ai/src/routes/model-status.ts
@@ -78,6 +78,54 @@ function parseMinutes(value: string | undefined): number | null {
     return minutes;
 }
 
+export type ModelHealthFetch = {
+    data: ModelHealthResponse;
+    timestamp: number;
+    stale: boolean;
+};
+
+// Health window shared by /v1/models/status and the model listing health
+// enrichment, so both surfaces describe the same data.
+export const MODEL_HEALTH_WINDOW_MINUTES = DEFAULT_MINUTES;
+
+// Fetch the cached Tinybird model health rows. Returns null when the fetch
+// fails and no stale cache exists. Shared by /v1/models/status and the model
+// listing health enrichment.
+export async function fetchModelHealthData(
+    minutes: number = DEFAULT_MINUTES,
+): Promise<ModelHealthFetch | null> {
+    const now = Date.now();
+    const cached = cache.get(minutes);
+    if (cached && now - cached.timestamp < CACHE_TTL_MS) {
+        log("Returning cached model health response for %d minutes", minutes);
+        setCacheEntry(minutes, cached);
+        return { data: cached.data, timestamp: cached.timestamp, stale: false };
+    }
+    try {
+        const url = new URL("/v0/pipes/model_health.json", TINYBIRD_HOST);
+        url.searchParams.set("token", TINYBIRD_PUBLIC_TOKEN);
+        url.searchParams.set("minutes", String(minutes));
+        log("Fetching model health from Tinybird: %s", url.toString());
+        const response = await fetch(url.toString());
+        if (!response.ok) {
+            throw new Error(`Tinybird responded with ${response.status}`);
+        }
+        const tinybirdData = (await response.json()) as ModelHealthResponse;
+        const timestamp = Date.now();
+        setCacheEntry(minutes, { data: tinybirdData, timestamp });
+        return { data: tinybirdData, timestamp, stale: false };
+    } catch (error) {
+        log("Error fetching model health: %O", error);
+        const stale = cache.get(minutes);
+        if (stale) {
+            log("Falling back to stale cache for %d minutes", minutes);
+            setCacheEntry(minutes, stale);
+            return { data: stale.data, timestamp: stale.timestamp, stale: true };
+        }
+        return null;
+    }
+}
+
 export const modelStatusRoutes = new Hono<Env>().get(
     "/v1/models/status",
     describeRoute({
@@ -144,51 +192,17 @@ export const modelStatusRoutes = new Hono<Env>().get(
             );
         }
 
-        const now = Date.now();
-        const cached = cache.get(minutes);
-        if (cached && now - cached.timestamp < CACHE_TTL_MS) {
-            log(
-                "Returning cached model health response for %d minutes",
-                minutes,
-            );
-            setCacheEntry(minutes, cached);
-            c.header(
-                DATA_TIMESTAMP_HEADER,
-                new Date(cached.timestamp).toISOString(),
-            );
-            return c.json(cached.data);
-        }
-
-        try {
-            const url = new URL("/v0/pipes/model_health.json", TINYBIRD_HOST);
-            url.searchParams.set("token", TINYBIRD_PUBLIC_TOKEN);
-            url.searchParams.set("minutes", String(minutes));
-            log("Fetching model health from Tinybird: %s", url.toString());
-
-            const response = await fetch(url.toString());
-            if (!response.ok) {
-                throw new Error(`Tinybird responded with ${response.status}`);
-            }
-
-            const tinybirdData = (await response.json()) as ModelHealthResponse;
-            const timestamp = Date.now();
-            setCacheEntry(minutes, { data: tinybirdData, timestamp });
-            c.header(DATA_TIMESTAMP_HEADER, new Date(timestamp).toISOString());
-            return c.json(tinybirdData);
-        } catch (error) {
-            log("Error fetching model health: %O", error);
-            const stale = cache.get(minutes);
-            if (stale) {
-                log("Falling back to stale cache for %d minutes", minutes);
-                setCacheEntry(minutes, stale);
-                c.header(
-                    DATA_TIMESTAMP_HEADER,
-                    new Date(stale.timestamp).toISOString(),
-                );
-                c.header(STALE_HEADER, "true");
-                return c.json(stale.data);
-            }
+        const result = await fetchModelHealthData(minutes);
+        if (!result) {
             return c.json({ error: "Failed to fetch model health data" }, 502);
         }
+        c.header(
+            DATA_TIMESTAMP_HEADER,
+            new Date(result.timestamp).toISOString(),
+        );
+        if (result.stale) {
+            c.header(STALE_HEADER, "true");
+        }
+        return c.json(result.data);
     },
 );

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -23,6 +23,7 @@ import {
     mediaResponseDescription,
 } from "../media/response-output.ts";
 import { mediaResponses } from "../media/responses.ts";
+import { fetchModelHealthData } from "./model-status.ts";
 import {
     formatOpenAIImageResponse,
     handleImageGeneration,
@@ -85,6 +86,7 @@ import {
 import {
     type ModelListQueryParams,
     ModelListQueryParamsSchema,
+    RELIABLE_SUCCESS_RATE_THRESHOLD,
 } from "@/schemas/models.ts";
 import { RealtimeRequestQueryParamsSchema } from "@/schemas/realtime.ts";
 import { GenerateTextRequestQueryParamsSchema } from "@/schemas/text.ts";
@@ -250,15 +252,87 @@ function hasPaidBalance(c: any): boolean | undefined {
 }
 
 // Optionally filter entries by the validated `?community` query parameter.
-function filterEntriesByCommunityParam(
+// Filter by model source. `official` keeps built-in (non-community) entries,
+// `community` keeps community entries. Omitted keeps everything.
+export function filterBySource(
     entries: GenerationModelEntry[],
-    communityParam: string | undefined,
+    source: "official" | "community" | undefined,
 ): GenerationModelEntry[] {
-    if (communityParam === undefined) return entries;
-    const wantCommunity = communityParam === "true" || communityParam === "1";
+    if (source === undefined) return entries;
+    const wantCommunity = source === "community";
     return entries.filter(
         (entry) => (entry.communityEndpoint !== undefined) === wantCommunity,
     );
+}
+
+// Optional header fallback for clients whose fixed base URLs cannot carry
+// query strings. The query parameter wins when both are present.
+function parseModelSourceHeader(
+    value: string | undefined,
+): "official" | "community" | undefined {
+    return value === "official" || value === "community" ? value : undefined;
+}
+
+// Minimal health metadata for one model. Fallback rescues end in 2xx and
+// count as successes; caller-side 4xx failures are excluded from the
+// denominator. Missing rows or an empty window mean unknown.
+export function healthFor(
+    info: GenerationModelEntry["info"],
+    rows: Array<{
+        model: string;
+        event_type: string;
+        total_requests: number;
+        status_2xx: number;
+        errors_4xx: number;
+        fallback_rescues: number;
+    }>,
+    options: { timestamp: number; minutes: number },
+) {
+    const row = rows.find((candidate) => candidate.model === info.name);
+    if (!row) return undefined;
+    const attempts = row.total_requests - row.errors_4xx;
+    if (attempts <= 0) return undefined;
+    return {
+        success_rate: Math.min(
+            1,
+            (row.status_2xx + row.fallback_rescues) / attempts,
+        ),
+        samples: row.total_requests,
+        window_minutes: options.minutes,
+        as_of: new Date(options.timestamp).toISOString(),
+    };
+}
+
+// Experimental (alpha) status stays separate from reliability; this check
+// only looks at the health window.
+export function isReliable(info: GenerationModelEntry["info"]): boolean {
+    return (
+        info.health !== undefined &&
+        info.health.success_rate >= RELIABLE_SUCCESS_RATE_THRESHOLD
+    );
+}
+
+// Attach minimal health metadata (success rate, samples, window, freshness)
+// to listing entries. Missing or unavailable health data means unknown:
+// entries without health rows stay untouched.
+function attachHealth(
+    entries: GenerationModelEntry[],
+    healthData: Awaited<ReturnType<typeof fetchModelHealthData>>,
+): GenerationModelEntry[] {
+    if (!healthData) return entries;
+    return entries.map((entry) => {
+        const health = healthFor(
+            entry.info,
+            healthData.data.data,
+            {
+                timestamp: healthData.timestamp,
+                minutes: MODEL_HEALTH_WINDOW_MINUTES,
+            },
+        );
+        return health
+            ? { ...entry, info: { ...entry.info, health } }
+            : entry;
+    });
 }
 
 // Factory for model-list endpoints: validates the community query parameter,
@@ -272,20 +346,38 @@ const modelsListHandler = (
     [
         validator("query", ModelListQueryParamsSchema),
         async (c: Context<Env>) => {
-            const { community } = c.req.valid(
+            const { source: querySource, reliable } = c.req.valid(
                 "query" as never,
             ) as ModelListQueryParams;
+            // The query parameter wins over the optional header so clients
+            // with fixed base URLs can still opt into source filtering.
+            const source =
+                querySource ??
+                parseModelSourceHeader(
+                    c.req.header("X-Pollinations-Model-Source"),
+                );
             const allowedModels = c.var.auth?.apiKey?.permissions?.models;
             const paidBalance = hasPaidBalance(c);
+            const entries = filterBySource(
+                filterEntriesByPermissions(
+                    await getEntries(c),
+                    allowedModels,
+                    paidBalance,
+                ),
+                source,
+            );
+            // Missing or unavailable health data means unknown: listings stay
+            // valid without the health field.
+            const healthData = await fetchModelHealthData().catch(
+                () => undefined,
+            );
+            const infos = attachHealth(entries, healthData).map(
+                (entry) => entry.info,
+            );
             return c.json(
-                filterEntriesByCommunityParam(
-                    filterEntriesByPermissions(
-                        await getEntries(c),
-                        allowedModels,
-                        paidBalance,
-                    ),
-                    community,
-                ).map((entry) => entry.info),
+                reliable === "true" || reliable === "1"
+                    ? infos.filter(isReliable)
+                    : infos,
             );
         },
     ] as const;
@@ -360,6 +452,7 @@ function toOpenAIModelEntry(entry: GenerationModelEntry) {
         ...(entry.info.per_user_rpm !== undefined && {
             per_user_rpm: entry.info.per_user_rpm,
         }),
+        ...(entry.info.health && { health: entry.info.health }),
     };
 }
 
@@ -403,7 +496,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Models (OpenAI-compatible)",
             description:
-                'Returns available models in the OpenAI-compatible format (`{object: "list", data: [...]}`), with Pollinations pricing and capability extensions. Official models are ordered by modality (text, image, video, 3D, audio, realtime, embedding), with each configured default first, followed by stable and then alpha/preview models from newest to oldest. Community models follow from newest to oldest. Use `/models`, `/text/models`, `/image/models`, `/audio/models`, or `/embeddings/models` for richer metadata. When authenticated: the owner\'s private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.',
+                'Returns available models in the OpenAI-compatible format (`{object: "list", data: [...]}`), with Pollinations pricing and capability extensions. Official models are ordered by modality (text, image, video, 3D, audio, realtime, embedding), with each configured default first, followed by stable and then alpha/preview models from newest to oldest. Community models follow from newest to oldest. Use `/models`, `/text/models`, `/image/models`, `/audio/models`, or `/embeddings/models` for richer metadata. When authenticated: the owner\'s private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?source=official` for official-only or `?source=community` for community-only listings; `?reliable=true` keeps only models with proven health (success rate of at least 0.9 in the health window).',
             responses: {
                 200: {
                     description: "Success",
@@ -418,18 +511,30 @@ export const proxyRoutes = new Hono<Env>()
         }),
         validator("query", ModelListQueryParamsSchema),
         async (c) => {
-            const { community } = c.req.valid(
+            const { source: querySource, reliable } = c.req.valid(
                 "query" as never,
             ) as ModelListQueryParams;
+            const source =
+                querySource ??
+                parseModelSourceHeader(
+                    c.req.header("X-Pollinations-Model-Source"),
+                );
             const allowedModels = c.var.auth?.apiKey?.permissions?.models;
             const paidBalance = hasPaidBalance(c);
-            const modelEntries = filterEntriesByCommunityParam(
+            const entries = filterBySource(
                 filterEntriesByPermissions(
                     await getVisibleModelEntries(c),
                     allowedModels,
                     paidBalance,
                 ),
-                community,
+                source,
+            );
+            const healthData = await fetchModelHealthData().catch(
+                () => undefined,
+            );
+            const reliableOnly = reliable === "true" || reliable === "1";
+            const modelEntries = attachHealth(entries, healthData).filter(
+                (entry) => (reliableOnly ? isReliable(entry.info) : true),
             );
             return c.json({
                 object: "list" as const,
@@ -468,16 +573,22 @@ export const proxyRoutes = new Hono<Env>()
                 });
             }
             // Same permission and paid-only semantics as the list endpoint.
-            const [entry] = filterEntriesByPermissions(
+            const [matched] = filterEntriesByPermissions(
                 [visible],
                 c.var.auth?.apiKey?.permissions?.models,
                 hasPaidBalance(c),
             );
-            if (!entry) {
+            if (!matched) {
                 throw new HTTPException(404, {
                     message: `Model '${modelId}' not found`,
                 });
             }
+            // Health metadata flows into individual lookups from the same
+            // cached window as the list endpoints.
+            const healthData = await fetchModelHealthData().catch(
+                () => undefined,
+            );
+            const [entry] = attachHealth([matched], healthData);
             return c.json(toOpenAIModelEntry(entry));
         },
     )
@@ -487,7 +598,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Models",
             description:
-                "Returns all available models with pricing, capabilities, and metadata. Official models are ordered by modality (text, image, video, 3D, audio, realtime, embedding), with each configured default first, followed by stable and then alpha/preview models from newest to oldest. Community models follow from newest to oldest. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
+                "Returns all available models with pricing, capabilities, and metadata. Official models are ordered by modality (text, image, video, 3D, audio, realtime, embedding), with each configured default first, followed by stable and then alpha/preview models from newest to oldest. Community models follow from newest to oldest. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?source=official` for official-only or `?source=community` for community-only listings; `?reliable=true` keeps only models with proven health (success rate of at least 0.9 in the health window).",
             responses: {
                 200: {
                     description: "Success",
@@ -508,7 +619,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List 3D Models",
             description:
-                "Returns all available 3D model generation models with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
+                "Returns all available 3D model generation models with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?source=official` for official-only or `?source=community` for community-only listings; `?reliable=true` keeps only models with proven health (success rate of at least 0.9 in the health window).",
             responses: {
                 200: {
                     description: "Success",
@@ -529,7 +640,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Image & Video Models",
             description:
-                "Returns all available image and video generation models with pricing, capabilities, and metadata. Video models are included here — check the `output_modalities` field to distinguish image vs video models. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
+                "Returns all available image and video generation models with pricing, capabilities, and metadata. Video models are included here — check the `output_modalities` field to distinguish image vs video models. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?source=official` for official-only or `?source=community` for community-only listings; `?reliable=true` keeps only models with proven health (success rate of at least 0.9 in the health window).",
             responses: {
                 200: {
                     description: "Success",
@@ -550,7 +661,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Video Models",
             description:
-                "Returns all available video generation models with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
+                "Returns all available video generation models with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?source=official` for official-only or `?source=community` for community-only listings; `?reliable=true` keeps only models with proven health (success rate of at least 0.9 in the health window).",
             responses: {
                 200: {
                     description: "Success",
@@ -571,7 +682,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Text Models (Detailed)",
             description:
-                "Returns all available text generation and community text models with pricing, capabilities, and metadata including context window size, supported modalities, and tool support. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
+                "Returns all available text generation and community text models with pricing, capabilities, and metadata including context window size, supported modalities, and tool support. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?source=official` for official-only or `?source=community` for community-only listings; `?reliable=true` keeps only models with proven health (success rate of at least 0.9 in the health window).",
             responses: {
                 200: {
                     description: "Success",
@@ -594,7 +705,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Audio Models",
             description:
-                "Returns all available audio models (text-to-speech, music generation, and transcription) with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
+                "Returns all available audio models (text-to-speech, music generation, and transcription) with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?source=official` for official-only or `?source=community` for community-only listings; `?reliable=true` keeps only models with proven health (success rate of at least 0.9 in the health window).",
             responses: {
                 200: {
                     description: "Success",
@@ -617,7 +728,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🔢 Embeddings"],
             summary: "List Embedding Models",
             description:
-                "Returns available embedding models with pricing, capabilities, and supported input modalities. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
+                "Returns available embedding models with pricing, capabilities, and supported input modalities. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?source=official` for official-only or `?source=community` for community-only listings; `?reliable=true` keeps only models with proven health (success rate of at least 0.9 in the health window).",
             responses: {
                 200: {
                     description: "Success",

--- a/gen.pollinations.ai/src/schemas/models.ts
+++ b/gen.pollinations.ai/src/schemas/models.ts
@@ -1,10 +1,24 @@
 import { z } from "zod";
 
 export const ModelListQueryParamsSchema = z.object({
-    community: z.enum(["true", "false", "1", "0"]).optional().meta({
-        description:
-            "Filter by community status: `true`/`1` for community-only, `false`/`0` for official-only. Omit for all models.",
-    }),
+    source: z
+        .enum(["official", "community"])
+        .optional()
+        .meta({
+            description:
+                "Filter by model source: `official` for built-in models, `community` for community models. Omit for all models.",
+        }),
+    reliable: z
+        .enum(["true", "false", "1", "0"])
+        .optional()
+        .meta({
+            description:
+                "Filter to models with proven reliability: health data in the default window must show a success rate of at least 0.9 with at least one sample. Models without health data are excluded.",
+        }),
 });
 
 export type ModelListQueryParams = z.infer<typeof ModelListQueryParamsSchema>;
+
+// Reliability threshold for the `reliable` model list filter: a model counts
+// as reliable when its health window shows at least this success rate.
+export const RELIABLE_SUCCESS_RATE_THRESHOLD = 0.9;

--- a/gen.pollinations.ai/test/model-source-health.test.ts
+++ b/gen.pollinations.ai/test/model-source-health.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import {
+    filterBySource,
+    healthFor,
+    isReliable,
+} from "@/routes/proxy.ts";
+import { RELIABLE_SUCCESS_RATE_THRESHOLD } from "@/schemas/models.ts";
+import type { GenerationModelEntry } from "@/model-registry.ts";
+
+function fakeEntry(community: boolean): GenerationModelEntry {
+    return {
+        communityEndpoint: community
+            ? ({ visibility: "public" } as never)
+            : undefined,
+    } as unknown as GenerationModelEntry;
+}
+
+const INFO_NAME = "openai/gpt-5.4-nano";
+
+const HEALTH_ROWS = [
+    {
+        model: INFO_NAME,
+        event_type: "generate.text",
+        total_requests: 100,
+        status_2xx: 80,
+        errors_4xx: 10,
+        errors_5xx: 10,
+        fallback_rescues: 3,
+    },
+];
+
+const OPTIONS = { timestamp: 1760000000000, minutes: 60 };
+
+describe("source filtering", () => {
+    const entries = [
+        fakeEntry(false),
+        fakeEntry(true),
+        fakeEntry(false),
+        fakeEntry(true),
+    ];
+
+    it("keeps everything when the source is omitted", () => {
+        expect(filterBySource(entries, undefined)).toHaveLength(4);
+    });
+
+    it("keeps only built-in entries for official", () => {
+        const official = filterBySource(entries, "official");
+        expect(official).toHaveLength(2);
+        expect(official.every((e) => e.communityEndpoint === undefined)).toBe(
+            true,
+        );
+    });
+
+    it("keeps only community entries for community", () => {
+        const community = filterBySource(entries, "community");
+        expect(community).toHaveLength(2);
+        expect(community.every((e) => e.communityEndpoint !== undefined)).toBe(
+            true,
+        );
+    });
+});
+
+describe("model health metadata", () => {
+    it("counts fallback rescues as successes and excludes caller-side failures", () => {
+        const health = healthFor(
+            { name: INFO_NAME } as never,
+            HEALTH_ROWS,
+            OPTIONS,
+        );
+        // successes = status_2xx + fallback_rescues = 83
+        // attempts = total_requests - errors_4xx = 90
+        expect(health?.success_rate).toBeCloseTo(83 / 90);
+        expect(health?.samples).toBe(100);
+        expect(health?.window_minutes).toBe(60);
+        expect(new Date(health?.as_of ?? "").getTime()).toBe(
+            OPTIONS.timestamp,
+        );
+    });
+
+    it("means unknown without health rows", () => {
+        const info = { name: "unknown/model" } as never;
+        expect(healthFor(info, HEALTH_ROWS, OPTIONS)).toBeUndefined();
+    });
+
+    it("means unknown for a model with no successful attempts", () => {
+        const empty = healthFor(
+            { name: INFO_NAME } as never,
+            [
+                {
+                    model: INFO_NAME,
+                    event_type: "generate.text",
+                    total_requests: 0,
+                    status_2xx: 0,
+                    errors_4xx: 0,
+                    errors_5xx: 0,
+                    fallback_rescues: 0,
+                },
+            ],
+            OPTIONS,
+        );
+        expect(empty).toBeUndefined();
+    });
+});
+
+describe("reliability filter", () => {
+    it("requires a success rate at or above the threshold", () => {
+        const atThreshold = isReliable({
+            name: INFO_NAME,
+            health: {
+                success_rate: RELIABLE_SUCCESS_RATE_THRESHOLD,
+                samples: 100,
+                window_minutes: 60,
+                as_of: "2026-09-11T00:00:00.000Z",
+            },
+        } as never);
+        expect(atThreshold).toBe(true);
+
+        const below = isReliable({
+            name: INFO_NAME,
+            health: {
+                success_rate: RELIABLE_SUCCESS_RATE_THRESHOLD - 0.05,
+                samples: 100,
+                window_minutes: 60,
+                as_of: "2026-09-11T00:00:00.000Z",
+            },
+        } as never);
+        expect(below).toBe(false);
+    });
+
+    it("means not reliable when health data is missing", () => {
+        expect(isReliable({ name: INFO_NAME } as never)).toBe(false);
+    });
+});

--- a/shared/registry/model-info.ts
+++ b/shared/registry/model-info.ts
@@ -92,6 +92,16 @@ export const ModelInfoSchema = z.object({
     output_modalities: z.array(z.enum(MODEL_OUTPUT_MODALITIES)).optional(),
     required_safety: z.array(z.enum(SAFETY_FEATURES)).optional(),
     supported_endpoints: z.array(z.string()).optional(),
+    supported_parameters: z.array(z.string()).optional(),
+    default_parameters: z.record(z.string(), z.unknown()).optional(),
+    health: z
+        .object({
+            success_rate: z.number().min(0).max(1),
+            samples: z.number().int().nonnegative(),
+            window_minutes: z.number().int().positive(),
+            as_of: z.string().datetime(),
+        })
+        .optional(),
     video_capabilities: z.array(z.enum(VIDEO_CAPABILITIES)).optional(),
     min_duration: z.number().positive().optional(),
     max_duration: z.number().positive().optional(),
@@ -207,6 +217,8 @@ export function modelInfoFromDefinition(
         output_modalities: service.outputModalities,
         required_safety: service.requiredSafetyFeatures,
         supported_endpoints: service.supportedEndpoints,
+        supported_parameters: service.supportedParameters,
+        default_parameters: service.defaultParameters,
         video_capabilities: service.videoCapabilities,
         min_duration: service.minDuration,
         max_duration: service.maxDuration,


### PR DESCRIPTION
Fixes #14535

Model list endpoints gain source/reliability discovery filters and minimal health metadata.

## What it does

- `?source=official|community` replaces the `?community=true|false|1|0` filter (the issue explicitly allows breaking compatibility); an optional `X-Pollinations-Model-Source` header does the same for clients whose fixed base URLs cannot carry query strings — the query parameter wins when both are present
- `?reliable=true` keeps only models whose health window shows a success rate of at least 0.9 (`RELIABLE_SUCCESS_RATE_THRESHOLD`); models without health data are excluded — unknown is not reliable
- Listings expose minimal `health` metadata — `success_rate` (0–1), `samples`, `window_minutes` (60), `as_of` freshness — computed from the same cached Tinybird `model_health` pipe that powers `/v1/models/status`, now extracted into a shared `fetchModelHealthData`
- Success rate counts fallback rescues as successes (they end in 2xx) and excludes caller-side 4xx failures from the denominator; missing data means unknown — entries without health rows stay untouched
- Experimental (`alpha`) status stays separate from reliability; access rules, permission filtering, and the default listing are unchanged

Applied to `/v1/models`, `/v1/models/:model`, `/models`, `/text/models`, and the other category lists through the shared `modelsListHandler`.

## Tests

New focused suite `gen.pollinations.ai/test/model-source-health.test.ts`:
- source filtering (official / community / omitted)
- health computation (fallback rescues as successes, caller-side failures excluded, unknown cases)
- the reliability threshold

## Docs + client examples

- `gen.pollinations.ai/src/docs/models.md` documents the filters, the health metadata, and client examples:
  ```bash
  curl "https://gen.pollinations.ai/v1/models?source=official"
  curl "https://gen.pollinations.ai/v1/models?reliable=true"
  curl -H "X-Pollinations-Model-Source: official" "https://gen.pollinations.ai/v1/models"
  ```

Information only: no generation behavior, billing, or access rules changed.
