### PR TITLE
fix: staging pollinations MCP worker

### DIFF
--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "node --test worker.test.js",
     "check": "wrangler deploy --dry-run",
-    "deploy": "wrangler deploy"
+    "deploy": "wrangler deploy",
+    "deploy:staging": "wrangler deploy --env staging"
   },
   "devDependencies": {
     "@modelcontextprotocol/client": "^2.0.0",

--- a/apps/mcp/wrangler.jsonc
+++ b/apps/mcp/wrangler.jsonc
@@ -15,5 +15,14 @@
       "custom_domain": true
     }
   ],
-  "observability": { "enabled": true }
+  "observability": { "enabled": true },
+  "env": {
+    "staging": {
+      "name": "pollinations-mcp-staging",
+      "workers_dev": false,
+      "routes": [],
+      "vars": { "POLLINATIONS_BASE_URL": "https://staging.gen.pollinations.ai" },
+      "observability": { "enabled": true }
+    }
+  }
 }

--- a/gen.pollinations.ai/wrangler.toml
+++ b/gen.pollinations.ai/wrangler.toml
@@ -221,7 +221,7 @@ service = "pollinations-enter-staging"
 
 [[env.staging.services]]
 binding = "POLLINATIONS_MCP"
-service = "pollinations-mcp"
+service = "pollinations-mcp-staging"
 
 [[env.staging.services]]
 binding = "FFMPEG_MCP"


### PR DESCRIPTION
- Adds a `staging` env to `apps/mcp` (Worker `pollinations-mcp-staging`, no routes, `POLLINATIONS_BASE_URL` = staging gen)
- Points gen staging's `POLLINATIONS_MCP` binding at it
- Before: gen staging called the production `pollinations-mcp` Worker, which called production gen with a staging-signed `ag_` run token, so every staging agent using the `pollinations` MCP got `Authentication failed`
- Production unchanged; staging Worker already deployed by hand
- Adds `deploy:staging` script to `apps/mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaGsSAmrHYji69S1Hw2EjV