### PR TITLE
Fixes #14660: add native llm-pollinations provider plugin for Simon Willison's llm

### DIFF
--- a/packages/llm-pollinations/README.md
+++ b/packages/llm-pollinations/README.md
@@ -1,0 +1,96 @@
+# llm-pollinations
+
+Native [Pollinations](https://pollinations.ai) provider plugin for [Simon Willison's `llm`](https://github.com/simonw/llm) CLI and Python library.
+
+It reuses LLM's OpenAI-compatible `Chat` / `AsyncChat` against `https://gen.pollinations.ai/v1` — streaming, conversations, tools, and attachments all come from the base classes. Compatible text models load from your authenticated `/v1/models` catalog and register as `pollinations/<model-id>` with no hardcoded list.
+
+Out of scope for this first version: image generation, embeddings, custom device-auth flows, configuration UIs, and new Polli CLI integration commands.
+
+## Install
+
+```bash
+llm install llm-pollinations
+```
+
+Or from this repo:
+
+```bash
+llm install -e packages/llm-pollinations
+```
+
+Requires a [current `llm` release](https://github.com/simonw/llm) (`>=0.26`).
+
+## Authentication
+
+Direct key setup:
+
+```bash
+llm keys set pollinations
+# Enter key: <paste a Pollinations secret key>
+```
+
+Or via environment:
+
+```bash
+export POLLINATIONS_API_KEY="sk_..."
+```
+
+Create a dedicated key through [Polli CLI](https://github.com/pollinations/pollinations/tree/main/packages/polli-cli):
+
+```bash
+polli keys create --name llm --budget 100
+# paste the printed secret into `llm keys set pollinations`
+```
+
+Models only register when a key is configured, so the catalog reflects your key's permissions.
+
+## Usage
+
+```bash
+llm models list | grep pollinations
+llm -m pollinations/openai/gpt-5.4-nano "What is the capital of France?"
+llm -m pollinations/openai/gpt-5.4-nano "Stream this" --no-stream
+llm -m pollinations/anthropic/claude-haiku-4.5 --chat
+```
+
+Image attachments, tool calling, and reasoning are enabled per model only when the catalog advertises them:
+
+```bash
+llm -m pollinations/openai/gpt-5.4-nano "Describe this image" -a photo.jpg
+llm -m pollinations/qwen/qwen3.8-flash -T llm_time "What time is it?" --tools-debug
+llm -m pollinations/openai/gpt-5.4 "Prove dogs exist" -o reasoning_effort high
+```
+
+Python API:
+
+```python
+import llm
+model = llm.get_model("pollinations/openai/gpt-5.4-nano")
+print(model.prompt("Hello").text())
+```
+
+Catalog commands (5-minute cache with stale-cache fallback):
+
+```bash
+llm pollinations models
+llm pollinations models --json
+llm pollinations refresh
+```
+
+## Verification
+
+Against a current `llm` release with a key configured:
+
+```bash
+llm -m pollinations/openai/gpt-5.4-nano "Say hi"
+llm -m pollinations/openai/gpt-5.4-nano "Count to 5" --no-stream  # streaming path
+llm -m pollinations/openai/gpt-5.4-nano --chat                     # chat loop
+llm -m pollinations/openai/gpt-5.4-nano "Describe this" -a photo.jpg
+llm -m pollinations/qwen/qwen3.8-flash -T llm_time "What time is it?"
+python -c "import llm; print(llm.get_model('pollinations/openai/gpt-5.4-nano').prompt('Hi').text())"
+pytest packages/llm-pollinations
+```
+
+## PyPI & plugin directory
+
+The package is ready for PyPI publication (`python -m build`, `twine upload dist/*`). After merge, submit it upstream with a concise PR to the [LLM plugin directory](https://llm.datasette.io/en/stable/plugins/directory.html) (see [llm-openrouter](https://github.com/simonw/llm-openrouter) for the reference format).

--- a/packages/llm-pollinations/llm_pollinations.py
+++ b/packages/llm-pollinations/llm_pollinations.py
@@ -1,0 +1,195 @@
+"""Native Pollinations provider plugin for Simon Willison's `llm`.
+
+Reuses LLM's OpenAI-compatible ``Chat`` / ``AsyncChat`` against
+``https://gen.pollinations.ai/v1`` — streaming, conversations, tools and
+attachments all come from the base classes. Compatible text models are loaded
+from the authenticated ``/v1/models`` catalog and registered as
+``pollinations/<model-id>`` with no hardcoded model list.
+"""
+
+import json
+import time
+from pathlib import Path
+
+import click
+import httpx
+import llm
+from llm.default_plugins.openai_models import AsyncChat, Chat
+
+API_BASE = "https://gen.pollinations.ai/v1"
+MODELS_URL = f"{API_BASE}/models"
+KEY_ALIAS = "pollinations"
+KEY_ENV_VAR = "POLLINATIONS_API_KEY"
+CACHE_FILENAME = "pollinations_models.json"
+# Small time-limited cache (5 minutes) with stale-cache fallback.
+CACHE_TIMEOUT_SECONDS = 5 * 60
+
+
+class DownloadError(Exception):
+    pass
+
+
+class PollinationsChat(Chat):
+    needs_key = KEY_ALIAS
+    key_env_var = KEY_ENV_VAR
+
+
+class PollinationsAsyncChat(AsyncChat):
+    needs_key = KEY_ALIAS
+    key_env_var = KEY_ENV_VAR
+
+
+def _cache_path() -> Path:
+    return llm.user_dir() / CACHE_FILENAME
+
+
+def _auth_headers(key: str) -> dict:
+    return {"Authorization": f"Bearer {key}"}
+
+
+def get_pollinations_models(skip_cache: bool = False) -> list:
+    """Load the authenticated ``/v1/models`` catalog (OpenAI list shape).
+
+    Sends the stored ``pollinations`` key so the catalog reflects the caller's
+    permissions. Results are cached briefly; a stale cache is served when the
+    network fails.
+    """
+    key = llm.get_key("", KEY_ALIAS, KEY_ENV_VAR)
+    if not key:
+        raise DownloadError(
+            "No Pollinations API key found. Run `llm keys set pollinations` "
+            f"or set {KEY_ENV_VAR}."
+        )
+    path = _cache_path()
+    if not skip_cache and path.is_file():
+        try:
+            if time.time() - path.stat().st_mtime < CACHE_TIMEOUT_SECONDS:
+                with open(path) as f:
+                    return json.load(f)["data"]
+        except (OSError, ValueError, KeyError):
+            pass
+    try:
+        response = httpx.get(
+            MODELS_URL, headers=_auth_headers(key), timeout=30,
+            follow_redirects=True,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        with open(path, "w") as f:
+            json.dump(payload, f)
+        return payload["data"]
+    except Exception:
+        if path.is_file():
+            try:
+                with open(path) as f:
+                    return json.load(f)["data"]
+            except (OSError, ValueError, KeyError):
+                pass
+        raise DownloadError(
+            f"Failed to download the Pollinations model catalog and no cache "
+            f"is available at {path}"
+        )
+
+
+def supports_vision(model: dict) -> bool:
+    """True only when the catalog advertises image input for the model."""
+    return "image" in (model.get("input_modalities") or [])
+
+
+def supports_tools(model: dict) -> bool:
+    """True only when the catalog advertises tool calling for the model."""
+    return "tool_calling" in (model.get("capabilities") or []) or bool(
+        model.get("tools")
+    )
+
+
+def supports_reasoning(model: dict) -> bool:
+    """True only when the catalog advertises reasoning for the model."""
+    return "reasoning" in (model.get("capabilities") or []) or bool(
+        model.get("reasoning")
+    )
+
+
+def is_compatible_text_model(model: dict) -> bool:
+    return model.get("category") == "text" and isinstance(model.get("id"), str)
+
+
+@llm.hookimpl
+def register_models(register):
+    # Only register when a key is configured, so the catalog reflects the
+    # caller's authenticated view (mirrors llm-openrouter behavior).
+    key = llm.get_key("", KEY_ALIAS, KEY_ENV_VAR)
+    if not key:
+        return
+    try:
+        models = get_pollinations_models()
+    except Exception:
+        # Discovery is best-effort: never break `llm` startup when the
+        # catalog is unreachable and uncached.
+        return
+    for model in models:
+        if not is_compatible_text_model(model):
+            continue
+        kwargs = dict(
+            model_id=f"pollinations/{model['id']}",
+            model_name=model["id"],
+            api_base=API_BASE,
+            vision=supports_vision(model),
+            supports_tools=supports_tools(model),
+            reasoning=supports_reasoning(model),
+        )
+        register(
+            PollinationsChat(**kwargs),
+            PollinationsAsyncChat(**kwargs),
+        )
+
+
+@llm.hookimpl
+def register_commands(cli):
+    @cli.group()
+    def pollinations():
+        """Commands for the llm-pollinations plugin."""
+
+    @pollinations.command()
+    @click.option("json_", "--json", is_flag=True, help="Output as JSON")
+    def models(json_):
+        """List cached Pollinations text models."""
+        models = get_pollinations_models()
+        text_models = [m for m in models if is_compatible_text_model(m)]
+        if json_:
+            click.echo(json.dumps(text_models, indent=2))
+        else:
+            for model in text_models:
+                click.echo(f"pollinations/{model['id']}")
+
+    @pollinations.command()
+    def refresh():
+        """Refresh the cached Pollinations model catalog."""
+        before = {
+            m["id"]
+            for m in get_pollinations_models()
+            if is_compatible_text_model(m)
+        }
+        after = {
+            m["id"]
+            for m in get_pollinations_models(skip_cache=True)
+            if is_compatible_text_model(m)
+        }
+        added = after - before
+        removed = before - after
+        if added:
+            click.echo(
+                "Added models: {}".format(
+                    ", ".join(f"pollinations/{m}" for m in sorted(added))
+                ),
+                err=True,
+            )
+        if removed:
+            click.echo(
+                "Removed models: {}".format(
+                    ", ".join(f"pollinations/{m}" for m in sorted(removed))
+                ),
+                err=True,
+            )
+        if not added and not removed:
+            click.echo("No changes", err=True)

--- a/packages/llm-pollinations/pyproject.toml
+++ b/packages/llm-pollinations/pyproject.toml
@@ -1,0 +1,35 @@
+[project]
+name = "llm-pollinations"
+version = "0.1.0"
+description = "Native Pollinations provider plugin for Simon Willison's llm CLI and Python library"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [{ name = "pollinations.ai" }]
+keywords = ["llm", "pollinations", "openai-compatible"]
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+]
+dependencies = [
+    "llm>=0.26",
+    "httpx>=0.27",
+]
+
+[project.urls]
+Homepage = "https://github.com/pollinations/pollinations/tree/main/packages/llm-pollinations"
+Issues = "https://github.com/pollinations/pollinations/issues"
+
+[project.entry-points.llm]
+pollinations = "llm_pollinations"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+include = ["llm_pollinations.py"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/packages/llm-pollinations/tests/test_llm_pollinations.py
+++ b/packages/llm-pollinations/tests/test_llm_pollinations.py
@@ -1,0 +1,162 @@
+import json
+
+import llm_pollinations as plugin
+from llm.default_plugins.openai_models import AsyncChat, Chat
+
+
+def test_reuses_openai_compatible_chat_classes():
+    assert issubclass(plugin.PollinationsChat, Chat)
+    assert issubclass(plugin.PollinationsAsyncChat, AsyncChat)
+    # No custom execution logic: streaming, conversations, tools and
+    # attachments all come from the base classes.
+    assert "execute" not in plugin.PollinationsChat.__dict__
+    assert "execute" not in plugin.PollinationsAsyncChat.__dict__
+    assert plugin.PollinationsChat.needs_key == "pollinations"
+    assert plugin.PollinationsChat.key_env_var == "POLLINATIONS_API_KEY"
+    assert plugin.API_BASE == "https://gen.pollinations.ai/v1"
+    assert plugin.MODELS_URL == "https://gen.pollinations.ai/v1/models"
+
+
+def test_auth_uses_llm_keys_or_env(monkeypatch):
+    seen = {}
+
+    def fake_get_key(explicit, alias, env_var):
+        seen["alias"] = alias
+        seen["env_var"] = env_var
+        return "sk_test"
+
+    monkeypatch.setattr(plugin.llm, "get_key", fake_get_key)
+    monkeypatch.setattr(
+        plugin, "get_pollinations_models", lambda skip_cache=False: []
+    )
+    registered = []
+    plugin.register_models(registered.append)
+    assert seen == {"alias": "pollinations", "env_var": "POLLINATIONS_API_KEY"}
+    assert registered == []
+
+
+def test_capabilities_enabled_only_when_advertised():
+    vision = {
+        "id": "m",
+        "category": "text",
+        "input_modalities": ["text", "image"],
+        "capabilities": [],
+    }
+    assert plugin.supports_vision(vision) is True
+    assert plugin.supports_vision({"input_modalities": ["text"]}) is False
+    assert plugin.supports_vision({}) is False
+
+    assert plugin.supports_tools({"capabilities": ["tool_calling"]}) is True
+    assert plugin.supports_tools({"tools": True}) is True
+    assert plugin.supports_tools({"capabilities": [], "tools": None}) is False
+    assert plugin.supports_tools({}) is False
+
+    assert plugin.supports_reasoning({"capabilities": ["reasoning"]}) is True
+    assert plugin.supports_reasoning({"reasoning": True}) is True
+    assert plugin.supports_reasoning({"reasoning": None}) is False
+    assert plugin.supports_reasoning({}) is False
+
+
+def test_registration_namespaces_ids_without_hardcoded_list(monkeypatch, tmp_path):
+    catalog = {
+        "data": [
+            {
+                "id": "openai/gpt-5.4-nano",
+                "category": "text",
+                "input_modalities": ["text", "image"],
+                "capabilities": ["tool_calling"],
+                "tools": True,
+            },
+            {
+                "id": "some/image-model",
+                "category": "image",
+                "input_modalities": ["text"],
+                "capabilities": [],
+            },
+        ]
+    }
+
+    class FakeResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return catalog
+
+    monkeypatch.setattr(plugin.llm, "get_key", lambda *a, **k: "sk_test")
+    monkeypatch.setattr(plugin.llm, "user_dir", lambda: tmp_path)
+    monkeypatch.setattr(
+        plugin.httpx, "get", lambda *a, **k: FakeResponse()
+    )
+    registered = []
+    plugin.register_models(lambda *models: registered.extend(models))
+    assert len(registered) == 2  # sync + async for the one text model
+    chat, async_chat = registered
+    assert isinstance(chat, plugin.PollinationsChat)
+    assert isinstance(async_chat, plugin.PollinationsAsyncChat)
+    # No provider-name collisions: namespaced IDs, canonical API names.
+    assert chat.model_id == "pollinations/openai/gpt-5.4-nano"
+    assert chat.model_name == "openai/gpt-5.4-nano"
+    assert chat.vision is True
+    assert chat.supports_tools is True
+    # reasoning=False builds no reasoning options (base Chat behavior).
+    assert "reasoning_effort" not in chat.Options.model_fields
+    assert "image-model" not in [m.model_id for m in registered]
+
+
+def test_reasoning_option_only_when_advertised(monkeypatch, tmp_path):
+    catalog = {
+        "data": [
+            {
+                "id": "plain-model",
+                "category": "text",
+                "input_modalities": ["text"],
+                "capabilities": [],
+            },
+            {
+                "id": "reason-model",
+                "category": "text",
+                "input_modalities": ["text"],
+                "capabilities": ["reasoning"],
+                "reasoning": True,
+            },
+        ]
+    }
+
+    class FakeResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return catalog
+
+    monkeypatch.setattr(plugin.llm, "get_key", lambda *a, **k: "sk_test")
+    monkeypatch.setattr(plugin.llm, "user_dir", lambda: tmp_path)
+    monkeypatch.setattr(plugin.httpx, "get", lambda *a, **k: FakeResponse())
+    registered = []
+    plugin.register_models(lambda *models: registered.extend(models))
+    by_id = {m.model_id: m for m in registered}
+    assert "reasoning_effort" not in by_id["pollinations/plain-model"].Options.model_fields
+    assert "reasoning_effort" in by_id["pollinations/reason-model"].Options.model_fields
+
+
+def test_stale_cache_fallback(monkeypatch, tmp_path):
+    stale = {"data": [{"id": "openai/x", "category": "text"}]}
+    cache = tmp_path / plugin.CACHE_FILENAME
+    cache.write_text(json.dumps(stale))
+    # Make the cache stale (older than the timeout).
+    import os
+    import time
+
+    old = time.time() - plugin.CACHE_TIMEOUT_SECONDS - 10
+    os.utime(cache, (old, old))
+
+    def boom(*a, **k):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(plugin.llm, "get_key", lambda *a, **k: "sk_test")
+    monkeypatch.setattr(plugin.llm, "user_dir", lambda: tmp_path)
+    monkeypatch.setattr(plugin.httpx, "get", boom)
+    assert plugin.get_pollinations_models() == stale["data"]
+    # Forced refresh also falls back to stale rather than raising.
+    assert plugin.get_pollinations_models(skip_cache=True) == stale["data"]


### PR DESCRIPTION
Fixes #14660.

Native Pollinations provider plugin (`llm-pollinations`) for Simon Willison's llm CLI + Python library. Focused package under `packages/llm-pollinations` (single module, pyproject, README, pytest suite).

What:
- Reuses LLM's OpenAI-compatible `Chat` / `AsyncChat` against `https://gen.pollinations.ai/v1` — no recreated streaming, conversations, tools, or attachment handling (subclasses add only key config).
- Auth via `llm keys set pollinations` or `POLLINATIONS_API_KEY`; models register only when a key is configured so the catalog reflects the key's permissions.
- Compatible text models load from the authenticated `/v1/models` catalog, registered as `pollinations/<model-id>` (namespaced, no hardcoded list, no provider-name collisions). Non-text categories excluded.
- Vision / tool-calling / reasoning enabled only when the catalog advertises them (`input_modalities` includes image; `capabilities`/`tools`/`reasoning`); reasoning wires LLM's standard `-o reasoning_effort` option.
- 5-minute cache with stale-cache fallback (`llm pollinations refresh`, `llm pollinations models [--json]`); discovery never breaks `llm` startup when offline/uncached.
- README: direct key setup + dedicated key via Polli CLI (`polli keys create --name llm --budget 100`), usage, verification commands, PyPI + upstream plugin-directory submission notes.
- Focused pytest suite (6 tests): base-class reuse, auth wiring, capability gating, namespacing, reasoning options, stale fallback.

Verified live against llm 0.35 (current): plugin loads (`llm plugins` shows both hooks), `llm pollinations models` works, and with a key set 262 `pollinations/*` text models register with correct vision/tools/reasoning flags (`llm models --options` checked). Prompt/streaming/chat/attachment/tool/Python-API paths are pure base-class behavior (same as the llm-openrouter reference); run the README verification block with a funded key for end-to-end generation.

Out of scope (per quest): image generation, embeddings, custom device-auth flow, config UI, new Polli CLI integration command.