### PR TITLE
Fixes #14599: expose supported/default chat parameters in model listings

### DIFF
--- a/gen.pollinations.ai/src/docs/models.md
+++ b/gen.pollinations.ai/src/docs/models.md
@@ -32,6 +32,28 @@ Rich model endpoints include `capabilities` for agentic/model traits:
 Modalities, video frame controls, voices, and context length remain separate
 structured fields.
 
+### Supported parameters
+
+Text models that have been verified through Pollinations expose Chat-API
+controls for settings UIs:
+
+- `supported_parameters`: controls the gateway forwards for this model
+  (e.g. `messages`, `max_tokens`, `tools`, `reasoning_effort`). Controls the
+  gateway silently strips (such as sampling params on some families) are
+  never listed here.
+- `default_parameters`: Pollinations-applied defaults. Empty when
+  Pollinations applies no default — unknown upstream defaults are never
+  invented.
+- `parameter_notes`: human-readable conditions (e.g. "`top_p` is dropped
+  when `temperature` is set", "thinking off by default").
+
+The fields appear on `/models`, `/text/models`, `/v1/models`, and
+`/v1/models/:model`, with identical values for an ID and its aliases.
+They describe the Chat API (`/v1/chat/completions`, `/text`) only — they do
+not describe the native Responses API (`/v1/responses`), which has its own
+parameters. Models without verified data omit the fields (unknown, not
+empty). Generation behavior, billing, and access rules are unchanged.
+
 Use `supported_endpoints` to discover which public API routes accept each
 model. `/v1/responses` identifies built-in models with a configured native
 Responses route, community text models and endpoint agents whose owner supplied

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -360,6 +360,15 @@ function toOpenAIModelEntry(entry: GenerationModelEntry) {
         ...(entry.info.per_user_rpm !== undefined && {
             per_user_rpm: entry.info.per_user_rpm,
         }),
+        ...(entry.info.supported_parameters && {
+            supported_parameters: entry.info.supported_parameters,
+        }),
+        ...(entry.info.default_parameters && {
+            default_parameters: entry.info.default_parameters,
+        }),
+        ...(entry.info.parameter_notes && {
+            parameter_notes: entry.info.parameter_notes,
+        }),
     };
 }
 

--- a/gen.pollinations.ai/test/model-parameters.test.ts
+++ b/gen.pollinations.ai/test/model-parameters.test.ts
@@ -1,0 +1,89 @@
+import { SELF } from "cloudflare:test";
+import { test } from "@shared/test/fixtures/index.ts";
+import { expect } from "vitest";
+
+async function fetchWorker(path: string, init: RequestInit = {}) {
+    return SELF.fetch(new Request(`https://gen.pollinations.ai${path}`, init));
+}
+
+const VERIFIED_MODELS = [
+    "openai/gpt-5.4-nano",
+    "openai/gpt-5.4",
+    "anthropic/claude-haiku-4.5",
+] as const;
+
+test("verified chat models expose supported/default parameters on rich listings", async () => {
+    for (const path of ["/models", "/text/models"]) {
+        const response = await fetchWorker(path);
+        expect(response.status).toBe(200);
+        const models = (await response.json()) as Record<string, unknown>[];
+        for (const name of VERIFIED_MODELS) {
+            const model = models.find((m) => m.name === name) as
+                | Record<string, unknown>
+                | undefined;
+            expect(model, `${name} on ${path}`).toBeDefined();
+            expect(model!.supported_parameters).toEqual(expect.any(Array));
+            expect(
+                (model!.supported_parameters as unknown[]).length,
+            ).toBeGreaterThan(0);
+            expect(model!.default_parameters).toEqual(expect.any(Object));
+            expect(model!.parameter_notes).toEqual(expect.any(String));
+        }
+    }
+});
+
+test("v1 models list and retrieve share parameter metadata (aliases consistent)", async () => {
+    const listResponse = await fetchWorker("/v1/models");
+    expect(listResponse.status).toBe(200);
+    const list = (await listResponse.json()) as {
+        data: Record<string, unknown>[];
+    };
+
+    const nano = list.data.find((m) => m.id === "openai/gpt-5.4-nano");
+    expect(nano).toBeDefined();
+    // Sampling controls are stripped by the gateway — never advertised.
+    expect(nano!.supported_parameters).not.toContain("temperature");
+    expect(nano!.supported_parameters).not.toContain("seed");
+    expect(nano!.supported_parameters).toContain("tools");
+
+    const reasoning = list.data.find((m) => m.id === "openai/gpt-5.4");
+    expect(reasoning!.supported_parameters).toContain("reasoning_effort");
+
+    const claude = list.data.find(
+        (m) => m.id === "anthropic/claude-haiku-4.5",
+    );
+    expect(claude!.supported_parameters).toContain("temperature");
+    expect(claude!.supported_parameters).toContain("reasoning_effort");
+    expect(claude!.default_parameters).toMatchObject({
+        reasoning_effort: "none",
+    });
+
+    // Retrieve matches list entry exactly (shared mapper).
+    for (const name of VERIFIED_MODELS) {
+        const retrieved = await fetchWorker(
+            `/v1/models/${encodeURIComponent(name)}`,
+        );
+        expect(retrieved.status).toBe(200);
+        expect(await retrieved.json()).toEqual(
+            list.data.find((m) => m.id === name),
+        );
+    }
+
+    // Alias resolves to the canonical entry with identical metadata.
+    const aliasResponse = await fetchWorker("/v1/models/claude-haiku");
+    expect(aliasResponse.status).toBe(200);
+    expect(await aliasResponse.json()).toEqual(
+        list.data.find((m) => m.id === "anthropic/claude-haiku-4.5"),
+    );
+});
+
+test("parameter metadata describes chat only and omits unknowns", async () => {
+    const response = await fetchWorker(
+        `/v1/models/${encodeURIComponent("openai/gpt-5.4-nano")}`,
+    );
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(String(body.parameter_notes)).toMatch(/chat api only/i);
+    expect(String(body.parameter_notes)).toMatch(/not \/v1\/responses/i);
+    // No invented upstream defaults.
+    expect(body.default_parameters).toEqual({});
+});

--- a/shared/registry/model-info.ts
+++ b/shared/registry/model-info.ts
@@ -119,6 +119,9 @@ export const ModelInfoSchema = z.object({
     alpha: z.boolean().optional(),
     flat_rate: z.boolean().optional(),
     added_date: z.number().optional(),
+    supported_parameters: z.array(z.string()).optional(),
+    default_parameters: z.record(z.string(), z.unknown()).optional(),
+    parameter_notes: z.string().optional(),
 });
 
 export type ModelInfo = z.infer<typeof ModelInfoSchema>;
@@ -231,6 +234,13 @@ export function modelInfoFromDefinition(
                 ? service.cost.promptTextTokens === undefined
                 : undefined),
         added_date: service.addedDate,
+        supported_parameters: service.supportedParameters
+            ? [...service.supportedParameters]
+            : undefined,
+        default_parameters: service.defaultParameters
+            ? { ...service.defaultParameters }
+            : undefined,
+        parameter_notes: service.parameterNotes,
     };
 }
 

--- a/shared/registry/registry.ts
+++ b/shared/registry/registry.ts
@@ -230,6 +230,21 @@ export type ModelDefinition = {
     maxReferenceVideos?: number; // Models with video input: effective accepted reference videos
     /** Internal provider-route output-token cap used for fallback compatibility. */
     maxCompletionTokens?: number;
+    /**
+     * Chat-completions controls that work through Pollinations for this model.
+     * Only list controls the gateway forwards (never ones it silently strips).
+     * Describes the Chat API (/v1/chat/completions, /text) — not the native
+     * Responses API, which has its own parameters.
+     */
+    supportedParameters?: string[];
+    /**
+     * Pollinations-applied defaults for supported controls.
+     * Omit unknown upstream defaults — an empty object means Pollinations
+     * applies no default and the upstream provider decides.
+     */
+    defaultParameters?: Record<string, unknown>;
+    /** Human-readable conditions, e.g. "top_p only when temperature is unset". */
+    parameterNotes?: string;
 };
 
 // Helper: Convert usage counts to rated USD-equivalent cost or Pollen charge.

--- a/shared/registry/text.ts
+++ b/shared/registry/text.ts
@@ -61,6 +61,23 @@ const TEXT_BASE_SERVICES = {
         tools: true,
         contextLength: 400000,
         isSpecialized: false,
+        // Verified through Pollinations: gateway strips sampling controls
+        // (see omitOpenAISampling in availableModels.ts), so they are NOT
+        // listed here. Vision works via image message parts (max 10 refs).
+        supportedParameters: [
+            "messages",
+            "model",
+            "max_tokens",
+            "max_completion_tokens",
+            "tools",
+            "tool_choice",
+            "response_format",
+            "stream",
+            "stop",
+        ],
+        defaultParameters: {},
+        parameterNotes:
+            "Chat API only (not /v1/responses). temperature, top_p, frequency_penalty, presence_penalty, repetition_penalty and seed are stripped by the gateway and have no effect; reasoning_effort is not supported on this non-reasoning model.",
     },
     "openai/gpt-5-nano": {
         aliases: ["gpt-5-nano", "gpt-5-nano-2025-08-07", "openai-fast"],
@@ -154,6 +171,23 @@ const TEXT_BASE_SERVICES = {
         reasoning: true,
         contextLength: 1050000,
         isSpecialized: false,
+        // Verified through Pollinations: sampling stripped (omitOpenAISampling);
+        // reasoning_effort is forwarded to the upstream reasoner.
+        supportedParameters: [
+            "messages",
+            "model",
+            "max_tokens",
+            "max_completion_tokens",
+            "reasoning_effort",
+            "tools",
+            "tool_choice",
+            "response_format",
+            "stream",
+            "stop",
+        ],
+        defaultParameters: {},
+        parameterNotes:
+            "Chat API only (not /v1/responses). temperature, top_p, frequency_penalty, presence_penalty, repetition_penalty and seed are stripped by the gateway and have no effect. Omit reasoning_effort for the upstream default reasoning level.",
     },
     "openai/gpt-5.4-mini": {
         aliases: ["gpt-5-mini", "openai-mini", "gpt-5.4-mini"],
@@ -1126,6 +1160,25 @@ const TEXT_BASE_SERVICES = {
         tools: true,
         contextLength: 200000,
         isSpecialized: false,
+        // Verified through Pollinations (Bedrock via Portkey gateway):
+        // preferTemperature drops top_p when temperature is set; enabling
+        // thinking via reasoning_effort strips temperature/top_p/top_k.
+        // Thinking is OFF by default (opt-in reasoning).
+        supportedParameters: [
+            "messages",
+            "model",
+            "max_tokens",
+            "temperature",
+            "top_p",
+            "reasoning_effort",
+            "tools",
+            "tool_choice",
+            "stream",
+            "stop",
+        ],
+        defaultParameters: { reasoning_effort: "none" },
+        parameterNotes:
+            "Chat API only (not /v1/responses). top_p is dropped when temperature is set (Bedrock accepts one, not both). temperature/top_p are dropped when reasoning is enabled. Thinking is off by default; pass reasoning_effort (minimal|low|medium|high) to enable budget thinking. seed and sampling beyond temperature/top_p are not supported.",
     },
     "anthropic/claude-sonnet-4.6": {
         aliases: ["claude-sonnet-4.6", "claude-sonnet", "claude"],

--- a/shared/schemas/openai.ts
+++ b/shared/schemas/openai.ts
@@ -746,6 +746,9 @@ export const OpenAIModelSchema = z
         reasoning: z.boolean().optional(),
         context_length: z.number().optional(),
         per_user_rpm: z.number().positive().nullable().optional(),
+        supported_parameters: z.array(z.string()).optional(),
+        default_parameters: z.record(z.string(), z.unknown()).optional(),
+        parameter_notes: z.string().optional(),
     })
     .meta({
         description: "OpenAI-compatible model object with capability metadata",


### PR DESCRIPTION
Fixes #14599.

Let apps discover which Chat controls a model supports and their Pollinations defaults, instead of guessing.

What:
- Registry-backed `supported_parameters` / `default_parameters` / `parameter_notes` on ModelDefinition + ModelInfo (shared/registry).
- Verified data for 3 official Chat models with different capabilities:
  - openai/gpt-5.4-nano (vision+tools, sampling stripped, no reasoning)
  - openai/gpt-5.4 (vision+tools+reasoning via reasoning_effort, sampling stripped)
  - anthropic/claude-haiku-4.5 (conditional temperature/top_p, opt-in thinking, default reasoning_effort none)
- Exposed on /models, /text/models, /v1/models and /v1/models/:model (shared mapper, aliases identical).
- OpenAPI schema updated (OpenAIModelSchema) + docs/models.md section.
- Info only: no generation, billing, or access-rule changes.

Notes:
- Only lists controls the gateway forwards (never silently-stripped sampling/seed); no invented upstream defaults (empty {} where Pollinations applies none).
- Explicitly Chat-API only, not /v1/responses.
- Focused test: gen.pollinations.ai/test/model-parameters.test.ts