### PR TITLE
fix: fully hide unlisted (hidden) models from docs, dashboard, and API descriptions

### DIFF
--- a/.claude/skills/model-management/SKILL.md
+++ b/.claude/skills/model-management/SKILL.md
@@ -134,7 +134,7 @@ Provider/runtime secrets (Azure, OpenAI, OpenRouter API keys, etc.) belong in `g
 | `gen.pollinations.ai/src/text/configs/modelConfigs.ts` | Per-model provider routing config |
 | `gen.pollinations.ai/src/text/configs/providerConfigs.ts` | Provider clients (Portkey, Bedrock, OpenAI-compat) |
 | `gen.pollinations.ai/src/text/availableModels.ts` | Service-name → config mapping (the slug you call) |
-| `shared/registry/text.ts` | `name`, `aliases`, `description`, `provider`, `inputModalities`, `outputModalities`, `tools`/`reasoning`/`search`, `cost` block, `priceMultiplier`, `paidOnly`, `addedDate`, `tier`, `alpha` |
+| `shared/registry/text.ts` | `name`, `aliases`, `description`, `provider`, `inputModalities`, `outputModalities`, `tools`/`reasoning`/`search`, `cost` block, `priceMultiplier`, `paidOnly`, `addedDate`, `tier`, `alpha`, `hidden` (unlisted: excluded from `/models` endpoints and dashboards, still resolvable and callable by id/alias — use for community models that should stay invite-only) |
 | `gen.pollinations.ai/secrets/{dev,staging,prod}.vars.json` | Encrypted provider API keys (SOPS) |
 
 ## Image / Video

--- a/enter.pollinations.ai/frontend/src/components/models/data.ts
+++ b/enter.pollinations.ai/frontend/src/components/models/data.ts
@@ -3,10 +3,10 @@
  */
 
 import { AUDIO_SERVICES } from "@shared/registry/audio.ts";
-import { EMBEDDING_SERVICES } from "@shared/registry/embeddings.ts";
 import { IMAGE_SERVICES } from "@shared/registry/image.ts";
 import {
     getPriceDefinition,
+    getVisibleEmbeddingModels,
     type ModelName,
     type PriceDefinition,
 } from "@shared/registry/registry.ts";
@@ -145,7 +145,7 @@ export const getModelPrices = (modelStats?: ModelStats): ModelPrice[] => {
 
     // Add embedding models — input-only pricing (output is a vector).
     // Gemini Embedding 2 bills every modality at its own per-million rate.
-    for (const serviceName of Object.keys(EMBEDDING_SERVICES)) {
+    for (const serviceName of getVisibleEmbeddingModels()) {
         const latestPrice = getPriceDefinition(serviceName as ModelName);
         if (!latestPrice) continue;
 

--- a/enter.pollinations.ai/src/routes/docs.ts
+++ b/enter.pollinations.ai/src/routes/docs.ts
@@ -1,7 +1,11 @@
 import { getPublicOrigin } from "@shared/public-origin.ts";
 import { AUDIO_SERVICES, ELEVENLABS_VOICES } from "@shared/registry/audio.ts";
 import { IMAGE_SERVICES } from "@shared/registry/image.ts";
-import type { ModelDefinition } from "@shared/registry/registry.ts";
+import {
+    getModelDefinition,
+    getVisibleImageModels,
+    type ModelDefinition,
+} from "@shared/registry/registry.ts";
 import { TEXT_SERVICES } from "@shared/registry/text.ts";
 import { Hono } from "hono";
 import { openAPIRouteHandler } from "hono-openapi";
@@ -19,24 +23,15 @@ const TEXT_ALIASES: Set<string> = new Set(
 );
 const ALL_ALIASES: Set<string> = new Set([...IMAGE_ALIASES, ...TEXT_ALIASES]);
 
-// Build dynamic model name lists from registry for tag descriptions
-const imageModelDisplayNames = Object.keys(IMAGE_SERVICES)
-    .filter(
-        (id) =>
-            !(
-                IMAGE_SERVICES[id as keyof typeof IMAGE_SERVICES]
-                    .outputModalities as string[] | undefined
-            )?.includes("video"),
-    )
+// Build dynamic model name lists from registry for tag descriptions.
+// Sourced from getVisibleImageModels() so hidden/unlisted models never
+// appear here even though they remain callable by id.
+const imageModelDisplayNames = getVisibleImageModels()
+    .filter((id) => !getModelDefinition(id).outputModalities?.includes("video"))
     .join(", ");
 
-const videoModelDisplayNames = Object.keys(IMAGE_SERVICES)
-    .filter((id) =>
-        (
-            IMAGE_SERVICES[id as keyof typeof IMAGE_SERVICES]
-                .outputModalities as string[] | undefined
-        )?.includes("video"),
-    )
+const videoModelDisplayNames = getVisibleImageModels()
+    .filter((id) => getModelDefinition(id).outputModalities?.includes("video"))
     .join(", ");
 
 function filterAliases(

--- a/gen.pollinations.ai/src/routes/docs.ts
+++ b/gen.pollinations.ai/src/routes/docs.ts
@@ -2,6 +2,13 @@ import { Scalar } from "@scalar/hono-api-reference";
 import { AUDIO_SERVICES, ELEVENLABS_VOICES } from "@shared/registry/audio.ts";
 import { EMBEDDING_SERVICES } from "@shared/registry/embeddings.ts";
 import { IMAGE_SERVICES } from "@shared/registry/image.ts";
+import {
+    getModelDefinition,
+    getVisibleAudioModels,
+    getVisibleEmbeddingModels,
+    getVisibleImageModels,
+    getVisibleTextModels,
+} from "@shared/registry/registry.ts";
 import { TEXT_SERVICES } from "@shared/registry/text.ts";
 import type { Context } from "hono";
 import { Hono } from "hono";
@@ -82,28 +89,19 @@ const ALL_ALIASES = new Set([
     ...EMBEDDING_ALIASES,
 ]);
 
-const imageModelDisplayNames = Object.keys(IMAGE_SERVICES)
-    .filter(
-        (id) =>
-            !(
-                IMAGE_SERVICES[id as keyof typeof IMAGE_SERVICES]
-                    .outputModalities as string[] | undefined
-            )?.includes("video"),
-    )
+// Sourced from getVisible*Models() so hidden/unlisted models never appear in
+// the docs prose even though they remain callable by id.
+const imageModelDisplayNames = getVisibleImageModels()
+    .filter((id) => !getModelDefinition(id).outputModalities?.includes("video"))
     .join(", ");
 
-const videoModelDisplayNames = Object.keys(IMAGE_SERVICES)
-    .filter((id) =>
-        (
-            IMAGE_SERVICES[id as keyof typeof IMAGE_SERVICES]
-                .outputModalities as string[] | undefined
-        )?.includes("video"),
-    )
+const videoModelDisplayNames = getVisibleImageModels()
+    .filter((id) => getModelDefinition(id).outputModalities?.includes("video"))
     .join(", ");
 
-const textModelDisplayNames = Object.keys(TEXT_SERVICES).join(", ");
-const audioModelDisplayNames = Object.keys(AUDIO_SERVICES).join(", ");
-const embeddingModelDisplayNames = Object.keys(EMBEDDING_SERVICES).join(", ");
+const textModelDisplayNames = getVisibleTextModels().join(", ");
+const audioModelDisplayNames = getVisibleAudioModels().join(", ");
+const embeddingModelDisplayNames = getVisibleEmbeddingModels().join(", ");
 
 function filterAliases(schema: OpenApiSchema): OpenApiSchema {
     return JSON.parse(

--- a/gen.pollinations.ai/src/routes/proxy.ts
+++ b/gen.pollinations.ai/src/routes/proxy.ts
@@ -20,14 +20,17 @@ const resolver = <T extends Parameters<typeof baseResolver>[0]>(schema: T) =>
     baseResolver(schema, { reused: "ref" });
 
 import { ELEVENLABS_VOICES } from "@shared/registry/audio.ts";
-import { DEFAULT_IMAGE_MODEL, IMAGE_SERVICES } from "@shared/registry/image.ts";
+import { DEFAULT_IMAGE_MODEL } from "@shared/registry/image.ts";
 import {
     getAudioModelsInfo,
     getEmbeddingModelsInfo,
     getImageModelsInfo,
     getTextModelsInfo,
 } from "@shared/registry/model-info.ts";
-import { getModelDefinition } from "@shared/registry/registry.ts";
+import {
+    getModelDefinition,
+    getVisibleImageModels,
+} from "@shared/registry/registry.ts";
 import {
     type CreateChatCompletionRequest,
     CreateChatCompletionRequestSchema,
@@ -64,20 +67,17 @@ import { errorResponseDescriptions } from "@/utils/api-docs.ts";
 import { checkBalance, generationAccess } from "@/utils/generation-access.ts";
 import { handleSimpleAudio } from "./audio.ts";
 
-// Build dynamic model lists from registry for use in API descriptions
-const imageModelNames = Object.entries(IMAGE_SERVICES)
-    .filter(
-        ([, svc]) =>
-            !(svc.outputModalities as string[] | undefined)?.includes("video"),
-    )
-    .map(([id]) => `\`${id}\``)
+// Build dynamic model lists from registry for use in API descriptions.
+// Sourced from getVisibleImageModels() so hidden/unlisted models are never
+// advertised here even though they remain callable by id.
+const imageModelNames = getVisibleImageModels()
+    .filter((id) => !getModelDefinition(id).outputModalities?.includes("video"))
+    .map((id) => `\`${id}\``)
     .join(", ");
 
-const videoModelNames = Object.entries(IMAGE_SERVICES)
-    .filter(([, svc]) =>
-        (svc.outputModalities as string[] | undefined)?.includes("video"),
-    )
-    .map(([id]) => `\`${id}\``)
+const videoModelNames = getVisibleImageModels()
+    .filter((id) => getModelDefinition(id).outputModalities?.includes("video"))
+    .map((id) => `\`${id}\``)
     .join(", ");
 
 const factory = createFactory<Env>();

--- a/gen.pollinations.ai/test/model-permissions.test.ts
+++ b/gen.pollinations.ai/test/model-permissions.test.ts
@@ -1,4 +1,22 @@
 import { SELF } from "cloudflare:test";
+import {
+    getAudioModelsInfo,
+    getEmbeddingModelsInfo,
+    getImageModelsInfo,
+    getTextModelsInfo,
+} from "@shared/registry/model-info.ts";
+import {
+    getAudioModels,
+    getEmbeddingModels,
+    getImageModels,
+    getModelDefinition,
+    getTextModels,
+    getVisibleAudioModels,
+    getVisibleEmbeddingModels,
+    getVisibleImageModels,
+    getVisibleTextModels,
+    resolveModelName,
+} from "@shared/registry/registry.ts";
 import { test } from "@shared/test/fixtures/index.ts";
 import { expect } from "vitest";
 
@@ -63,4 +81,47 @@ test("filters paid-only audio models by paid balance", async ({
     expect(freeModelNames).toContain("universal-2");
     expect(freeModelNames).not.toContain("scribe");
     expect(paidModelNames).toContain("scribe");
+});
+
+// Registry-level invariant behind "unlisted" community models: `hidden: true`
+// must drop a model from every listing surface while leaving it fully
+// resolvable/callable by id or alias. No model is hidden today, so this
+// mostly proves the non-hidden branch now and guards the hidden branch the
+// moment a model sets the flag.
+test("hidden models are excluded from visible/info lists but still resolve by id", () => {
+    const groups = [
+        {
+            all: getTextModels(),
+            visible: getVisibleTextModels(),
+            info: getTextModelsInfo(),
+        },
+        {
+            all: getImageModels(),
+            visible: getVisibleImageModels(),
+            info: getImageModelsInfo(),
+        },
+        {
+            all: getAudioModels(),
+            visible: getVisibleAudioModels(),
+            info: getAudioModelsInfo(),
+        },
+        {
+            all: getEmbeddingModels(),
+            visible: getVisibleEmbeddingModels(),
+            info: getEmbeddingModelsInfo(),
+        },
+    ];
+
+    for (const { all, visible, info } of groups) {
+        const visibleIds = new Set<string>(visible);
+        const infoNames = new Set(info.map((m) => m.name));
+
+        for (const id of all) {
+            const isHidden = !!getModelDefinition(id).hidden;
+            expect(visibleIds.has(id)).toBe(!isHidden);
+            expect(infoNames.has(id)).toBe(!isHidden);
+            // Hidden or not, the model must still resolve by its own canonical id.
+            expect(resolveModelName(id)).toBe(id);
+        }
+    }
 });


### PR DESCRIPTION
Fixes 4 spots (proxy.ts, gen docs.ts, enter docs.ts, enter data.ts) that read raw registry maps instead of the existing getVisible*Models() filters, so a hidden: true model would still leak into API descriptions, docs prose, and the dashboard pricing table
Adds a registry test pinning hidden ⟺ excluded from visible/info lists while staying resolvable by id
Documents the hidden field in the model-management skill (existed in code, wasn't listed)
No behavior change today (no model is currently hidden) — this closes a latent leak so the mechanism actually works once a community model uses it