### PR TITLE
fix: log the tail and a summary of failed text streams

### DIFF
--- a/gen.pollinations.ai/src/middleware/track.ts
+++ b/gen.pollinations.ai/src/middleware/track.ts
@@ -93,12 +93,16 @@ import {
 import type { LoggerVariables } from "@/middleware/logger.ts";
 import type { ModelVariables } from "@/middleware/model.ts";
 import type { FrontendKeyRateLimitVariables } from "@/middleware/rate-limit-durable.ts";
-import { CHAT_USAGE_MISSING_AT_DONE_MESSAGE } from "@/text/chat/usage.ts";
 import {
     getResponsesEventUsage,
     isResponsesFailure,
     normalizeResponsesTerminalEvent,
 } from "@/text/responses/tracking.ts";
+import {
+    createStreamSummary,
+    summarizeChunk,
+    trimStreamEvents,
+} from "@/text/streamSummary.ts";
 import { generateRandomId, parseBooleanLike } from "@/util.ts";
 import { releaseApiKeyBudgetReservation } from "@/utils/generation-access.ts";
 import {
@@ -769,7 +773,6 @@ export async function trackResponse(
                         : finishError.status === CONTENT_POLICY_STATUS
                           ? "Upstream rejected generation for content policy"
                           : "Upstream ended generation with finish_reason=error",
-                errorDetails: streamErrorDetails(output),
             },
             errorOutput: output,
         };
@@ -803,7 +806,6 @@ export async function trackResponse(
                 errorTracking: {
                     errorResponseCode: "usage_missing",
                     errorMessage: `Provider omitted valid usage for model ${resolvedModelRequested}`,
-                    errorDetails: streamErrorDetails(output),
                 },
                 errorOutput: output ?? { streamEvents: [] },
             };
@@ -907,35 +909,6 @@ function finishReasonError(
     return undefined;
 }
 
-// A failed stream is explained by its end, not its first 16 KB of deltas: log
-// the opening chunks plus the tail, and let the summary account for the rest.
-const LOGGED_STREAM_HEAD = 2;
-const LOGGED_STREAM_TAIL = 30;
-
-function trimStreamEvents(output: unknown): unknown {
-    const streamEvents = (output as { streamEvents?: unknown } | null)
-        ?.streamEvents;
-    if (
-        !Array.isArray(streamEvents) ||
-        streamEvents.length <= LOGGED_STREAM_HEAD + LOGGED_STREAM_TAIL
-    ) {
-        return output;
-    }
-    return {
-        ...(output as object),
-        streamEvents: [
-            ...streamEvents.slice(0, LOGGED_STREAM_HEAD),
-            ...streamEvents.slice(-LOGGED_STREAM_TAIL),
-        ],
-    };
-}
-
-function streamErrorDetails(output: unknown): string | undefined {
-    const summary = (output as { streamSummary?: unknown } | null)
-        ?.streamSummary;
-    return summary ? JSON.stringify(summary) : undefined;
-}
-
 function stringifyErrorOutput(output: unknown): string {
     try {
         return JSON.stringify(trimStreamEvents(output)).slice(0, 16_000);
@@ -1006,45 +979,6 @@ function getContentTypeGuard(
 }
 
 const STREAM_DONE = Symbol("stream-done");
-
-// How a stream went, in a form that fits one analytics column.
-type StreamSummary = {
-    chunks: number;
-    contentChars: number;
-    reasoningChars: number;
-    finishReason: string | null;
-    doneSeen: boolean;
-};
-
-function summarizeChunk(event: unknown, summary: StreamSummary): void {
-    summary.chunks += 1;
-    const chunk = event as {
-        choices?: unknown;
-        error?: { code?: unknown; message?: unknown };
-    } | null;
-    if (
-        chunk?.error?.code === "usage_missing" &&
-        chunk.error.message === CHAT_USAGE_MISSING_AT_DONE_MESSAGE
-    ) {
-        summary.doneSeen = true;
-    }
-    if (!Array.isArray(chunk?.choices)) return;
-    for (const choice of chunk.choices as {
-        delta?: { content?: unknown; reasoning_content?: unknown };
-        finish_reason?: unknown;
-    }[]) {
-        const delta = choice?.delta;
-        if (typeof delta?.content === "string") {
-            summary.contentChars += delta.content.length;
-        }
-        if (typeof delta?.reasoning_content === "string") {
-            summary.reasoningChars += delta.reasoning_content.length;
-        }
-        if (typeof choice?.finish_reason === "string") {
-            summary.finishReason = choice.finish_reason;
-        }
-    }
-}
 
 async function* extractResponseStream(
     response: Response,
@@ -1410,13 +1344,7 @@ async function extractUsageAndContentFilterResultsStream(
     // Every chunk is kept: billing rules scan them all (Gemini grounding
     // metadata can sit on any chunk); only the error log is trimmed.
     const streamEvents: unknown[] = [];
-    const streamSummary: StreamSummary = {
-        chunks: 0,
-        contentChars: 0,
-        reasoningChars: 0,
-        finishReason: null,
-        doneSeen: false,
-    };
+    const streamSummary = createStreamSummary();
 
     for await (const event of events) {
         if (event === STREAM_DONE) {
@@ -1603,8 +1531,7 @@ type ErrorData = {
     errorResponseCode?: string;
     errorSource?: string;
     errorMessage?: string;
-    // Only the short stream summary; stack traces stay out of the row.
-    errorDetails?: string;
+    // errorStack and errorDetails removed to reduce D1 memory usage
 };
 
 export function collectErrorData(status: number, error?: Error): ErrorData {
@@ -1616,7 +1543,8 @@ export function collectErrorData(status: number, error?: Error): ErrorData {
         explicitCode = error.errorCode;
     }
     if (error instanceof PaymentRequiredError) explicitCode = error.errorCode;
-    // Stack traces are logged but not stored in the row.
+    // Note: errorStack and errorDetails removed to reduce D1 memory usage
+    // Stack traces and details are still logged but not stored in the database
     return {
         // Prefer the error's explicit code (e.g. content_policy_violation) so
         // analytics can distinguish it from a generic status-derived code.

--- a/gen.pollinations.ai/src/middleware/track.ts
+++ b/gen.pollinations.ai/src/middleware/track.ts
@@ -93,6 +93,7 @@ import {
 import type { LoggerVariables } from "@/middleware/logger.ts";
 import type { ModelVariables } from "@/middleware/model.ts";
 import type { FrontendKeyRateLimitVariables } from "@/middleware/rate-limit-durable.ts";
+import { CHAT_USAGE_MISSING_AT_DONE_MESSAGE } from "@/text/chat/usage.ts";
 import {
     getResponsesEventUsage,
     isResponsesFailure,
@@ -768,6 +769,7 @@ export async function trackResponse(
                         : finishError.status === CONTENT_POLICY_STATUS
                           ? "Upstream rejected generation for content policy"
                           : "Upstream ended generation with finish_reason=error",
+                errorDetails: streamErrorDetails(output),
             },
             errorOutput: output,
         };
@@ -801,6 +803,7 @@ export async function trackResponse(
                 errorTracking: {
                     errorResponseCode: "usage_missing",
                     errorMessage: `Provider omitted valid usage for model ${resolvedModelRequested}`,
+                    errorDetails: streamErrorDetails(output),
                 },
                 errorOutput: output ?? { streamEvents: [] },
             };
@@ -904,9 +907,38 @@ function finishReasonError(
     return undefined;
 }
 
+// A failed stream is explained by its end, not its first 16 KB of deltas: log
+// the opening chunks plus the tail, and let the summary account for the rest.
+const LOGGED_STREAM_HEAD = 2;
+const LOGGED_STREAM_TAIL = 30;
+
+function trimStreamEvents(output: unknown): unknown {
+    const streamEvents = (output as { streamEvents?: unknown } | null)
+        ?.streamEvents;
+    if (
+        !Array.isArray(streamEvents) ||
+        streamEvents.length <= LOGGED_STREAM_HEAD + LOGGED_STREAM_TAIL
+    ) {
+        return output;
+    }
+    return {
+        ...(output as object),
+        streamEvents: [
+            ...streamEvents.slice(0, LOGGED_STREAM_HEAD),
+            ...streamEvents.slice(-LOGGED_STREAM_TAIL),
+        ],
+    };
+}
+
+function streamErrorDetails(output: unknown): string | undefined {
+    const summary = (output as { streamSummary?: unknown } | null)
+        ?.streamSummary;
+    return summary ? JSON.stringify(summary) : undefined;
+}
+
 function stringifyErrorOutput(output: unknown): string {
     try {
-        return JSON.stringify(output).slice(0, 16_000);
+        return JSON.stringify(trimStreamEvents(output)).slice(0, 16_000);
     } catch (error) {
         return JSON.stringify({
             error: "error_output_json_stringify_failed",
@@ -973,19 +1005,69 @@ function getContentTypeGuard(
     return null;
 }
 
+const STREAM_DONE = Symbol("stream-done");
+
+// How a stream went, in a form that fits one analytics column.
+type StreamSummary = {
+    chunks: number;
+    contentChars: number;
+    reasoningChars: number;
+    finishReason: string | null;
+    doneSeen: boolean;
+};
+
+function summarizeChunk(event: unknown, summary: StreamSummary): void {
+    summary.chunks += 1;
+    const chunk = event as {
+        choices?: unknown;
+        error?: { code?: unknown; message?: unknown };
+    } | null;
+    if (
+        chunk?.error?.code === "usage_missing" &&
+        chunk.error.message === CHAT_USAGE_MISSING_AT_DONE_MESSAGE
+    ) {
+        summary.doneSeen = true;
+    }
+    if (!Array.isArray(chunk?.choices)) return;
+    for (const choice of chunk.choices as {
+        delta?: { content?: unknown; reasoning_content?: unknown };
+        finish_reason?: unknown;
+    }[]) {
+        const delta = choice?.delta;
+        if (typeof delta?.content === "string") {
+            summary.contentChars += delta.content.length;
+        }
+        if (typeof delta?.reasoning_content === "string") {
+            summary.reasoningChars += delta.reasoning_content.length;
+        }
+        if (typeof choice?.finish_reason === "string") {
+            summary.finishReason = choice.finish_reason;
+        }
+    }
+}
+
 async function* extractResponseStream(
     response: Response,
 ): AsyncGenerator<unknown> {
     if (!response.body) return;
 
     const textDecoder = new TextDecoderStream();
+    // The parser only dispatches on a blank line; some providers close after
+    // a single newline, so terminate the last event ourselves.
+    const closeLastEvent = new TransformStream<string, string>({
+        flush: (controller) => controller.enqueue("\n\n"),
+    });
     const sseParser = new EventSourceParserStream();
     const eventStream = response.body
         .pipeThrough(textDecoder)
+        .pipeThrough(closeLastEvent)
         .pipeThrough(sseParser);
 
     for await (const event of asyncIteratorStream(eventStream)) {
-        if (event.data === "[DONE]") return;
+        if (event.data === "[DONE]") {
+            yield STREAM_DONE;
+            return;
+        }
 
         let data: unknown;
         try {
@@ -1325,15 +1407,29 @@ async function extractUsageAndContentFilterResultsStream(
     let hasExplicitCacheHit = false;
     let promptFilterResults: ContentFilterResult = {};
     let completionFilterResults: ContentFilterResult = {};
+    // Every chunk is kept: billing rules scan them all (Gemini grounding
+    // metadata can sit on any chunk); only the error log is trimmed.
     const streamEvents: unknown[] = [];
+    const streamSummary: StreamSummary = {
+        chunks: 0,
+        contentChars: 0,
+        reasoningChars: 0,
+        finishReason: null,
+        doneSeen: false,
+    };
 
     for await (const event of events) {
+        if (event === STREAM_DONE) {
+            streamSummary.doneSeen = true;
+            continue;
+        }
         const parseResult = EventSchema.safeParse(event);
         // Optional choice/filter metadata must not invalidate genuine usage.
         const usageResult = EventSchema.shape.usage.safeParse(
             (event as { usage?: unknown } | null)?.usage,
         );
         streamEvents.push(event);
+        summarizeChunk(event, streamSummary);
 
         const incomingPromptFilterResults =
             parseResult.data?.prompt_filter_results?.map(
@@ -1383,16 +1479,13 @@ async function extractUsageAndContentFilterResultsStream(
     // community endpoint that name is its upstream's, and after a rescue it
     // belongs to a different owner's model than the one that served.
     const servedModel = servedModelId || model;
+    const output =
+        streamEvents.length > 0 ? { streamEvents, streamSummary } : undefined;
     if (!servedModel || !usage) {
         log.error("No usage object found in event stream");
-        return {
-            modelUsage: null,
-            output: streamEvents.length > 0 ? { streamEvents } : undefined,
-            contentFilterResults,
-        };
+        return { modelUsage: null, output, contentFilterResults };
     }
 
-    const output = streamEvents.length > 0 ? { streamEvents } : undefined;
     return {
         modelUsage: {
             model: servedModel,
@@ -1510,7 +1603,8 @@ type ErrorData = {
     errorResponseCode?: string;
     errorSource?: string;
     errorMessage?: string;
-    // errorStack and errorDetails removed to reduce D1 memory usage
+    // Only the short stream summary; stack traces stay out of the row.
+    errorDetails?: string;
 };
 
 export function collectErrorData(status: number, error?: Error): ErrorData {
@@ -1522,8 +1616,7 @@ export function collectErrorData(status: number, error?: Error): ErrorData {
         explicitCode = error.errorCode;
     }
     if (error instanceof PaymentRequiredError) explicitCode = error.errorCode;
-    // Note: errorStack and errorDetails removed to reduce D1 memory usage
-    // Stack traces and details are still logged but not stored in the database
+    // Stack traces are logged but not stored in the row.
     return {
         // Prefer the error's explicit code (e.g. content_policy_violation) so
         // analytics can distinguish it from a generic status-derived code.

--- a/gen.pollinations.ai/src/middleware/track.ts
+++ b/gen.pollinations.ai/src/middleware/track.ts
@@ -98,11 +98,7 @@ import {
     isResponsesFailure,
     normalizeResponsesTerminalEvent,
 } from "@/text/responses/tracking.ts";
-import {
-    createStreamSummary,
-    summarizeChunk,
-    trimStreamEvents,
-} from "@/text/streamSummary.ts";
+import { summarizeStreamForLog } from "@/text/streamSummary.ts";
 import { generateRandomId, parseBooleanLike } from "@/util.ts";
 import { releaseApiKeyBudgetReservation } from "@/utils/generation-access.ts";
 import {
@@ -911,7 +907,7 @@ function finishReasonError(
 
 function stringifyErrorOutput(output: unknown): string {
     try {
-        return JSON.stringify(trimStreamEvents(output)).slice(0, 16_000);
+        return JSON.stringify(summarizeStreamForLog(output)).slice(0, 16_000);
     } catch (error) {
         return JSON.stringify({
             error: "error_output_json_stringify_failed",
@@ -1344,11 +1340,11 @@ async function extractUsageAndContentFilterResultsStream(
     // Every chunk is kept: billing rules scan them all (Gemini grounding
     // metadata can sit on any chunk); only the error log is trimmed.
     const streamEvents: unknown[] = [];
-    const streamSummary = createStreamSummary();
+    let doneSeen = false;
 
     for await (const event of events) {
         if (event === STREAM_DONE) {
-            streamSummary.doneSeen = true;
+            doneSeen = true;
             continue;
         }
         const parseResult = EventSchema.safeParse(event);
@@ -1357,7 +1353,6 @@ async function extractUsageAndContentFilterResultsStream(
             (event as { usage?: unknown } | null)?.usage,
         );
         streamEvents.push(event);
-        summarizeChunk(event, streamSummary);
 
         const incomingPromptFilterResults =
             parseResult.data?.prompt_filter_results?.map(
@@ -1408,7 +1403,7 @@ async function extractUsageAndContentFilterResultsStream(
     // belongs to a different owner's model than the one that served.
     const servedModel = servedModelId || model;
     const output =
-        streamEvents.length > 0 ? { streamEvents, streamSummary } : undefined;
+        streamEvents.length > 0 ? { streamEvents, doneSeen } : undefined;
     if (!servedModel || !usage) {
         log.error("No usage object found in event stream");
         return { modelUsage: null, output, contentFilterResults };

--- a/gen.pollinations.ai/src/text/chat/usage.ts
+++ b/gen.pollinations.ai/src/text/chat/usage.ts
@@ -18,6 +18,12 @@ export class ChatUsageError extends Error {
     override readonly name = "ChatUsageError";
 }
 
+// Tracking reads this off the emitted error event: the validator drops the
+// provider's [DONE] when usage is missing there, so the message is the only
+// record that the sentinel arrived.
+export const CHAT_USAGE_MISSING_AT_DONE_MESSAGE =
+    "Chat Completions provider returned invalid or omitted terminal usage";
+
 export function createChatStreamUsageValidator() {
     const decoder = new TextDecoder();
     let lastUsage: unknown;
@@ -33,7 +39,7 @@ export function createChatStreamUsageValidator() {
                     !CompletionUsageSchema.safeParse(lastUsage).success
                 ) {
                     throw new ChatUsageError(
-                        "Chat Completions provider returned invalid or omitted terminal usage",
+                        CHAT_USAGE_MISSING_AT_DONE_MESSAGE,
                     );
                 }
                 doneSeen = true;

--- a/gen.pollinations.ai/src/text/streamSummary.ts
+++ b/gen.pollinations.ai/src/text/streamSummary.ts
@@ -1,0 +1,75 @@
+import { CHAT_USAGE_MISSING_AT_DONE_MESSAGE } from "./chat/usage.ts";
+
+// How a text stream went, in a form that fits one analytics column.
+export type StreamSummary = {
+    chunks: number;
+    contentChars: number;
+    reasoningChars: number;
+    finishReason: string | null;
+    doneSeen: boolean;
+};
+
+export function createStreamSummary(): StreamSummary {
+    return {
+        chunks: 0,
+        contentChars: 0,
+        reasoningChars: 0,
+        finishReason: null,
+        doneSeen: false,
+    };
+}
+
+export function summarizeChunk(event: unknown, summary: StreamSummary): void {
+    summary.chunks += 1;
+    const chunk = event as {
+        choices?: unknown;
+        error?: { code?: unknown; message?: unknown };
+    } | null;
+    // The usage validator swallows the provider's [DONE] when it fails there;
+    // its error event is the only record that the sentinel arrived.
+    if (
+        chunk?.error?.code === "usage_missing" &&
+        chunk.error.message === CHAT_USAGE_MISSING_AT_DONE_MESSAGE
+    ) {
+        summary.doneSeen = true;
+    }
+    if (!Array.isArray(chunk?.choices)) return;
+    for (const choice of chunk.choices as {
+        delta?: { content?: unknown; reasoning_content?: unknown };
+        finish_reason?: unknown;
+    }[]) {
+        const delta = choice?.delta;
+        if (typeof delta?.content === "string") {
+            summary.contentChars += delta.content.length;
+        }
+        if (typeof delta?.reasoning_content === "string") {
+            summary.reasoningChars += delta.reasoning_content.length;
+        }
+        if (typeof choice?.finish_reason === "string") {
+            summary.finishReason = choice.finish_reason;
+        }
+    }
+}
+
+// A failed stream is explained by its end, not its first 16 KB of deltas: log
+// the opening chunks plus the tail, and let the summary account for the rest.
+const LOGGED_STREAM_HEAD = 2;
+const LOGGED_STREAM_TAIL = 30;
+
+export function trimStreamEvents(output: unknown): unknown {
+    const streamEvents = (output as { streamEvents?: unknown } | null)
+        ?.streamEvents;
+    if (
+        !Array.isArray(streamEvents) ||
+        streamEvents.length <= LOGGED_STREAM_HEAD + LOGGED_STREAM_TAIL
+    ) {
+        return output;
+    }
+    return {
+        ...(output as object),
+        streamEvents: [
+            ...streamEvents.slice(0, LOGGED_STREAM_HEAD),
+            ...streamEvents.slice(-LOGGED_STREAM_TAIL),
+        ],
+    };
+}

--- a/gen.pollinations.ai/src/text/streamSummary.ts
+++ b/gen.pollinations.ai/src/text/streamSummary.ts
@@ -1,75 +1,37 @@
 import { CHAT_USAGE_MISSING_AT_DONE_MESSAGE } from "./chat/usage.ts";
 
-// How a text stream went, in a form that fits one analytics column.
-export type StreamSummary = {
-    chunks: number;
-    contentChars: number;
-    reasoningChars: number;
-    finishReason: string | null;
-    doneSeen: boolean;
-};
-
-export function createStreamSummary(): StreamSummary {
-    return {
-        chunks: 0,
-        contentChars: 0,
-        reasoningChars: 0,
-        finishReason: null,
-        doneSeen: false,
-    };
-}
-
-export function summarizeChunk(event: unknown, summary: StreamSummary): void {
-    summary.chunks += 1;
-    const chunk = event as {
-        choices?: unknown;
-        error?: { code?: unknown; message?: unknown };
-    } | null;
-    // The usage validator swallows the provider's [DONE] when it fails there;
-    // its error event is the only record that the sentinel arrived.
-    if (
-        chunk?.error?.code === "usage_missing" &&
-        chunk.error.message === CHAT_USAGE_MISSING_AT_DONE_MESSAGE
-    ) {
-        summary.doneSeen = true;
-    }
-    if (!Array.isArray(chunk?.choices)) return;
-    for (const choice of chunk.choices as {
-        delta?: { content?: unknown; reasoning_content?: unknown };
-        finish_reason?: unknown;
-    }[]) {
-        const delta = choice?.delta;
-        if (typeof delta?.content === "string") {
-            summary.contentChars += delta.content.length;
-        }
-        if (typeof delta?.reasoning_content === "string") {
-            summary.reasoningChars += delta.reasoning_content.length;
-        }
-        if (typeof choice?.finish_reason === "string") {
-            summary.finishReason = choice.finish_reason;
-        }
-    }
-}
-
 // A failed stream is explained by its end, not its first 16 KB of deltas: log
-// the opening chunks plus the tail, and let the summary account for the rest.
+// the opening chunks plus the tail, and say how many chunks there were.
 const LOGGED_STREAM_HEAD = 2;
 const LOGGED_STREAM_TAIL = 30;
 
-export function trimStreamEvents(output: unknown): unknown {
-    const streamEvents = (output as { streamEvents?: unknown } | null)
-        ?.streamEvents;
-    if (
-        !Array.isArray(streamEvents) ||
-        streamEvents.length <= LOGGED_STREAM_HEAD + LOGGED_STREAM_TAIL
-    ) {
-        return output;
-    }
+// The usage validator swallows the provider's [DONE] when it fails there; its
+// error event is the only record that the sentinel arrived.
+function isUsageMissingAtDone(event: unknown): boolean {
+    const error = (
+        event as { error?: { code?: unknown; message?: unknown } } | null
+    )?.error;
+    return (
+        error?.code === "usage_missing" &&
+        error.message === CHAT_USAGE_MISSING_AT_DONE_MESSAGE
+    );
+}
+
+export function summarizeStreamForLog(output: unknown): unknown {
+    const { streamEvents, doneSeen } = (output ?? {}) as {
+        streamEvents?: unknown;
+        doneSeen?: boolean;
+    };
+    if (!Array.isArray(streamEvents)) return output;
     return {
-        ...(output as object),
-        streamEvents: [
-            ...streamEvents.slice(0, LOGGED_STREAM_HEAD),
-            ...streamEvents.slice(-LOGGED_STREAM_TAIL),
-        ],
+        chunks: streamEvents.length,
+        doneSeen: doneSeen === true || streamEvents.some(isUsageMissingAtDone),
+        streamEvents:
+            streamEvents.length > LOGGED_STREAM_HEAD + LOGGED_STREAM_TAIL
+                ? [
+                      ...streamEvents.slice(0, LOGGED_STREAM_HEAD),
+                      ...streamEvents.slice(-LOGGED_STREAM_TAIL),
+                  ]
+                : streamEvents,
     };
 }

--- a/gen.pollinations.ai/test/tracking-observability.test.ts
+++ b/gen.pollinations.ai/test/tracking-observability.test.ts
@@ -849,7 +849,6 @@ describe("tracking observability", () => {
             isBilledUsage: false,
             errorResponseCode: "upstream_finish_reason_error",
             errorMessage: "Upstream ended generation with finish_reason=error",
-            errorDetails: JSON.stringify(streamSummary),
         });
         const errorEvent = (await errorRequest?.json()) as Record<
             string,
@@ -967,7 +966,6 @@ describe("tracking observability", () => {
             responseStatus: 502,
             isBilledUsage: false,
             errorResponseCode: "usage_missing",
-            errorDetails: JSON.stringify(streamSummary),
         });
         const errorRequest = tinybirdRequests.find(
             (request) =>
@@ -3035,12 +3033,14 @@ describe("trackResponse missing usage", () => {
         expect(tracking.isBilledUsage).toBe(false);
         expect(tracking.cost?.totalCost).toBeGreaterThan(0);
         expect(tracking.errorTracking?.errorResponseCode).toBe("usage_missing");
-        expect(JSON.parse(tracking.errorTracking?.errorDetails ?? "")).toEqual({
-            chunks: 2,
-            contentChars: 0,
-            reasoningChars: 0,
-            finishReason: null,
-            doneSeen: false,
+        expect(tracking.errorOutput).toMatchObject({
+            streamSummary: {
+                chunks: 2,
+                contentChars: 0,
+                reasoningChars: 0,
+                finishReason: null,
+                doneSeen: false,
+            },
         });
     });
 
@@ -3062,12 +3062,14 @@ describe("trackResponse missing usage", () => {
         );
         expect(tracking.responseStatus).toBe(502);
         expect(tracking.errorTracking?.errorResponseCode).toBe("usage_missing");
-        expect(JSON.parse(tracking.errorTracking?.errorDetails ?? "")).toEqual({
-            chunks: 2,
-            contentChars: "partial".length,
-            reasoningChars: 0,
-            finishReason: null,
-            doneSeen: true,
+        expect(tracking.errorOutput).toMatchObject({
+            streamSummary: {
+                chunks: 2,
+                contentChars: "partial".length,
+                reasoningChars: 0,
+                finishReason: null,
+                doneSeen: true,
+            },
         });
     });
 

--- a/gen.pollinations.ai/test/tracking-observability.test.ts
+++ b/gen.pollinations.ai/test/tracking-observability.test.ts
@@ -837,11 +837,19 @@ describe("tracking observability", () => {
                 new URL(request.url).searchParams.get("name") === "error_event",
         );
         expect(tinybirdRequests).toHaveLength(2);
+        const streamSummary = {
+            chunks: 3,
+            contentChars: "partial output".length,
+            reasoningChars: 0,
+            finishReason: "error",
+            doneSeen: true,
+        };
         await expect(generationRequest?.json()).resolves.toMatchObject({
             responseStatus: 502,
             isBilledUsage: false,
             errorResponseCode: "upstream_finish_reason_error",
             errorMessage: "Upstream ended generation with finish_reason=error",
+            errorDetails: JSON.stringify(streamSummary),
         });
         const errorEvent = (await errorRequest?.json()) as Record<
             string,
@@ -868,6 +876,7 @@ describe("tracking observability", () => {
         });
         const loggedOutput = JSON.parse(errorEvent.upstream_body as string) as {
             streamEvents: unknown[];
+            streamSummary: unknown;
         };
         expect(loggedOutput.streamEvents).toHaveLength(3);
         expect(loggedOutput.streamEvents[1]).toMatchObject({
@@ -878,7 +887,106 @@ describe("tracking observability", () => {
                 },
             ],
         });
+        expect(loggedOutput.streamSummary).toEqual(streamSummary);
         expect(consumePollen).toHaveBeenCalledWith(0);
+    });
+
+    it("logs the head and tail of a long stream that ends without usage", async () => {
+        const tinybirdRequests: Request[] = [];
+        vi.spyOn(globalThis, "fetch").mockImplementation(
+            async (input, init) => {
+                tinybirdRequests.push(new Request(input, init));
+                return new Response("ok");
+            },
+        );
+        const chunks = Array.from({ length: 50 }, (_, index) =>
+            JSON.stringify({
+                id: `chunk-${index}`,
+                model: "gpt-5-nano",
+                choices: [
+                    {
+                        index: 0,
+                        delta: { content: "x", reasoning_content: "yy" },
+                        finish_reason: null,
+                    },
+                ],
+            }),
+        );
+        const upstreamBody = [...chunks, "[DONE]"]
+            .map((data) => `data: ${data}\n\n`)
+            .join("");
+        const upstream = new Response(upstreamBody, {
+            headers: { "content-type": "text/event-stream" },
+        });
+
+        const ctx = createExecutionContext();
+        const response = await createTrackedResponseApp(
+            async () => {},
+            "generate.text",
+            upstream,
+        ).fetch(
+            new Request("https://gen.pollinations.ai/upstream", {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify({
+                    model: "openai/gpt-5.4-nano",
+                    stream: true,
+                    messages: [{ role: "user", content: "test" }],
+                }),
+            }),
+            {
+                DB: env.DB,
+                ENVIRONMENT: "test",
+                LOG_LEVEL: "debug",
+                LOG_FORMAT: "text",
+                BETTER_AUTH_SECRET: "test_secret",
+                TINYBIRD_INGEST_URL:
+                    "https://tinybird.test/v0/events?name=generation_event_v2",
+                TINYBIRD_INGEST_TOKEN: "test_tinybird_token",
+            } as CloudflareBindings,
+            ctx,
+        );
+
+        expect(response.status).toBe(200);
+        await expect(response.text()).resolves.toBe(upstreamBody);
+        await waitOnExecutionContext(ctx);
+
+        const streamSummary = {
+            chunks: 50,
+            contentChars: 50,
+            reasoningChars: 100,
+            finishReason: null,
+            doneSeen: true,
+        };
+        const generationRequest = tinybirdRequests.find(
+            (request) =>
+                new URL(request.url).searchParams.get("name") ===
+                "generation_event_v2",
+        );
+        await expect(generationRequest?.json()).resolves.toMatchObject({
+            responseStatus: 502,
+            isBilledUsage: false,
+            errorResponseCode: "usage_missing",
+            errorDetails: JSON.stringify(streamSummary),
+        });
+        const errorRequest = tinybirdRequests.find(
+            (request) =>
+                new URL(request.url).searchParams.get("name") === "error_event",
+        );
+        const errorEvent = (await errorRequest?.json()) as Record<
+            string,
+            unknown
+        >;
+        const loggedOutput = JSON.parse(errorEvent.upstream_body as string) as {
+            streamEvents: { id: string }[];
+            streamSummary: unknown;
+        };
+        expect(loggedOutput.streamSummary).toEqual(streamSummary);
+        expect(loggedOutput.streamEvents.map((event) => event.id)).toEqual([
+            "chunk-0",
+            "chunk-1",
+            ...Array.from({ length: 30 }, (_, index) => `chunk-${index + 20}`),
+        ]);
     });
 
     it.each([
@@ -2927,6 +3035,40 @@ describe("trackResponse missing usage", () => {
         expect(tracking.isBilledUsage).toBe(false);
         expect(tracking.cost?.totalCost).toBeGreaterThan(0);
         expect(tracking.errorTracking?.errorResponseCode).toBe("usage_missing");
+        expect(JSON.parse(tracking.errorTracking?.errorDetails ?? "")).toEqual({
+            chunks: 2,
+            contentChars: 0,
+            reasoningChars: 0,
+            finishReason: null,
+            doneSeen: false,
+        });
+    });
+
+    it("records that [DONE] arrived when the validator rejects a stream there", async () => {
+        const chunk = {
+            choices: [{ delta: { content: "partial" }, finish_reason: null }],
+        };
+        // The validator swallows this [DONE]; the tracker must still see it.
+        const upstream = new Blob([
+            `data: ${JSON.stringify(chunk)}\n\ndata: [DONE]\n\n`,
+        ]).stream();
+        const tracking = await trackResponse(
+            "generate.text",
+            requestTrackingFixture(true),
+            new Response(requireChatStreamUsage(upstream), {
+                headers: { "content-type": "text/event-stream" },
+            }),
+            candidateFixture(),
+        );
+        expect(tracking.responseStatus).toBe(502);
+        expect(tracking.errorTracking?.errorResponseCode).toBe("usage_missing");
+        expect(JSON.parse(tracking.errorTracking?.errorDetails ?? "")).toEqual({
+            chunks: 2,
+            contentChars: "partial".length,
+            reasoningChars: 0,
+            finishReason: null,
+            doneSeen: true,
+        });
     });
 
     it.each([

--- a/gen.pollinations.ai/test/tracking-observability.test.ts
+++ b/gen.pollinations.ai/test/tracking-observability.test.ts
@@ -59,6 +59,7 @@ import {
     resetGenerationModelRegistryCache,
 } from "../src/model-registry.ts";
 import { requireChatStreamUsage } from "../src/text/chat/usage.ts";
+import { summarizeStreamForLog } from "../src/text/streamSummary.ts";
 import { withInlineGenerationCoordinator } from "./helpers/inline-generation-coordinator.ts";
 
 afterEach(() => {
@@ -837,13 +838,6 @@ describe("tracking observability", () => {
                 new URL(request.url).searchParams.get("name") === "error_event",
         );
         expect(tinybirdRequests).toHaveLength(2);
-        const streamSummary = {
-            chunks: 3,
-            contentChars: "partial output".length,
-            reasoningChars: 0,
-            finishReason: "error",
-            doneSeen: true,
-        };
         await expect(generationRequest?.json()).resolves.toMatchObject({
             responseStatus: 502,
             isBilledUsage: false,
@@ -875,8 +869,8 @@ describe("tracking observability", () => {
         });
         const loggedOutput = JSON.parse(errorEvent.upstream_body as string) as {
             streamEvents: unknown[];
-            streamSummary: unknown;
         };
+        expect(loggedOutput).toMatchObject({ chunks: 3, doneSeen: true });
         expect(loggedOutput.streamEvents).toHaveLength(3);
         expect(loggedOutput.streamEvents[1]).toMatchObject({
             choices: [
@@ -886,7 +880,6 @@ describe("tracking observability", () => {
                 },
             ],
         });
-        expect(loggedOutput.streamSummary).toEqual(streamSummary);
         expect(consumePollen).toHaveBeenCalledWith(0);
     });
 
@@ -950,13 +943,6 @@ describe("tracking observability", () => {
         await expect(response.text()).resolves.toBe(upstreamBody);
         await waitOnExecutionContext(ctx);
 
-        const streamSummary = {
-            chunks: 50,
-            contentChars: 50,
-            reasoningChars: 100,
-            finishReason: null,
-            doneSeen: true,
-        };
         const generationRequest = tinybirdRequests.find(
             (request) =>
                 new URL(request.url).searchParams.get("name") ===
@@ -977,9 +963,8 @@ describe("tracking observability", () => {
         >;
         const loggedOutput = JSON.parse(errorEvent.upstream_body as string) as {
             streamEvents: { id: string }[];
-            streamSummary: unknown;
         };
-        expect(loggedOutput.streamSummary).toEqual(streamSummary);
+        expect(loggedOutput).toMatchObject({ chunks: 50, doneSeen: true });
         expect(loggedOutput.streamEvents.map((event) => event.id)).toEqual([
             "chunk-0",
             "chunk-1",
@@ -3033,14 +3018,9 @@ describe("trackResponse missing usage", () => {
         expect(tracking.isBilledUsage).toBe(false);
         expect(tracking.cost?.totalCost).toBeGreaterThan(0);
         expect(tracking.errorTracking?.errorResponseCode).toBe("usage_missing");
-        expect(tracking.errorOutput).toMatchObject({
-            streamSummary: {
-                chunks: 2,
-                contentChars: 0,
-                reasoningChars: 0,
-                finishReason: null,
-                doneSeen: false,
-            },
+        expect(summarizeStreamForLog(tracking.errorOutput)).toMatchObject({
+            chunks: 2,
+            doneSeen: false,
         });
     });
 
@@ -3062,14 +3042,9 @@ describe("trackResponse missing usage", () => {
         );
         expect(tracking.responseStatus).toBe(502);
         expect(tracking.errorTracking?.errorResponseCode).toBe("usage_missing");
-        expect(tracking.errorOutput).toMatchObject({
-            streamSummary: {
-                chunks: 2,
-                contentChars: "partial".length,
-                reasoningChars: 0,
-                finishReason: null,
-                doneSeen: true,
-            },
+        expect(summarizeStreamForLog(tracking.errorOutput)).toMatchObject({
+            chunks: 2,
+            doneSeen: true,
         });
     });
 

--- a/shared/schemas/generation-event.ts
+++ b/shared/schemas/generation-event.ts
@@ -152,7 +152,6 @@ export type TinybirdEvent = {
     errorResponseCode?: string;
     errorSource?: string;
     errorMessage?: string;
-    errorDetails?: string;
 };
 
 export type GenerationEventPriceParams = {

--- a/shared/schemas/generation-event.ts
+++ b/shared/schemas/generation-event.ts
@@ -152,6 +152,7 @@ export type TinybirdEvent = {
     errorResponseCode?: string;
     errorSource?: string;
     errorMessage?: string;
+    errorDetails?: string;
 };
 
 export type GenerationEventPriceParams = {


### PR DESCRIPTION
- Logs the first 2 and last 30 chunks of a failed text stream to `error_event` instead of the first 16 KB, which for a long generation was only opening reasoning deltas and never the end.
- Adds `chunks` and `doneSeen` next to the logged chunks in the same `error_event` upstream body, so the reader knows how much was omitted and whether the provider sent `[DONE]`. No provider chunk structure is parsed. `generation_event_v2` is unchanged.
- Fix the tracker's SSE parser dropping a final event that closes on a single newline (the usage validator already handled this).
- Log shaping lives in `src/text/streamSummary.ts`, called once at log time; `track.ts` only tracks one boolean. The in-memory chunk buffer is unchanged: Gemini grounding billing scans every chunk, so capping it could underbill.

Context: a 213 s `z-ai/glm-5.3` stream on Fireworks ended with `[DONE]` and no usage; its error row held ~40 leading reasoning tokens and nothing about how it ended.

Tests: `tracking-observability` (58), `error-observability`, `static-provider-fallbacks`, `generation-deduplication`, `test/text/**` pass locally; tsc and biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mNrP6DkRQmm3YStNjfFv3
