### PR TITLE
fix: preserve prompt agent error messages

### DIFF
--- a/gen.pollinations.ai/src/text/agents/responses.ts
+++ b/gen.pollinations.ai/src/text/agents/responses.ts
@@ -1,3 +1,4 @@
+import { communityEndpointErrorDetail } from "@shared/community-endpoints.ts";
 import {
     type CreateResponseRequest,
     CreateResponseRequestSchema,
@@ -546,6 +547,12 @@ function responseObject(
     return response;
 }
 
+function errorMessage(error: unknown): string {
+    const message =
+        typeof error === "string" ? error : communityEndpointErrorDetail(error);
+    return message?.trim() ? message : "Agent request failed";
+}
+
 function errorResponse(error: unknown): Response {
     const invalid = error instanceof AgentResponsesRequestError;
     const upstreamStatus = APICallError.isInstance(error)
@@ -559,7 +566,7 @@ function errorResponse(error: unknown): Response {
     return Response.json(
         {
             error: {
-                message: error instanceof Error ? error.message : String(error),
+                message: errorMessage(error),
                 type: invalid ? "invalid_request_error" : "server_error",
                 code: invalid ? "unsupported_parameter" : "agent_error",
                 param: invalid ? error.param : null,
@@ -630,8 +637,7 @@ function streamResponse(
                     { response },
                 );
             } catch (error) {
-                const message =
-                    error instanceof Error ? error.message : String(error);
+                const message = errorMessage(error);
                 const responseError = { code: "agent_error", message };
                 send("error", { ...responseError, param: null });
                 send("response.failed", {

--- a/gen.pollinations.ai/test/text/agents/responses.test.ts
+++ b/gen.pollinations.ai/test/text/agents/responses.test.ts
@@ -366,6 +366,80 @@ describe("managed agent Responses runtime", () => {
     });
 
     it.each([
+        [
+            "Provider temporarily unavailable",
+            "Provider temporarily unavailable",
+        ],
+        ["   ", "Agent request failed"],
+    ])("reports an upstream stream error message %j", async (message, expected) => {
+        const fetchMock = vi.fn(
+            async () =>
+                new Response(
+                    `data: ${JSON.stringify({
+                        error: {
+                            message,
+                            type: "server_error",
+                            code: "provider_unavailable",
+                            param: { authorization: "private-provider-detail" },
+                        },
+                    })}\n\ndata: [DONE]\n\n`,
+                    { headers: { "content-type": "text/event-stream" } },
+                ),
+        );
+        vi.stubGlobal("fetch", fetchMock);
+
+        const response = await handlePromptAgentResponsesRequest(
+            request({ stream: true }),
+            new AbortController().signal,
+            RUNTIME,
+        );
+        const body = await response.text();
+        expect(streamEvents(body)).toMatchObject([
+            { type: "response.created" },
+            { type: "error", code: "agent_error", message: expected },
+            {
+                type: "response.failed",
+                response: {
+                    status: "failed",
+                    usage: null,
+                    error: { code: "agent_error", message: expected },
+                },
+            },
+        ]);
+        expect(body).not.toContain("private-provider-detail");
+        expect(body.match(/data: \[DONE\]/g)).toHaveLength(1);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+        [new Error("Connection failed"), "Connection failed"],
+        ["Connection failed", "Connection failed"],
+        [{ message: "Connection failed" }, "Connection failed"],
+        [{ message: "   " }, "Agent request failed"],
+        [{ authorization: "private-provider-detail" }, "Agent request failed"],
+    ])("reports a safe JSON error for %j", async (error, expected) => {
+        const response = await handlePromptAgentResponsesRequest(
+            request({}),
+            new AbortController().signal,
+            {
+                ...RUNTIME,
+                fetcher: async () => {
+                    throw error;
+                },
+            },
+        );
+        expect(response.status).toBe(502);
+        expect(await response.json()).toEqual({
+            error: {
+                message: expected,
+                type: "server_error",
+                code: "agent_error",
+                param: null,
+            },
+        });
+    });
+
+    it.each([
         false,
         true,
     ])("fails closed when stream:%s omits usage", async (stream) => {


### PR DESCRIPTION
- Preserves meaningful SDK error messages in prompt-agent JSON responses and SSE error/response.failed events.
- Reuses the existing safe message extractor; falls back for blank or unknown errors without serializing private diagnostic fields.
- Adds real-SDK regressions for upstream stream errors and JSON failures; 84 scoped tests, Gen TypeScript, and Biome pass.
- Addresses a pre-existing issue found during review of #14622; independent of the code-agent implementation.