### PR TITLE
feat: triple prompt agent step and tool-call limits

### DIFF
--- a/gen.pollinations.ai/src/text/agents/runtime.ts
+++ b/gen.pollinations.ai/src/text/agents/runtime.ts
@@ -33,8 +33,8 @@ export type PromptAgentRuntime = {
 
 type McpClient = Awaited<ReturnType<typeof createMCPClient>>;
 type McpTool = Awaited<ReturnType<McpClient["tools"]>>[string];
-const MAX_STEPS = 8;
-const MAX_TOOL_CALLS = 16;
+const MAX_STEPS = 24;
+const MAX_TOOL_CALLS = 48;
 const MCP_INITIALIZATION_TIMEOUT_MS = 15_000;
 const STEP_LIMIT_MESSAGE =
     "The agent reached its maximum number of tool-use steps without a final answer.";

--- a/gen.pollinations.ai/test/text/agents/runtime.test.ts
+++ b/gen.pollinations.ai/test/text/agents/runtime.test.ts
@@ -473,16 +473,16 @@ describe("prompt-agent runtime", () => {
                 error: { message: "Upstream failed" },
             });
         } else {
-            expect(modelCalls).toBe(8);
-            expect(toolCalls).toBe(8);
+            expect(modelCalls).toBe(24);
+            expect(toolCalls).toBe(24);
             expect(body).toMatchObject({
                 status: "incomplete",
                 incomplete_details: { reason: "max_output_tokens" },
                 usage: {
-                    input_tokens: 8,
-                    output_tokens: 8,
-                    total_tokens: 16,
-                    tool_call_counts: { mcp_call: 8 },
+                    input_tokens: 24,
+                    output_tokens: 24,
+                    total_tokens: 48,
+                    tool_call_counts: { mcp_call: 24 },
                 },
             });
             expect(responseOutputText(body)).toBe(
@@ -553,7 +553,7 @@ describe("prompt-agent runtime", () => {
                                     role: "assistant",
                                     content: "",
                                     tool_calls: Array.from(
-                                        { length: 17 },
+                                        { length: 49 },
                                         (_, index) => ({
                                             id: `call-${index}`,
                                             type: "function",
@@ -601,8 +601,8 @@ describe("prompt-agent runtime", () => {
             usage: { tool_call_counts: { mcp_call: number } };
         };
         expect(response.status).toBe(200);
-        expect(mcpToolCalls).toBe(16);
-        expect(body.usage.tool_call_counts.mcp_call).toBe(16);
+        expect(mcpToolCalls).toBe(48);
+        expect(body.usage.tool_call_counts.mcp_call).toBe(48);
     });
 
     it.each([


### PR DESCRIPTION
- `MAX_STEPS` 8 → 24, `MAX_TOOL_CALLS` 16 → 48 in the prompt agent runtime
- Agents with a bash tool hit the old cap on ordinary multi-file tasks and ended with "reached its maximum number of tool-use steps"
- Runtime tests updated to the new caps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WaGsSAmrHYji69S1Hw2EjV