### PR TITLE
fix: keep unknown agent costs out of free pricing

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/model-catalog.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-catalog.ts
@@ -207,7 +207,9 @@ function baseModelPrice(model: ApiModelInfo): ModelPrice | null {
         supportedEndpoints: model.supported_endpoints,
         capabilities: model.capabilities ?? [],
         paidOnly: model.paid_only,
+        // Agents may spend Pollen downstream even when their wrapper is free.
         free:
+            !model.agent &&
             model.pricing !== undefined &&
             inputSortPrice === undefined &&
             outputSortPrice === undefined,

--- a/enter.pollinations.ai/test/model-calculations.test.ts
+++ b/enter.pollinations.ai/test/model-calculations.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { calculatePerPollen } from "../frontend/src/components/models/calculations.ts";
 import { getModelPricesFromCatalog } from "../frontend/src/components/models/model-catalog.ts";
+import {
+    matchesModelQuery,
+    parseModelQuery,
+} from "../frontend/src/components/models/model-query.ts";
+import { sortModels } from "../frontend/src/components/models/model-sort.ts";
 import type { ModelPrice } from "../frontend/src/components/models/types.ts";
 
 function model(overrides: Partial<ModelPrice> = {}): ModelPrice {
@@ -48,5 +53,52 @@ describe("model per-pollen calculations", () => {
 
         expect(freeModel?.free).toBe(true);
         expect(calculatePerPollen(freeModel)).toBe("∞");
+    });
+
+    it.each([
+        undefined,
+        0,
+        0.02,
+    ])("does not mistake an agent's free wrapper for its run cost (%s)", (avgCost) => {
+        const prices = getModelPricesFromCatalog(
+            [
+                {
+                    name: "owner/agent",
+                    category: "text",
+                    agent: true,
+                    community: true,
+                    pricing: { currency: "pollen" },
+                },
+                {
+                    name: "free-model",
+                    category: "text",
+                    pricing: { currency: "pollen" },
+                },
+            ],
+            avgCost === undefined
+                ? undefined
+                : {
+                      "owner/agent": { avgCost, requestCount: 3 },
+                  },
+        );
+        const [agent, freeModel] = prices;
+
+        expect(agent.free).toBe(false);
+        expect(calculatePerPollen(agent)).toBe(avgCost ? "50" : "—");
+        expect(matchesModelQuery(agent, parseModelQuery("access:free"))).toBe(
+            false,
+        );
+        expect(freeModel.free).toBe(true);
+        expect(calculatePerPollen(freeModel)).toBe("∞");
+        expect(sortModels(prices, "price-low").map(({ name }) => name)).toEqual(
+            ["free-model", "owner/agent"],
+        );
+        expect(
+            sortModels(prices, "price-high").map(({ name }) => name),
+        ).toEqual(
+            avgCost
+                ? ["owner/agent", "free-model"]
+                : ["free-model", "owner/agent"],
+        );
     });
 });


### PR DESCRIPTION
- Treat zero-priced agent listings as unknown run cost until measured usage is available; agents may spend Pollen downstream.
- Keep ordinary free models at ∞ requests/Pollen and preserve measured cost estimates; the existing free filter, badges, and price sorting follow the same catalog flag.
- Add direct catalog-to-display/filter/sort regressions for missing, zero, and positive observations. Validation: 55 targeted tests, Enter typecheck, frontend build, and Biome pass.
- Independent follow-up from #14622; completes the display behavior introduced by #13467. No billing, Tinybird, or API changes.