### PR TITLE
feat: track referral visitor login status

### DIFF
--- a/enter.pollinations.ai/observability/datasources/referral_event.datasource
+++ b/enter.pollinations.ai/observability/datasources/referral_event.datasource
@@ -6,7 +6,9 @@ Visits to enter.pollinations.ai from tracked referral links.
 
 SCHEMA >
 `timestamp` DateTime               `json:$.timestamp`,
-`ref`       LowCardinality(String) `json:$.ref`
+`ref`       LowCardinality(String) `json:$.ref`,
+-- NULL for historical events or failed session lookups.
+`logged_in` Nullable(Bool)          `json:$.logged_in`
 
 ENGINE "MergeTree"
 ENGINE_SORTING_KEY "timestamp, ref"

--- a/enter.pollinations.ai/observability/datasources/referral_event.datasource
+++ b/enter.pollinations.ai/observability/datasources/referral_event.datasource
@@ -7,8 +7,7 @@ Visits to enter.pollinations.ai from tracked referral links.
 SCHEMA >
 `timestamp` DateTime               `json:$.timestamp`,
 `ref`       LowCardinality(String) `json:$.ref`,
--- NULL for historical events or failed session lookups.
-`logged_in` Nullable(Bool)          `json:$.logged_in`
+`metadata`  String                 `json:$.metadata` DEFAULT '{}'
 
 ENGINE "MergeTree"
 ENGINE_SORTING_KEY "timestamp, ref"

--- a/enter.pollinations.ai/src/routes/referral.ts
+++ b/enter.pollinations.ai/src/routes/referral.ts
@@ -1,13 +1,30 @@
 import type { Logger } from "@logtape/logtape";
 import { getTinybirdDatasourceIngestUrl } from "@shared/events.ts";
 import { Hono } from "hono";
+import { createAuth } from "../auth.ts";
 import type { Env } from "../env.ts";
 
 async function trackReferral(
     env: CloudflareBindings,
     ref: string,
+    headers: Headers,
     log: Logger,
 ): Promise<void> {
+    const timestamp = new Date().toISOString();
+    let loggedIn: boolean | null = null;
+    try {
+        const session = await createAuth(env).api.getSession({
+            headers,
+            query: { disableRefresh: true },
+        });
+        loggedIn = Boolean(session?.user);
+    } catch (error) {
+        // Keep the arrival even when session lookup fails; unknown is not signed out.
+        log.warn("Could not determine referral login status: {error}", {
+            error,
+        });
+    }
+
     const response = await fetch(
         getTinybirdDatasourceIngestUrl(
             env.TINYBIRD_INGEST_URL,
@@ -20,8 +37,9 @@ async function trackReferral(
                 "Content-Type": "application/x-ndjson",
             },
             body: JSON.stringify({
-                timestamp: new Date().toISOString(),
+                timestamp,
                 ref,
+                logged_in: loggedIn,
             }),
         },
     );
@@ -42,10 +60,11 @@ export const referralRoutes = new Hono<Env>().post("/", (c) => {
         ref === "agent_low_balance_quests"
     ) {
         c.executionCtx.waitUntil(
-            trackReferral(c.env, ref, c.get("log")).catch((error) =>
-                c.get("log").warn("Referral event ingest failed: {error}", {
-                    error,
-                }),
+            trackReferral(c.env, ref, c.req.raw.headers, c.get("log")).catch(
+                (error) =>
+                    c.get("log").warn("Referral event ingest failed: {error}", {
+                        error,
+                    }),
             ),
         );
     }

--- a/enter.pollinations.ai/src/routes/referral.ts
+++ b/enter.pollinations.ai/src/routes/referral.ts
@@ -39,7 +39,7 @@ async function trackReferral(
             body: JSON.stringify({
                 timestamp,
                 ref,
-                logged_in: loggedIn,
+                metadata: JSON.stringify({ logged_in: loggedIn }),
             }),
         },
     );

--- a/enter.pollinations.ai/test/referral.test.ts
+++ b/enter.pollinations.ai/test/referral.test.ts
@@ -1,4 +1,6 @@
-import { SELF } from "cloudflare:test";
+import { env, SELF } from "cloudflare:test";
+import { session as sessionTable } from "@shared/db/better-auth.ts";
+import { drizzle } from "drizzle-orm/d1";
 import { expect } from "vitest";
 import { test } from "./fixtures.ts";
 
@@ -16,11 +18,68 @@ for (const ref of [
         );
 
         expect(response.status).toBe(204);
-        expect(mocks.tinybird.state.referralEvents).toEqual([
-            expect.objectContaining({ ref }),
-        ]);
+        await expect
+            .poll(() => mocks.tinybird.state.referralEvents)
+            .toEqual([expect.objectContaining({ ref, logged_in: false })]);
+    });
+
+    test(`tracks a signed-in ${ref} referral`, async ({
+        mocks,
+        sessionToken,
+    }) => {
+        await mocks.enable("tinybird");
+        const response = await SELF.fetch(
+            `http://localhost:3000/api/referral?ref=${ref}`,
+            {
+                method: "POST",
+                headers: {
+                    Cookie: `better-auth.session_token=${sessionToken}`,
+                },
+            },
+        );
+
+        expect(response.status).toBe(204);
+        await expect
+            .poll(() => mocks.tinybird.state.referralEvents)
+            .toEqual([{ timestamp: expect.any(String), ref, logged_in: true }]);
     });
 }
+
+test("an expired session counts as signed out", async ({
+    mocks,
+    sessionToken,
+}) => {
+    await mocks.enable("tinybird");
+    await drizzle(env.DB)
+        .update(sessionTable)
+        .set({ expiresAt: new Date(0) });
+    const response = await SELF.fetch(
+        "http://localhost:3000/api/referral?ref=agent_low_balance_topup",
+        {
+            method: "POST",
+            headers: { Cookie: `better-auth.session_token=${sessionToken}` },
+        },
+    );
+    expect(response.status).toBe(204);
+    await expect
+        .poll(() => mocks.tinybird.state.referralEvents)
+        .toEqual([expect.objectContaining({ logged_in: false })]);
+});
+
+test("an API key alone does not count as a signed-in visitor", async ({
+    mocks,
+    apiKey,
+}) => {
+    await mocks.enable("tinybird");
+    const response = await SELF.fetch(
+        "http://localhost:3000/api/referral?ref=agent_low_balance_topup",
+        { method: "POST", headers: { Authorization: `Bearer ${apiKey}` } },
+    );
+    expect(response.status).toBe(204);
+    await expect
+        .poll(() => mocks.tinybird.state.referralEvents)
+        .toEqual([expect.objectContaining({ logged_in: false })]);
+});
 
 test("does not track unknown referrals", async ({ mocks }) => {
     await mocks.enable("tinybird");
@@ -31,5 +90,5 @@ test("does not track unknown referrals", async ({ mocks }) => {
     );
 
     expect(response.status).toBe(204);
-    expect(mocks.tinybird.state.referralEvents).toEqual([]);
+    await expect.poll(() => mocks.tinybird.state.referralEvents).toEqual([]);
 });

--- a/enter.pollinations.ai/test/referral.test.ts
+++ b/enter.pollinations.ai/test/referral.test.ts
@@ -20,7 +20,12 @@ for (const ref of [
         expect(response.status).toBe(204);
         await expect
             .poll(() => mocks.tinybird.state.referralEvents)
-            .toEqual([expect.objectContaining({ ref, logged_in: false })]);
+            .toEqual([
+                expect.objectContaining({
+                    ref,
+                    metadata: '{"logged_in":false}',
+                }),
+            ]);
     });
 
     test(`tracks a signed-in ${ref} referral`, async ({
@@ -41,7 +46,13 @@ for (const ref of [
         expect(response.status).toBe(204);
         await expect
             .poll(() => mocks.tinybird.state.referralEvents)
-            .toEqual([{ timestamp: expect.any(String), ref, logged_in: true }]);
+            .toEqual([
+                {
+                    timestamp: expect.any(String),
+                    ref,
+                    metadata: '{"logged_in":true}',
+                },
+            ]);
     });
 }
 
@@ -63,7 +74,9 @@ test("an expired session counts as signed out", async ({
     expect(response.status).toBe(204);
     await expect
         .poll(() => mocks.tinybird.state.referralEvents)
-        .toEqual([expect.objectContaining({ logged_in: false })]);
+        .toEqual([
+            expect.objectContaining({ metadata: '{"logged_in":false}' }),
+        ]);
 });
 
 test("an API key alone does not count as a signed-in visitor", async ({
@@ -78,7 +91,9 @@ test("an API key alone does not count as a signed-in visitor", async ({
     expect(response.status).toBe(204);
     await expect
         .poll(() => mocks.tinybird.state.referralEvents)
-        .toEqual([expect.objectContaining({ logged_in: false })]);
+        .toEqual([
+            expect.objectContaining({ metadata: '{"logged_in":false}' }),
+        ]);
 });
 
 test("does not track unknown referrals", async ({ mocks }) => {


### PR DESCRIPTION
- Adds signed-in / signed-out status at arrival to existing referral analytics, including the low-balance links from #14700. Sends no user IDs and does not compare visitors with API-key owners.
- Stores `logged_in` in a JSON-string `metadata` column so additional properties need no new columns. Historical events default to `{}`; failed session lookups store `logged_in: null`. Both mean unknown, not signed out.
- Reads the browser session in the existing background task without refreshing it. Links and frontend behavior stay unchanged.
- Validates signed-in, signed-out, expired-session, API-key-only, and unknown-ref cases: all 9 tests pass, plus type check and Biome. The earlier local staging build passed; no live staging deployment or end-to-end staging test has been performed.
- Requires the Tinybird datasource update in staging and production before Worker rollout.
