### PR TITLE
feat(community): publish models as hidden

### DIFF
--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-dialog.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-dialog.tsx
@@ -514,14 +514,15 @@ export function CommunityEndpointDialog({
                     {!isEdit &&
                         !isEndpointAgent &&
                         form.visibility === "public" && (
-                            <FieldStack
-                                label="Catalog visibility"
-                                helper="Unlisted models are excluded from public catalogs and search but remain callable by exact model ID. Public listing still follows the 3-hour approval delay."
-                            >
+                            <fieldset className="flex flex-col gap-2">
+                                <legend className="text-sm font-semibold text-theme-text-strong">
+                                    Catalog visibility
+                                </legend>
                                 <label className="flex items-center gap-2 text-sm">
                                     <input
                                         type="checkbox"
                                         checked={form.hidden}
+                                        aria-describedby="community-model-hidden-help"
                                         onChange={(event) =>
                                             setForm((current) => ({
                                                 ...current,
@@ -531,7 +532,16 @@ export function CommunityEndpointDialog({
                                     />
                                     Publish as hidden
                                 </label>
-                            </FieldStack>
+                                <p
+                                    id="community-model-hidden-help"
+                                    className="text-xs leading-5 text-theme-text-muted"
+                                >
+                                    Unlisted models stay out of public catalogs
+                                    and search. Anyone with the model ID can
+                                    call it after the usual 3-hour public
+                                    publishing delay.
+                                </p>
+                            </fieldset>
                         )}
 
                     {form.visibility === "public" && (

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-dialog.tsx
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/community-endpoint-dialog.tsx
@@ -286,6 +286,7 @@ export function CommunityEndpointDialog({
         try {
             const payload = toEndpointPayload(
                 formWithVisiblePrices(form, visiblePriceKeys),
+                !isEdit,
             );
             await onSubmit(payload, form.bearerToken.trim());
             onOpenChange(false);
@@ -509,6 +510,29 @@ export function CommunityEndpointDialog({
                             }))
                         }
                     />
+
+                    {!isEdit &&
+                        !isEndpointAgent &&
+                        form.visibility === "public" && (
+                            <FieldStack
+                                label="Catalog visibility"
+                                helper="Unlisted models are excluded from public catalogs and search but remain callable by exact model ID. Public listing still follows the 3-hour approval delay."
+                            >
+                                <label className="flex items-center gap-2 text-sm">
+                                    <input
+                                        type="checkbox"
+                                        checked={form.hidden}
+                                        onChange={(event) =>
+                                            setForm((current) => ({
+                                                ...current,
+                                                hidden: event.target.checked,
+                                            }))
+                                        }
+                                    />
+                                    Publish as hidden
+                                </label>
+                            </FieldStack>
+                        )}
 
                     {form.visibility === "public" && (
                         <Alert intent="warning" title="Public provider duties">

--- a/enter.pollinations.ai/frontend/src/components/community-endpoints/types.ts
+++ b/enter.pollinations.ai/frontend/src/components/community-endpoints/types.ts
@@ -219,6 +219,7 @@ export type EndpointFormState = ModelListingFormState & {
     url: string;
     upstreamModel: string;
     bearerToken: string;
+    hidden: boolean;
     // Callers may only spend Paid Pollen. Useful for pay-as-you-go upstreams.
     paidOnly: boolean;
     requiredSafetyFeatures: SafetyFeature[];
@@ -237,6 +238,7 @@ type ModelListingPayload = {
 };
 
 export type EndpointPayload = ModelListingPayload & {
+    hidden?: boolean;
     imagePricing: CommunityEndpointImagePricing;
     upstreamModel: string;
     paidOnly: boolean;
@@ -293,6 +295,7 @@ export const emptyForm: EndpointFormState = {
     url: "",
     upstreamModel: "",
     bearerToken: "",
+    hidden: false,
     paidOnly: false,
     requiredSafetyFeatures: [],
     fallbacks: [],
@@ -412,6 +415,7 @@ export function endpointToForm(endpoint: EditableEndpoint): EndpointFormState {
         title: endpoint.title,
         description: endpoint.description ?? "",
         visibility,
+        hidden: endpoint.hiddenAt !== null,
         perUserRpm: endpoint.perUserRpm?.toString() ?? "",
         api: endpoint.modality === "text" ? endpoint.api : "chat_completions",
         url: endpoint.modality === "text" ? endpoint.url : endpoint.baseUrl,
@@ -587,11 +591,17 @@ function listingFieldsToPayload(form: ModelListingFormState) {
     };
 }
 
-export function toEndpointPayload(form: EndpointFormState): EndpointPayload {
+export function toEndpointPayload(
+    form: EndpointFormState,
+    includeHidden = false,
+): EndpointPayload {
     const modality = form.modality;
     const imagePricing = modality === "image" ? form.imagePricing : "request";
     return {
         ...listingFieldsToPayload(form),
+        ...(includeHidden && form.visibility === "public"
+            ? { hidden: form.hidden }
+            : {}),
         ...(modality === "text"
             ? { modality, api: form.api, url: form.url.trim() }
             : { modality, baseUrl: form.url.trim() }),

--- a/enter.pollinations.ai/src/routes/community-endpoints.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints.ts
@@ -601,6 +601,9 @@ export const communityEndpointsRoutes = new Hono<Env>()
                         : null,
                     pendingVisibility: queuesPublication ? "public" : null,
                     pendingAt: queuesPublication ? new Date() : null,
+                    hiddenAt: input.hidden ? new Date() : null,
+                    hiddenReason: input.hidden ? "Hidden by owner" : null,
+                    hiddenBy: input.hidden ? "owner" : null,
                     createdAt: new Date(),
                     updatedAt: new Date(),
                 })

--- a/enter.pollinations.ai/src/routes/community-endpoints/schemas.ts
+++ b/enter.pollinations.ai/src/routes/community-endpoints/schemas.ts
@@ -147,6 +147,7 @@ const ProxyCreateFieldsSchema = {
     title: EndpointFieldsSchema.title,
     description: EndpointFieldsSchema.description,
     visibility: VisibilitySchema.optional().default("private"),
+    hidden: z.boolean().optional().default(false),
     bearerToken: EndpointFieldsSchema.bearerToken,
     upstreamModel: EndpointFieldsSchema.upstreamModel,
     imagePricing: ImagePricingSchema.optional().default("request"),

--- a/enter.pollinations.ai/test/integration/community-endpoint-policy.test.ts
+++ b/enter.pollinations.ai/test/integration/community-endpoint-policy.test.ts
@@ -323,6 +323,16 @@ describe("community endpoint configuration policy", () => {
             pending: { visibility: "public" },
         });
         expect(hidden.hiddenAt).toEqual(expect.any(String));
+        const hiddenRow = await drizzle(env.DB, {
+            schema,
+        }).query.communityEndpoint.findFirst({
+            where: eq(schema.communityEndpoint.id, hidden.id as string),
+        });
+        expect(hiddenRow).toMatchObject({
+            hiddenBy: "owner",
+            hiddenReason: "Hidden by owner",
+        });
+        expect(hiddenRow?.hiddenAt).not.toBeNull();
 
         const modelsResponse = await SELF.fetch(endpointUrl, {
             headers: {

--- a/enter.pollinations.ai/test/integration/community-endpoint-policy.test.ts
+++ b/enter.pollinations.ai/test/integration/community-endpoint-policy.test.ts
@@ -289,6 +289,72 @@ describe("community endpoint configuration policy", () => {
         }
     });
 
+    test("creates hidden models by owner choice and rejects non-boolean values", async ({
+        sessionToken,
+    }) => {
+        const created = await postModel(sessionToken, "", {
+            name: "visible-by-default",
+            title: "Visible by default",
+            api: "chat_completions",
+            url: "https://text.example.com/v1/chat/completions",
+            bearerToken: "test-provider-token",
+        });
+        expect(created).toMatchObject({
+            visibility: "private",
+            hidden: false,
+            hiddenAt: null,
+            hiddenReason: null,
+        });
+
+        await approveCommunityModels();
+        const hidden = await postModel(sessionToken, "", {
+            name: "hidden-on-create",
+            title: "Hidden on create",
+            visibility: "public",
+            api: "chat_completions",
+            url: "https://text.example.com/v1/chat/completions",
+            bearerToken: "test-provider-token",
+            hidden: true,
+        });
+        expect(hidden).toMatchObject({
+            visibility: "private",
+            hidden: true,
+            hiddenReason: "Hidden by owner",
+            pending: { visibility: "public" },
+        });
+        expect(hidden.hiddenAt).toEqual(expect.any(String));
+
+        const modelsResponse = await SELF.fetch(endpointUrl, {
+            headers: {
+                Cookie: `better-auth.session_token=${sessionToken}`,
+            },
+        });
+        expect(modelsResponse.status).toBe(200);
+        const models = await modelsResponse.json<{
+            data: { id: string; hidden: boolean }[];
+        }>();
+        expect(
+            models.data.find((model) => model.id === hidden.id),
+        ).toMatchObject({ hidden: true });
+
+        const invalid = await SELF.fetch(endpointUrl, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Cookie: `better-auth.session_token=${sessionToken}`,
+            },
+            body: JSON.stringify({
+                name: "invalid-hidden-type",
+                title: "Invalid hidden type",
+                api: "chat_completions",
+                url: "https://text.example.com/v1/chat/completions",
+                bearerToken: "test-provider-token",
+                hidden: "true",
+            }),
+        });
+        expect(invalid.status).toBe(400);
+    });
+
     test("keeps fallback writes and candidate discovery aligned", async ({
         sessionToken,
     }) => {

--- a/gen.pollinations.ai/test/community-endpoints.test.ts
+++ b/gen.pollinations.ai/test/community-endpoints.test.ts
@@ -4274,8 +4274,8 @@ fixtureTest(
             promptTextPrice: 0.1 / 1_000_000,
             completionTextPrice: 0.2 / 1_000_000,
             hiddenAt: new Date(),
-            hiddenReason: "repeated upstream 500s",
-            hiddenBy: "monitor",
+            hiddenReason: "Hidden by owner",
+            hiddenBy: "owner",
             createdAt: new Date(),
             updatedAt: new Date(),
         });
@@ -4494,7 +4494,7 @@ fixtureTest(
 );
 
 fixtureTest(
-    "routes canonical and aliased calls to a hidden community model with a canonical-only key",
+    "routes canonical and aliased calls to an owner-hidden community model with a canonical-only key",
     async () => {
         const ownerGithubUsername = `owner-${crypto.randomUUID().slice(0, 8)}`;
         const modelName = `disabled-call-${crypto.randomUUID().slice(0, 8)}`;
@@ -4522,8 +4522,8 @@ fixtureTest(
             promptTextPrice: 0.1 / 1_000_000,
             completionTextPrice: 0.2 / 1_000_000,
             hiddenAt: new Date(),
-            hiddenReason: "repeated upstream 500s",
-            hiddenBy: "monitor",
+            hiddenReason: "Hidden by owner",
+            hiddenBy: "owner",
             createdAt: new Date(),
             updatedAt: new Date(),
         });


### PR DESCRIPTION
Adds an optional hidden publish mode for community models.

- Stores the existing owner-hidden state during creation when selected.
- Keeps visibility, the public approval delay, owner management, and exact-ID calls unchanged.
- Tests default visibility, hidden creation, invalid input, catalog omission, and exact-ID routing.