### PR TITLE
fix: derive monitor model category from catalog metadata

### DIFF
--- a/operations/model-monitor/src/model-data.js
+++ b/operations/model-monitor/src/model-data.js
@@ -21,6 +21,8 @@ export function normalizeCatalogModel(model) {
 
 // Match statistics by the recorded ID only. An alias may have represented
 // another version in the past, so it must never transfer historical health.
+// Identity is the exception: what a model *is* comes from catalog metadata,
+// never from the shape of the recorded ID or the endpoint it was served on.
 export function mergeModelHealth(models, healthStats, catalogAvailable) {
     const stats = healthStats.filter((row) => row.model !== "undefined");
     const matchesEndpoint = (model, row) =>
@@ -46,11 +48,22 @@ export function mergeModelHealth(models, healthStats, catalogAvailable) {
                 ),
         )
         .map((row) => {
-            const type = row.event_type?.replace("generate.", "") || "unknown";
+            const eventType =
+                row.event_type?.replace("generate.", "") || "unknown";
             const sameName = models.filter((model) => model.name === row.model);
+            const aliased = models.find(
+                (model) =>
+                    model.aliases.includes(row.model) &&
+                    matchesEndpoint(model, row),
+            );
             let catalogStatus = "unregistered";
             let description = "Unregistered model";
             let community = row.provider === "community";
+            // Endpoints are coarser than categories: video and 3D both record
+            // image events. Only fall back to the event type when no catalog
+            // entry claims this ID.
+            let type = eventType;
+            let endpointType = eventType;
             if (catalogAvailable === false) {
                 catalogStatus = "catalog-unavailable";
                 description = "Unknown model while live catalog is unavailable";
@@ -58,23 +71,20 @@ export function mergeModelHealth(models, healthStats, catalogAvailable) {
                 catalogStatus = "anomaly";
                 community = sameName.some((model) => model.community);
                 const types = [...new Set(sameName.map((model) => model.type))];
-                description = `Unexpected ${type} traffic; registered as ${types.sort().join("/")}`;
-            } else if (
-                models.some(
-                    (model) =>
-                        model.aliases.includes(row.model) &&
-                        matchesEndpoint(model, row),
-                )
-            ) {
+                description = `Unexpected ${eventType} traffic; registered as ${types.sort().join("/")}`;
+            } else if (aliased) {
                 catalogStatus = "historical";
                 description =
                     "Historical ID, now an alias. Recorded traffic is kept separate from current model health.";
+                community = aliased.community;
+                type = aliased.type;
+                endpointType = aliased.endpointType;
             }
             return {
                 name: row.model || "(unknown)",
                 community,
                 type,
-                endpointType: type,
+                endpointType,
                 provider: row.provider,
                 description,
                 catalogStatus,

--- a/operations/model-monitor/src/model-data.test.js
+++ b/operations/model-monitor/src/model-data.test.js
@@ -122,9 +122,47 @@ test("video aliases use image events while preserving video favorites", () => {
         true,
     );
     assert.equal(results[1].catalogStatus, "historical");
+    assert.equal(results[1].type, "video");
+    assert.equal(results[1].endpointType, "image");
     assert.deepEqual(migrateFavorites(["video-old-video"], results), [
         "video-publisher/video-1",
     ]);
+});
+
+test("renamed community models keep their catalog category and scope", () => {
+    const renamed = normalizeCatalogModel({
+        name: "community/owner/seedance",
+        category: "video",
+        community: true,
+        aliases: ["owner/seedance"],
+    });
+    const [, historical] = mergeModelHealth(
+        [renamed],
+        [
+            {
+                model: "owner/seedance",
+                event_type: "generate.image",
+                provider: "community",
+                total_requests: 3,
+                status_2xx: 3,
+            },
+        ],
+        true,
+    );
+    assert.equal(historical.catalogStatus, "historical");
+    assert.equal(historical.type, "video");
+    assert.equal(historical.community, true);
+});
+
+test("unregistered traffic still falls back to the event type", () => {
+    const [unregistered] = mergeModelHealth(
+        [],
+        [{ model: "owner/deleted", event_type: "generate.image" }],
+        true,
+    );
+    assert.equal(unregistered.catalogStatus, "unregistered");
+    assert.equal(unregistered.type, "image");
+    assert.equal(unregistered.community, false);
 });
 
 test("favorites migrate and deduplicate without erasing unknown selections", () => {


### PR DESCRIPTION
The `community/` prefix rename (#14621) turned every legacy community ID into an alias, so all pre-rename traffic now arrives in the model monitor as a historical alias row. Those rows took their category from the recorded event type instead of the catalog.

- Endpoints are coarser than categories: video and 3D both record `generate.image`, so `NamanSoni78/Seedance-2.5` showed under Image instead of Video
- `mergeModelHealth` now reads `type`, `endpointType` and `community` from the aliased catalog entry
- Event type stays the fallback for genuinely unregistered traffic (deleted community endpoints)
- Recorded health is still kept separate from the canonical model, unchanged

Verified against the live catalog and `/v1/models/status`: 225 alias-resolvable rows, one category mismatch before the fix, none after. Scope (Official/Community) was already correct via `provider`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKMPrAfe4wMNBNdZ96Yqmr