### PR TITLE
Fixes #14535: filter model catalogs by source and reliability, expose health

### DIFF
--- a/gen.pollinations.ai/src/docs/models.md
+++ b/gen.pollinations.ai/src/docs/models.md
@@ -15,17 +15,97 @@ Discover available models with pricing, capabilities, and metadata. No authentic
 
 ### Query Parameters
 
-All model discovery endpoints accept an optional `community` query parameter:
-
 | Parameter | Values | Behaviour |
 |-----------|--------|-----------|
 | *(omitted)* | | Returns all models (default, backward-compatible) |
-| `community=false` | `false`, `0` | Excludes community models — returns official models only |
-| `community=true` | `true`, `1` | Returns community models only |
+| `source=official` | `official` | Official Pollinations-operated models only (Enter `source:official` terminology) |
+| `source=community` | `community` | Community-published models only |
+| `source=all` | `all` | Everything (same as omitting) |
+| `community=false` | `false`, `0` | Deprecated alias for `source=official` |
+| `community=true` | `true`, `1` | Deprecated alias for `source=community` |
+| `include_health=true` | `true`, `1` | Attach minimal `health` metadata per model (default: omitted) |
+| `health_window=1440` | `1`–`10080` | Health rolling window in minutes (default `60`, like `/v1/models/status`) |
+| `min_success_rate=0.95` | `0`–`1` | Keep only models at/above this success rate; unknown-health models are excluded |
 
-Any other value (e.g. `tru`, `yes`, `2`) returns **400 Bad Request**.
+If `source` and `community` disagree the request is rejected with **400** —
+use `source`. Any other invalid value also returns **400**.
 
-Example: `GET /models?community=false`
+Filtering is discovery-only: it runs after API-key permissions and paid-balance
+rules and never changes what you may generate with. Default listings (no
+params) are unchanged.
+
+Examples:
+
+```bash
+GET /v1/models?source=official
+GET /text/models?source=official&include_health=true&health_window=1440
+GET /v1/models?min_success_rate=0.95&include_health=true
+```
+
+### Health metadata
+
+Opt-in per-model `health` (same source as `GET /v1/models/status` and the
+dashboard uptime dot):
+
+```json
+{
+  "success_rate": 0.987,
+  "sample_count": 1523,
+  "window_minutes": 60,
+  "fetched_at": "2026-09-11T05:00:00.000Z",
+  "status": "healthy",
+  "stale": true
+}
+```
+
+- `success_rate`: `status_2xx / (status_2xx + errors_5xx)` in the window
+  (`0`–`1`, `null` when unknown). Tinybird `2xx` already includes
+  fallback-rescued requests, so rescues count as successes; caller-side `4xx`
+  failures are excluded.
+- `sample_count`: reliability sample (`2xx + 5xx`); `0` with
+  `status: "unknown"` means no data in the window — unknown, not unhealthy.
+- `status`: `healthy` / `degraded` (≥10% `5xx`) / `down` (≥50% `5xx`) /
+  `unknown`, reusing dashboard semantics. Experimental (`alpha`) status is
+  separate and never folded into reliability.
+- `stale: true` appears only when Tinybird was unreachable and a cached
+  window was served; listings never fail because health is unavailable.
+
+### Client setup (Open WebUI, LibreChat, Cline)
+
+These clients append `/models` to the configured base URL, so query strings
+embedded in the base URL break discovery. Configure the plain base URL and
+pass filters as headers instead (query params take precedence when both are
+set; headers also work for generation clients that forward them):
+
+| Header | Equivalent query |
+|--------|------------------|
+| `X-Pollinations-Source: official` | `?source=official` |
+| `X-Pollinations-Include-Health: true` | `?include_health=true` |
+| `X-Pollinations-Health-Window: 1440` | `?health_window=1440` |
+| `X-Pollinations-Min-Success-Rate: 0.95` | `?min_success_rate=0.95` |
+
+```bash
+# curl: official-only discovery + generation still uses the full catalog
+curl -H "X-Pollinations-Source: official" https://gen.pollinations.ai/v1/models
+curl https://gen.pollinations.ai/v1/models?source=official
+
+# Open WebUI: Admin Panel → Connections → OpenAI-compatible endpoint
+# Base URL: https://gen.pollinations.ai/v1 (no query string)
+# Add HTTP header: X-Pollinations-Source = official
+
+# LibreChat (administrator-configured custom endpoint, librechat.yaml):
+# customEndpoints:
+#   - name: "Pollinations"
+#     apiKey: "${POLLINATIONS_API_KEY}"
+#     baseURL: "https://gen.pollinations.ai/v1"
+#     headers:
+#       X-Pollinations-Source: "official"
+
+# Cline (OpenAI-compatible provider):
+# Base URL: https://gen.pollinations.ai/v1, API key: your Pollinations key.
+# Cline does not send custom headers for discovery; use the default catalog
+# (all models) for setup, then select an official model for generation.
+```
 
 Rich model endpoints include `capabilities` for agentic/model traits:
 `tool_calling`, `reasoning`, `web_search`, and `code_execution`.
@@ -44,6 +124,6 @@ error; use their native endpoint until attachments are supported here.
 
 ## Community Models
 
-Community models use an `owner/model` id and appear in the same discovery responses as Pollinations-operated models. Use `community=true` to return only community models or `community=false` to exclude them.
+Community models use an `owner/model` id and appear in the same discovery responses as Pollinations-operated models. Use `source=community` to return only community models or `source=official` to exclude them (`community=true/false` still works as a deprecated alias).
 
 For registration, publishing, pricing, fallbacks, and health monitoring, see [Publish a Model](/docs#tag/publish-a-model). For ownership endpoints and schemas, see [Community Models](/docs#tag/community-models) under Resources.

--- a/gen.pollinations.ai/src/model-health.ts
+++ b/gen.pollinations.ai/src/model-health.ts
@@ -1,0 +1,321 @@
+import debug from "debug";
+import { z } from "zod";
+
+const log = debug("pollinations:model-health");
+
+// Public Tinybird pipe — same source as GET /v1/models/status
+// (see src/routes/model-status.ts, which owns the canonical fetcher).
+// Mirrored here so model listings can attach minimal health metadata
+// without coupling the discovery path to the monitor route.
+const TINYBIRD_HOST = "https://api.europe-west2.gcp.tinybird.co";
+const TINYBIRD_PUBLIC_TOKEN =
+    "p.eyJ1IjogImFjYTYzZjc5LThjNTYtNDhlNC05NWJjLWEyYmFjMTY0NmJkMyIsICJpZCI6ICI5ZWZmMGM3Ni1kOTZkLTQwYjgtYWQwOC1mNDFlMmRiYjBmYTIiLCAiaG9zdCI6ICJnY3AtZXVyb3BlLXdlc3QyIn0.6VnVkAQ5h_fkcDZVDUoU38dzTxaw0xo3DnmKkhECbA8";
+
+const CACHE_TTL_MS = 60_000;
+const MAX_CACHE_ENTRIES = 16;
+export const DEFAULT_HEALTH_WINDOW_MINUTES = 60;
+
+const HealthRowSchema = z.object({
+    model: z.string(),
+    event_type: z.string(),
+    status_2xx: z.number().int().nonnegative().catch(0),
+    errors_4xx: z.number().int().nonnegative().catch(0),
+    errors_5xx: z.number().int().nonnegative().catch(0),
+    fallback_rescues: z.number().int().nonnegative().catch(0),
+});
+
+export type HealthRow = z.infer<typeof HealthRowSchema>;
+
+export type ModelHealthStatus = "healthy" | "degraded" | "down" | "unknown";
+
+export type ModelHealth = {
+    /** 0–1 share of reliability-sample requests that succeeded, null when unknown. */
+    success_rate: number | null;
+    /** Reliability sample size: 2xx + 5xx (caller-side 4xx excluded). */
+    sample_count: number;
+    window_minutes: number;
+    fetched_at: string;
+    status: ModelHealthStatus;
+    stale?: boolean;
+};
+
+type CacheEntry = {
+    rows: HealthRow[];
+    fetchedAt: number;
+};
+
+const cache = new Map<number, CacheEntry>();
+
+function setCacheEntry(minutes: number, entry: CacheEntry) {
+    cache.delete(minutes);
+    cache.set(minutes, entry);
+    if (cache.size > MAX_CACHE_ENTRIES) {
+        const oldest = cache.keys().next().value;
+        if (oldest !== undefined) cache.delete(oldest);
+    }
+}
+
+type Aggregated = { success: number; errors5xx: number };
+
+function aggregateRows(rows: HealthRow[]): Map<string, Aggregated> {
+    const map = new Map<string, Aggregated>();
+    for (const row of rows) {
+        const key = healthKey(row.model, row.event_type);
+        const current = map.get(key) ?? { success: 0, errors5xx: 0 };
+        // status_2xx already includes fallback-rescued requests: per quest,
+        // fallback rescues count as successes (no double-counting).
+        current.success += row.status_2xx;
+        current.errors5xx += row.errors_5xx;
+        map.set(key, current);
+    }
+    return map;
+}
+
+/**
+ * Dashboard semantics, reused from the Enter/play UI (useModelUptime):
+ * match on model id + event type, success = 2xx (rescues included),
+ * caller-side 4xx excluded, missing data means unknown. Experimental
+ * (alpha) status is orthogonal and never folded into reliability.
+ */
+export function computeModelHealth(
+    row: { success: number; errors5xx: number } | undefined,
+    windowMinutes: number,
+    fetchedAt: string,
+    stale = false,
+): ModelHealth {
+    const success = row?.success ?? 0;
+    const errors5xx = row?.errors5xx ?? 0;
+    const sampleCount = success + errors5xx;
+    if (sampleCount === 0) {
+        return {
+            success_rate: null,
+            sample_count: 0,
+            window_minutes: windowMinutes,
+            fetched_at: fetchedAt,
+            status: "unknown",
+            ...(stale && { stale: true }),
+        };
+    }
+    const successRate = success / sampleCount;
+    const pct5xx = (errors5xx / sampleCount) * 100;
+    const status: ModelHealthStatus =
+        pct5xx >= 50 ? "down" : pct5xx >= 10 ? "degraded" : "healthy";
+    return {
+        success_rate: successRate,
+        sample_count: sampleCount,
+        window_minutes: windowMinutes,
+        fetched_at: fetchedAt,
+        status,
+        ...(stale && { stale: true }),
+    };
+}
+
+export async function getModelHealthMap(
+    minutes: number,
+    fetchImpl: typeof fetch = fetch,
+): Promise<{ map: Map<string, Aggregated>; fetchedAt: string; stale: boolean }> {
+    const windowMinutes =
+        Number.isInteger(minutes) && minutes >= 1 && minutes <= 10080
+            ? minutes
+            : DEFAULT_HEALTH_WINDOW_MINUTES;
+    const now = Date.now();
+    const cached = cache.get(windowMinutes);
+    if (cached && now - cached.fetchedAt < CACHE_TTL_MS) {
+        setCacheEntry(windowMinutes, cached);
+        return {
+            map: aggregateRows(cached.rows),
+            fetchedAt: new Date(cached.fetchedAt).toISOString(),
+            stale: false,
+        };
+    }
+    try {
+        const url = new URL("/v0/pipes/model_health.json", TINYBIRD_HOST);
+        url.searchParams.set("token", TINYBIRD_PUBLIC_TOKEN);
+        url.searchParams.set("minutes", String(windowMinutes));
+        const response = await fetchImpl(url.toString());
+        if (!response.ok) throw new Error(`Tinybird ${response.status}`);
+        const body = (await response.json()) as { data?: unknown[] };
+        const rows: HealthRow[] = [];
+        for (const item of body.data ?? []) {
+            const parsed = HealthRowSchema.safeParse(item);
+            if (parsed.success) rows.push(parsed.data);
+        }
+        const fetchedAt = Date.now();
+        setCacheEntry(windowMinutes, { rows, fetchedAt });
+        return {
+            map: aggregateRows(rows),
+            fetchedAt: new Date(fetchedAt).toISOString(),
+            stale: false,
+        };
+    } catch (error) {
+        log("Model health fetch failed: %O", error);
+        if (cached) {
+            setCacheEntry(windowMinutes, cached);
+            return {
+                map: aggregateRows(cached.rows),
+                fetchedAt: new Date(cached.fetchedAt).toISOString(),
+                stale: true,
+            };
+        }
+        return {
+            map: new Map(),
+            fetchedAt: new Date(now).toISOString(),
+            stale: false,
+        };
+    }
+}
+
+export function healthKey(modelId: string, eventType: string): string {
+    return `${modelId}::${eventType}`;
+}
+
+// Header names for clients (Open WebUI, LibreChat, Cline) that append
+// `/models` to the configured base URL, which breaks embedded query strings.
+// Custom headers pass through untouched; query params take precedence.
+export const MODEL_SOURCE_HEADER = "x-pollinations-source";
+export const MODEL_INCLUDE_HEALTH_HEADER = "x-pollinations-include-health";
+export const MODEL_HEALTH_WINDOW_HEADER = "x-pollinations-health-window";
+export const MODEL_MIN_SUCCESS_RATE_HEADER =
+    "x-pollinations-min-success-rate";
+
+export type ResolvedModelListOptions = {
+    source: "official" | "community" | "all";
+    includeHealth: boolean;
+    healthWindow: number;
+    minSuccessRate: number | undefined;
+};
+
+function parseBooleanHeader(value: string | null): boolean | undefined {
+    if (value === null) return undefined;
+    const normalized = value.trim().toLowerCase();
+    if (normalized === "true" || normalized === "1") return true;
+    if (normalized === "false" || normalized === "0") return false;
+    return undefined;
+}
+
+/**
+ * Merge query params (preferred) with header fallbacks. Returns a 400 message
+ * when values conflict or are invalid, otherwise the resolved options.
+ */
+export function resolveModelListOptions(
+    query: {
+        community?: string;
+        source?: string;
+        include_health?: string;
+        health_window?: number;
+        min_success_rate?: number;
+    },
+    headers: Headers,
+): { ok: true; options: ResolvedModelListOptions } | { ok: false; error: string } {
+    const headerSource = headers.get(MODEL_SOURCE_HEADER)?.trim().toLowerCase();
+    if (
+        headerSource !== undefined &&
+        headerSource !== null &&
+        headerSource !== "" &&
+        !["official", "community", "all"].includes(headerSource)
+    ) {
+        return {
+            ok: false,
+            error: `Invalid ${MODEL_SOURCE_HEADER} header: expected official, community, or all`,
+        };
+    }
+    const source = (query.source ??
+        (headerSource || undefined) ??
+        "all") as "official" | "community" | "all";
+
+    // Deprecated `community` alias must agree with `source` when both are set.
+    if (query.community !== undefined) {
+        const wantCommunity =
+            query.community === "true" || query.community === "1";
+        const implied = wantCommunity ? "community" : "official";
+        if (query.source !== undefined && query.source !== implied) {
+            return {
+                ok: false,
+                error: "Conflicting filters: `source` and `community` disagree; use `source` (official|community|all).",
+            };
+        }
+        if (query.source === undefined && headerSource && headerSource !== implied && headerSource !== "all") {
+            return {
+                ok: false,
+                error: `Conflicting filters: \`community\` and \`${MODEL_SOURCE_HEADER}\` disagree; use one source filter.`,
+            };
+        }
+        if (query.source === undefined && (!headerSource || headerSource === "all")) {
+            return {
+                ok: true,
+                options: {
+                    ...resolveHealthOptions(query, headers),
+                    source: implied,
+                },
+            };
+        }
+    }
+    const health = resolveHealthOptions(query, headers);
+    if (!health.ok) return health;
+    return { ok: true, options: { ...health.options, source } };
+}
+
+function resolveHealthOptions(
+    query: {
+        include_health?: string;
+        health_window?: number;
+        min_success_rate?: number;
+    },
+    headers: Headers,
+): { ok: true; options: Omit<ResolvedModelListOptions, "source"> } | { ok: false; error: string } {
+    const headerInclude = parseBooleanHeader(
+        headers.get(MODEL_INCLUDE_HEALTH_HEADER),
+    );
+    if (
+        headers.get(MODEL_INCLUDE_HEALTH_HEADER) !== null &&
+        headerInclude === undefined
+    ) {
+        return {
+            ok: false,
+            error: `Invalid ${MODEL_INCLUDE_HEALTH_HEADER} header: expected true, false, 1, or 0`,
+        };
+    }
+    const includeHealth =
+        query.include_health !== undefined
+            ? query.include_health === "true" || query.include_health === "1"
+            : (headerInclude ?? false);
+
+    const headerWindowRaw = headers.get(MODEL_HEALTH_WINDOW_HEADER);
+    let headerWindow: number | undefined;
+    if (headerWindowRaw !== null) {
+        headerWindow = Number(headerWindowRaw);
+        if (!Number.isInteger(headerWindow) || headerWindow < 1 || headerWindow > 10080) {
+            return {
+                ok: false,
+                error: `Invalid ${MODEL_HEALTH_WINDOW_HEADER} header: expected an integer between 1 and 10080`,
+            };
+        }
+    }
+    const healthWindow = query.health_window ?? headerWindow ?? DEFAULT_HEALTH_WINDOW_MINUTES;
+
+    const headerRateRaw = headers.get(MODEL_MIN_SUCCESS_RATE_HEADER);
+    let headerRate: number | undefined;
+    if (headerRateRaw !== null) {
+        headerRate = Number(headerRateRaw);
+        if (!Number.isFinite(headerRate) || headerRate < 0 || headerRate > 1) {
+            return {
+                ok: false,
+                error: `Invalid ${MODEL_MIN_SUCCESS_RATE_HEADER} header: expected a number between 0 and 1`,
+            };
+        }
+    }
+    const minSuccessRate = query.min_success_rate ?? headerRate;
+
+    return { ok: true, options: { includeHealth, healthWindow, minSuccessRate } };
+}
+
+export function filterEntriesBySource<T extends { communityEndpoint?: unknown }>(
+    entries: T[],
+    source: "official" | "community" | "all",
+): T[] {
+    if (source === "all") return entries;
+    const wantCommunity = source === "community";
+    return entries.filter(
+        (entry) => (entry.communityEndpoint !== undefined) === wantCommunity,
+    );
+}

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -88,6 +88,14 @@ import {
 } from "@/schemas/models.ts";
 import { RealtimeRequestQueryParamsSchema } from "@/schemas/realtime.ts";
 import { GenerateTextRequestQueryParamsSchema } from "@/schemas/text.ts";
+import {
+    computeModelHealth,
+    filterEntriesBySource,
+    getModelHealthMap,
+    healthKey,
+    type ModelHealth,
+    resolveModelListOptions,
+} from "../model-health.ts";
 import { generateCreateResponse } from "@/text/responses/handler.ts";
 import {
     apiKeyBudgetReservation,
@@ -249,21 +257,51 @@ function hasPaidBalance(c: any): boolean | undefined {
     return (user.packBalance ?? 0) > 0;
 }
 
-// Optionally filter entries by the validated `?community` query parameter.
-function filterEntriesByCommunityParam(
+// Optionally filter entries by source (`?source=official|community|all`,
+// Enter dashboard terminology). The deprecated `?community` alias is honored
+// when `source` is absent; when both are set they must agree (checked in
+// resolveModelListOptions — a conflict is a 400, not a silent override).
+// Filtering is discovery-only: it runs after permission/paid-balance filtering
+// and never changes generation permissions or default listings.
+
+async function attachHealth(
     entries: GenerationModelEntry[],
-    communityParam: string | undefined,
-): GenerationModelEntry[] {
-    if (communityParam === undefined) return entries;
-    const wantCommunity = communityParam === "true" || communityParam === "1";
-    return entries.filter(
-        (entry) => (entry.communityEndpoint !== undefined) === wantCommunity,
-    );
+    windowMinutes: number,
+): Promise<{ entry: GenerationModelEntry; health: ModelHealth }[]> {
+    const { map, fetchedAt, stale } = await getModelHealthMap(windowMinutes);
+    return entries.map((entry) => ({
+        entry,
+        health: computeModelHealth(
+            map.get(healthKey(entry.id, entry.eventType)),
+            windowMinutes,
+            fetchedAt,
+            stale,
+        ),
+    }));
 }
 
-// Factory for model-list endpoints: validates the community query parameter,
-// filters by API key permissions, paid balance, and community flag,
-// then returns the model list as JSON.
+// Keep only models meeting a success-rate threshold. Unknown health (no data
+// in the window) is excluded by this filter; without the filter, unknown
+// models are still listed with (optional) `status: "unknown"`.
+async function applyHealthFilter(
+    entries: GenerationModelEntry[],
+    minSuccessRate: number | undefined,
+    windowMinutes: number,
+): Promise<GenerationModelEntry[]> {
+    if (minSuccessRate === undefined) return entries;
+    const withHealth = await attachHealth(entries, windowMinutes);
+    return withHealth
+        .filter(
+            ({ health }) =>
+                health.success_rate !== null &&
+                health.success_rate >= minSuccessRate,
+        )
+        .map(({ entry }) => entry);
+}
+
+// Factory for model-list endpoints: validates the model-list query parameters,
+// filters by API key permissions, paid balance, then source/reliability,
+// optionally attaches minimal health metadata, then returns JSON.
 const modelsListHandler = (
     getEntries: (
         c: Context<Env>,
@@ -272,20 +310,42 @@ const modelsListHandler = (
     [
         validator("query", ModelListQueryParamsSchema),
         async (c: Context<Env>) => {
-            const { community } = c.req.valid(
-                "query" as never,
-            ) as ModelListQueryParams;
+            const query = c.req.valid("query" as never) as ModelListQueryParams;
+            const resolved = resolveModelListOptions(
+                {
+                    community: query.community,
+                    source: query.source,
+                    include_health: query.include_health,
+                    health_window: query.health_window,
+                    min_success_rate: query.min_success_rate,
+                },
+                c.req.raw.headers,
+            );
+            if (!resolved.ok) {
+                return c.json({ error: resolved.error }, 400);
+            }
+            const { source, includeHealth, healthWindow, minSuccessRate } =
+                resolved.options;
             const allowedModels = c.var.auth?.apiKey?.permissions?.models;
             const paidBalance = hasPaidBalance(c);
+            let entries = filterEntriesBySource(
+                filterEntriesByPermissions(
+                    await getEntries(c),
+                    allowedModels,
+                    paidBalance,
+                ),
+                source,
+            );
+            entries = await applyHealthFilter(entries, minSuccessRate, healthWindow);
+            if (!includeHealth) {
+                return c.json(entries.map((entry) => entry.info));
+            }
+            const withHealth = await attachHealth(entries, healthWindow);
             return c.json(
-                filterEntriesByCommunityParam(
-                    filterEntriesByPermissions(
-                        await getEntries(c),
-                        allowedModels,
-                        paidBalance,
-                    ),
-                    community,
-                ).map((entry) => entry.info),
+                withHealth.map(({ entry, health }) => ({
+                    ...entry.info,
+                    health,
+                })),
             );
         },
     ] as const;
@@ -331,8 +391,12 @@ async function getVisibleVideoModelEntries(c: Context<Env>) {
 // Single OpenAI-compatible mapper shared by /v1/models (list) and
 // /v1/models/:model (retrieve). `created` derives from the registry addedDate
 // so both endpoints return stable timestamps instead of per-request wall-clock
-// values.
-function toOpenAIModelEntry(entry: GenerationModelEntry) {
+// values. Pass `health` (from attachHealth) to include minimal reliability
+// metadata; when omitted the field is absent and default payloads are unchanged.
+function toOpenAIModelEntry(
+    entry: GenerationModelEntry,
+    health?: ModelHealth,
+) {
     return {
         id: entry.info.name,
         object: "model" as const,
@@ -360,6 +424,7 @@ function toOpenAIModelEntry(entry: GenerationModelEntry) {
         ...(entry.info.per_user_rpm !== undefined && {
             per_user_rpm: entry.info.per_user_rpm,
         }),
+        ...(health && { health }),
     };
 }
 
@@ -403,7 +468,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Models (OpenAI-compatible)",
             description:
-                'Returns available models in the OpenAI-compatible format (`{object: "list", data: [...]}`), with Pollinations pricing and capability extensions. Official models are ordered by modality (text, image, video, 3D, audio, realtime, embedding), with each configured default first, followed by stable and then alpha/preview models from newest to oldest. Community models follow from newest to oldest. Use `/models`, `/text/models`, `/image/models`, `/audio/models`, or `/embeddings/models` for richer metadata. When authenticated: the owner\'s private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.',
+                'Returns available models in the OpenAI-compatible format (`{object: "list", data: [...]}`), with Pollinations pricing and capability extensions. Official models are ordered by modality (text, image, video, 3D, audio, realtime, embedding), with each configured default first, followed by stable and then alpha/preview models from newest to oldest. Community models follow from newest to oldest. Use `/models`, `/text/models`, `/image/models`, `/audio/models`, or `/embeddings/models` for richer metadata. When authenticated: the owner\'s private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?source=official` for official-only or `?source=community` for community-only listings (`?community=false/true` still works as a deprecated alias); `?include_health=true` attaches minimal reliability metadata and `?min_success_rate=0.95` keeps only reliable models. Filters are discovery-only and never change generation permissions.',
             responses: {
                 200: {
                     description: "Success",
@@ -418,22 +483,49 @@ export const proxyRoutes = new Hono<Env>()
         }),
         validator("query", ModelListQueryParamsSchema),
         async (c) => {
-            const { community } = c.req.valid(
-                "query" as never,
-            ) as ModelListQueryParams;
+            const query = c.req.valid("query" as never) as ModelListQueryParams;
+            const resolved = resolveModelListOptions(
+                {
+                    community: query.community,
+                    source: query.source,
+                    include_health: query.include_health,
+                    health_window: query.health_window,
+                    min_success_rate: query.min_success_rate,
+                },
+                c.req.raw.headers,
+            );
+            if (!resolved.ok) {
+                return c.json({ error: resolved.error }, 400);
+            }
+            const { source, includeHealth, healthWindow, minSuccessRate } =
+                resolved.options;
             const allowedModels = c.var.auth?.apiKey?.permissions?.models;
             const paidBalance = hasPaidBalance(c);
-            const modelEntries = filterEntriesByCommunityParam(
+            let modelEntries = filterEntriesBySource(
                 filterEntriesByPermissions(
                     await getVisibleModelEntries(c),
                     allowedModels,
                     paidBalance,
                 ),
-                community,
+                source,
             );
+            modelEntries = await applyHealthFilter(
+                modelEntries,
+                minSuccessRate,
+                healthWindow,
+            );
+            if (!includeHealth) {
+                return c.json({
+                    object: "list" as const,
+                    data: modelEntries.map((entry) => toOpenAIModelEntry(entry)),
+                });
+            }
+            const withHealth = await attachHealth(modelEntries, healthWindow);
             return c.json({
                 object: "list" as const,
-                data: modelEntries.map(toOpenAIModelEntry),
+                data: withHealth.map(({ entry, health }) =>
+                    toOpenAIModelEntry(entry, health),
+                ),
             });
         },
     )
@@ -456,6 +548,7 @@ export const proxyRoutes = new Hono<Env>()
                 ...errorResponseDescriptions(400, 401, 404, 500),
             },
         }),
+        validator("query", ModelListQueryParamsSchema),
         async (c) => {
             // Unknown, hidden, permission-filtered, and unaffordable models
             // all collapse to the same 404 so the endpoint does not leak
@@ -478,7 +571,25 @@ export const proxyRoutes = new Hono<Env>()
                     message: `Model '${modelId}' not found`,
                 });
             }
-            return c.json(toOpenAIModelEntry(entry));
+            const query = c.req.valid("query" as never) as ModelListQueryParams;
+            const resolved = resolveModelListOptions(
+                {
+                    include_health: query.include_health,
+                    health_window: query.health_window,
+                },
+                c.req.raw.headers,
+            );
+            if (!resolved.ok) {
+                return c.json({ error: resolved.error }, 400);
+            }
+            if (!resolved.options.includeHealth) {
+                return c.json(toOpenAIModelEntry(entry));
+            }
+            const [{ health }] = await attachHealth(
+                [entry],
+                resolved.options.healthWindow,
+            );
+            return c.json(toOpenAIModelEntry(entry, health));
         },
     )
     .get(
@@ -487,7 +598,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Models",
             description:
-                "Returns all available models with pricing, capabilities, and metadata. Official models are ordered by modality (text, image, video, 3D, audio, realtime, embedding), with each configured default first, followed by stable and then alpha/preview models from newest to oldest. Community models follow from newest to oldest. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
+                "Returns all available models with pricing, capabilities, and metadata. Official models are ordered by modality (text, image, video, 3D, audio, realtime, embedding), with each configured default first, followed by stable and then alpha/preview models from newest to oldest. Community models follow from newest to oldest. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?source=official` for official-only or `?source=community` for community-only listings (`?community=false/true` still works as a deprecated alias); `?include_health=true` attaches minimal reliability metadata and `?min_success_rate=0.95` keeps only reliable models. Filters are discovery-only and never change generation permissions.",
             responses: {
                 200: {
                     description: "Success",
@@ -508,7 +619,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List 3D Models",
             description:
-                "Returns all available 3D model generation models with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
+                "Returns all available 3D model generation models with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?source=official` for official-only or `?source=community` for community-only listings (`?community=false/true` still works as a deprecated alias); `?include_health=true` attaches minimal reliability metadata and `?min_success_rate=0.95` keeps only reliable models. Filters are discovery-only and never change generation permissions.",
             responses: {
                 200: {
                     description: "Success",
@@ -529,7 +640,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Image & Video Models",
             description:
-                "Returns all available image and video generation models with pricing, capabilities, and metadata. Video models are included here — check the `output_modalities` field to distinguish image vs video models. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
+                "Returns all available image and video generation models with pricing, capabilities, and metadata. Video models are included here — check the `output_modalities` field to distinguish image vs video models. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?source=official` for official-only or `?source=community` for community-only listings (`?community=false/true` still works as a deprecated alias); `?include_health=true` attaches minimal reliability metadata and `?min_success_rate=0.95` keeps only reliable models. Filters are discovery-only and never change generation permissions.",
             responses: {
                 200: {
                     description: "Success",
@@ -550,7 +661,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Video Models",
             description:
-                "Returns all available video generation models with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
+                "Returns all available video generation models with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?source=official` for official-only or `?source=community` for community-only listings (`?community=false/true` still works as a deprecated alias); `?include_health=true` attaches minimal reliability metadata and `?min_success_rate=0.95` keeps only reliable models. Filters are discovery-only and never change generation permissions.",
             responses: {
                 200: {
                     description: "Success",
@@ -571,7 +682,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Text Models (Detailed)",
             description:
-                "Returns all available text generation and community text models with pricing, capabilities, and metadata including context window size, supported modalities, and tool support. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
+                "Returns all available text generation and community text models with pricing, capabilities, and metadata including context window size, supported modalities, and tool support. When authenticated: the owner's private community models are included, models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?source=official` for official-only or `?source=community` for community-only listings (`?community=false/true` still works as a deprecated alias); `?include_health=true` attaches minimal reliability metadata and `?min_success_rate=0.95` keeps only reliable models. Filters are discovery-only and never change generation permissions.",
             responses: {
                 200: {
                     description: "Success",
@@ -594,7 +705,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🤖 Models"],
             summary: "List Audio Models",
             description:
-                "Returns all available audio models (text-to-speech, music generation, and transcription) with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
+                "Returns all available audio models (text-to-speech, music generation, and transcription) with pricing, capabilities, and metadata. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?source=official` for official-only or `?source=community` for community-only listings (`?community=false/true` still works as a deprecated alias); `?include_health=true` attaches minimal reliability metadata and `?min_success_rate=0.95` keeps only reliable models. Filters are discovery-only and never change generation permissions.",
             responses: {
                 200: {
                     description: "Success",
@@ -617,7 +728,7 @@ export const proxyRoutes = new Hono<Env>()
             tags: ["🔢 Embeddings"],
             summary: "List Embedding Models",
             description:
-                "Returns available embedding models with pricing, capabilities, and supported input modalities. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?community=false` to exclude community models or `?community=true` to return only community models.",
+                "Returns available embedding models with pricing, capabilities, and supported input modalities. When authenticated: models are filtered by API key permissions, and `paid_only` models are hidden if the account has no paid balance. Pass `?source=official` for official-only or `?source=community` for community-only listings (`?community=false/true` still works as a deprecated alias); `?include_health=true` attaches minimal reliability metadata and `?min_success_rate=0.95` keeps only reliable models. Filters are discovery-only and never change generation permissions.",
             responses: {
                 200: {
                     description: "Success",

--- a/gen.pollinations.ai/src/schemas/models.ts
+++ b/gen.pollinations.ai/src/schemas/models.ts
@@ -3,7 +3,29 @@ import { z } from "zod";
 export const ModelListQueryParamsSchema = z.object({
     community: z.enum(["true", "false", "1", "0"]).optional().meta({
         description:
-            "Filter by community status: `true`/`1` for community-only, `false`/`0` for official-only. Omit for all models.",
+            "Deprecated alias for `source`. `true`/`1` = community-only, `false`/`0` = official-only. Omit for all models. If `source` is also set it must agree, otherwise the request is rejected with 400.",
+    }),
+    source: z.enum(["official", "community", "all"]).optional().meta({
+        description:
+            "Filter by model source using Enter dashboard terminology: `official` for Pollinations-operated models, `community` for community-published models, `all` for everything (default). Replaces `community`.",
+    }),
+    include_health: z.enum(["true", "false", "1", "0"]).optional().meta({
+        description:
+            "Attach minimal `health` metadata per model (success rate, sample count, window, freshness). Omitted by default so default listings are unchanged. When `min_success_rate` is set, health is fetched for filtering even if not attached.",
+    }),
+    health_window: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .max(10080)
+        .optional()
+        .meta({
+            description:
+                "Rolling health window in minutes (1–10080). Defaults to 60, matching `GET /v1/models/status`. Only used when health is fetched (`include_health=true` or `min_success_rate` set).",
+        }),
+    min_success_rate: z.coerce.number().min(0).max(1).optional().meta({
+        description:
+            "Keep only models whose health `success_rate` meets this threshold (0–1). Models with unknown health (no data in the window) are excluded by this filter. Discovery-only: never changes generation permissions.",
     }),
 });
 

--- a/gen.pollinations.ai/test/model-filters-health.test.ts
+++ b/gen.pollinations.ai/test/model-filters-health.test.ts
@@ -1,0 +1,155 @@
+import { SELF } from "cloudflare:test";
+import { test } from "@shared/test/fixtures/index.ts";
+import { expect } from "vitest";
+import {
+    computeModelHealth,
+    filterEntriesBySource,
+    resolveModelListOptions,
+} from "../src/model-health.ts";
+
+async function fetchWorker(path: string, init: RequestInit = {}) {
+    return SELF.fetch(new Request(`https://gen.pollinations.ai${path}`, init));
+}
+
+function headers(init?: Record<string, string>): Headers {
+    return new Headers(init);
+}
+
+test("source filter uses Enter terminology and honors the community alias", () => {
+    const official = { communityEndpoint: undefined };
+    const community = { communityEndpoint: {} };
+    const entries = [official, community];
+
+    expect(filterEntriesBySource(entries, "official")).toEqual([official]);
+    expect(filterEntriesBySource(entries, "community")).toEqual([community]);
+    expect(filterEntriesBySource(entries, "all")).toEqual(entries);
+
+    const viaAlias = resolveModelListOptions(
+        { community: "false" },
+        headers(),
+    );
+    expect(viaAlias).toMatchObject({ ok: true, options: { source: "official" } });
+
+    const conflict = resolveModelListOptions(
+        { community: "true", source: "official" },
+        headers(),
+    );
+    expect(conflict.ok).toBe(false);
+});
+
+test("header fallbacks work for clients that cannot use query strings", () => {
+    const resolved = resolveModelListOptions(
+        {},
+        headers({
+            "X-Pollinations-Source": "official",
+            "X-Pollinations-Include-Health": "true",
+            "X-Pollinations-Health-Window": "1440",
+            "X-Pollinations-Min-Success-Rate": "0.9",
+        }),
+    );
+    expect(resolved).toMatchObject({
+        ok: true,
+        options: {
+            source: "official",
+            includeHealth: true,
+            healthWindow: 1440,
+            minSuccessRate: 0.9,
+        },
+    });
+
+    const badHeader = resolveModelListOptions(
+        {},
+        headers({ "X-Pollinations-Source": "nope" }),
+    );
+    expect(badHeader.ok).toBe(false);
+});
+
+test("health math counts rescues as successes and excludes caller failures", () => {
+    // status_2xx already includes fallback rescues — no double counting.
+    const healthy = computeModelHealth(
+        { success: 95, errors5xx: 5 },
+        60,
+        "2026-09-11T00:00:00.000Z",
+    );
+    expect(healthy.success_rate).toBeCloseTo(0.95);
+    expect(healthy.sample_count).toBe(100);
+    expect(healthy.status).toBe("healthy");
+
+    const degraded = computeModelHealth(
+        { success: 85, errors5xx: 15 },
+        60,
+        "2026-09-11T00:00:00.000Z",
+    );
+    expect(degraded.status).toBe("degraded");
+
+    const down = computeModelHealth(
+        { success: 40, errors5xx: 60 },
+        60,
+        "2026-09-11T00:00:00.000Z",
+    );
+    expect(down.status).toBe("down");
+
+    // Missing data means unknown — never folded into reliability, and alpha
+    // (experimental) status stays a separate model field.
+    const unknown = computeModelHealth(
+        undefined,
+        60,
+        "2026-09-11T00:00:00.000Z",
+    );
+    expect(unknown).toMatchObject({
+        success_rate: null,
+        sample_count: 0,
+        status: "unknown",
+    });
+});
+
+test("default listings are unchanged and source filtering works", async () => {
+    const all = await fetchWorker("/v1/models");
+    expect(all.status).toBe(200);
+    const allBody = (await all.json()) as { data: Record<string, unknown>[] };
+    expect(allBody.data.length).toBeGreaterThan(0);
+    // Health omitted by default.
+    expect(allBody.data[0]).not.toHaveProperty("health");
+
+    const official = await fetchWorker("/v1/models?source=official");
+    expect(official.status).toBe(200);
+    const officialBody = (await official.json()) as {
+        data: { community: boolean }[];
+    };
+    expect(officialBody.data.length).toBeGreaterThan(0);
+    expect(officialBody.data.length).toBeLessThan(allBody.data.length);
+    expect(
+        officialBody.data.every((m) => m.community === false),
+    ).toBe(true);
+
+    const alias = await fetchWorker("/v1/models?community=false");
+    expect(alias.status).toBe(200);
+    expect(((await alias.json()) as typeof officialBody).data).toEqual(
+        officialBody.data,
+    );
+
+    // Invalid values and conflicting filters are 400, not silent.
+    expect((await fetchWorker("/v1/models?source=nope")).status).toBe(400);
+    expect(
+        (await fetchWorker("/v1/models?source=official&community=true")).status,
+    ).toBe(400);
+    expect(
+        (
+            await fetchWorker("/v1/models", {
+                headers: { "X-Pollinations-Source": "nope" },
+            })
+        ).status,
+    ).toBe(400);
+});
+
+test("health is opt-in and reliability filtering excludes unknowns", async () => {
+    // min_success_rate=1 with a mocked-empty health window would be live-data
+    // dependent, so only assert the validation boundary here: out-of-range
+    // thresholds are rejected before any health fetch.
+    expect((await fetchWorker("/v1/models?min_success_rate=2")).status).toBe(
+        400,
+    );
+    expect(
+        (await fetchWorker("/v1/models?health_window=0")).status,
+    ).toBe(400);
+});

--- a/shared/registry/model-info.ts
+++ b/shared/registry/model-info.ts
@@ -119,6 +119,16 @@ export const ModelInfoSchema = z.object({
     alpha: z.boolean().optional(),
     flat_rate: z.boolean().optional(),
     added_date: z.number().optional(),
+    health: z
+        .object({
+            success_rate: z.number().min(0).max(1).nullable(),
+            sample_count: z.number().int().nonnegative(),
+            window_minutes: z.number().int().positive(),
+            fetched_at: z.string(),
+            status: z.enum(["healthy", "degraded", "down", "unknown"]),
+            stale: z.boolean().optional(),
+        })
+        .optional(),
 });
 
 export type ModelInfo = z.infer<typeof ModelInfoSchema>;

--- a/shared/schemas/openai.ts
+++ b/shared/schemas/openai.ts
@@ -746,6 +746,16 @@ export const OpenAIModelSchema = z
         reasoning: z.boolean().optional(),
         context_length: z.number().optional(),
         per_user_rpm: z.number().positive().nullable().optional(),
+        health: z
+            .object({
+                success_rate: z.number().min(0).max(1).nullable(),
+                sample_count: z.number().int().nonnegative(),
+                window_minutes: z.number().int().positive(),
+                fetched_at: z.string(),
+                status: z.enum(["healthy", "degraded", "down", "unknown"]),
+                stale: z.boolean().optional(),
+            })
+            .optional(),
     })
     .meta({
         description: "OpenAI-compatible model object with capability metadata",


### PR DESCRIPTION
Fixes #14535.

Filter model listings (official-only or reliable) and expose minimal health, without changing generation permissions or default listings.

What:
- New `?source=official|community|all` (Enter dashboard terminology) across /v1/models and all rich lists (/models, /text|image|video|audio|embeddings|3d/models). Deprecated `?community=true/false` kept as alias; conflict is 400.
- Header equivalents for Open WebUI / LibreChat / Cline (they append /models, so base-URL queries break): X-Pollinations-Source, X-Pollinations-Include-Health, X-Pollinations-Health-Window, X-Pollinations-Min-Success-Rate. Query wins over header.
- Opt-in `health` per model: {success_rate 0-1|null, sample_count, window_minutes, fetched_at, status healthy|degraded|down|unknown, stale?}. Reuses Tinybird model_health (same source as /v1/models/status) with 60s cache + stale fallback; listings never fail on health errors.
- Math: success = status_2xx (includes fallback rescues), failures = errors_5xx, caller 4xx excluded; missing data = unknown; alpha/experimental stays separate.
- `?min_success_rate=0-1` (+ header) keeps only models meeting threshold; unknown excluded by the filter. Discovery-only, after permissions/paid-balance checks.
- Docs: models.md gains filter table, health semantics, and client setup (Open WebUI header, LibreChat admin yaml, Cline note).
- Focused test: model-filters-health.test.ts (source/alias/conflict, headers, health math, default unchanged, 400 boundaries).

No generic filtering framework, no base-path presets, no generation/billing/access changes.