### PR TITLE
chore: promote main to production

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/models/model-catalog.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/model-catalog.ts
@@ -207,7 +207,9 @@ function baseModelPrice(model: ApiModelInfo): ModelPrice | null {
         supportedEndpoints: model.supported_endpoints,
         capabilities: model.capabilities ?? [],
         paidOnly: model.paid_only,
+        // Agents may spend Pollen downstream even when their wrapper is free.
         free:
+            !model.agent &&
             model.pricing !== undefined &&
             inputSortPrice === undefined &&
             outputSortPrice === undefined,

--- a/enter.pollinations.ai/src/routes/agents.ts
+++ b/enter.pollinations.ai/src/routes/agents.ts
@@ -319,6 +319,10 @@ export const agentsRoutes = new Hono<Env>()
                             ? stored.description
                             : input.description || null,
                     visibility,
+                    ...(input.visibility === "private" && {
+                        pendingVisibility: null,
+                        pendingAt: null,
+                    }),
                     requiredSafetyFeatures:
                         input.requiredSafetyFeatures ??
                         stored.requiredSafetyFeatures,

--- a/enter.pollinations.ai/test/integration/community-endpoint-price-delay.test.ts
+++ b/enter.pollinations.ai/test/integration/community-endpoint-price-delay.test.ts
@@ -2,6 +2,7 @@ import { env, SELF } from "cloudflare:test";
 import {
     COMMUNITY_ENDPOINT_CHANGE_DELAY_MS,
     COMMUNITY_ENDPOINT_PRICE_FIELDS,
+    effectiveCommunityEndpointVisibility,
 } from "@shared/community-endpoints.ts";
 import * as schema from "@shared/db/better-auth.ts";
 import { getVisibleModelIdsForUser } from "@shared/registry/visible-model-ids.ts";
@@ -293,6 +294,86 @@ describe("community endpoint 3-hour price-change delay", () => {
             visibility: "public",
             pending: null,
         });
+    });
+
+    test("only explicit private agent updates cancel queued publication", async ({
+        sessionToken,
+    }) => {
+        await approveCommunityModels();
+        const agentsUrl = "http://localhost:3000/api/account/agents";
+        const headers = {
+            "Content-Type": "application/json",
+            Cookie: `better-auth.session_token=${sessionToken}`,
+        };
+        const config = {
+            systemPrompt: "Answer briefly.",
+            baseModel: "openai",
+        };
+        const createdResponse = await SELF.fetch(agentsUrl, {
+            method: "POST",
+            headers,
+            body: JSON.stringify({
+                ...config,
+                name: "cancel-prompt-publication",
+                title: "Prompt agent",
+            }),
+        });
+        expect(createdResponse.status).toBe(200);
+        const { id } = await createdResponse.json<{ id: string }>();
+        const queued = await postModel(sessionToken, `/${id}/update`, {
+            visibility: "public",
+        });
+        expect(queued).toMatchObject({
+            visibility: "private",
+            pending: { visibility: "public" },
+        });
+        const db = drizzle(env.DB, { schema });
+        const before = await db.query.communityEndpoint.findFirst({
+            where: eq(schema.communityEndpoint.id, id),
+        });
+
+        const editedResponse = await SELF.fetch(`${agentsUrl}/${id}`, {
+            method: "PATCH",
+            headers,
+            body: JSON.stringify({ ...config, title: "Renamed prompt agent" }),
+        });
+        expect(editedResponse.status).toBe(200);
+        await editedResponse.text();
+        const edited = await db.query.communityEndpoint.findFirst({
+            where: eq(schema.communityEndpoint.id, id),
+        });
+        expect(edited?.pendingVisibility).toBe("public");
+        expect(edited?.pendingAt).toEqual(before?.pendingAt);
+
+        const privateResponse = await SELF.fetch(`${agentsUrl}/${id}`, {
+            method: "PATCH",
+            headers,
+            body: JSON.stringify({ ...config, visibility: "private" }),
+        });
+        expect(privateResponse.status).toBe(200);
+        expect(await privateResponse.json()).toMatchObject({
+            visibility: "private",
+        });
+        const cancelled = await db.query.communityEndpoint.findFirst({
+            where: eq(schema.communityEndpoint.id, id),
+        });
+        if (!cancelled) throw new Error("Agent not found");
+        expect(cancelled).toMatchObject({
+            visibility: "private",
+            pendingVisibility: null,
+            pendingAt: null,
+        });
+        expect(
+            effectiveCommunityEndpointVisibility(
+                cancelled.visibility,
+                cancelled.pendingVisibility,
+                cancelled.pendingAt,
+                Date.now() + COMMUNITY_ENDPOINT_CHANGE_DELAY_MS + 1000,
+            ),
+        ).toBe("private");
+        expect(
+            await getVisibleModelIdsForUser(env.DB, "another-user"),
+        ).not.toContain(queued.modelId);
     });
 
     test("public-to-private is immediate and clears any pending price change", async ({

--- a/enter.pollinations.ai/test/model-calculations.test.ts
+++ b/enter.pollinations.ai/test/model-calculations.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { calculatePerPollen } from "../frontend/src/components/models/calculations.ts";
 import { getModelPricesFromCatalog } from "../frontend/src/components/models/model-catalog.ts";
+import {
+    matchesModelQuery,
+    parseModelQuery,
+} from "../frontend/src/components/models/model-query.ts";
+import { sortModels } from "../frontend/src/components/models/model-sort.ts";
 import type { ModelPrice } from "../frontend/src/components/models/types.ts";
 
 function model(overrides: Partial<ModelPrice> = {}): ModelPrice {
@@ -48,5 +53,52 @@ describe("model per-pollen calculations", () => {
 
         expect(freeModel?.free).toBe(true);
         expect(calculatePerPollen(freeModel)).toBe("∞");
+    });
+
+    it.each([
+        undefined,
+        0,
+        0.02,
+    ])("does not mistake an agent's free wrapper for its run cost (%s)", (avgCost) => {
+        const prices = getModelPricesFromCatalog(
+            [
+                {
+                    name: "owner/agent",
+                    category: "text",
+                    agent: true,
+                    community: true,
+                    pricing: { currency: "pollen" },
+                },
+                {
+                    name: "free-model",
+                    category: "text",
+                    pricing: { currency: "pollen" },
+                },
+            ],
+            avgCost === undefined
+                ? undefined
+                : {
+                      "owner/agent": { avgCost, requestCount: 3 },
+                  },
+        );
+        const [agent, freeModel] = prices;
+
+        expect(agent.free).toBe(false);
+        expect(calculatePerPollen(agent)).toBe(avgCost ? "50" : "—");
+        expect(matchesModelQuery(agent, parseModelQuery("access:free"))).toBe(
+            false,
+        );
+        expect(freeModel.free).toBe(true);
+        expect(calculatePerPollen(freeModel)).toBe("∞");
+        expect(sortModels(prices, "price-low").map(({ name }) => name)).toEqual(
+            ["free-model", "owner/agent"],
+        );
+        expect(
+            sortModels(prices, "price-high").map(({ name }) => name),
+        ).toEqual(
+            avgCost
+                ? ["owner/agent", "free-model"]
+                : ["free-model", "owner/agent"],
+        );
     });
 });

--- a/gen.pollinations.ai/src/text/agents/responses.ts
+++ b/gen.pollinations.ai/src/text/agents/responses.ts
@@ -1,3 +1,4 @@
+import { communityEndpointErrorDetail } from "@shared/community-endpoints.ts";
 import {
     type CreateResponseRequest,
     CreateResponseRequestSchema,
@@ -546,6 +547,12 @@ function responseObject(
     return response;
 }
 
+function errorMessage(error: unknown): string {
+    const message =
+        typeof error === "string" ? error : communityEndpointErrorDetail(error);
+    return message?.trim() ? message : "Agent request failed";
+}
+
 function errorResponse(error: unknown): Response {
     const invalid = error instanceof AgentResponsesRequestError;
     const upstreamStatus = APICallError.isInstance(error)
@@ -559,7 +566,7 @@ function errorResponse(error: unknown): Response {
     return Response.json(
         {
             error: {
-                message: error instanceof Error ? error.message : String(error),
+                message: errorMessage(error),
                 type: invalid ? "invalid_request_error" : "server_error",
                 code: invalid ? "unsupported_parameter" : "agent_error",
                 param: invalid ? error.param : null,
@@ -630,8 +637,7 @@ function streamResponse(
                     { response },
                 );
             } catch (error) {
-                const message =
-                    error instanceof Error ? error.message : String(error);
+                const message = errorMessage(error);
                 const responseError = { code: "agent_error", message };
                 send("error", { ...responseError, param: null });
                 send("response.failed", {

--- a/gen.pollinations.ai/test/text/agents/responses.test.ts
+++ b/gen.pollinations.ai/test/text/agents/responses.test.ts
@@ -366,6 +366,80 @@ describe("managed agent Responses runtime", () => {
     });
 
     it.each([
+        [
+            "Provider temporarily unavailable",
+            "Provider temporarily unavailable",
+        ],
+        ["   ", "Agent request failed"],
+    ])("reports an upstream stream error message %j", async (message, expected) => {
+        const fetchMock = vi.fn(
+            async () =>
+                new Response(
+                    `data: ${JSON.stringify({
+                        error: {
+                            message,
+                            type: "server_error",
+                            code: "provider_unavailable",
+                            param: { authorization: "private-provider-detail" },
+                        },
+                    })}\n\ndata: [DONE]\n\n`,
+                    { headers: { "content-type": "text/event-stream" } },
+                ),
+        );
+        vi.stubGlobal("fetch", fetchMock);
+
+        const response = await handlePromptAgentResponsesRequest(
+            request({ stream: true }),
+            new AbortController().signal,
+            RUNTIME,
+        );
+        const body = await response.text();
+        expect(streamEvents(body)).toMatchObject([
+            { type: "response.created" },
+            { type: "error", code: "agent_error", message: expected },
+            {
+                type: "response.failed",
+                response: {
+                    status: "failed",
+                    usage: null,
+                    error: { code: "agent_error", message: expected },
+                },
+            },
+        ]);
+        expect(body).not.toContain("private-provider-detail");
+        expect(body.match(/data: \[DONE\]/g)).toHaveLength(1);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([
+        [new Error("Connection failed"), "Connection failed"],
+        ["Connection failed", "Connection failed"],
+        [{ message: "Connection failed" }, "Connection failed"],
+        [{ message: "   " }, "Agent request failed"],
+        [{ authorization: "private-provider-detail" }, "Agent request failed"],
+    ])("reports a safe JSON error for %j", async (error, expected) => {
+        const response = await handlePromptAgentResponsesRequest(
+            request({}),
+            new AbortController().signal,
+            {
+                ...RUNTIME,
+                fetcher: async () => {
+                    throw error;
+                },
+            },
+        );
+        expect(response.status).toBe(502);
+        expect(await response.json()).toEqual({
+            error: {
+                message: expected,
+                type: "server_error",
+                code: "agent_error",
+                param: null,
+            },
+        });
+    });
+
+    it.each([
         false,
         true,
     ])("fails closed when stream:%s omits usage", async (stream) => {


### PR DESCRIPTION
- Promotes #14709: show unknown agent costs instead of free
- Promotes #14710: cancel queued publication when agents become private
- Promotes #14711: preserve meaningful prompt-agent error messages
- Preflight: clean merge-tree, no secret or Tinybird changes, all feature CI green