### PR TITLE
feat: pass the exhausted key id through low-balance notice links

### DIFF
--- a/enter.pollinations.ai/frontend/src/main.tsx
+++ b/enter.pollinations.ai/frontend/src/main.tsx
@@ -4,13 +4,17 @@ import ReactDOM from "react-dom/client";
 import { config } from "./config";
 import { routeTree } from "./routeTree.gen";
 
-const ref = new URLSearchParams(window.location.search).get("ref");
+const search = new URLSearchParams(window.location.search);
+const ref = search.get("ref");
 if (
     ref === "image" ||
     ref === "agent_low_balance_topup" ||
     ref === "agent_low_balance_quests"
 ) {
-    navigator.sendBeacon(`${config.apiBaseUrl}/referral?ref=${ref}`);
+    const query = new URLSearchParams({ ref });
+    const keyId = search.get("key_id");
+    if (keyId) query.set("key_id", keyId);
+    navigator.sendBeacon(`${config.apiBaseUrl}/referral?${query}`);
 }
 
 // Register the router instance for type safety

--- a/enter.pollinations.ai/src/routes/referral.ts
+++ b/enter.pollinations.ai/src/routes/referral.ts
@@ -1,28 +1,50 @@
 import type { Logger } from "@logtape/logtape";
+import { apikey } from "@shared/db/better-auth.ts";
 import { getTinybirdDatasourceIngestUrl } from "@shared/events.ts";
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
 import { Hono } from "hono";
 import { createAuth } from "../auth.ts";
 import type { Env } from "../env.ts";
 
+// API key ids are opaque; anything else in the URL is dropped, never stored.
+const KEY_ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
+
 async function trackReferral(
     env: CloudflareBindings,
     ref: string,
+    keyId: string | null,
     headers: Headers,
     log: Logger,
 ): Promise<void> {
     const timestamp = new Date().toISOString();
     let loggedIn: boolean | null = null;
+    let userId: string | undefined;
     try {
         const session = await createAuth(env).api.getSession({
             headers,
             query: { disableRefresh: true },
         });
         loggedIn = Boolean(session?.user);
+        userId = session?.user?.id;
     } catch (error) {
         // Keep the arrival even when session lookup fails; unknown is not signed out.
         log.warn("Could not determine referral login status: {error}", {
             error,
         });
+    }
+
+    const metadata: Record<string, unknown> = { logged_in: loggedIn };
+    if (keyId) {
+        // is_owner: true = signed in as the key's owner, false = not the owner
+        // or signed out, null = key not found.
+        const owner = await drizzle(env.DB)
+            .select({ userId: apikey.referenceId })
+            .from(apikey)
+            .where(eq(apikey.id, keyId))
+            .get();
+        metadata.key_id = keyId;
+        metadata.is_owner = owner ? owner.userId === userId : null;
     }
 
     const response = await fetch(
@@ -39,7 +61,7 @@ async function trackReferral(
             body: JSON.stringify({
                 timestamp,
                 ref,
-                metadata: JSON.stringify({ logged_in: loggedIn }),
+                metadata: JSON.stringify(metadata),
             }),
         },
     );
@@ -53,6 +75,8 @@ async function trackReferral(
 
 export const referralRoutes = new Hono<Env>().post("/", (c) => {
     const ref = c.req.query("ref");
+    const rawKeyId = c.req.query("key_id") ?? "";
+    const keyId = KEY_ID_PATTERN.test(rawKeyId) ? rawKeyId : null;
 
     if (
         ref === "image" ||
@@ -60,11 +84,16 @@ export const referralRoutes = new Hono<Env>().post("/", (c) => {
         ref === "agent_low_balance_quests"
     ) {
         c.executionCtx.waitUntil(
-            trackReferral(c.env, ref, c.req.raw.headers, c.get("log")).catch(
-                (error) =>
-                    c.get("log").warn("Referral event ingest failed: {error}", {
-                        error,
-                    }),
+            trackReferral(
+                c.env,
+                ref,
+                keyId,
+                c.req.raw.headers,
+                c.get("log"),
+            ).catch((error) =>
+                c.get("log").warn("Referral event ingest failed: {error}", {
+                    error,
+                }),
             ),
         );
     }

--- a/enter.pollinations.ai/test/referral.test.ts
+++ b/enter.pollinations.ai/test/referral.test.ts
@@ -1,5 +1,5 @@
 import { env, SELF } from "cloudflare:test";
-import { session as sessionTable } from "@shared/db/better-auth.ts";
+import { apikey, session as sessionTable } from "@shared/db/better-auth.ts";
 import { drizzle } from "drizzle-orm/d1";
 import { expect } from "vitest";
 import { test } from "./fixtures.ts";
@@ -87,6 +87,78 @@ test("an API key alone does not count as a signed-in visitor", async ({
     const response = await SELF.fetch(
         "http://localhost:3000/api/referral?ref=agent_low_balance_topup",
         { method: "POST", headers: { Authorization: `Bearer ${apiKey}` } },
+    );
+    expect(response.status).toBe(204);
+    await expect
+        .poll(() => mocks.tinybird.state.referralEvents)
+        .toEqual([
+            expect.objectContaining({ metadata: '{"logged_in":false}' }),
+        ]);
+});
+
+test("records the key id and whether the visitor owns it", async ({
+    mocks,
+    sessionToken,
+    apiKey,
+}) => {
+    await mocks.enable("tinybird");
+    expect(apiKey).toBeTruthy();
+    const [ownKey] = await drizzle(env.DB).select().from(apikey);
+    const url = `http://localhost:3000/api/referral?ref=agent_low_balance_topup&key_id=${ownKey.id}`;
+
+    // Signed in as the owner
+    let response = await SELF.fetch(url, {
+        method: "POST",
+        headers: { Cookie: `better-auth.session_token=${sessionToken}` },
+    });
+    expect(response.status).toBe(204);
+    await expect
+        .poll(() => mocks.tinybird.state.referralEvents)
+        .toEqual([
+            expect.objectContaining({
+                metadata: JSON.stringify({
+                    logged_in: true,
+                    key_id: ownKey.id,
+                    is_owner: true,
+                }),
+            }),
+        ]);
+
+    // Signed out: the key exists but the visitor is not verified as its owner
+    response = await SELF.fetch(url, { method: "POST" });
+    expect(response.status).toBe(204);
+    await expect
+        .poll(() => mocks.tinybird.state.referralEvents.at(-1)?.metadata)
+        .toBe(
+            JSON.stringify({
+                logged_in: false,
+                key_id: ownKey.id,
+                is_owner: false,
+            }),
+        );
+
+    // Unknown key: recorded, ownership unknown
+    response = await SELF.fetch(
+        "http://localhost:3000/api/referral?ref=agent_low_balance_topup&key_id=doesnotexist",
+        { method: "POST" },
+    );
+    expect(response.status).toBe(204);
+    await expect
+        .poll(() => mocks.tinybird.state.referralEvents.at(-1)?.metadata)
+        .toBe(
+            JSON.stringify({
+                logged_in: false,
+                key_id: "doesnotexist",
+                is_owner: null,
+            }),
+        );
+});
+
+test("drops a malformed key id", async ({ mocks }) => {
+    await mocks.enable("tinybird");
+    const response = await SELF.fetch(
+        "http://localhost:3000/api/referral?ref=agent_low_balance_quests&key_id=not%20an%20id",
+        { method: "POST" },
     );
     expect(response.status).toBe(204);
     await expect

--- a/gen.pollinations.ai/src/middleware/text-balance-notice.ts
+++ b/gen.pollinations.ai/src/middleware/text-balance-notice.ts
@@ -19,12 +19,17 @@ import {
 // Set false to restore HTTP 402 for every insufficient-balance response.
 export const TEXT_BALANCE_NOTICE_ENABLED = true;
 
-const MESSAGE =
-    "The account behind this API key doesn't have enough credits. " +
-    "Please " +
-    "[top up](https://enter.pollinations.ai/pollen?ref=agent_low_balance_topup) or " +
-    "[complete a quest](https://enter.pollinations.ai/quests?ref=agent_low_balance_quests), then try again.\n\n" +
-    "If this isn’t your Pollinations account, contact whoever runs the app or service you’re using.";
+/** The key id lets the landing page tell whether the visitor owns the exhausted key. */
+function noticeMessage(apiKeyId?: string): string {
+    const keyQuery = apiKeyId ? `&key_id=${encodeURIComponent(apiKeyId)}` : "";
+    return (
+        "The account behind this API key doesn't have enough credits. " +
+        "Please " +
+        `[top up](https://enter.pollinations.ai/pollen?ref=agent_low_balance_topup${keyQuery}) or ` +
+        `[complete a quest](https://enter.pollinations.ai/quests?ref=agent_low_balance_quests${keyQuery}), then try again.\n\n` +
+        "If this isn’t your Pollinations account, contact whoever runs the app or service you’re using."
+    );
+}
 
 /** Wrap tracking and caching so they capture the original 402 before formatting. */
 export const textBalanceNotice = createMiddleware<Env>(async (c, next) => {
@@ -59,6 +64,7 @@ export const textBalanceNotice = createMiddleware<Env>(async (c, next) => {
     if (jsonAlias || format === "json_object" || format === "json_schema")
         return;
 
+    const message = noticeMessage(c.var.auth?.apiKey?.id);
     // Hono preserves the old headers on replacement; update and pass them along.
     const headers = c.res.headers;
     headers.set("Cache-Control", "private, no-store");
@@ -69,12 +75,12 @@ export const textBalanceNotice = createMiddleware<Env>(async (c, next) => {
         c.req.path !== "/v1/chat/completions"
     ) {
         headers.set("Content-Type", "text/plain; charset=utf-8");
-        c.res = new Response(MESSAGE, { headers });
+        c.res = new Response(message, { headers });
         return;
     }
 
     const model = c.var.model.requested ?? c.var.model.resolved;
-    const response = createTextResponse(model, MESSAGE, {
+    const response = createTextResponse(model, message, {
         input_tokens: 0,
         output_tokens: 0,
         total_tokens: 0,

--- a/gen.pollinations.ai/test/text-balance-notice.test.ts
+++ b/gen.pollinations.ai/test/text-balance-notice.test.ts
@@ -187,8 +187,12 @@ describe("text balance notice", () => {
                 expect(response.headers.get("cache-control")).toBe(
                     "private, no-store",
                 );
-                expect(body).toContain("?ref=agent_low_balance_topup");
-                expect(body).toContain("?ref=agent_low_balance_quests");
+                expect(body).toContain(
+                    `?ref=agent_low_balance_topup&key_id=${caller.id}`,
+                );
+                expect(body).toContain(
+                    `?ref=agent_low_balance_quests&key_id=${caller.id}`,
+                );
                 if (stream) {
                     expect(response.headers.get("content-type")).toContain(
                         "text/event-stream",


### PR DESCRIPTION
- Adds `key_id=<api key id>` to both links in the low-balance text notice (gen). The id is opaque and cannot authenticate; the secret is never exposed.
- Enter forwards `key_id` with the referral beacon and records `key_id` plus `is_owner` in the existing `metadata` JSON: `true` when the visitor is signed in as the key's owner, `false` when signed out or a different user, `null` when the key is unknown. No Tinybird schema change.
- Malformed ids are dropped before storage; no `key_id` keeps the previous `{"logged_in":…}` shape.
- Tests: gen notice suite (24) and enter referral suite (11, two new) pass; gen typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Ecg1YzWH8FmCwPEQRJCmc