### PR TITLE
feat(image): add 1080p support for minimax h3 max turbo

### DIFF
--- a/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
+++ b/enter.pollinations.ai/test/__snapshots__/effective-prices.snapshot.test.ts.snap
@@ -1391,6 +1391,9 @@ exports[`effective cost and price per model — snapshot 1`] = `
       "completionVideoSeconds": 0.00625,
     },
     "costVariants": {
+      "1080p": {
+        "completionVideoSeconds": 0.02,
+      },
       "768p": {
         "completionVideoSeconds": 0.01,
       },

--- a/gen.pollinations.ai/src/image/models/minimaxH3Model.ts
+++ b/gen.pollinations.ai/src/image/models/minimaxH3Model.ts
@@ -23,6 +23,7 @@ const H3_RESOLUTIONS = {
 const H3_MAX_TURBO_RESOLUTIONS = {
     "480p": "480P",
     "768p": "768P",
+    "1080p": "1080P",
 } as const;
 const H3_MAX_TURBO_DURATIONS = [5, 10, 15] as const;
 const H3_MAX_TURBO_ASPECT_RATIOS = [

--- a/gen.pollinations.ai/test/image/minimaxH3Model.test.ts
+++ b/gen.pollinations.ai/test/image/minimaxH3Model.test.ts
@@ -208,7 +208,10 @@ describe("callMinimaxH3MaxTurboAPI", () => {
         expect(requests[0]?.body?.aspect_ratio).toBe(expectedAspectRatio);
     });
 
-    it("forwards first and last frame URLs to the image route", async () => {
+    it.each([
+        ["768p", "768P"],
+        ["1080p", "1080P"],
+    ] as const)("forwards first and last frame URLs at %s to the image route", async (resolution, upstreamResolution) => {
         const requests: ProviderRequest[] = [];
         mockH3Fetch(requests);
         const start = "https://media.pollinations.ai/start.png";
@@ -218,7 +221,7 @@ describe("callMinimaxH3MaxTurboAPI", () => {
             ...baseParams,
             model: "minimax/minimax-h3-max-turbo",
             duration: 10,
-            resolution: "768p",
+            resolution,
             image: [start, end],
         });
 
@@ -227,7 +230,7 @@ describe("callMinimaxH3MaxTurboAPI", () => {
             body: {
                 prompt: "a seamless camera move",
                 duration: 10,
-                resolution: "768P",
+                resolution: upstreamResolution,
                 seed: 42,
                 enable_safety_checker: true,
                 prompt_expansion_mode: "balanced",

--- a/gen.pollinations.ai/test/image/minimaxH3Model.test.ts
+++ b/gen.pollinations.ai/test/image/minimaxH3Model.test.ts
@@ -144,10 +144,13 @@ describe("callMinimaxH3MaxTurboAPI", () => {
     it.each([
         [5, "480p", "480P"],
         [5, "768p", "768P"],
+        [5, "1080p", "1080P"],
         [10, "480p", "480P"],
         [10, "768p", "768P"],
+        [10, "1080p", "1080P"],
         [15, "480p", "480P"],
         [15, "768p", "768P"],
+        [15, "1080p", "1080P"],
     ] as const)("routes %ss at %s with deterministic billing", async (duration, resolution, upstreamResolution) => {
         const requests: ProviderRequest[] = [];
         mockH3Fetch(requests);

--- a/gen.pollinations.ai/test/image/params.test.ts
+++ b/gen.pollinations.ai/test/image/params.test.ts
@@ -66,7 +66,7 @@ describe("ImageParamsSchema", () => {
                 }).success,
             ).toBe(true);
         }
-        for (const resolution of ["480p", "768p"] as const) {
+        for (const resolution of ["480p", "768p", "1080p"] as const) {
             expect(
                 ImageParamsSchema.safeParse({
                     model: "minimax/minimax-h3-max-turbo",

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -1366,21 +1366,27 @@ const IMAGE_BASE_SERVICES = {
         ...defineCostVariants(
             {
                 "768p": { completionVideoSeconds: 0.01 },
+                "1080p": { completionVideoSeconds: 0.02 },
             },
-            matchResolution("768p"),
+            matchResolution("768p", "1080p"),
             {
                 "768p": {
                     label: "768p",
                     description:
                         "Applies when the requested video resolution is 768p.",
                 },
+                "1080p": {
+                    label: "1080p",
+                    description:
+                        "Applies when the requested video resolution is 1080p.",
+                },
             },
             "480p",
         ),
-        resolutions: ["480p", "768p"],
+        resolutions: ["480p", "768p", "1080p"],
         title: "MiniMax H3 Max Turbo",
         description:
-            "Fast 5–15 second video with synchronized audio and first/last-frame control at 480p or 768p",
+            "Fast 5–15 second video with synchronized audio and first/last-frame control at 480p, 768p, or 1080p",
         inputModalities: ["text", "image"],
         outputModalities: ["video", "audio"],
         videoCapabilities: ["start_frame", "end_frame", "audio_output"],

--- a/shared/registry/image.ts
+++ b/shared/registry/image.ts
@@ -1359,7 +1359,7 @@ const IMAGE_BASE_SERVICES = {
         addedDate: new Date("2026-09-04").getTime(),
         priceMultiplier: 1,
         paidOnly: true,
-        // fal launch pricing through 2026-09-07; restore list rates on 2026-09-08.
+        // fal launch pricing through 2026-09-14; restore list rates on 2026-09-15.
         cost: {
             completionVideoSeconds: 0.00625, // 480p per output second.
         },


### PR DESCRIPTION
- Adds 1080p to `minimax/minimax-h3-max-turbo` for text-to-video and first/last-frame image-to-video, including catalog resolution and billing variants.
- Uses fal's current $0.02/s 1080p promotion; retains 480p/768p rates, paid-only access, multiplier 1, existing fal routes, and no fallback. fal refines 1080p from a native 768p source.
- Corrects the promotion end to September 14; [fal lists regular rates from September 15](https://fal.ai/minimax-h3-max). Deferred pricing PR #14431 includes 1080p at $0.08/s and must follow this PR.
- Extends the existing first/last-frame regression test to 1080p. Focused Gen tests: 187 passed; pricing tests: 109 passed; both worker typechecks and Biome pass.
- Live verification: direct fal text/frame requests passed with 16 billable units × $0.00625 = $0.10 per five-second 1080p clip. Local native generation, `/v1/images/generations`, `/v1/images/edits`, all six aspect ratios, 5/10/15s, audio, 480p/768p regressions, 4xx validation, and paid-only denial passed. Wallet debits and staging Tinybird events reconcile. Disconnect/rejoin passed: one fal request, one 15s/$0.30 billing event, byte-identical cached retry, no second debit. Longest measured local completion: 28.34s. No production deployment performed.
