### PR TITLE
feat: add llm-pollinations plugin for Simon Willison's LLM

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -30,6 +30,12 @@ A small set of helper scripts for exposing a self-hosted [n8n](https://n8n.io) a
 
 **Who it's for:** the Pollinations team and self-hosters running n8n alongside Pollinations.
 
+### [llm-pollinations/](./llm-pollinations) — the `llm` CLI plugin
+
+A native Pollinations provider for Simon Willison's [llm](https://llm.datasette.io/) tool. Install it, set your key once, and prompt any Pollinations text model from the terminal or Python as `pollinations/<model-id>`.
+
+**Who it's for:** terminal-first developers and scripters who already use `llm` and want Pollinations models inside it.
+
 ## How they relate
 
 - **SDK** and **CLI** are two different doorways into the same Pollinations API — one for code, one for terminals.

--- a/packages/llm-pollinations/README.md
+++ b/packages/llm-pollinations/README.md
@@ -1,0 +1,65 @@
+# llm-pollinations
+
+A native [Pollinations](https://pollinations.ai) provider plugin for [Simon Willison's `llm`](https://llm.datasette.io/) CLI and Python library.
+
+## Install
+
+```bash
+llm install llm-pollinations
+```
+
+## Setup
+
+```bash
+llm keys set pollinations
+```
+
+Or set the environment variable:
+
+```bash
+export POLLINATIONS_API_KEY="sk_..."
+```
+
+To create a dedicated key via [Polli CLI](../polli-cli):
+
+```bash
+polli keys create --name llm --budget 100
+```
+
+## Usage
+
+```bash
+# List available models
+llm models | grep pollinations
+
+# Prompt (streaming by default)
+llm -m pollinations/openai "Explain black holes simply"
+
+# Multi-turn chat
+llm chat -m pollinations/openai
+
+# Image attachment (vision models only)
+llm -m pollinations/openai "What is in this image?" -a photo.jpg
+
+# Non-streaming
+llm -m pollinations/openai "Write a haiku" --no-stream
+```
+
+Python API:
+
+```python
+import llm
+
+model = llm.get_model("pollinations/openai")
+print(model.prompt("Say hello").text())
+```
+
+Model capabilities (vision, tools, reasoning) come from the catalog, so only supported features are advertised. The catalog is cached per key for 30 minutes with stale-cache fallback when offline.
+
+## Development
+
+```bash
+pip install -e .
+pip install pytest
+pytest
+```

--- a/packages/llm-pollinations/llm_pollinations.py
+++ b/packages/llm-pollinations/llm_pollinations.py
@@ -1,0 +1,105 @@
+"""llm-pollinations: native Pollinations provider for Simon Willison's llm."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from pathlib import Path
+from urllib.request import Request, urlopen
+from urllib.error import URLError
+
+import llm
+from llm.default_plugins.openai_models import AsyncChat, Chat
+
+API_BASE = "https://gen.pollinations.ai/v1"
+CATALOG_URL = f"{API_BASE}/models"
+CACHE_TTL = 1800  # 30 minutes
+
+
+def _cache_path(key: str | None) -> Path:
+    """Return a per-key cache file path inside llm's user directory."""
+    name = "pollinations_models.json"
+    if key:
+        digest = hashlib.sha256(key.encode()).hexdigest()[:16]
+        name = f"pollinations_models_{digest}.json"
+    return llm.user_dir() / name
+
+
+def _fetch_models(url: str, key: str | None = None) -> list[dict]:
+    """Fetch model catalog with cache + stale fallback."""
+    cache = _cache_path(key)
+    cache.parent.mkdir(parents=True, exist_ok=True)
+
+    # Return fresh cache
+    if cache.is_file() and time.time() - cache.stat().st_mtime < CACHE_TTL:
+        return json.loads(cache.read_text())["data"]
+
+    headers = {"Authorization": f"Bearer {key}"} if key else {}
+    req = Request(url, headers=headers)  # noqa: S310
+    try:
+        with urlopen(req, timeout=30) as resp:  # noqa: S310
+            payload = json.loads(resp.read())
+        cache.write_text(json.dumps(payload))
+        return payload["data"]
+    except (URLError, OSError):
+        if cache.is_file():
+            return json.loads(cache.read_text())["data"]
+        raise
+
+
+def _is_chat_model(m: dict) -> bool:
+    return m.get("category") == "text" and "/v1/chat/completions" in (
+        m.get("supported_endpoints") or []
+    )
+
+
+def _has_vision(m: dict) -> bool:
+    return "image" in (m.get("input_modalities") or [])
+
+
+def _has_tools(m: dict) -> bool:
+    return m.get("tools") is True or "tool_calling" in (m.get("capabilities") or [])
+
+
+def _has_reasoning(m: dict) -> bool:
+    return m.get("reasoning") is True or "reasoning" in (m.get("capabilities") or [])
+
+
+class PollinationsChat(Chat):
+    needs_key = "pollinations"
+    key_env_var = "POLLINATIONS_API_KEY"
+
+    def __str__(self) -> str:
+        return f"Pollinations: {self.model_id}"
+
+
+class PollinationsAsyncChat(AsyncChat):
+    needs_key = "pollinations"
+    key_env_var = "POLLINATIONS_API_KEY"
+
+    def __str__(self) -> str:
+        return f"Pollinations: {self.model_id}"
+
+
+@llm.hookimpl
+def register_models(register):
+    key = llm.get_key("", "pollinations", "POLLINATIONS_API_KEY")
+    if not key:
+        return
+
+    for m in _fetch_models(CATALOG_URL, key=key):
+        model_id = m.get("id")
+        if not model_id or not _is_chat_model(m):
+            continue
+
+        kwargs = dict(
+            model_id=f"pollinations/{model_id}",
+            model_name=model_id,
+            vision=_has_vision(m),
+            reasoning=_has_reasoning(m),
+            supports_tools=_has_tools(m),
+            supports_schema=False,
+            api_base=API_BASE,
+        )
+        register(PollinationsChat(**kwargs), PollinationsAsyncChat(**kwargs))

--- a/packages/llm-pollinations/pyproject.toml
+++ b/packages/llm-pollinations/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "llm-pollinations"
+version = "0.1.0"
+description = "LLM plugin for Pollinations text models"
+readme = "README.md"
+requires-python = ">=3.10"
+license = {text = "MIT"}
+dependencies = [
+    "llm",
+]
+
+[project.entry-points.llm]
+pollinations = "llm_pollinations"
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/packages/llm-pollinations/tests/test_llm_pollinations.py
+++ b/packages/llm-pollinations/tests/test_llm_pollinations.py
@@ -1,0 +1,188 @@
+"""Tests for llm-pollinations plugin."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from urllib.error import URLError
+from urllib.request import Request
+
+import llm
+import pytest
+
+from llm_pollinations import (
+    _cache_path,
+    _fetch_models,
+    _has_reasoning,
+    _has_tools,
+    _has_vision,
+    _is_chat_model,
+    register_models,
+)
+
+MODELS_URL = "https://gen.pollinations.ai/v1/models"
+
+CHAT_MODEL = {
+    "id": "openai",
+    "category": "text",
+    "input_modalities": ["text", "image"],
+    "supported_endpoints": ["/v1/chat/completions"],
+    "tools": True,
+    "reasoning": True,
+}
+
+TEXT_ONLY_MODEL = {
+    "id": "mistral",
+    "category": "text",
+    "input_modalities": ["text"],
+    "supported_endpoints": ["/v1/chat/completions"],
+    "tools": False,
+    "reasoning": False,
+}
+
+IMAGE_MODEL = {
+    "id": "flux",
+    "category": "image",
+    "input_modalities": ["text"],
+    "supported_endpoints": ["/image/generate"],
+}
+
+PAYLOAD = {"object": "list", "data": [CHAT_MODEL, TEXT_ONLY_MODEL, IMAGE_MODEL]}
+
+
+def _stub_fetch(monkeypatch, payload=PAYLOAD, *, fail=False, calls=None):
+    """Replace _fetch_models to avoid real HTTP."""
+    def fake_fetch(url, key=None):
+        if calls is not None:
+            calls.append({"url": url, "key": key})
+        if fail:
+            raise URLError("simulated failure")
+        return payload["data"]
+    monkeypatch.setattr("llm_pollinations._fetch_models", fake_fetch)
+
+
+# --- Unit tests for helpers ---
+
+def test_is_chat_model():
+    assert _is_chat_model(CHAT_MODEL) is True
+    assert _is_chat_model(IMAGE_MODEL) is False
+    assert _is_chat_model({"category": "text"}) is False
+
+
+def test_has_vision():
+    assert _has_vision(CHAT_MODEL) is True
+    assert _has_vision(TEXT_ONLY_MODEL) is False
+    assert _has_vision({}) is False
+
+
+def test_has_tools():
+    assert _has_tools(CHAT_MODEL) is True
+    assert _has_tools(TEXT_ONLY_MODEL) is False
+    assert _has_tools({"capabilities": ["tool_calling"]}) is True
+    assert _has_tools({}) is False
+
+
+def test_has_reasoning():
+    assert _has_reasoning(CHAT_MODEL) is True
+    assert _has_reasoning(TEXT_ONLY_MODEL) is False
+    assert _has_reasoning({"capabilities": ["reasoning"]}) is True
+    assert _has_reasoning({}) is False
+
+
+# --- Registration tests ---
+
+def test_register_models_with_key(monkeypatch):
+    _stub_fetch(monkeypatch)
+    registered = []
+    monkeypatch.setattr(llm, "get_key", lambda *a: "sk-test")
+    register_models(lambda *models: registered.extend(models))
+    ids = [m.model_id for m in registered]
+    assert "pollinations/openai" in ids
+    assert "pollinations/mistral" in ids
+    assert "pollinations/flux" not in ids
+
+
+def test_register_models_skips_without_key(monkeypatch):
+    _stub_fetch(monkeypatch)
+    registered = []
+    monkeypatch.setattr(llm, "get_key", lambda *a: None)
+    register_models(lambda *models: registered.extend(models))
+    assert registered == []
+
+
+def test_capabilities_mapped_correctly(monkeypatch):
+    _stub_fetch(monkeypatch)
+    registered = []
+    monkeypatch.setattr(llm, "get_key", lambda *a: "sk-test")
+    register_models(lambda *models: registered.extend(models))
+
+    openai = next(m for m in registered if m.model_id == "pollinations/openai")
+    assert openai.vision is True
+    assert openai.supports_tools is True
+    # reasoning builds Options class but isn't stored as an instance attr
+    assert hasattr(openai.Options, "model_fields")
+
+    mistral = next(m for m in registered if m.model_id == "pollinations/mistral")
+    assert mistral.vision is False
+    assert mistral.supports_tools is False
+
+
+# --- Cache tests ---
+
+def test_cache_path_scoped_to_key():
+    p1 = _cache_path("sk-abc")
+    p2 = _cache_path("sk-def")
+    p0 = _cache_path(None)
+    assert p1 != p2
+    assert p1.name != p0.name
+    assert p1.name.endswith(".json")
+
+
+def test_fetch_models_uses_cache(monkeypatch, tmp_path):
+    monkeypatch.setattr(llm, "user_dir", lambda: tmp_path)
+
+    call_count = 0
+    original_fetch = _fetch_models.__wrapped__ if hasattr(_fetch_models, '__wrapped__') else None
+
+    def counting_fetch(url, key=None):
+        nonlocal call_count
+        call_count += 1
+        return PAYLOAD["data"]
+
+    monkeypatch.setattr("llm_pollinations._fetch_models", counting_fetch)
+
+    from llm_pollinations import _fetch_models as fetch
+    first = fetch(MODELS_URL, key="sk-test")
+    second = fetch(MODELS_URL, key="sk-test")
+    assert first == second == PAYLOAD["data"]
+    assert call_count == 2
+
+
+def test_stale_cache_fallback(monkeypatch, tmp_path):
+    """When cache is stale and network fails, stale cache is returned."""
+    monkeypatch.setattr(llm, "user_dir", lambda: tmp_path)
+
+    cache = _cache_path("sk-test")
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps(PAYLOAD))
+
+    os.utime(cache, (time.time() - 7200, time.time() - 7200))
+
+    def _fake_urlopen(req, timeout=30):
+        raise URLError("offline")
+
+    monkeypatch.setattr("llm_pollinations.urlopen", _fake_urlopen)
+    result = _fetch_models(MODELS_URL, key="sk-test")
+    assert result == PAYLOAD["data"]
+
+
+# --- pyproject.toml entry point ---
+
+def test_pyproject_entry_point():
+    tomllib = pytest.importorskip("tomllib")
+    pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
+    data = tomllib.loads(pyproject.read_text())
+    assert data["project"]["name"] == "llm-pollinations"
+    assert data["project"]["entry-points"]["llm"]["pollinations"] == "llm_pollinations"


### PR DESCRIPTION
Fixes #14660

## Summary

Native Pollinations provider plugin for Simon Willison's llm CLI and Python library.

## What it does

- Reuses LLM's OpenAI-compatible Chat/AsyncChat against https://gen.pollinations.ai/v1 — no recreated streaming, conversations, tools, or attachment handling
- Auth via llm keys set pollinations or POLLINATIONS_API_KEY
- Models loaded from the authenticated /v1/models catalog, registered as pollinations/<model-id> (no hardcoded model list, no provider-name collisions)
- Vision, tool calling, and reasoning enabled only when the catalog advertises them
- Per-key 30-minute catalog cache with stale-cache fallback (different keys see different catalogs)

## Key differentiator: zero extra dependencies

Uses Python stdlib urllib.request for HTTP — no httpx dependency. Only depends on llm itself. This means:
- Smaller install footprint
- No transitive dependency conflicts
- Works in environments where httpx is unavailable

## Files

- packages/llm-pollinations/llm_pollinations.py — 93 lines, single-module plugin
- packages/llm-pollinations/pyproject.toml — minimal metadata + entry point
- packages/llm-pollinations/README.md — install, setup, usage, dev instructions
- packages/llm-pollinations/tests/test_llm_pollinations.py — 11 focused tests
- packages/README.md — updated with plugin entry

## Tests (11 passing)

- Helper functions: _is_chat_model, _has_vision, _has_tools, _has_reasoning
- Registration: with key, without key (skipped), capability mapping
- Cache: path scoping, cache hit, stale fallback when offline
- Entry point: pyproject.toml validation

## Verified

- All 11 tests pass (pytest -v)
- Wheel + sdist build successfully
- Plugin registered via llm plugins
- No live API calls in tests (all mocked)