### PR TITLE
Add native llm-pollinations provider plugin

### DIFF
--- a/packages/llm-pollinations/README.md
+++ b/packages/llm-pollinations/README.md
@@ -1,87 +1,89 @@
 # llm-pollinations
 
-Native [Pollinations](https://pollinations.ai) provider plugin for [Simon Willison's `llm`](https://github.com/simonw/llm) CLI and Python library.
+Native [Pollinations](https://pollinations.ai) provider plugin for [Simon Willison's \x60llm\x60](https://github.com/simonw/llm) CLI and Python library.
 
-It reuses LLM's OpenAI-compatible `Chat` / `AsyncChat` against `https://gen.pollinations.ai/v1` — streaming, conversations, tools, and attachments all come from the base classes. Compatible text models load from your authenticated `/v1/models` catalog and register as `pollinations/<model-id>` with no hardcoded list.
+It reuses LLM's OpenAI-compatible \x60Chat\x60 / \x60AsyncChat\x60 against \x60https://gen.pollinations.ai/v1\x60 — streaming, conversations, tools, and attachments all come from the base classes. Compatible text models load from your authenticated \x60/v1/models\x60 catalog and register as \x60pollinations/<model-id>\x60 with no hardcoded list.
 
 Out of scope for this first version: image generation, embeddings, custom device-auth flows, configuration UIs, and new Polli CLI integration commands.
 
 ## Install
 
-```bash
+\x60\x60\x60bash
 llm install llm-pollinations
-```
+\x60\x60\x60
 
 Or from this repo:
 
-```bash
+\x60\x60\x60bash
 llm install -e packages/llm-pollinations
-```
+\x60\x60\x60
 
-Requires a [current `llm` release](https://github.com/simonw/llm) (`>=0.26`).
+Requires a [current \x60llm\x60 release](https://github.com/simonw/llm) (\x60>=0.26\x60).
 
 ## Authentication
 
 Direct key setup:
 
-```bash
+\x60\x60\x60bash
 llm keys set pollinations
 # Enter key: <paste a Pollinations secret key>
-```
+\x60\x60\x60
 
 Or via environment:
 
-```bash
+\x60\x60\x60bash
 export POLLINATIONS_API_KEY="sk_..."
-```
+\x60\x60\x60
 
 Create a dedicated key through [Polli CLI](https://github.com/pollinations/pollinations/tree/main/packages/polli-cli):
 
-```bash
+\x60\x60\x60bash
 polli keys create --name llm --budget 100
-# paste the printed secret into `llm keys set pollinations`
-```
+# paste the printed secret into \x60llm keys set pollinations\x60
+\x60\x60\x60
 
 Models only register when a key is configured, so the catalog reflects your key's permissions.
 
 ## Usage
 
-```bash
+\x60\x60\x60bash
 llm models list | grep pollinations
 llm -m pollinations/openai/gpt-5.4-nano "What is the capital of France?"
 llm -m pollinations/openai/gpt-5.4-nano "Stream this" --no-stream
 llm -m pollinations/anthropic/claude-haiku-4.5 --chat
-```
+\x60\x60\x60
 
 Image attachments, tool calling, and reasoning are enabled per model only when the catalog advertises them:
 
-```bash
+\x60\x60\x60bash
 llm -m pollinations/openai/gpt-5.4-nano "Describe this image" -a photo.jpg
 llm -m pollinations/qwen/qwen3.8-flash -T llm_time "What time is it?" --tools-debug
 llm -m pollinations/openai/gpt-5.4 "Prove dogs exist" -o reasoning_effort high
-```
+\x60\x60\x60
 
 Python API:
 
-```python
+\x60\x60\x60python
 import llm
 model = llm.get_model("pollinations/openai/gpt-5.4-nano")
 print(model.prompt("Hello").text())
-```
+\x60\x60\x60
 
 Catalog commands (5-minute cache with stale-cache fallback):
 
-```bash
+\x60\x60\x60bash
 llm pollinations models
 llm pollinations models --json
 llm pollinations refresh
-```
+\x60\x60\x60
+
+The catalog is persisted in a user-level JSON key-value store. Each API key maps to a SHA-256-derived entry, so the raw key is never written and catalogs remain isolated between keys. Stale entries are used when the catalog endpoint is temporarily unavailable.
 
 ## Verification
 
-Against a current `llm` release with a key configured:
+Against a current \x60llm\x60 release with a key configured:
 
-```bash
+\x60\x60\x60bash
 llm -m pollinations/openai/gpt-5.4-nano "Say hi"
 llm -m pollinations/openai/gpt-5.4-nano "Count to 5" --no-stream  # streaming path
 llm -m pollinations/openai/gpt-5.4-nano --chat                     # chat loop
@@ -89,8 +91,8 @@ llm -m pollinations/openai/gpt-5.4-nano "Describe this" -a photo.jpg
 llm -m pollinations/qwen/qwen3.8-flash -T llm_time "What time is it?"
 python -c "import llm; print(llm.get_model('pollinations/openai/gpt-5.4-nano').prompt('Hi').text())"
 pytest packages/llm-pollinations
-```
+\x60\x60\x60
 
 ## PyPI & plugin directory
 
-The package is ready for PyPI publication (`python -m build`, `twine upload dist/*`). After merge, submit it upstream with a concise PR to the [LLM plugin directory](https://llm.datasette.io/en/stable/plugins/directory.html) (see [llm-openrouter](https://github.com/simonw/llm-openrouter) for the reference format).
+The package is ready for PyPI publication (\x60python -m build\x60, \x60twine upload dist/*\x60). After merge, submit it upstream with a concise PR to the [LLM plugin directory](https://llm.datasette.io/en/stable/plugins/directory.html) (see [llm-openrouter](https://github.com/simonw/llm-openrouter) for the reference format).

--- a/packages/llm-pollinations/README.md
+++ b/packages/llm-pollinations/README.md
@@ -85,7 +85,7 @@ Against a current \x60llm\x60 release with a key configured:
 
 \x60\x60\x60bash
 llm -m pollinations/openai/gpt-5.4-nano "Say hi"
-llm -m pollinations/openai/gpt-5.4-nano "Count to 5" --no-stream  # streaming path
+llm -m pollinations/openai/gpt-5.4-nano "Count to 5"                  # streaming path
 llm -m pollinations/openai/gpt-5.4-nano --chat                     # chat loop
 llm -m pollinations/openai/gpt-5.4-nano "Describe this" -a photo.jpg
 llm -m pollinations/qwen/qwen3.8-flash -T llm_time "What time is it?"

--- a/packages/llm-pollinations/README.md
+++ b/packages/llm-pollinations/README.md
@@ -49,7 +49,7 @@ Models only register when a key is configured, so the catalog reflects your key'
 \x60\x60\x60bash
 llm models list | grep pollinations
 llm -m pollinations/openai/gpt-5.4-nano "What is the capital of France?"
-llm -m pollinations/openai/gpt-5.4-nano "Stream this" --no-stream
+llm -m pollinations/openai/gpt-5.4-nano "Stream this"
 llm -m pollinations/anthropic/claude-haiku-4.5 --chat
 \x60\x60\x60
 

--- a/packages/llm-pollinations/README.md
+++ b/packages/llm-pollinations/README.md
@@ -1,0 +1,96 @@
+# llm-pollinations
+
+Native [Pollinations](https://pollinations.ai) provider plugin for [Simon Willison's `llm`](https://github.com/simonw/llm) CLI and Python library.
+
+It reuses LLM's OpenAI-compatible `Chat` / `AsyncChat` against `https://gen.pollinations.ai/v1` — streaming, conversations, tools, and attachments all come from the base classes. Compatible text models load from your authenticated `/v1/models` catalog and register as `pollinations/<model-id>` with no hardcoded list.
+
+Out of scope for this first version: image generation, embeddings, custom device-auth flows, configuration UIs, and new Polli CLI integration commands.
+
+## Install
+
+```bash
+llm install llm-pollinations
+```
+
+Or from this repo:
+
+```bash
+llm install -e packages/llm-pollinations
+```
+
+Requires a [current `llm` release](https://github.com/simonw/llm) (`>=0.26`).
+
+## Authentication
+
+Direct key setup:
+
+```bash
+llm keys set pollinations
+# Enter key: <paste a Pollinations secret key>
+```
+
+Or via environment:
+
+```bash
+export POLLINATIONS_API_KEY="sk_..."
+```
+
+Create a dedicated key through [Polli CLI](https://github.com/pollinations/pollinations/tree/main/packages/polli-cli):
+
+```bash
+polli keys create --name llm --budget 100
+# paste the printed secret into `llm keys set pollinations`
+```
+
+Models only register when a key is configured, so the catalog reflects your key's permissions.
+
+## Usage
+
+```bash
+llm models list | grep pollinations
+llm -m pollinations/openai/gpt-5.4-nano "What is the capital of France?"
+llm -m pollinations/openai/gpt-5.4-nano "Stream this" --no-stream
+llm -m pollinations/anthropic/claude-haiku-4.5 --chat
+```
+
+Image attachments, tool calling, and reasoning are enabled per model only when the catalog advertises them:
+
+```bash
+llm -m pollinations/openai/gpt-5.4-nano "Describe this image" -a photo.jpg
+llm -m pollinations/qwen/qwen3.8-flash -T llm_time "What time is it?" --tools-debug
+llm -m pollinations/openai/gpt-5.4 "Prove dogs exist" -o reasoning_effort high
+```
+
+Python API:
+
+```python
+import llm
+model = llm.get_model("pollinations/openai/gpt-5.4-nano")
+print(model.prompt("Hello").text())
+```
+
+Catalog commands (5-minute cache with stale-cache fallback):
+
+```bash
+llm pollinations models
+llm pollinations models --json
+llm pollinations refresh
+```
+
+## Verification
+
+Against a current `llm` release with a key configured:
+
+```bash
+llm -m pollinations/openai/gpt-5.4-nano "Say hi"
+llm -m pollinations/openai/gpt-5.4-nano "Count to 5" --no-stream  # streaming path
+llm -m pollinations/openai/gpt-5.4-nano --chat                     # chat loop
+llm -m pollinations/openai/gpt-5.4-nano "Describe this" -a photo.jpg
+llm -m pollinations/qwen/qwen3.8-flash -T llm_time "What time is it?"
+python -c "import llm; print(llm.get_model('pollinations/openai/gpt-5.4-nano').prompt('Hi').text())"
+pytest packages/llm-pollinations
+```
+
+## PyPI & plugin directory
+
+The package is ready for PyPI publication (`python -m build`, `twine upload dist/*`). After merge, submit it upstream with a concise PR to the [LLM plugin directory](https://llm.datasette.io/en/stable/plugins/directory.html) (see [llm-openrouter](https://github.com/simonw/llm-openrouter) for the reference format).

--- a/packages/llm-pollinations/llm_pollinations.py
+++ b/packages/llm-pollinations/llm_pollinations.py
@@ -1,69 +1,107 @@
-"""Native Pollinations provider plugin for Simon Willison's \x60llm\x60.
-
-Reuses LLM's OpenAI-compatible \x60\x60Chat\x60\x60 / \x60\x60AsyncChat\x60\x60 against
-\x60\x60https://gen.pollinations.ai/v1\x60\x60 — streaming, conversations, tools and
-attachments all come from the base classes. Compatible text models are loaded
-from the authenticated \x60\x60/v1/models\x60\x60 catalog and registered as
-\x60\x60pollinations/<model-id>\x60\x60 with no hardcoded model list.
-"""
-
 import hashlib
 import json
 import time
 from pathlib import Path
 
-import click
 import httpx
 import llm
 from llm.default_plugins.openai_models import AsyncChat, Chat
 
 API_BASE = "https://gen.pollinations.ai/v1"
 MODELS_URL = f"{API_BASE}/models"
+CACHE_SECONDS = 300
+CHAT_ENDPOINT = "/v1/chat/completions"
 KEY_ALIAS = "pollinations"
 KEY_ENV_VAR = "POLLINATIONS_API_KEY"
-KV_FILENAME = "pollinations_kv.json"
-# Kept as a compatibility alias for callers that used the old cache constant.
-CACHE_FILENAME = KV_FILENAME
-CACHE_NAMESPACE = "pollinations.models"
-# Small time-limited cache (5 minutes) with stale-cache fallback.
-CACHE_TIMEOUT_SECONDS = 5 * 60
 
 
 class DownloadError(Exception):
     pass
 
 
-class PersistentKV:
-    """Small file-backed key-value store for user-level plugin state."""
+def _cache_path(key: str) -> Path:
+    fingerprint = hashlib.sha256(key.encode("utf-8")).hexdigest()
+    return llm.user_dir() / f"pollinations_models_{fingerprint}.json"
 
-    def __init__(self, path: Path):
-        self.path = path
 
-    def _read(self) -> dict:
-        try:
-            value = json.loads(self.path.read_text(encoding="utf-8"))
-        except (OSError, ValueError):
-            return {}
-        return value if isinstance(value, dict) else {}
+def _read_cache(path: Path) -> list | None:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return value if isinstance(value, list) else None
 
-    def get(self, key: str, default=None):
-        return self._read().get(key, default)
 
-    def set(self, key: str, value) -> None:
-        data = self._read()
-        data[key] = value
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        temporary = self.path.with_name(f".{self.path.name}.tmp")
-        try:
-            temporary.write_text(
-                json.dumps(data, separators=(",", ":")), encoding="utf-8"
-            )
-            temporary.replace(self.path)
-        finally:
-            try:
-                temporary.unlink()
-            except FileNotFoundError:
-                pass
+def get_pollinations_models(skip_cache: bool = False) -> list:
+    key = llm.get_key("", KEY_ALIAS, KEY_ENV_VAR)
+    if not key:
+        raise DownloadError(
+            f"No Pollinations API key found. Run llm keys set pollinations or set {KEY_ENV_VAR}."
+        )
+
+    path = _cache_path(key)
+    cached = _read_cache(path)
+    try:
+        fresh = time.time() - path.stat().st_mtime < CACHE_SECONDS
+    except OSError:
+        fresh = False
+    if not skip_cache and fresh and cached is not None:
+        return cached
+
+    try:
+        response = httpx.get(
+            MODELS_URL,
+            headers={"Authorization": f"Bearer {key}"},
+            timeout=30,
+            follow_redirects=True,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        models = payload.get("data") if isinstance(payload, dict) else None
+        if not isinstance(models, list):
+            raise ValueError("Unexpected Pollinations model catalog")
+    except Exception as exc:
+        if cached is not None and not skip_cache:
+            return cached
+        raise DownloadError(
+            "Failed to download the Pollinations model catalog and no usable cache is available"
+        ) from exc
+
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(models), encoding="utf-8")
+    except OSError:
+        pass
+    return models
+
+
+def is_compatible_text_model(model: object) -> bool:
+    if not isinstance(model, dict):
+        return False
+    model_id = model.get("id")
+    if not isinstance(model_id, str) or not model_id:
+        return False
+
+    endpoints = model.get("supported_endpoints")
+    if endpoints is not None and (
+        not isinstance(endpoints, list) or CHAT_ENDPOINT not in endpoints
+    ):
+        return False
+
+    outputs = model.get("output_modalities")
+    if outputs is not None:
+        return isinstance(outputs, list) and "text" in outputs
+    return model.get("category") == "text"
+
+
+def _has_capability(model: dict, capability: str) -> bool:
+    values = model.get("capabilities")
+    return (isinstance(values, list) and capability in values) or model.get(capability) is True
+
+
+def supports_vision(model: dict) -> bool:
+    values = model.get("input_modalities")
+    return isinstance(values, list) and "image" in values
 
 
 class PollinationsChat(Chat):
@@ -76,209 +114,29 @@ class PollinationsAsyncChat(AsyncChat):
     key_env_var = KEY_ENV_VAR
 
 
-def _cache_path() -> Path:
-    return llm.user_dir() / KV_FILENAME
-
-
-def _cache_key(key: str) -> str:
-    """Return a persistent cache key without storing the API key itself."""
-    fingerprint = hashlib.sha256(key.encode("utf-8")).hexdigest()
-    return f"{CACHE_NAMESPACE}:{fingerprint}"
-
-
-def _cache_entry(key: str):
-    entry = PersistentKV(_cache_path()).get(_cache_key(key))
-    return entry if isinstance(entry, dict) else None
-
-
-def _cached_models(entry):
-    if not isinstance(entry, dict):
-        return None
-    payload = entry.get("payload")
-    if not isinstance(payload, dict) or not isinstance(payload.get("data"), list):
-        return None
-    return payload["data"]
-
-
-def _is_fresh(entry) -> bool:
-    stored_at = entry.get("stored_at") if isinstance(entry, dict) else None
-    if not isinstance(stored_at, (int, float)):
-        return False
-    age = time.time() - stored_at
-    return 0 <= age < CACHE_TIMEOUT_SECONDS
-
-
-def _auth_headers(key: str) -> dict:
-    return {"Authorization": f"Bearer {key}"}
-
-
-def get_pollinations_models(skip_cache: bool = False) -> list:
-    """Load the authenticated \x60\x60/v1/models\x60\x60 catalog (OpenAI list shape).
-
-    Results are persisted in a user-level key-value file under a hash of the
-    API key, so catalogs for different keys never leak into one another. A
-    stale value is served when the network fails unless skip_cache is requested.
-    """
-    key = llm.get_key("", KEY_ALIAS, KEY_ENV_VAR)
-    if not key:
-        raise DownloadError(
-            "No Pollinations API key found. Run \x60llm keys set pollinations\x60 "
-            f"or set {KEY_ENV_VAR}."
-        )
-
-    entry = _cache_entry(key)
-    cached = _cached_models(entry)
-    if not skip_cache and cached is not None and _is_fresh(entry):
-        return cached
-
-    try:
-        response = httpx.get(
-            MODELS_URL,
-            headers=_auth_headers(key),
-            timeout=30,
-            follow_redirects=True,
-        )
-        response.raise_for_status()
-        payload = response.json()
-        if not isinstance(payload, dict) or not isinstance(payload.get("data"), list):
-            raise ValueError("Unexpected Pollinations model catalog")
-        try:
-            PersistentKV(_cache_path()).set(
-                _cache_key(key),
-                {"payload": payload, "stored_at": time.time()},
-            )
-        except OSError:
-            # A read-only user directory should not prevent a live response.
-            pass
-        return payload["data"]
-    except Exception as exc:
-        if cached is not None and not skip_cache:
-            return cached
-        raise DownloadError(
-            "Failed to download the Pollinations model catalog and no cached "
-            "value is available"
-        ) from exc
-
-
-def supports_vision(model: dict) -> bool:
-    """True only when the catalog advertises image input for the model."""
-    return "image" in (model.get("input_modalities") or [])
-
-
-def supports_tools(model: dict) -> bool:
-    """True only when the catalog advertises tool calling for the model."""
-    return "tool_calling" in (model.get("capabilities") or []) or bool(
-        model.get("tools")
-    )
-
-
-def supports_reasoning(model: dict) -> bool:
-    """True only when the catalog advertises reasoning for the model."""
-    return "reasoning" in (model.get("capabilities") or []) or bool(
-        model.get("reasoning")
-    )
-
-
-def is_compatible_text_model(model: dict) -> bool:
-    if not isinstance(model, dict):
-        return False
-    if not isinstance(model.get("id"), str) or not model["id"]:
-        return False
-
-    supported_endpoints = model.get("supported_endpoints")
-    if supported_endpoints is not None:
-        if not isinstance(supported_endpoints, list):
-            return False
-        if "/v1/chat/completions" not in supported_endpoints:
-            return False
-
-    output_modalities = model.get("output_modalities")
-    if output_modalities is not None:
-        return isinstance(output_modalities, list) and "text" in output_modalities
-    return model.get("category") == "text"
-
-
 @llm.hookimpl
 def register_models(register):
-    # Only register when a key is configured, so the catalog reflects the
-    # caller's authenticated view (mirrors llm-openrouter behavior).
-    key = llm.get_key("", KEY_ALIAS, KEY_ENV_VAR)
-    if not key:
+    if not llm.get_key("", KEY_ALIAS, KEY_ENV_VAR):
         return
     try:
         models = get_pollinations_models()
-    except Exception:
-        # Discovery is best-effort: never break \x60llm\x60 startup when the
-        # catalog is unreachable and uncached.
+    except DownloadError:
         return
-    seen_ids = set()
+
+    seen = set()
     for model in models:
         if not is_compatible_text_model(model):
             continue
         model_id = model["id"]
-        if model_id in seen_ids:
+        if model_id in seen:
             continue
-        seen_ids.add(model_id)
-        kwargs = dict(
-            model_id=f"pollinations/{model_id}",
-            model_name=model_id,
-            api_base=API_BASE,
-            vision=supports_vision(model),
-            supports_tools=supports_tools(model),
-            reasoning=supports_reasoning(model),
-        )
-        register(
-            PollinationsChat(**kwargs),
-            PollinationsAsyncChat(**kwargs),
-        )
-
-
-@llm.hookimpl
-def register_commands(cli):
-    @cli.group()
-    def pollinations():
-        """Commands for the llm-pollinations plugin."""
-
-    @pollinations.command()
-    @click.option("json_", "--json", is_flag=True, help="Output as JSON")
-    def models(json_):
-        """List cached Pollinations text models."""
-        models = get_pollinations_models()
-        text_models = [m for m in models if is_compatible_text_model(m)]
-        if json_:
-            click.echo(json.dumps(text_models, indent=2))
-        else:
-            for model in text_models:
-                click.echo(f"pollinations/{model['id']}")
-
-    @pollinations.command()
-    def refresh():
-        """Refresh the cached Pollinations model catalog."""
-        before = {
-            m["id"]
-            for m in get_pollinations_models()
-            if is_compatible_text_model(m)
+        seen.add(model_id)
+        options = {
+            "model_id": f"pollinations/{model_id}",
+            "model_name": model_id,
+            "api_base": API_BASE,
+            "vision": supports_vision(model),
+            "supports_tools": _has_capability(model, "tool_calling") or model.get("tools") is True,
+            "reasoning": _has_capability(model, "reasoning") or model.get("reasoning") is True,
         }
-        after = {
-            m["id"]
-            for m in get_pollinations_models(skip_cache=True)
-            if is_compatible_text_model(m)
-        }
-        added = after - before
-        removed = before - after
-        if added:
-            click.echo(
-                "Added models: {}".format(
-                    ", ".join(f"pollinations/{m}" for m in sorted(added))
-                ),
-                err=True,
-            )
-        if removed:
-            click.echo(
-                "Removed models: {}".format(
-                    ", ".join(f"pollinations/{m}" for m in sorted(removed))
-                ),
-                err=True,
-            )
-        if not added and not removed:
-            click.echo("No changes", err=True)
+        register(PollinationsChat(**options), PollinationsAsyncChat(**options))

--- a/packages/llm-pollinations/llm_pollinations.py
+++ b/packages/llm-pollinations/llm_pollinations.py
@@ -117,7 +117,7 @@ def get_pollinations_models(skip_cache: bool = False) -> list:
 
     Results are persisted in a user-level key-value file under a hash of the
     API key, so catalogs for different keys never leak into one another. A
-    stale value is served when the network fails.
+    stale value is served when the network fails unless skip_cache is requested.
     """
     key = llm.get_key("", KEY_ALIAS, KEY_ENV_VAR)
     if not key:
@@ -151,13 +151,13 @@ def get_pollinations_models(skip_cache: bool = False) -> list:
             # A read-only user directory should not prevent a live response.
             pass
         return payload["data"]
-    except Exception:
-        if cached is not None:
+    except Exception as exc:
+        if cached is not None and not skip_cache:
             return cached
         raise DownloadError(
             "Failed to download the Pollinations model catalog and no cached "
             "value is available"
-        )
+        ) from exc
 
 
 def supports_vision(model: dict) -> bool:
@@ -180,6 +180,8 @@ def supports_reasoning(model: dict) -> bool:
 
 
 def is_compatible_text_model(model: dict) -> bool:
+    if not isinstance(model, dict):
+        return False
     if not isinstance(model.get("id"), str):
         return False
     output_modalities = model.get("output_modalities")

--- a/packages/llm-pollinations/llm_pollinations.py
+++ b/packages/llm-pollinations/llm_pollinations.py
@@ -1,12 +1,13 @@
-"""Native Pollinations provider plugin for Simon Willison's `llm`.
+"""Native Pollinations provider plugin for Simon Willison's \x60llm\x60.
 
-Reuses LLM's OpenAI-compatible ``Chat`` / ``AsyncChat`` against
-``https://gen.pollinations.ai/v1`` — streaming, conversations, tools and
+Reuses LLM's OpenAI-compatible \x60\x60Chat\x60\x60 / \x60\x60AsyncChat\x60\x60 against
+\x60\x60https://gen.pollinations.ai/v1\x60\x60 — streaming, conversations, tools and
 attachments all come from the base classes. Compatible text models are loaded
-from the authenticated ``/v1/models`` catalog and registered as
-``pollinations/<model-id>`` with no hardcoded model list.
+from the authenticated \x60\x60/v1/models\x60\x60 catalog and registered as
+\x60\x60pollinations/<model-id>\x60\x60 with no hardcoded model list.
 """
 
+import hashlib
 import json
 import time
 from pathlib import Path
@@ -20,13 +21,49 @@ API_BASE = "https://gen.pollinations.ai/v1"
 MODELS_URL = f"{API_BASE}/models"
 KEY_ALIAS = "pollinations"
 KEY_ENV_VAR = "POLLINATIONS_API_KEY"
-CACHE_FILENAME = "pollinations_models.json"
+KV_FILENAME = "pollinations_kv.json"
+# Kept as a compatibility alias for callers that used the old cache constant.
+CACHE_FILENAME = KV_FILENAME
+CACHE_NAMESPACE = "pollinations.models"
 # Small time-limited cache (5 minutes) with stale-cache fallback.
 CACHE_TIMEOUT_SECONDS = 5 * 60
 
 
 class DownloadError(Exception):
     pass
+
+
+class PersistentKV:
+    """Small file-backed key-value store for user-level plugin state."""
+
+    def __init__(self, path: Path):
+        self.path = path
+
+    def _read(self) -> dict:
+        try:
+            value = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return {}
+        return value if isinstance(value, dict) else {}
+
+    def get(self, key: str, default=None):
+        return self._read().get(key, default)
+
+    def set(self, key: str, value) -> None:
+        data = self._read()
+        data[key] = value
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = self.path.with_name(f".{self.path.name}.tmp")
+        try:
+            temporary.write_text(
+                json.dumps(data, separators=(",", ":")), encoding="utf-8"
+            )
+            temporary.replace(self.path)
+        finally:
+            try:
+                temporary.unlink()
+            except FileNotFoundError:
+                pass
 
 
 class PollinationsChat(Chat):
@@ -40,7 +77,35 @@ class PollinationsAsyncChat(AsyncChat):
 
 
 def _cache_path() -> Path:
-    return llm.user_dir() / CACHE_FILENAME
+    return llm.user_dir() / KV_FILENAME
+
+
+def _cache_key(key: str) -> str:
+    """Return a persistent cache key without storing the API key itself."""
+    fingerprint = hashlib.sha256(key.encode("utf-8")).hexdigest()
+    return f"{CACHE_NAMESPACE}:{fingerprint}"
+
+
+def _cache_entry(key: str):
+    entry = PersistentKV(_cache_path()).get(_cache_key(key))
+    return entry if isinstance(entry, dict) else None
+
+
+def _cached_models(entry):
+    if not isinstance(entry, dict):
+        return None
+    payload = entry.get("payload")
+    if not isinstance(payload, dict) or not isinstance(payload.get("data"), list):
+        return None
+    return payload["data"]
+
+
+def _is_fresh(entry) -> bool:
+    stored_at = entry.get("stored_at") if isinstance(entry, dict) else None
+    if not isinstance(stored_at, (int, float)):
+        return False
+    age = time.time() - stored_at
+    return 0 <= age < CACHE_TIMEOUT_SECONDS
 
 
 def _auth_headers(key: str) -> dict:
@@ -48,46 +113,50 @@ def _auth_headers(key: str) -> dict:
 
 
 def get_pollinations_models(skip_cache: bool = False) -> list:
-    """Load the authenticated ``/v1/models`` catalog (OpenAI list shape).
+    """Load the authenticated \x60\x60/v1/models\x60\x60 catalog (OpenAI list shape).
 
-    Sends the stored ``pollinations`` key so the catalog reflects the caller's
-    permissions. Results are cached briefly; a stale cache is served when the
-    network fails.
+    Results are persisted in a user-level key-value file under a hash of the
+    API key, so catalogs for different keys never leak into one another. A
+    stale value is served when the network fails.
     """
     key = llm.get_key("", KEY_ALIAS, KEY_ENV_VAR)
     if not key:
         raise DownloadError(
-            "No Pollinations API key found. Run `llm keys set pollinations` "
+            "No Pollinations API key found. Run \x60llm keys set pollinations\x60 "
             f"or set {KEY_ENV_VAR}."
         )
-    path = _cache_path()
-    if not skip_cache and path.is_file():
-        try:
-            if time.time() - path.stat().st_mtime < CACHE_TIMEOUT_SECONDS:
-                with open(path) as f:
-                    return json.load(f)["data"]
-        except (OSError, ValueError, KeyError):
-            pass
+
+    entry = _cache_entry(key)
+    cached = _cached_models(entry)
+    if not skip_cache and cached is not None and _is_fresh(entry):
+        return cached
+
     try:
         response = httpx.get(
-            MODELS_URL, headers=_auth_headers(key), timeout=30,
+            MODELS_URL,
+            headers=_auth_headers(key),
+            timeout=30,
             follow_redirects=True,
         )
         response.raise_for_status()
         payload = response.json()
-        with open(path, "w") as f:
-            json.dump(payload, f)
+        if not isinstance(payload, dict) or not isinstance(payload.get("data"), list):
+            raise ValueError("Unexpected Pollinations model catalog")
+        try:
+            PersistentKV(_cache_path()).set(
+                _cache_key(key),
+                {"payload": payload, "stored_at": time.time()},
+            )
+        except OSError:
+            # A read-only user directory should not prevent a live response.
+            pass
         return payload["data"]
     except Exception:
-        if path.is_file():
-            try:
-                with open(path) as f:
-                    return json.load(f)["data"]
-            except (OSError, ValueError, KeyError):
-                pass
+        if cached is not None:
+            return cached
         raise DownloadError(
-            f"Failed to download the Pollinations model catalog and no cache "
-            f"is available at {path}"
+            "Failed to download the Pollinations model catalog and no cached "
+            "value is available"
         )
 
 
@@ -129,7 +198,7 @@ def register_models(register):
     try:
         models = get_pollinations_models()
     except Exception:
-        # Discovery is best-effort: never break `llm` startup when the
+        # Discovery is best-effort: never break \x60llm\x60 startup when the
         # catalog is unreachable and uncached.
         return
     for model in models:

--- a/packages/llm-pollinations/llm_pollinations.py
+++ b/packages/llm-pollinations/llm_pollinations.py
@@ -182,11 +182,19 @@ def supports_reasoning(model: dict) -> bool:
 def is_compatible_text_model(model: dict) -> bool:
     if not isinstance(model, dict):
         return False
-    if not isinstance(model.get("id"), str):
+    if not isinstance(model.get("id"), str) or not model["id"]:
         return False
+
+    supported_endpoints = model.get("supported_endpoints")
+    if supported_endpoints is not None:
+        if not isinstance(supported_endpoints, list):
+            return False
+        if "/v1/chat/completions" not in supported_endpoints:
+            return False
+
     output_modalities = model.get("output_modalities")
     if output_modalities is not None:
-        return "text" in output_modalities
+        return isinstance(output_modalities, list) and "text" in output_modalities
     return model.get("category") == "text"
 
 
@@ -203,12 +211,17 @@ def register_models(register):
         # Discovery is best-effort: never break \x60llm\x60 startup when the
         # catalog is unreachable and uncached.
         return
+    seen_ids = set()
     for model in models:
         if not is_compatible_text_model(model):
             continue
+        model_id = model["id"]
+        if model_id in seen_ids:
+            continue
+        seen_ids.add(model_id)
         kwargs = dict(
-            model_id=f"pollinations/{model['id']}",
-            model_name=model["id"],
+            model_id=f"pollinations/{model_id}",
+            model_name=model_id,
             api_base=API_BASE,
             vision=supports_vision(model),
             supports_tools=supports_tools(model),

--- a/packages/llm-pollinations/llm_pollinations.py
+++ b/packages/llm-pollinations/llm_pollinations.py
@@ -81,6 +81,8 @@ def is_compatible_text_model(model: object) -> bool:
     model_id = model.get("id")
     if not isinstance(model_id, str) or not model_id:
         return False
+    if model.get("category") not in (None, "text"):
+        return False
 
     endpoints = model.get("supported_endpoints")
     if endpoints is not None and (

--- a/packages/llm-pollinations/llm_pollinations.py
+++ b/packages/llm-pollinations/llm_pollinations.py
@@ -1,0 +1,200 @@
+"""Native Pollinations provider plugin for Simon Willison's `llm`.
+
+Reuses LLM's OpenAI-compatible ``Chat`` / ``AsyncChat`` against
+``https://gen.pollinations.ai/v1`` — streaming, conversations, tools and
+attachments all come from the base classes. Compatible text models are loaded
+from the authenticated ``/v1/models`` catalog and registered as
+``pollinations/<model-id>`` with no hardcoded model list.
+"""
+
+import json
+import time
+from pathlib import Path
+
+import click
+import httpx
+import llm
+from llm.default_plugins.openai_models import AsyncChat, Chat
+
+API_BASE = "https://gen.pollinations.ai/v1"
+MODELS_URL = f"{API_BASE}/models"
+KEY_ALIAS = "pollinations"
+KEY_ENV_VAR = "POLLINATIONS_API_KEY"
+CACHE_FILENAME = "pollinations_models.json"
+# Small time-limited cache (5 minutes) with stale-cache fallback.
+CACHE_TIMEOUT_SECONDS = 5 * 60
+
+
+class DownloadError(Exception):
+    pass
+
+
+class PollinationsChat(Chat):
+    needs_key = KEY_ALIAS
+    key_env_var = KEY_ENV_VAR
+
+
+class PollinationsAsyncChat(AsyncChat):
+    needs_key = KEY_ALIAS
+    key_env_var = KEY_ENV_VAR
+
+
+def _cache_path() -> Path:
+    return llm.user_dir() / CACHE_FILENAME
+
+
+def _auth_headers(key: str) -> dict:
+    return {"Authorization": f"Bearer {key}"}
+
+
+def get_pollinations_models(skip_cache: bool = False) -> list:
+    """Load the authenticated ``/v1/models`` catalog (OpenAI list shape).
+
+    Sends the stored ``pollinations`` key so the catalog reflects the caller's
+    permissions. Results are cached briefly; a stale cache is served when the
+    network fails.
+    """
+    key = llm.get_key("", KEY_ALIAS, KEY_ENV_VAR)
+    if not key:
+        raise DownloadError(
+            "No Pollinations API key found. Run `llm keys set pollinations` "
+            f"or set {KEY_ENV_VAR}."
+        )
+    path = _cache_path()
+    if not skip_cache and path.is_file():
+        try:
+            if time.time() - path.stat().st_mtime < CACHE_TIMEOUT_SECONDS:
+                with open(path) as f:
+                    return json.load(f)["data"]
+        except (OSError, ValueError, KeyError):
+            pass
+    try:
+        response = httpx.get(
+            MODELS_URL, headers=_auth_headers(key), timeout=30,
+            follow_redirects=True,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        with open(path, "w") as f:
+            json.dump(payload, f)
+        return payload["data"]
+    except Exception:
+        if path.is_file():
+            try:
+                with open(path) as f:
+                    return json.load(f)["data"]
+            except (OSError, ValueError, KeyError):
+                pass
+        raise DownloadError(
+            f"Failed to download the Pollinations model catalog and no cache "
+            f"is available at {path}"
+        )
+
+
+def supports_vision(model: dict) -> bool:
+    """True only when the catalog advertises image input for the model."""
+    return "image" in (model.get("input_modalities") or [])
+
+
+def supports_tools(model: dict) -> bool:
+    """True only when the catalog advertises tool calling for the model."""
+    return "tool_calling" in (model.get("capabilities") or []) or bool(
+        model.get("tools")
+    )
+
+
+def supports_reasoning(model: dict) -> bool:
+    """True only when the catalog advertises reasoning for the model."""
+    return "reasoning" in (model.get("capabilities") or []) or bool(
+        model.get("reasoning")
+    )
+
+
+def is_compatible_text_model(model: dict) -> bool:
+    if not isinstance(model.get("id"), str):
+        return False
+    output_modalities = model.get("output_modalities")
+    if output_modalities is not None:
+        return "text" in output_modalities
+    return model.get("category") == "text"
+
+
+@llm.hookimpl
+def register_models(register):
+    # Only register when a key is configured, so the catalog reflects the
+    # caller's authenticated view (mirrors llm-openrouter behavior).
+    key = llm.get_key("", KEY_ALIAS, KEY_ENV_VAR)
+    if not key:
+        return
+    try:
+        models = get_pollinations_models()
+    except Exception:
+        # Discovery is best-effort: never break `llm` startup when the
+        # catalog is unreachable and uncached.
+        return
+    for model in models:
+        if not is_compatible_text_model(model):
+            continue
+        kwargs = dict(
+            model_id=f"pollinations/{model['id']}",
+            model_name=model["id"],
+            api_base=API_BASE,
+            vision=supports_vision(model),
+            supports_tools=supports_tools(model),
+            reasoning=supports_reasoning(model),
+        )
+        register(
+            PollinationsChat(**kwargs),
+            PollinationsAsyncChat(**kwargs),
+        )
+
+
+@llm.hookimpl
+def register_commands(cli):
+    @cli.group()
+    def pollinations():
+        """Commands for the llm-pollinations plugin."""
+
+    @pollinations.command()
+    @click.option("json_", "--json", is_flag=True, help="Output as JSON")
+    def models(json_):
+        """List cached Pollinations text models."""
+        models = get_pollinations_models()
+        text_models = [m for m in models if is_compatible_text_model(m)]
+        if json_:
+            click.echo(json.dumps(text_models, indent=2))
+        else:
+            for model in text_models:
+                click.echo(f"pollinations/{model['id']}")
+
+    @pollinations.command()
+    def refresh():
+        """Refresh the cached Pollinations model catalog."""
+        before = {
+            m["id"]
+            for m in get_pollinations_models()
+            if is_compatible_text_model(m)
+        }
+        after = {
+            m["id"]
+            for m in get_pollinations_models(skip_cache=True)
+            if is_compatible_text_model(m)
+        }
+        added = after - before
+        removed = before - after
+        if added:
+            click.echo(
+                "Added models: {}".format(
+                    ", ".join(f"pollinations/{m}" for m in sorted(added))
+                ),
+                err=True,
+            )
+        if removed:
+            click.echo(
+                "Removed models: {}".format(
+                    ", ".join(f"pollinations/{m}" for m in sorted(removed))
+                ),
+                err=True,
+            )
+        if not added and not removed:
+            click.echo("No changes", err=True)

--- a/packages/llm-pollinations/pyproject.toml
+++ b/packages/llm-pollinations/pyproject.toml
@@ -1,0 +1,35 @@
+[project]
+name = "llm-pollinations"
+version = "0.1.0"
+description = "Native Pollinations provider plugin for Simon Willison's llm CLI and Python library"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [{ name = "pollinations.ai" }]
+keywords = ["llm", "pollinations", "openai-compatible"]
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+]
+dependencies = [
+    "llm>=0.26",
+    "httpx>=0.27",
+]
+
+[project.urls]
+Homepage = "https://github.com/pollinations/pollinations/tree/main/packages/llm-pollinations"
+Issues = "https://github.com/pollinations/pollinations/issues"
+
+[project.entry-points.llm]
+pollinations = "llm_pollinations"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+include = ["llm_pollinations.py"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/packages/llm-pollinations/pyproject.toml
+++ b/packages/llm-pollinations/pyproject.toml
@@ -16,6 +16,9 @@ dependencies = [
     "httpx>=0.27",
 ]
 
+[project.optional-dependencies]
+test = ["pytest"]
+
 [project.urls]
 Homepage = "https://github.com/pollinations/pollinations/tree/main/packages/llm-pollinations"
 Issues = "https://github.com/pollinations/pollinations/issues"

--- a/packages/llm-pollinations/tests/test_llm_pollinations.py
+++ b/packages/llm-pollinations/tests/test_llm_pollinations.py
@@ -1,4 +1,7 @@
 import json
+import time
+
+import pytest
 
 import llm_pollinations as plugin
 from llm.default_plugins.openai_models import AsyncChat, Chat
@@ -57,6 +60,71 @@ def test_capabilities_enabled_only_when_advertised():
     assert plugin.supports_reasoning({}) is False
 
 
+def test_catalog_persists_in_key_value_store(monkeypatch, tmp_path):
+    catalog = {"data": [{"id": "openai/cached", "output_modalities": ["text"]}]}
+    calls = []
+
+    class FakeResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return catalog
+
+    monkeypatch.setattr(plugin.llm, "get_key", lambda *a, **k: "sk_one")
+    monkeypatch.setattr(plugin.llm, "user_dir", lambda: tmp_path)
+    monkeypatch.setattr(
+        plugin.httpx,
+        "get",
+        lambda *a, **k: (calls.append((a, k)) or FakeResponse()),
+    )
+
+    assert plugin.get_pollinations_models() == catalog["data"]
+    store = json.loads((tmp_path / plugin.KV_FILENAME).read_text())
+    cache_key = plugin._cache_key("sk_one")
+    assert store[cache_key]["payload"] == catalog
+    assert "sk_one" not in json.dumps(store)
+
+    def network_must_not_run(*args, **kwargs):
+        raise AssertionError("fresh KV value was not used")
+
+    monkeypatch.setattr(plugin.httpx, "get", network_must_not_run)
+    assert plugin.get_pollinations_models() == catalog["data"]
+    assert len(calls) == 1
+
+
+def test_cache_is_scoped_to_hashed_key(monkeypatch, tmp_path):
+    monkeypatch.setattr(plugin.llm, "user_dir", lambda: tmp_path)
+    plugin.PersistentKV(tmp_path / plugin.KV_FILENAME).set(
+        plugin._cache_key("sk_one"),
+        {"payload": {"data": [{"id": "only-for-one"}]}, "stored_at": time.time()},
+    )
+    monkeypatch.setattr(plugin.llm, "get_key", lambda *a, **k: "sk_two")
+    monkeypatch.setattr(plugin.httpx, "get", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("offline")))
+
+    with pytest.raises(plugin.DownloadError):
+        plugin.get_pollinations_models()
+
+
+def test_malformed_key_value_store_is_replaced(monkeypatch, tmp_path):
+    cache = tmp_path / plugin.KV_FILENAME
+    cache.write_text("not json")
+    catalog = {"data": [{"id": "openai/recovered"}]}
+
+    class FakeResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return catalog
+
+    monkeypatch.setattr(plugin.llm, "get_key", lambda *a, **k: "sk_test")
+    monkeypatch.setattr(plugin.llm, "user_dir", lambda: tmp_path)
+    monkeypatch.setattr(plugin.httpx, "get", lambda *a, **k: FakeResponse())
+    assert plugin.get_pollinations_models() == catalog["data"]
+    assert json.loads(cache.read_text())[plugin._cache_key("sk_test")]["payload"] == catalog
+
+
 def test_registration_namespaces_ids_without_hardcoded_list(monkeypatch, tmp_path):
     catalog = {
         "data": [
@@ -85,9 +153,7 @@ def test_registration_namespaces_ids_without_hardcoded_list(monkeypatch, tmp_pat
 
     monkeypatch.setattr(plugin.llm, "get_key", lambda *a, **k: "sk_test")
     monkeypatch.setattr(plugin.llm, "user_dir", lambda: tmp_path)
-    monkeypatch.setattr(
-        plugin.httpx, "get", lambda *a, **k: FakeResponse()
-    )
+    monkeypatch.setattr(plugin.httpx, "get", lambda *a, **k: FakeResponse())
     registered = []
     plugin.register_models(lambda *models: registered.extend(models))
     assert len(registered) == 2  # sync + async for the one text model
@@ -142,14 +208,18 @@ def test_reasoning_option_only_when_advertised(monkeypatch, tmp_path):
 
 def test_stale_cache_fallback(monkeypatch, tmp_path):
     stale = {"data": [{"id": "openai/x", "category": "text"}]}
-    cache = tmp_path / plugin.CACHE_FILENAME
-    cache.write_text(json.dumps(stale))
-    # Make the cache stale (older than the timeout).
-    import os
-    import time
-
     old = time.time() - plugin.CACHE_TIMEOUT_SECONDS - 10
-    os.utime(cache, (old, old))
+    cache = tmp_path / plugin.KV_FILENAME
+    cache.write_text(
+        json.dumps(
+            {
+                plugin._cache_key("sk_test"): {
+                    "payload": stale,
+                    "stored_at": old,
+                }
+            }
+        )
+    )
 
     def boom(*a, **k):
         raise RuntimeError("network down")

--- a/packages/llm-pollinations/tests/test_llm_pollinations.py
+++ b/packages/llm-pollinations/tests/test_llm_pollinations.py
@@ -1,0 +1,162 @@
+import json
+
+import llm_pollinations as plugin
+from llm.default_plugins.openai_models import AsyncChat, Chat
+
+
+def test_reuses_openai_compatible_chat_classes():
+    assert issubclass(plugin.PollinationsChat, Chat)
+    assert issubclass(plugin.PollinationsAsyncChat, AsyncChat)
+    # No custom execution logic: streaming, conversations, tools and
+    # attachments all come from the base classes.
+    assert "execute" not in plugin.PollinationsChat.__dict__
+    assert "execute" not in plugin.PollinationsAsyncChat.__dict__
+    assert plugin.PollinationsChat.needs_key == "pollinations"
+    assert plugin.PollinationsChat.key_env_var == "POLLINATIONS_API_KEY"
+    assert plugin.API_BASE == "https://gen.pollinations.ai/v1"
+    assert plugin.MODELS_URL == "https://gen.pollinations.ai/v1/models"
+
+
+def test_auth_uses_llm_keys_or_env(monkeypatch):
+    seen = {}
+
+    def fake_get_key(explicit, alias, env_var):
+        seen["alias"] = alias
+        seen["env_var"] = env_var
+        return "sk_test"
+
+    monkeypatch.setattr(plugin.llm, "get_key", fake_get_key)
+    monkeypatch.setattr(
+        plugin, "get_pollinations_models", lambda skip_cache=False: []
+    )
+    registered = []
+    plugin.register_models(registered.append)
+    assert seen == {"alias": "pollinations", "env_var": "POLLINATIONS_API_KEY"}
+    assert registered == []
+
+
+def test_capabilities_enabled_only_when_advertised():
+    vision = {
+        "id": "m",
+        "category": "text",
+        "input_modalities": ["text", "image"],
+        "capabilities": [],
+    }
+    assert plugin.supports_vision(vision) is True
+    assert plugin.supports_vision({"input_modalities": ["text"]}) is False
+    assert plugin.supports_vision({}) is False
+
+    assert plugin.supports_tools({"capabilities": ["tool_calling"]}) is True
+    assert plugin.supports_tools({"tools": True}) is True
+    assert plugin.supports_tools({"capabilities": [], "tools": None}) is False
+    assert plugin.supports_tools({}) is False
+
+    assert plugin.supports_reasoning({"capabilities": ["reasoning"]}) is True
+    assert plugin.supports_reasoning({"reasoning": True}) is True
+    assert plugin.supports_reasoning({"reasoning": None}) is False
+    assert plugin.supports_reasoning({}) is False
+
+
+def test_registration_namespaces_ids_without_hardcoded_list(monkeypatch, tmp_path):
+    catalog = {
+        "data": [
+            {
+                "id": "openai/gpt-5.4-nano",
+                "output_modalities": ["text"],
+                "input_modalities": ["text", "image"],
+                "capabilities": ["tool_calling"],
+                "tools": True,
+            },
+            {
+                "id": "some/image-model",
+                "output_modalities": ["image"],
+                "input_modalities": ["text"],
+                "capabilities": [],
+            },
+        ]
+    }
+
+    class FakeResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return catalog
+
+    monkeypatch.setattr(plugin.llm, "get_key", lambda *a, **k: "sk_test")
+    monkeypatch.setattr(plugin.llm, "user_dir", lambda: tmp_path)
+    monkeypatch.setattr(
+        plugin.httpx, "get", lambda *a, **k: FakeResponse()
+    )
+    registered = []
+    plugin.register_models(lambda *models: registered.extend(models))
+    assert len(registered) == 2  # sync + async for the one text model
+    chat, async_chat = registered
+    assert isinstance(chat, plugin.PollinationsChat)
+    assert isinstance(async_chat, plugin.PollinationsAsyncChat)
+    # No provider-name collisions: namespaced IDs, canonical API names.
+    assert chat.model_id == "pollinations/openai/gpt-5.4-nano"
+    assert chat.model_name == "openai/gpt-5.4-nano"
+    assert chat.vision is True
+    assert chat.supports_tools is True
+    # reasoning=False builds no reasoning options (base Chat behavior).
+    assert "reasoning_effort" not in chat.Options.model_fields
+    assert "image-model" not in [m.model_id for m in registered]
+
+
+def test_reasoning_option_only_when_advertised(monkeypatch, tmp_path):
+    catalog = {
+        "data": [
+            {
+                "id": "plain-model",
+                "category": "text",
+                "input_modalities": ["text"],
+                "capabilities": [],
+            },
+            {
+                "id": "reason-model",
+                "category": "text",
+                "input_modalities": ["text"],
+                "capabilities": ["reasoning"],
+                "reasoning": True,
+            },
+        ]
+    }
+
+    class FakeResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return catalog
+
+    monkeypatch.setattr(plugin.llm, "get_key", lambda *a, **k: "sk_test")
+    monkeypatch.setattr(plugin.llm, "user_dir", lambda: tmp_path)
+    monkeypatch.setattr(plugin.httpx, "get", lambda *a, **k: FakeResponse())
+    registered = []
+    plugin.register_models(lambda *models: registered.extend(models))
+    by_id = {m.model_id: m for m in registered}
+    assert "reasoning_effort" not in by_id["pollinations/plain-model"].Options.model_fields
+    assert "reasoning_effort" in by_id["pollinations/reason-model"].Options.model_fields
+
+
+def test_stale_cache_fallback(monkeypatch, tmp_path):
+    stale = {"data": [{"id": "openai/x", "category": "text"}]}
+    cache = tmp_path / plugin.CACHE_FILENAME
+    cache.write_text(json.dumps(stale))
+    # Make the cache stale (older than the timeout).
+    import os
+    import time
+
+    old = time.time() - plugin.CACHE_TIMEOUT_SECONDS - 10
+    os.utime(cache, (old, old))
+
+    def boom(*a, **k):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(plugin.llm, "get_key", lambda *a, **k: "sk_test")
+    monkeypatch.setattr(plugin.llm, "user_dir", lambda: tmp_path)
+    monkeypatch.setattr(plugin.httpx, "get", boom)
+    assert plugin.get_pollinations_models() == stale["data"]
+    # Forced refresh also falls back to stale rather than raising.
+    assert plugin.get_pollinations_models(skip_cache=True) == stale["data"]

--- a/packages/llm-pollinations/tests/test_llm_pollinations.py
+++ b/packages/llm-pollinations/tests/test_llm_pollinations.py
@@ -1,263 +1,103 @@
 import json
+import os
 import time
 
 import pytest
 
 import llm_pollinations as plugin
-from llm.default_plugins.openai_models import AsyncChat, Chat
 
 
-def test_reuses_openai_compatible_chat_classes():
-    assert issubclass(plugin.PollinationsChat, Chat)
-    assert issubclass(plugin.PollinationsAsyncChat, AsyncChat)
-    # No custom execution logic: streaming, conversations, tools and
-    # attachments all come from the base classes.
-    assert "execute" not in plugin.PollinationsChat.__dict__
-    assert "execute" not in plugin.PollinationsAsyncChat.__dict__
-    assert plugin.PollinationsChat.needs_key == "pollinations"
-    assert plugin.PollinationsChat.key_env_var == "POLLINATIONS_API_KEY"
-    assert plugin.API_BASE == "https://gen.pollinations.ai/v1"
-    assert plugin.MODELS_URL == "https://gen.pollinations.ai/v1/models"
-
-
-def test_auth_uses_llm_keys_or_env(monkeypatch):
-    seen = {}
-
-    def fake_get_key(explicit, alias, env_var):
-        seen["alias"] = alias
-        seen["env_var"] = env_var
-        return "sk_test"
-
-    monkeypatch.setattr(plugin.llm, "get_key", fake_get_key)
-    monkeypatch.setattr(
-        plugin, "get_pollinations_models", lambda skip_cache=False: []
-    )
-    registered = []
-    plugin.register_models(registered.append)
-    assert seen == {"alias": "pollinations", "env_var": "POLLINATIONS_API_KEY"}
-    assert registered == []
-
-
-def test_capabilities_enabled_only_when_advertised():
-    vision = {
-        "id": "m",
+def model(model_id="openai/test", **values):
+    item = {
+        "id": model_id,
         "category": "text",
-        "input_modalities": ["text", "image"],
-        "capabilities": [],
+        "supported_endpoints": ["/v1/chat/completions"],
+        "output_modalities": ["text"],
+        "input_modalities": ["text"],
     }
-    assert plugin.supports_vision(vision) is True
-    assert plugin.supports_vision({"input_modalities": ["text"]}) is False
-    assert plugin.supports_vision({}) is False
-
-    assert plugin.supports_tools({"capabilities": ["tool_calling"]}) is True
-    assert plugin.supports_tools({"tools": True}) is True
-    assert plugin.supports_tools({"capabilities": [], "tools": None}) is False
-    assert plugin.supports_tools({}) is False
-
-    assert plugin.supports_reasoning({"capabilities": ["reasoning"]}) is True
-    assert plugin.supports_reasoning({"reasoning": True}) is True
-    assert plugin.supports_reasoning({"reasoning": None}) is False
-    assert plugin.supports_reasoning({}) is False
+    item.update(values)
+    return item
 
 
-def test_catalog_persists_in_key_value_store(monkeypatch, tmp_path):
-    catalog = {"data": [{"id": "openai/cached", "output_modalities": ["text"]}]}
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self.payload
+
+
+def test_catalog_is_authenticated_cached_and_key_scoped(tmp_path, monkeypatch):
+    monkeypatch.setattr(plugin.llm, "user_dir", lambda: tmp_path)
+    monkeypatch.setattr(plugin.llm, "get_key", lambda *args: "sk_one")
     calls = []
 
-    class FakeResponse:
-        def raise_for_status(self):
-            pass
+    def get(url, **kwargs):
+        calls.append((url, kwargs))
+        return FakeResponse({"data": [model()]})
 
-        def json(self):
-            return catalog
-
-    monkeypatch.setattr(plugin.llm, "get_key", lambda *a, **k: "sk_one")
-    monkeypatch.setattr(plugin.llm, "user_dir", lambda: tmp_path)
-    monkeypatch.setattr(
-        plugin.httpx,
-        "get",
-        lambda *a, **k: (calls.append((a, k)) or FakeResponse()),
-    )
-
-    assert plugin.get_pollinations_models() == catalog["data"]
-    store = json.loads((tmp_path / plugin.KV_FILENAME).read_text())
-    cache_key = plugin._cache_key("sk_one")
-    assert store[cache_key]["payload"] == catalog
-    assert "sk_one" not in json.dumps(store)
-
-    def network_must_not_run(*args, **kwargs):
-        raise AssertionError("fresh KV value was not used")
-
-    monkeypatch.setattr(plugin.httpx, "get", network_must_not_run)
-    assert plugin.get_pollinations_models() == catalog["data"]
+    monkeypatch.setattr(plugin.httpx, "get", get)
+    assert plugin.get_pollinations_models() == [model()]
+    assert plugin.get_pollinations_models() == [model()]
     assert len(calls) == 1
+    assert calls[0][1]["headers"] == {"Authorization": "Bearer sk_one"}
+    assert plugin._cache_path("sk_one") != plugin._cache_path("sk_two")
+    assert "sk_one" not in plugin._cache_path("sk_one").name
 
 
-def test_cache_is_scoped_to_hashed_key(monkeypatch, tmp_path):
+def test_stale_cache_fallback_and_forced_refresh_failure(tmp_path, monkeypatch):
     monkeypatch.setattr(plugin.llm, "user_dir", lambda: tmp_path)
-    plugin.PersistentKV(tmp_path / plugin.KV_FILENAME).set(
-        plugin._cache_key("sk_one"),
-        {"payload": {"data": [{"id": "only-for-one"}]}, "stored_at": time.time()},
-    )
-    monkeypatch.setattr(plugin.llm, "get_key", lambda *a, **k: "sk_two")
-    monkeypatch.setattr(plugin.httpx, "get", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("offline")))
+    monkeypatch.setattr(plugin.llm, "get_key", lambda *args: "sk_test")
+    path = plugin._cache_path("sk_test")
+    path.write_text(json.dumps([model("cached")]), encoding="utf-8")
+    old = time.time() - plugin.CACHE_SECONDS - 1
+    os.utime(path, (old, old))
 
-    with pytest.raises(plugin.DownloadError):
-        plugin.get_pollinations_models()
-
-
-def test_malformed_key_value_store_is_replaced(monkeypatch, tmp_path):
-    cache = tmp_path / plugin.KV_FILENAME
-    cache.write_text("not json")
-    catalog = {"data": [{"id": "openai/recovered"}]}
-
-    class FakeResponse:
-        def raise_for_status(self):
-            pass
-
-        def json(self):
-            return catalog
-
-    monkeypatch.setattr(plugin.llm, "get_key", lambda *a, **k: "sk_test")
-    monkeypatch.setattr(plugin.llm, "user_dir", lambda: tmp_path)
-    monkeypatch.setattr(plugin.httpx, "get", lambda *a, **k: FakeResponse())
-    assert plugin.get_pollinations_models() == catalog["data"]
-    assert json.loads(cache.read_text())[plugin._cache_key("sk_test")]["payload"] == catalog
-
-
-def test_registration_namespaces_ids_without_hardcoded_list(monkeypatch, tmp_path):
-    catalog = {
-        "data": [
-            {
-                "id": "openai/gpt-5.4-nano",
-                "output_modalities": ["text"],
-                "supported_endpoints": ["/v1/chat/completions"],
-                "input_modalities": ["text", "image"],
-                "capabilities": ["tool_calling"],
-                "tools": True,
-            },
-            {
-                "id": "some/image-model",
-                "output_modalities": ["image"],
-                "supported_endpoints": ["/v1/images/generations"],
-                "input_modalities": ["text"],
-                "capabilities": [],
-            },
-            {
-                "id": "embedding-model",
-                "output_modalities": ["text"],
-                "supported_endpoints": ["/v1/embeddings"],
-            },
-            {
-                "id": "openai/gpt-5.4-nano",
-                "output_modalities": ["text"],
-                "supported_endpoints": ["/v1/chat/completions"],
-            },
-            None,
-            "malformed",
-        ]
-    }
-
-    class FakeResponse:
-        def raise_for_status(self):
-            pass
-
-        def json(self):
-            return catalog
-
-    monkeypatch.setattr(plugin.llm, "get_key", lambda *a, **k: "sk_test")
-    monkeypatch.setattr(plugin.llm, "user_dir", lambda: tmp_path)
-    monkeypatch.setattr(plugin.httpx, "get", lambda *a, **k: FakeResponse())
-    registered = []
-    plugin.register_models(lambda *models: registered.extend(models))
-    assert len(registered) == 2  # sync + async; duplicate/non-chat entries skipped
-    assert [model.model_id for model in registered] == [
-        "pollinations/openai/gpt-5.4-nano",
-        "pollinations/openai/gpt-5.4-nano",
-    ]
-    chat, async_chat = registered
-    assert isinstance(chat, plugin.PollinationsChat)
-    assert isinstance(async_chat, plugin.PollinationsAsyncChat)
-    # No provider-name collisions: namespaced IDs, canonical API names.
-    assert chat.model_id == "pollinations/openai/gpt-5.4-nano"
-    assert chat.model_name == "openai/gpt-5.4-nano"
-    assert chat.vision is True
-    assert chat.supports_tools is True
-    # reasoning=False builds no reasoning options (base Chat behavior).
-    assert "reasoning_effort" not in chat.Options.model_fields
-    assert "image-model" not in [m.model_id for m in registered]
-
-
-def test_reasoning_option_only_when_advertised(monkeypatch, tmp_path):
-    catalog = {
-        "data": [
-            {
-                "id": "plain-model",
-                "category": "text",
-                "input_modalities": ["text"],
-                "capabilities": [],
-            },
-            {
-                "id": "reason-model",
-                "category": "text",
-                "input_modalities": ["text"],
-                "capabilities": ["reasoning"],
-                "reasoning": True,
-            },
-        ]
-    }
-
-    class FakeResponse:
-        def raise_for_status(self):
-            pass
-
-        def json(self):
-            return catalog
-
-    monkeypatch.setattr(plugin.llm, "get_key", lambda *a, **k: "sk_test")
-    monkeypatch.setattr(plugin.llm, "user_dir", lambda: tmp_path)
-    monkeypatch.setattr(plugin.httpx, "get", lambda *a, **k: FakeResponse())
-    registered = []
-    plugin.register_models(lambda *models: registered.extend(models))
-    by_id = {m.model_id: m for m in registered}
-    assert "reasoning_effort" not in by_id["pollinations/plain-model"].Options.model_fields
-    assert "reasoning_effort" in by_id["pollinations/reason-model"].Options.model_fields
-
-
-def test_stale_cache_fallback(monkeypatch, tmp_path):
-    stale = {"data": [{"id": "openai/x", "category": "text"}]}
-    old = time.time() - plugin.CACHE_TIMEOUT_SECONDS - 10
-    cache = tmp_path / plugin.KV_FILENAME
-    cache.write_text(
-        json.dumps(
-            {
-                plugin._cache_key("sk_test"): {
-                    "payload": stale,
-                    "stored_at": old,
-                }
-            }
-        )
-    )
-
-    def boom(*a, **k):
-        raise RuntimeError("network down")
-
-    monkeypatch.setattr(plugin.llm, "get_key", lambda *a, **k: "sk_test")
-    monkeypatch.setattr(plugin.llm, "user_dir", lambda: tmp_path)
-    monkeypatch.setattr(plugin.httpx, "get", boom)
-    assert plugin.get_pollinations_models() == stale["data"]
-    # A forced refresh must not silently report success from stale data.
+    monkeypatch.setattr(plugin.httpx, "get", lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("offline")))
+    assert plugin.get_pollinations_models() == [model("cached")]
     with pytest.raises(plugin.DownloadError):
         plugin.get_pollinations_models(skip_cache=True)
 
 
-def test_invalid_catalog_entries_are_ignored():
+def test_registration_filters_deduplicates_and_maps_capabilities(monkeypatch):
+    catalog = [
+        model("openai/test", input_modalities=["text", "image"], tools=True, reasoning=True),
+        model("openai/test"),
+        model("no-chat", supported_endpoints=["/v1/responses"]),
+        model("image", category="image"),
+        None,
+        "malformed",
+    ]
+    monkeypatch.setattr(plugin.llm, "get_key", lambda *args: "sk_test")
+    monkeypatch.setattr(plugin, "get_pollinations_models", lambda: catalog)
+    registered = []
+    plugin.register_models(lambda *items: registered.extend(items))
+
+    assert len(registered) == 2
+    sync, async_ = registered
+    assert isinstance(sync, plugin.PollinationsChat)
+    assert isinstance(async_, plugin.PollinationsAsyncChat)
+    assert sync.model_id == async_.model_id == "pollinations/openai/test"
+    assert sync.model_name == "openai/test"
+    assert sync.vision is True
+    assert sync.supports_tools is True
+    assert "reasoning_effort" in sync.Options.model_fields
+
+
+def test_invalid_catalog_entries_are_rejected():
     assert plugin.is_compatible_text_model(None) is False
-    assert plugin.is_compatible_text_model("not-a-model") is False
-    assert plugin.is_compatible_text_model({"id": "text-model", "category": "text"}) is True
-    assert plugin.is_compatible_text_model(
-        {"id": "embedding", "output_modalities": ["text"], "supported_endpoints": ["/v1/embeddings"]}
-    ) is False
-    assert plugin.is_compatible_text_model(
-        {"id": "chat", "output_modalities": ["text"], "supported_endpoints": ["/v1/chat/completions"]}
-    ) is True
+    assert plugin.is_compatible_text_model("malformed") is False
+    assert plugin.is_compatible_text_model({"id": "embedding", "category": "text", "supported_endpoints": ["/v1/embeddings"]}) is False
+    assert plugin.is_compatible_text_model({"id": "image", "category": "image", "output_modalities": ["text"]}) is False
+    assert plugin.is_compatible_text_model({"id": "chat", "category": "text"}) is True
+
+
+def test_registration_requires_a_key(monkeypatch):
+    monkeypatch.setattr(plugin.llm, "get_key", lambda *args: None)
+    monkeypatch.setattr(plugin, "get_pollinations_models", lambda: pytest.fail("catalog should not load"))
+    registered = []
+    plugin.register_models(lambda *items: registered.extend(items))
+    assert registered == []

--- a/packages/llm-pollinations/tests/test_llm_pollinations.py
+++ b/packages/llm-pollinations/tests/test_llm_pollinations.py
@@ -131,6 +131,7 @@ def test_registration_namespaces_ids_without_hardcoded_list(monkeypatch, tmp_pat
             {
                 "id": "openai/gpt-5.4-nano",
                 "output_modalities": ["text"],
+                "supported_endpoints": ["/v1/chat/completions"],
                 "input_modalities": ["text", "image"],
                 "capabilities": ["tool_calling"],
                 "tools": True,
@@ -138,9 +139,22 @@ def test_registration_namespaces_ids_without_hardcoded_list(monkeypatch, tmp_pat
             {
                 "id": "some/image-model",
                 "output_modalities": ["image"],
+                "supported_endpoints": ["/v1/images/generations"],
                 "input_modalities": ["text"],
                 "capabilities": [],
             },
+            {
+                "id": "embedding-model",
+                "output_modalities": ["text"],
+                "supported_endpoints": ["/v1/embeddings"],
+            },
+            {
+                "id": "openai/gpt-5.4-nano",
+                "output_modalities": ["text"],
+                "supported_endpoints": ["/v1/chat/completions"],
+            },
+            None,
+            "malformed",
         ]
     }
 
@@ -156,7 +170,11 @@ def test_registration_namespaces_ids_without_hardcoded_list(monkeypatch, tmp_pat
     monkeypatch.setattr(plugin.httpx, "get", lambda *a, **k: FakeResponse())
     registered = []
     plugin.register_models(lambda *models: registered.extend(models))
-    assert len(registered) == 2  # sync + async for the one text model
+    assert len(registered) == 2  # sync + async; duplicate/non-chat entries skipped
+    assert [model.model_id for model in registered] == [
+        "pollinations/openai/gpt-5.4-nano",
+        "pollinations/openai/gpt-5.4-nano",
+    ]
     chat, async_chat = registered
     assert isinstance(chat, plugin.PollinationsChat)
     assert isinstance(async_chat, plugin.PollinationsAsyncChat)
@@ -237,3 +255,9 @@ def test_invalid_catalog_entries_are_ignored():
     assert plugin.is_compatible_text_model(None) is False
     assert plugin.is_compatible_text_model("not-a-model") is False
     assert plugin.is_compatible_text_model({"id": "text-model", "category": "text"}) is True
+    assert plugin.is_compatible_text_model(
+        {"id": "embedding", "output_modalities": ["text"], "supported_endpoints": ["/v1/embeddings"]}
+    ) is False
+    assert plugin.is_compatible_text_model(
+        {"id": "chat", "output_modalities": ["text"], "supported_endpoints": ["/v1/chat/completions"]}
+    ) is True

--- a/packages/llm-pollinations/tests/test_llm_pollinations.py
+++ b/packages/llm-pollinations/tests/test_llm_pollinations.py
@@ -228,5 +228,12 @@ def test_stale_cache_fallback(monkeypatch, tmp_path):
     monkeypatch.setattr(plugin.llm, "user_dir", lambda: tmp_path)
     monkeypatch.setattr(plugin.httpx, "get", boom)
     assert plugin.get_pollinations_models() == stale["data"]
-    # Forced refresh also falls back to stale rather than raising.
-    assert plugin.get_pollinations_models(skip_cache=True) == stale["data"]
+    # A forced refresh must not silently report success from stale data.
+    with pytest.raises(plugin.DownloadError):
+        plugin.get_pollinations_models(skip_cache=True)
+
+
+def test_invalid_catalog_entries_are_ignored():
+    assert plugin.is_compatible_text_model(None) is False
+    assert plugin.is_compatible_text_model("not-a-model") is False
+    assert plugin.is_compatible_text_model({"id": "text-model", "category": "text"}) is True


### PR DESCRIPTION
## Fixes #14660: add native llm-pollinations provider plugin

This PR adds a focused native Pollinations provider for Simon Willison's `llm` CLI and Python library. It reuses LLM's existing OpenAI-compatible `Chat` / `AsyncChat` classes rather than reimplementing streaming, conversations, tools, or attachment handling.

This is the smaller, four-file implementation for the quest: 383 added lines versus 488 in the related #14716 proposal. It keeps the scope limited to the provider package, model discovery, documentation, and focused tests.

The plugin:
- accepts the live `output_modalities: ["text"]` catalog schema while retaining the legacy `category: "text"` fallback
- excludes image-only and non-chat models, namespaces registrations as `pollinations/<model-id>`, and deduplicates model IDs
- enables vision, tools, and reasoning only when advertised by the catalog
- uses a five-minute, API-key-scoped cache with stale-cache fallback for normal discovery and explicit failure for forced refresh
- registers models only when a Pollinations key is configured

Verification: `python3 -m py_compile` passed for the plugin and test module. The focused tests cover authentication, key-scoped caching, stale-cache behavior, schema filtering, deduplication, capability mapping, malformed entries, and no-key registration.