### PR TITLE
fix: report code agent failures with their real status and message

### DIFF
--- a/enter.pollinations.ai/src/services/code-agent-runtime.js
+++ b/enter.pollinations.ai/src/services/code-agent-runtime.js
@@ -1,3 +1,4 @@
+import { agentResponsesError } from "../../../shared/agents/responses.ts";
 import { createCodeAgentAI } from "./code-agent-ai.ts";
 
 function jsonError(message) {
@@ -157,9 +158,11 @@ export default function createCodeAgentWorker(agent) {
                 return response instanceof Response
                     ? response
                     : jsonError("Code agent must return a Response");
-            } catch {
-                console.error("Code agent execution failed");
-                return jsonError("Code agent execution failed");
+            } catch (error) {
+                // Surface the failure like a prompt agent does: the caller's
+                // status for model errors, otherwise 502 with the message.
+                console.error("Code agent execution failed", error);
+                return agentResponsesError(error);
             }
         },
     };

--- a/enter.pollinations.ai/test/code-agent.test.ts
+++ b/enter.pollinations.ai/test/code-agent.test.ts
@@ -1,5 +1,5 @@
 import { runtimeModule, sdkModules } from "virtual:code-agent-sdk";
-import { jsonSchema, tool } from "ai";
+import { generateText, jsonSchema, tool } from "ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createWorker as createComposioWorker } from "../../apps/composio-mcp/worker.js";
 import {
@@ -305,6 +305,36 @@ describe("code agent AI SDK", () => {
         );
         expect(response.status).toBe(400);
         expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("passes model errors raised outside respond through to the caller", async () => {
+        vi.stubGlobal("fetch", async () =>
+            Response.json(
+                { error: { message: "Insufficient balance" } },
+                { status: 402 },
+            ),
+        );
+        const worker = createCodeAgentWorker(async ({ model }) => {
+            const { text } = await generateText({
+                model: model("test-model"),
+                prompt: "Hello",
+                maxRetries: 0,
+            });
+            return new Response(text);
+        });
+        const response = await worker.fetch(
+            request({ input: "Hello" }),
+            runtimeEnv,
+        );
+        expect(response.status).toBe(402);
+        await expect(response.json()).resolves.toEqual({
+            error: {
+                message: "Insufficient balance",
+                type: "server_error",
+                code: "agent_error",
+                param: null,
+            },
+        });
     });
 
     it("caps executed MCP calls and reports only actual executions", async () => {
@@ -777,10 +807,10 @@ describe("code agent runtime", () => {
     });
 
     it.each([
-        "http",
-        "rpc",
-        "missing-result",
-    ])("returns a generic failure for MCP %s errors", async (failure) => {
+        ["http", "MCP tool call failed (503)"],
+        ["rpc", "upstream detail"],
+        ["missing-result", "MCP tool call returned no result"],
+    ])("reports MCP %s errors to the caller", async (failure, message) => {
         vi.stubGlobal("fetch", async (_url, init) => {
             if (failure === "http")
                 return new Response("upstream detail", { status: 503 });
@@ -801,9 +831,14 @@ describe("code agent runtime", () => {
             new Request("https://agent.test"),
             runtimeEnv,
         );
-        expect(response.status).toBe(500);
+        expect(response.status).toBe(502);
         await expect(response.json()).resolves.toEqual({
-            error: { message: "Code agent execution failed" },
+            error: {
+                message,
+                type: "server_error",
+                code: "agent_error",
+                param: null,
+            },
         });
     });
 });


### PR DESCRIPTION
- Fix: errors thrown outside `respond()` in a code agent isolate (e.g. an MCP `tools/list` failure, or a direct `generateText` call hitting 402) collapsed into a generic 500 "Code agent execution failed".
- Reuses the shared `agentResponsesError` mapping already bundled in the runtime: model errors keep their upstream status, everything else returns 502 with the message, the same as prompt agents.
- Updates the MCP failure tests to assert the real messages and adds a 402 pass-through test.
- Existing code agents pick this up on their next sync (the runtime bundle is pinned at deploy time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKMPrAfe4wMNBNdZ96Yqmr