### PR TITLE
Promote main to production

### DIFF
--- a/apps/openwebui/worker.js
+++ b/apps/openwebui/worker.js
@@ -149,7 +149,18 @@ function openwebui(env) {
 
 export default {
     async fetch(request, env) {
-        return openwebui(env).fetch(request);
+        const response = await openwebui(env).fetch(request);
+        if (response.webSocket) return response;
+        // Send the full chat URL as the referrer when a user follows a link
+        // out of a chat, so enter's top-up and key pages can bring them back
+        // to that chat. The browser default would send the origin only.
+        const headers = new Headers(response.headers);
+        headers.set("Referrer-Policy", "no-referrer-when-downgrade");
+        return new Response(response.body, {
+            status: response.status,
+            statusText: response.statusText,
+            headers,
+        });
     },
 
     // Keepalive: a request every 5 minutes resets sleepAfter.

--- a/enter.pollinations.ai/frontend/src/components/keys/edit-api-key-dialog.tsx
+++ b/enter.pollinations.ai/frontend/src/components/keys/edit-api-key-dialog.tsx
@@ -13,7 +13,7 @@ import {
     LockIcon,
     ScrollArea,
 } from "@pollinations/ui";
-import type { FC } from "react";
+import type { FC, ReactNode } from "react";
 import { useState } from "react";
 import { KeyPermissionsInputs, useKeyPermissions } from "./key-permissions.tsx";
 import {
@@ -29,6 +29,7 @@ interface EditApiKeyDialogProps {
     apiKey: ApiKey;
     onUpdate: (id: string, updates: ApiKeyUpdateParams) => Promise<void>;
     onClose: () => void;
+    header?: ReactNode;
 }
 
 function cleanRedirectUris(uris: string[]): string[] {
@@ -39,6 +40,7 @@ export const EditApiKeyDialog: FC<EditApiKeyDialogProps> = ({
     apiKey,
     onUpdate,
     onClose,
+    header,
 }) => {
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [name, setName] = useState(apiKey.name || "");
@@ -127,6 +129,7 @@ export const EditApiKeyDialog: FC<EditApiKeyDialogProps> = ({
             onOpenChange={(open) => !open && onClose()}
             contentClassName="flex max-h-[calc(100dvh-2rem)] flex-col"
         >
+            {header}
             <div className="shrink-0 p-6 pb-4">
                 <DialogTitle className="text-xl font-bold mb-4">
                     {appKey ? "Edit App Key" : "Edit API Key"}

--- a/enter.pollinations.ai/frontend/src/components/pollen/auto-top-up-panel.tsx
+++ b/enter.pollinations.ai/frontend/src/components/pollen/auto-top-up-panel.tsx
@@ -69,6 +69,7 @@ export type BillingState = {
 
 type AutoTopUpPanelProps = {
     initialBillingState: BillingState | null;
+    returnToTopUp?: { redirect?: string };
 };
 
 const DEFAULT_PACK_AMOUNT_USD = 10;
@@ -123,6 +124,7 @@ type ToggleStatus = "off" | "draft" | "on";
 
 export const AutoTopUpPanel: FC<AutoTopUpPanelProps> = ({
     initialBillingState,
+    returnToTopUp,
 }) => {
     const [billingState, setBillingState] = useState(initialBillingState);
     const [packAmountUsd, setPackAmountUsd] = useState(
@@ -190,7 +192,9 @@ export const AutoTopUpPanel: FC<AutoTopUpPanelProps> = ({
                 clearAutoTopUpDraft();
             }
             const response = await apiClient.stripe.billing.portal.$post({
-                json: {},
+                json: returnToTopUp
+                    ? { return: "top-up", redirect: returnToTopUp.redirect }
+                    : {},
             });
             const payload = (await response.json().catch(() => ({}))) as {
                 url?: unknown;

--- a/enter.pollinations.ai/frontend/src/components/pollen/index.ts
+++ b/enter.pollinations.ai/frontend/src/components/pollen/index.ts
@@ -4,3 +4,4 @@ export {
     PollenBalance,
     SidebarWallet,
 } from "./pollen-balance.tsx";
+export { PollenPackPurchase } from "./pollen-pack-purchase.tsx";

--- a/enter.pollinations.ai/frontend/src/components/pollen/pollen-balance.tsx
+++ b/enter.pollinations.ai/frontend/src/components/pollen/pollen-balance.tsx
@@ -2,14 +2,12 @@ import {
     CardIcon,
     ClockIcon,
     CopyButton,
-    ExternalLinkButton,
     GlobeIcon,
     InfoTip,
     InlineLink,
     MailIcon,
     SproutIcon,
     Surface,
-    Tooltip,
     WalletIcon,
 } from "@pollinations/ui";
 import {
@@ -17,22 +15,19 @@ import {
     WalletBalanceCard,
     WalletKindIcon,
 } from "@pollinations/ui/wallet";
-import {
-    calculateServiceFeeCents,
-    formatUsdCentsCompact,
-    POLLEN_PACKS,
-} from "@shared/pollen-packs.ts";
 import { Link } from "@tanstack/react-router";
 import type { FC, ReactNode } from "react";
 import { AutoTopUpPanel, type BillingState } from "./auto-top-up-panel.tsx";
 import { PaymentTrustBadge } from "./payment-trust-badge.tsx";
-import { PollenPackSlider } from "./pollen-pack-controls.tsx";
+import { PollenPackPurchase } from "./pollen-pack-purchase.tsx";
 
 type PollenBalanceProps = {
     tierBalance: number;
     packBalance: number;
     paidWeek?: number;
     tierWeek?: number;
+    /** Only the two balance cards: no total row, no "how it works" footer. */
+    compact?: boolean;
 };
 
 const BALANCE_DISPLAY_EPSILON = 0.0001;
@@ -77,6 +72,7 @@ export const PollenBalance: FC<PollenBalanceProps> = ({
     packBalance,
     paidWeek = 0,
     tierWeek = 0,
+    compact = false,
 }) => {
     const displayTierBalance = normalizeDisplayBalance(tierBalance);
     const displayPaidBalance = normalizeDisplayBalance(packBalance);
@@ -155,49 +151,53 @@ export const PollenBalance: FC<PollenBalanceProps> = ({
                 />
             </div>
 
-            {/* Total + 7d earnings below */}
-            <div className="flex items-start justify-between gap-3 pt-3">
-                <span className="text-sm font-bold uppercase tracking-wide text-theme-text-soft pt-1">
-                    Total
-                </span>
-                <div className="flex flex-col items-end leading-tight">
-                    <span className="flex items-baseline gap-1.5">
-                        <span className="text-2xl sm:text-3xl font-bold tabular-nums leading-none tracking-tight text-theme-text-soft">
-                            {formatPollen(totalPollen)}
+            {!compact && (
+                <>
+                    {/* Total + 7d earnings below */}
+                    <div className="flex items-start justify-between gap-3 pt-3">
+                        <span className="text-sm font-bold uppercase tracking-wide text-theme-text-soft pt-1">
+                            Total
                         </span>
-                        <span className="text-xs font-bold text-theme-text-soft">
-                            pollen
-                        </span>
-                    </span>
-                    {totalWeek > 0 && (
-                        <span className="mt-1 text-sm font-bold tabular-nums text-intent-success-text">
-                            +{formatPollen(totalWeek)}{" "}
-                            <span className="font-medium text-theme-text-muted">
-                                / 7d
+                        <div className="flex flex-col items-end leading-tight">
+                            <span className="flex items-baseline gap-1.5">
+                                <span className="text-2xl sm:text-3xl font-bold tabular-nums leading-none tracking-tight text-theme-text-soft">
+                                    {formatPollen(totalPollen)}
+                                </span>
+                                <span className="text-xs font-bold text-theme-text-soft">
+                                    pollen
+                                </span>
                             </span>
-                        </span>
-                    )}
-                </div>
-            </div>
+                            {totalWeek > 0 && (
+                                <span className="mt-1 text-sm font-bold tabular-nums text-intent-success-text">
+                                    +{formatPollen(totalWeek)}{" "}
+                                    <span className="font-medium text-theme-text-muted">
+                                        / 7d
+                                    </span>
+                                </span>
+                            )}
+                        </div>
+                    </div>
 
-            {/* Footer: learn more */}
-            <div className="mt-4 space-y-2 border-t border-divider pt-4 text-[13px] leading-snug text-theme-text-muted">
-                <p className="flex items-start gap-1.5">
-                    <WalletIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                    <span>
-                        Your wallet holds Pollen you've purchased plus Pollen
-                        you've earned.{" "}
-                        <InlineLink
-                            as={Link}
-                            to="/news"
-                            hash="how-does-my-pollen-wallet-work"
-                            external={false}
-                        >
-                            How it works
-                        </InlineLink>
-                    </span>
-                </p>
-            </div>
+                    {/* Footer: learn more */}
+                    <div className="mt-4 space-y-2 border-t border-divider pt-4 text-[13px] leading-snug text-theme-text-muted">
+                        <p className="flex items-start gap-1.5">
+                            <WalletIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                            <span>
+                                Your wallet holds Pollen you've purchased plus
+                                Pollen you've earned.{" "}
+                                <InlineLink
+                                    as={Link}
+                                    to="/news"
+                                    hash="how-does-my-pollen-wallet-work"
+                                    external={false}
+                                >
+                                    How it works
+                                </InlineLink>
+                            </span>
+                        </p>
+                    </div>
+                </>
+            )}
         </div>
     );
 };
@@ -261,74 +261,28 @@ type BuyPollenPanelProps = {
     initialBillingState: BillingState | null;
     selectedPackAmount: number;
     onSelectedPackAmountChange: (amount: number) => void;
+    /** Standalone /top-up: Stripe returns there, carrying the app link. */
+    returnToTopUp?: { redirect?: string };
 };
 
 export const BuyPollenPanel: FC<BuyPollenPanelProps> = ({
     initialBillingState,
     selectedPackAmount,
     onSelectedPackAmountChange,
+    returnToTopUp,
 }) => {
-    const selectedPackIndex = Math.max(
-        0,
-        POLLEN_PACKS.findIndex((pack) => pack.amountUsd === selectedPackAmount),
-    );
-    const selectedPack = POLLEN_PACKS[selectedPackIndex] ?? POLLEN_PACKS[0];
-    const serviceFeeCents = selectedPack
-        ? calculateServiceFeeCents(selectedPack.amountUsd * 100)
-        : 0;
-    const subtotalBeforeTaxCents =
-        (selectedPack?.amountUsd ?? 0) * 100 + serviceFeeCents;
-    const chargeLabel = selectedPack
-        ? formatUsdCentsCompact(subtotalBeforeTaxCents)
-        : "$0";
-
     return (
         <>
+            <PollenPackPurchase
+                selectedPackAmount={selectedPackAmount}
+                onSelectedPackAmountChange={onSelectedPackAmountChange}
+                returnToTopUp={returnToTopUp}
+            />
             <Surface>
-                {selectedPack && (
-                    <div className="flex w-full flex-col items-start gap-4 sm:flex-row sm:items-center sm:gap-4 sm:pb-20">
-                        <div className="w-full min-w-0 flex-1 pb-20 sm:pb-0">
-                            <PollenPackSlider
-                                value={selectedPack.amountUsd}
-                                onChange={onSelectedPackAmountChange}
-                                selectedBadgeLabel={chargeLabel}
-                                selectedBadgeDetail={`incl. ${formatUsdCentsCompact(serviceFeeCents)} fee`}
-                            />
-                        </div>
-                        <Tooltip
-                            content={
-                                <span className="block">
-                                    Buy{" "}
-                                    <span className="font-semibold text-theme-text-strong">
-                                        {selectedPack.amountUsd} pollen
-                                    </span>{" "}
-                                    for{" "}
-                                    <span className="font-semibold text-theme-text-strong">
-                                        {chargeLabel}
-                                    </span>
-                                    <span className="mt-1 block text-theme-text-muted">
-                                        Tax calculated at checkout
-                                    </span>
-                                </span>
-                            }
-                            displayContents
-                        >
-                            <ExternalLinkButton
-                                href={`/api/stripe/checkout/${selectedPack.packKey}`}
-                                target="_self"
-                                className="w-28 min-w-0 gap-1.5 self-start text-center shadow-none sm:shrink-0 sm:self-center"
-                            >
-                                <span className="inline-flex items-center gap-1.5">
-                                    <WalletIcon className="h-4 w-4 shrink-0" />
-                                    Buy
-                                </span>
-                            </ExternalLinkButton>
-                        </Tooltip>
-                    </div>
-                )}
-            </Surface>
-            <Surface>
-                <AutoTopUpPanel initialBillingState={initialBillingState} />
+                <AutoTopUpPanel
+                    initialBillingState={initialBillingState}
+                    returnToTopUp={returnToTopUp}
+                />
             </Surface>
             <div className="mt-4 space-y-2 border-t border-divider pt-4 text-[13px] leading-snug text-theme-text-muted">
                 <PaymentTrustBadge className="mt-0 pt-0" />

--- a/enter.pollinations.ai/frontend/src/components/pollen/pollen-pack-purchase.tsx
+++ b/enter.pollinations.ai/frontend/src/components/pollen/pollen-pack-purchase.tsx
@@ -1,0 +1,94 @@
+import {
+    ExternalLinkButton,
+    Surface,
+    Tooltip,
+    WalletIcon,
+} from "@pollinations/ui";
+import {
+    calculateServiceFeeCents,
+    formatUsdCentsCompact,
+    POLLEN_PACKS,
+} from "@shared/pollen-packs.ts";
+import type { FC } from "react";
+import { PollenPackSlider } from "./pollen-pack-controls.tsx";
+
+type PollenPackPurchaseProps = {
+    selectedPackAmount: number;
+    onSelectedPackAmountChange: (amount: number) => void;
+    /** Standalone /top-up: Stripe returns there, carrying the app link. */
+    returnToTopUp?: { redirect?: string };
+};
+
+/** The pack slider and Buy button: the one thing a top-up needs. */
+export const PollenPackPurchase: FC<PollenPackPurchaseProps> = ({
+    selectedPackAmount,
+    onSelectedPackAmountChange,
+    returnToTopUp,
+}) => {
+    const selectedPackIndex = Math.max(
+        0,
+        POLLEN_PACKS.findIndex((pack) => pack.amountUsd === selectedPackAmount),
+    );
+    const selectedPack = POLLEN_PACKS[selectedPackIndex] ?? POLLEN_PACKS[0];
+    if (!selectedPack) return null;
+    const serviceFeeCents = calculateServiceFeeCents(
+        selectedPack.amountUsd * 100,
+    );
+    const chargeLabel = formatUsdCentsCompact(
+        selectedPack.amountUsd * 100 + serviceFeeCents,
+    );
+    const checkoutParams = new URLSearchParams();
+    if (returnToTopUp) {
+        checkoutParams.set("return", "top-up");
+        if (returnToTopUp.redirect)
+            checkoutParams.set("redirect", returnToTopUp.redirect);
+    }
+    const checkoutQuery = checkoutParams.toString();
+    const checkoutHref =
+        `/api/stripe/checkout/${selectedPack.packKey}` +
+        (checkoutQuery ? `?${checkoutQuery}` : "");
+
+    return (
+        <Surface>
+            <div className="flex w-full flex-col items-start gap-4 sm:flex-row sm:items-center sm:gap-4 sm:pb-20">
+                <div className="w-full min-w-0 flex-1 pb-20 sm:pb-0">
+                    <PollenPackSlider
+                        value={selectedPack.amountUsd}
+                        onChange={onSelectedPackAmountChange}
+                        selectedBadgeLabel={chargeLabel}
+                        selectedBadgeDetail={`incl. ${formatUsdCentsCompact(serviceFeeCents)} fee`}
+                    />
+                </div>
+                <Tooltip
+                    content={
+                        <span className="block">
+                            Buy{" "}
+                            <span className="font-semibold text-theme-text-strong">
+                                {selectedPack.amountUsd} pollen
+                            </span>{" "}
+                            for{" "}
+                            <span className="font-semibold text-theme-text-strong">
+                                {chargeLabel}
+                            </span>
+                            <span className="mt-1 block text-theme-text-muted">
+                                Tax calculated at checkout
+                            </span>
+                        </span>
+                    }
+                    displayContents
+                >
+                    <ExternalLinkButton
+                        href={checkoutHref}
+                        target="_self"
+                        className="w-28 min-w-0 gap-1.5 self-start text-center shadow-none sm:shrink-0 sm:self-center"
+                    >
+                        <span className="inline-flex items-center gap-1.5">
+                            <WalletIcon className="h-4 w-4 shrink-0" />
+                            Buy
+                        </span>
+                    </ExternalLinkButton>
+                </Tooltip>
+            </div>
+        </Surface>
+    );
+};

--- a/enter.pollinations.ai/frontend/src/lib/return-to-app.tsx
+++ b/enter.pollinations.ai/frontend/src/lib/return-to-app.tsx
@@ -1,0 +1,70 @@
+import { Button } from "@pollinations/ui";
+import type { FC } from "react";
+
+/** An absolute http(s) URL, else null. Used for the `redirect` search param. */
+export function parseAppUrl(value: unknown): string | null {
+    if (typeof value !== "string" || !value) return null;
+    try {
+        const url = new URL(value);
+        if (url.protocol !== "https:" && url.protocol !== "http:") return null;
+        return url.href;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * The page that linked here, when it is not this dashboard. Browsers send
+ * only the origin for cross-site links unless the app relaxes its referrer
+ * policy (Open WebUI's worker does, so its chat URL comes through). Pages
+ * store it in their own URL on first load, because after a Stripe round
+ * trip the referrer is Stripe.
+ */
+export function referrerAppUrl(): string | null {
+    const referrer = parseAppUrl(document.referrer);
+    if (!referrer) return null;
+    const url = new URL(referrer);
+    if (url.origin === window.location.origin) return null;
+    url.hash = "";
+    return url.href;
+}
+
+/**
+ * The URL to store as `redirect` on first load, or null to keep what we
+ * have. The link usually carries the app's origin from the key's metadata;
+ * the referrer wins when it is on that same origin, because it can name the
+ * exact chat the user left. A referrer from elsewhere never overrides an
+ * explicit redirect.
+ */
+export function preferredReturnUrl(
+    redirect: string | undefined,
+): string | null {
+    const referrer = referrerAppUrl();
+    if (!referrer || referrer === redirect) return null;
+    if (!redirect) return referrer;
+    return new URL(referrer).origin === new URL(redirect).origin
+        ? referrer
+        : null;
+}
+
+/**
+ * A plain link back, never an automatic redirect: `redirect` is caller
+ * supplied, so the user should see the host before leaving this origin.
+ * Renders nothing when no app is known; done screens say so in their copy.
+ */
+export const ReturnToApp: FC<{ returnUrl: string | null }> = ({
+    returnUrl,
+}) => {
+    if (!returnUrl) return null;
+    return (
+        <div className="space-y-3">
+            <Button as="a" href={returnUrl} className="w-full">
+                Back to {new URL(returnUrl).hostname}
+            </Button>
+            <p className="text-sm text-theme-text-muted">
+                If the app is still open in another tab, you can close this one
+                instead.
+            </p>
+        </div>
+    );
+};

--- a/enter.pollinations.ai/frontend/src/lib/top-up-search.ts
+++ b/enter.pollinations.ai/frontend/src/lib/top-up-search.ts
@@ -1,0 +1,34 @@
+import { isPollenPackKey, type PollenPackKey } from "@shared/pollen-packs.ts";
+import { parseAppUrl } from "./return-to-app.tsx";
+
+type TopUpSearch = {
+    pack?: PollenPackKey;
+    redirect?: string;
+    stripe_success?: boolean;
+    stripe_canceled?: boolean;
+    stripe_billing_return?: boolean;
+};
+
+export function validateTopUpSearch(
+    search: Record<string, unknown>,
+): TopUpSearch {
+    return {
+        stripe_billing_return:
+            search.stripe_billing_return === true ||
+            search.stripe_billing_return === "true" ||
+            undefined,
+        pack:
+            typeof search.pack === "string" && isPollenPackKey(search.pack)
+                ? search.pack
+                : undefined,
+        redirect: parseAppUrl(search.redirect) ?? undefined,
+        stripe_success:
+            search.stripe_success === true ||
+            search.stripe_success === "true" ||
+            undefined,
+        stripe_canceled:
+            search.stripe_canceled === true ||
+            search.stripe_canceled === "true" ||
+            undefined,
+    };
+}

--- a/enter.pollinations.ai/frontend/src/lib/update-api-key.ts
+++ b/enter.pollinations.ai/frontend/src/lib/update-api-key.ts
@@ -1,0 +1,25 @@
+import { apiClient } from "../api.ts";
+import type { ApiKeyUpdateParams } from "../components/keys/types.ts";
+
+/** Server-side fields of a key (budget, models, expiry, permissions). */
+export async function updateApiKey(
+    id: string,
+    updates: ApiKeyUpdateParams,
+): Promise<void> {
+    const response = await apiClient["api-keys"][":id"].update.$post({
+        param: { id },
+        json: {
+            ...updates,
+            expiresAt:
+                updates.expiresAt instanceof Date
+                    ? updates.expiresAt.toISOString()
+                    : updates.expiresAt,
+        },
+    });
+    if (!response.ok) {
+        const error = await response.json();
+        throw new Error(
+            (error as { message?: string }).message || "Update failed",
+        );
+    }
+}

--- a/enter.pollinations.ai/frontend/src/routeTree.gen.ts
+++ b/enter.pollinations.ai/frontend/src/routeTree.gen.ts
@@ -9,11 +9,13 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as TopUpRouteImport } from './routes/top-up'
 import { Route as TermsRouteImport } from './routes/terms'
 import { Route as SignInRouteImport } from './routes/sign-in'
 import { Route as RefundsRouteImport } from './routes/refunds'
 import { Route as PrivacyRouteImport } from './routes/privacy'
 import { Route as ErrorRouteImport } from './routes/error'
+import { Route as EditKeyRouteImport } from './routes/edit-key'
 import { Route as DeviceRouteImport } from './routes/device'
 import { Route as AuthorizeRouteImport } from './routes/authorize'
 import { Route as DashboardRouteImport } from './routes/_dashboard'
@@ -28,6 +30,11 @@ import { Route as DashboardKeysRouteImport } from './routes/_dashboard.keys'
 import { Route as DashboardActivityRouteImport } from './routes/_dashboard.activity'
 import { Route as DashboardAccountRouteImport } from './routes/_dashboard.account'
 
+const TopUpRoute = TopUpRouteImport.update({
+  id: '/top-up',
+  path: '/top-up',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const TermsRoute = TermsRouteImport.update({
   id: '/terms',
   path: '/terms',
@@ -51,6 +58,11 @@ const PrivacyRoute = PrivacyRouteImport.update({
 const ErrorRoute = ErrorRouteImport.update({
   id: '/error',
   path: '/error',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const EditKeyRoute = EditKeyRouteImport.update({
+  id: '/edit-key',
+  path: '/edit-key',
   getParentRoute: () => rootRouteImport,
 } as any)
 const DeviceRoute = DeviceRouteImport.update({
@@ -122,11 +134,13 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/authorize': typeof AuthorizeRoute
   '/device': typeof DeviceRoute
+  '/edit-key': typeof EditKeyRoute
   '/error': typeof ErrorRoute
   '/privacy': typeof PrivacyRoute
   '/refunds': typeof RefundsRoute
   '/sign-in': typeof SignInRoute
   '/terms': typeof TermsRoute
+  '/top-up': typeof TopUpRoute
   '/account': typeof DashboardAccountRoute
   '/activity': typeof DashboardActivityRoute
   '/keys': typeof DashboardKeysRoute
@@ -141,11 +155,13 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/authorize': typeof AuthorizeRoute
   '/device': typeof DeviceRoute
+  '/edit-key': typeof EditKeyRoute
   '/error': typeof ErrorRoute
   '/privacy': typeof PrivacyRoute
   '/refunds': typeof RefundsRoute
   '/sign-in': typeof SignInRoute
   '/terms': typeof TermsRoute
+  '/top-up': typeof TopUpRoute
   '/account': typeof DashboardAccountRoute
   '/activity': typeof DashboardActivityRoute
   '/keys': typeof DashboardKeysRoute
@@ -162,11 +178,13 @@ export interface FileRoutesById {
   '/_dashboard': typeof DashboardRouteWithChildren
   '/authorize': typeof AuthorizeRoute
   '/device': typeof DeviceRoute
+  '/edit-key': typeof EditKeyRoute
   '/error': typeof ErrorRoute
   '/privacy': typeof PrivacyRoute
   '/refunds': typeof RefundsRoute
   '/sign-in': typeof SignInRoute
   '/terms': typeof TermsRoute
+  '/top-up': typeof TopUpRoute
   '/_dashboard/account': typeof DashboardAccountRoute
   '/_dashboard/activity': typeof DashboardActivityRoute
   '/_dashboard/keys': typeof DashboardKeysRoute
@@ -183,11 +201,13 @@ export interface FileRouteTypes {
     | '/'
     | '/authorize'
     | '/device'
+    | '/edit-key'
     | '/error'
     | '/privacy'
     | '/refunds'
     | '/sign-in'
     | '/terms'
+    | '/top-up'
     | '/account'
     | '/activity'
     | '/keys'
@@ -202,11 +222,13 @@ export interface FileRouteTypes {
     | '/'
     | '/authorize'
     | '/device'
+    | '/edit-key'
     | '/error'
     | '/privacy'
     | '/refunds'
     | '/sign-in'
     | '/terms'
+    | '/top-up'
     | '/account'
     | '/activity'
     | '/keys'
@@ -222,11 +244,13 @@ export interface FileRouteTypes {
     | '/_dashboard'
     | '/authorize'
     | '/device'
+    | '/edit-key'
     | '/error'
     | '/privacy'
     | '/refunds'
     | '/sign-in'
     | '/terms'
+    | '/top-up'
     | '/_dashboard/account'
     | '/_dashboard/activity'
     | '/_dashboard/keys'
@@ -243,16 +267,25 @@ export interface RootRouteChildren {
   DashboardRoute: typeof DashboardRouteWithChildren
   AuthorizeRoute: typeof AuthorizeRoute
   DeviceRoute: typeof DeviceRoute
+  EditKeyRoute: typeof EditKeyRoute
   ErrorRoute: typeof ErrorRoute
   PrivacyRoute: typeof PrivacyRoute
   RefundsRoute: typeof RefundsRoute
   SignInRoute: typeof SignInRoute
   TermsRoute: typeof TermsRoute
+  TopUpRoute: typeof TopUpRoute
   AppSignInRoute: typeof AppSignInRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/top-up': {
+      id: '/top-up'
+      path: '/top-up'
+      fullPath: '/top-up'
+      preLoaderRoute: typeof TopUpRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/terms': {
       id: '/terms'
       path: '/terms'
@@ -286,6 +319,13 @@ declare module '@tanstack/react-router' {
       path: '/error'
       fullPath: '/error'
       preLoaderRoute: typeof ErrorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/edit-key': {
+      id: '/edit-key'
+      path: '/edit-key'
+      fullPath: '/edit-key'
+      preLoaderRoute: typeof EditKeyRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/device': {
@@ -413,11 +453,13 @@ const rootRouteChildren: RootRouteChildren = {
   DashboardRoute: DashboardRouteWithChildren,
   AuthorizeRoute: AuthorizeRoute,
   DeviceRoute: DeviceRoute,
+  EditKeyRoute: EditKeyRoute,
   ErrorRoute: ErrorRoute,
   PrivacyRoute: PrivacyRoute,
   RefundsRoute: RefundsRoute,
   SignInRoute: SignInRoute,
   TermsRoute: TermsRoute,
+  TopUpRoute: TopUpRoute,
   AppSignInRoute: AppSignInRoute,
 }
 export const routeTree = rootRouteImport

--- a/enter.pollinations.ai/frontend/src/routes/_dashboard.keys.tsx
+++ b/enter.pollinations.ai/frontend/src/routes/_dashboard.keys.tsx
@@ -1,12 +1,13 @@
 import { createFileRoute, redirect, useRouter } from "@tanstack/react-router";
-import { apiClient } from "../api.ts";
 import { authClient } from "../auth.ts";
 import {
     ApiKeyList,
+    type ApiKeyUpdateParams,
     type CreateApiKey,
     type CreateApiKeyResponse,
 } from "../components/keys";
 import { createKeyWithPermissions } from "../lib/create-api-key.ts";
+import { updateApiKey } from "../lib/update-api-key.ts";
 import { Route as DashboardRoute } from "./_dashboard.tsx";
 
 export const Route = createFileRoute("/_dashboard/keys")({
@@ -69,30 +70,9 @@ function KeysPage() {
 
     async function handleUpdateApiKey(
         id: string,
-        updates: {
-            name?: string;
-            allowedModels?: string[] | null;
-            pollenBudget?: number | null;
-            accountPermissions?: string[] | null;
-            expiresAt?: Date | null;
-        },
+        updates: ApiKeyUpdateParams,
     ): Promise<void> {
-        const response = await apiClient["api-keys"][":id"].update.$post({
-            param: { id },
-            json: {
-                ...updates,
-                expiresAt:
-                    updates.expiresAt instanceof Date
-                        ? updates.expiresAt.toISOString()
-                        : updates.expiresAt,
-            },
-        });
-        if (!response.ok) {
-            const error = await response.json();
-            throw new Error(
-                (error as { message?: string }).message || "Update failed",
-            );
-        }
+        await updateApiKey(id, updates);
         await router.invalidate();
     }
 

--- a/enter.pollinations.ai/frontend/src/routes/edit-key.tsx
+++ b/enter.pollinations.ai/frontend/src/routes/edit-key.tsx
@@ -1,0 +1,174 @@
+import { AccountIdentity, Button } from "@pollinations/ui";
+import {
+    AuthInfoCard,
+    AuthModal,
+    AuthModalHeader,
+    AuthModalLoading,
+    ErrorBanner,
+} from "@pollinations/ui/auth";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
+import { apiClient } from "../api.ts";
+import { authClient } from "../auth.ts";
+import type { ApiKey } from "../components/keys";
+import { EditApiKeyDialog } from "../components/keys/edit-api-key-dialog.tsx";
+import { useGitHubSignIn } from "../hooks/use-github-sign-in.ts";
+import {
+    parseAppUrl,
+    preferredReturnUrl,
+    ReturnToApp,
+} from "../lib/return-to-app.tsx";
+import { updateApiKey } from "../lib/update-api-key.ts";
+
+type EditKeySearch = {
+    id: string;
+    redirect?: string;
+};
+
+/**
+ * Standalone key editor for one key, shown on the auth-flow background.
+ * Linked from the key-budget notice gen returns inside chats, so the user
+ * can raise the budget and go back to the app.
+ */
+export const Route = createFileRoute("/edit-key")({
+    validateSearch: (search: Record<string, unknown>): EditKeySearch => ({
+        id: typeof search.id === "string" ? search.id : "",
+        redirect: parseAppUrl(search.redirect) ?? undefined,
+    }),
+    component: EditKeyPage,
+});
+
+type Outcome = "editing" | "saved" | "closed";
+
+function EditKeyPage() {
+    const { id, redirect } = Route.useSearch();
+    const navigate = useNavigate({ from: "/edit-key" });
+    const { data: session, isPending } = authClient.useSession();
+    const user = session?.user;
+    const { isSigningIn, error: signInError, signIn } = useGitHubSignIn();
+    const [apiKey, setApiKey] = useState<ApiKey | null | undefined>(undefined);
+    const [outcome, setOutcome] = useState<Outcome>("editing");
+    const returnUrl = redirect ?? null;
+
+    useEffect(() => {
+        const from = preferredReturnUrl(redirect);
+        if (from) {
+            void navigate({
+                search: (prev) => ({ ...prev, redirect: from }),
+                replace: true,
+            });
+        }
+    }, [navigate, redirect]);
+
+    useEffect(() => {
+        if (!user || !id) return;
+        apiClient["api-keys"]
+            .$get()
+            .then((response) => (response.ok ? response.json() : null))
+            .then((result) => {
+                const keys = (result?.data ?? []) as ApiKey[];
+                setApiKey(keys.find((key) => key.id === id) ?? null);
+            })
+            .catch(() => setApiKey(null));
+    }, [user, id]);
+
+    if (isPending) return <AuthModalLoading />;
+
+    if (!user) {
+        return (
+            <AuthModal
+                dialog={{ label: "Sign in to edit this key" }}
+                tone={signInError ? "error" : undefined}
+            >
+                <AuthModalHeader />
+                <div className="px-6 pb-6 pt-4 space-y-4">
+                    {signInError ? (
+                        <ErrorBanner>{signInError}</ErrorBanner>
+                    ) : (
+                        <AuthInfoCard title="Edit API key">
+                            <p className="text-sm text-theme-text-base">
+                                Sign in to change this key's budget and limits.
+                            </p>
+                        </AuthInfoCard>
+                    )}
+                    <div className="flex justify-end">
+                        <Button
+                            as="button"
+                            onClick={signIn}
+                            disabled={isSigningIn}
+                        >
+                            {isSigningIn
+                                ? "Signing in..."
+                                : "Continue with GitHub"}
+                        </Button>
+                    </div>
+                </div>
+            </AuthModal>
+        );
+    }
+
+    const accountHeader = (
+        <AuthModalHeader>
+            <AccountIdentity
+                name={user.githubUsername || user.name}
+                avatarUrl={user.image}
+            />
+        </AuthModalHeader>
+    );
+
+    if (outcome !== "editing") {
+        return (
+            <AuthModal dialog={{ label: "Key updated" }}>
+                {accountHeader}
+                <div className="px-6 pb-6 pt-4 space-y-4">
+                    <AuthInfoCard
+                        title={
+                            outcome === "saved" ? "Key updated" : "No changes"
+                        }
+                    >
+                        <p className="text-sm text-theme-text-base">
+                            {outcome === "saved"
+                                ? "The new limits apply to the next request. "
+                                : "The key was left as it is. "}
+                            You can close this tab and return to the app.
+                        </p>
+                    </AuthInfoCard>
+                    <ReturnToApp returnUrl={returnUrl} />
+                </div>
+            </AuthModal>
+        );
+    }
+
+    if (!id || apiKey === null) {
+        return (
+            <AuthModal dialog={{ label: "Key not found" }} tone="error">
+                {accountHeader}
+                <div className="px-6 pb-6 pt-4 space-y-4">
+                    <ErrorBanner>
+                        This key doesn't exist or belongs to another account.
+                    </ErrorBanner>
+                    <ReturnToApp returnUrl={returnUrl} />
+                </div>
+            </AuthModal>
+        );
+    }
+
+    if (apiKey === undefined) return <AuthModalLoading />;
+
+    return (
+        <EditApiKeyDialog
+            key={apiKey.id}
+            apiKey={apiKey}
+            header={accountHeader}
+            onUpdate={async (keyId, updates) => {
+                await updateApiKey(keyId, updates);
+                setOutcome("saved");
+            }}
+            onClose={() =>
+                setOutcome((current) =>
+                    current === "editing" ? "closed" : current,
+                )
+            }
+        />
+    );
+}

--- a/enter.pollinations.ai/frontend/src/routes/top-up.tsx
+++ b/enter.pollinations.ai/frontend/src/routes/top-up.tsx
@@ -1,0 +1,241 @@
+import { AccountIdentity, Button, Section } from "@pollinations/ui";
+import {
+    AuthInfoCard,
+    AuthModal,
+    AuthModalHeader,
+    AuthModalLoading,
+    ErrorBanner,
+} from "@pollinations/ui/auth";
+import {
+    getPollenPackByAmount,
+    getPollenPackByKey,
+    POLLEN_PACKS,
+} from "@shared/pollen-packs.ts";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
+import { apiClient } from "../api.ts";
+import { authClient } from "../auth.ts";
+import { BuyPollenPanel, PollenBalance } from "../components/pollen";
+import type { BillingState } from "../components/pollen/auto-top-up-panel.tsx";
+import { useGitHubSignIn } from "../hooks/use-github-sign-in.ts";
+import { preferredReturnUrl, ReturnToApp } from "../lib/return-to-app.tsx";
+
+import { validateTopUpSearch } from "../lib/top-up-search.ts";
+
+type WalletState = {
+    tierBalance: number;
+    packBalance: number;
+    paidWeek?: number;
+    tierWeek?: number;
+};
+
+/**
+ * Standalone top-up: the wallet and top-up sections of the pollen page on
+ * the auth-flow background, without the dashboard around them. Linked from
+ * the low-balance notice gen returns inside chats, so the user can pay and
+ * go back to the app.
+ */
+export const Route = createFileRoute("/top-up")({
+    validateSearch: validateTopUpSearch,
+    component: TopUpPage,
+});
+
+function TopUpPage() {
+    const search = Route.useSearch();
+    const navigate = useNavigate({ from: "/top-up" });
+    const { data: session, isPending } = authClient.useSession();
+    const user = session?.user;
+    const { isSigningIn, error: signInError, signIn } = useGitHubSignIn();
+    const [wallet, setWallet] = useState<WalletState | null>(null);
+    const [walletError, setWalletError] = useState(false);
+    const [loadAttempt, setLoadAttempt] = useState(0);
+    const [billing, setBilling] = useState<BillingState | null | undefined>(
+        undefined,
+    );
+    const returnUrl = search.redirect ?? null;
+    const selectedPack =
+        getPollenPackByKey(search.pack ?? "p5") ?? POLLEN_PACKS[0];
+
+    // Remember which app sent us before Stripe overwrites the referrer.
+    useEffect(() => {
+        if (
+            search.stripe_success ||
+            search.stripe_canceled ||
+            search.stripe_billing_return
+        )
+            return;
+        const from = preferredReturnUrl(search.redirect);
+        if (from) {
+            void navigate({
+                search: (prev) => ({ ...prev, redirect: from }),
+                replace: true,
+            });
+        }
+    }, [
+        navigate,
+        search.redirect,
+        search.stripe_success,
+        search.stripe_canceled,
+        search.stripe_billing_return,
+    ]);
+
+    // biome-ignore lint/correctness/useExhaustiveDependencies: loadAttempt retries the requests when the user selects Try again.
+    useEffect(() => {
+        if (!user) return;
+        let canceled = false;
+        setWallet(null);
+        setWalletError(false);
+        setBilling(undefined);
+
+        apiClient.customer.balance
+            .$get()
+            .then((r) => {
+                if (!r.ok) throw new Error("Failed to load wallet");
+                return r.json();
+            })
+            .then((data) => {
+                if (canceled) return;
+                setWallet({
+                    tierBalance: data.tierBalance ?? 0,
+                    packBalance: data.packBalance ?? 0,
+                });
+                // Earnings are optional; their failure must not hide the wallet.
+                void apiClient.customer.balance.today
+                    .$get()
+                    .then((r) => (r.ok ? r.json() : null))
+                    .then((earnings) => {
+                        if (!canceled && earnings) {
+                            setWallet((w) => (w ? { ...w, ...earnings } : w));
+                        }
+                    })
+                    .catch(() => {});
+            })
+            .catch(() => {
+                if (!canceled) setWalletError(true);
+            });
+        apiClient.stripe.billing
+            .$get()
+            .then((r) => (r.ok ? r.json() : null))
+            .catch(() => null)
+            .then((data) => {
+                if (!canceled) setBilling(data);
+            });
+        return () => {
+            canceled = true;
+        };
+    }, [user, loadAttempt]);
+
+    if (isPending) return <AuthModalLoading />;
+
+    if (!user) {
+        return (
+            <AuthModal
+                dialog={{ label: "Sign in to top up" }}
+                tone={signInError ? "error" : undefined}
+            >
+                <AuthModalHeader />
+                <div className="px-6 pb-6 pt-4 space-y-4">
+                    {signInError ? (
+                        <ErrorBanner>{signInError}</ErrorBanner>
+                    ) : (
+                        <AuthInfoCard title="Top up">
+                            <p className="text-sm text-theme-text-base">
+                                Sign in to add Pollen to your wallet.
+                            </p>
+                        </AuthInfoCard>
+                    )}
+                    <div className="flex justify-end">
+                        <Button
+                            as="button"
+                            onClick={signIn}
+                            disabled={isSigningIn}
+                        >
+                            {isSigningIn
+                                ? "Signing in..."
+                                : "Continue with GitHub"}
+                        </Button>
+                    </div>
+                </div>
+            </AuthModal>
+        );
+    }
+
+    const accountIdentity = (
+        <AccountIdentity
+            name={user.githubUsername || user.name}
+            avatarUrl={user.image}
+        />
+    );
+
+    if (search.stripe_success) {
+        return (
+            <AuthModal dialog={{ label: "Pollen added" }}>
+                <AuthModalHeader>{accountIdentity}</AuthModalHeader>
+                <div className="px-6 pb-6 pt-4 space-y-4">
+                    <AuthInfoCard title="Pollen added">
+                        <p className="text-sm text-theme-text-base">
+                            Your payment went through. You can close this tab
+                            and return to the app.
+                        </p>
+                    </AuthInfoCard>
+                    {wallet && <PollenBalance {...wallet} compact />}
+                    <ReturnToApp returnUrl={returnUrl} />
+                </div>
+            </AuthModal>
+        );
+    }
+
+    if (walletError) {
+        return (
+            <AuthModal dialog={{ label: "Top up" }} tone="error">
+                <AuthModalHeader>{accountIdentity}</AuthModalHeader>
+                <div className="px-6 pb-6 pt-4 space-y-4">
+                    <ErrorBanner>
+                        Could not load your wallet. Please try again.
+                    </ErrorBanner>
+                    <Button
+                        as="button"
+                        onClick={() => setLoadAttempt((attempt) => attempt + 1)}
+                    >
+                        Try again
+                    </Button>
+                </div>
+            </AuthModal>
+        );
+    }
+
+    if (!wallet || billing === undefined) return <AuthModalLoading />;
+
+    return (
+        <AuthModal dialog={{ label: "Top up" }} contentClassName="max-w-2xl">
+            <AuthModalHeader>{accountIdentity}</AuthModalHeader>
+            <div className="flex flex-col gap-6 px-6 pb-6 pt-4">
+                {search.stripe_canceled && (
+                    <ErrorBanner>Checkout was cancelled.</ErrorBanner>
+                )}
+                <Section title="Wallet">
+                    <PollenBalance {...wallet} compact />
+                </Section>
+                <Section title="Top-up" framed>
+                    <BuyPollenPanel
+                        initialBillingState={billing}
+                        selectedPackAmount={selectedPack?.amountUsd ?? 5}
+                        onSelectedPackAmountChange={(amount) => {
+                            const pack = getPollenPackByAmount(amount);
+                            if (pack) {
+                                void navigate({
+                                    search: (prev) => ({
+                                        ...prev,
+                                        pack: pack.packKey,
+                                    }),
+                                });
+                            }
+                        }}
+                        returnToTopUp={{ redirect: search.redirect }}
+                    />
+                </Section>
+                <ReturnToApp returnUrl={returnUrl} />
+            </div>
+        </AuthModal>
+    );
+}

--- a/enter.pollinations.ai/src/routes/stripe.ts
+++ b/enter.pollinations.ai/src/routes/stripe.ts
@@ -69,10 +69,17 @@ export const stripeRoutes = new Hono<Env>()
         // Create Stripe client
         const stripe = createStripeClient(c.env);
 
-        // Return checkout sessions to the Pollen page for this environment.
+        // Return the buyer to the standalone top-up page when checkout
+        // started there, else to the Pollen dashboard. Both paths are fixed
+        // here, so the return URL is always on this origin.
         const baseUrl =
             c.env.STRIPE_SUCCESS_URL || PUBLIC_URLS.enter.production;
-        const pollenUrl = new URL("/pollen", baseUrl);
+        const pollenUrl = new URL(
+            c.req.query("return") === "top-up" ? "/top-up" : "/pollen",
+            baseUrl,
+        );
+        const appRedirect = c.req.query("redirect");
+        if (appRedirect) pollenUrl.searchParams.set("redirect", appRedirect);
         pollenUrl.searchParams.set("pack", pack.packKey);
         const pollenReturnUrl = pollenUrl.toString();
 
@@ -220,8 +227,19 @@ export const stripeRoutes = new Hono<Env>()
     .post("/billing/portal", async (c) => {
         const user = await requireSessionUser(c);
 
+        const body = (await c.req.json().catch(() => null)) as {
+            return?: unknown;
+            redirect?: unknown;
+        } | null;
+
         try {
-            const session = await createBillingPortalSession(c.env, user.id);
+            const session = await createBillingPortalSession(c.env, user.id, {
+                topUp: body?.return === "top-up",
+                redirect:
+                    typeof body?.redirect === "string"
+                        ? body.redirect
+                        : undefined,
+            });
 
             if (!session.url) {
                 return c.json(

--- a/enter.pollinations.ai/src/utils/stripe-billing/portal.ts
+++ b/enter.pollinations.ai/src/utils/stripe-billing/portal.ts
@@ -13,6 +13,7 @@ import { getOrCreateStripeCustomerId } from "./customer.ts";
 export async function createBillingPortalSession(
     env: CloudflareBindings,
     userId: string,
+    returnTo?: BillingReturn,
 ): Promise<Stripe.BillingPortal.Session> {
     const stripe = createStripeClient(env);
     const customer = await getOrCreateStripeCustomerId(env, userId);
@@ -26,7 +27,7 @@ export async function createBillingPortalSession(
     return stripe.billingPortal.sessions.create({
         customer,
         configuration,
-        return_url: returnUrl,
+        return_url: getBillingReturnUrl(env, returnTo),
     });
 }
 
@@ -136,9 +137,16 @@ function isBillingPortalConfigurationCurrent(
     return (currentPmc ?? undefined) === paymentMethodConfiguration;
 }
 
-function getBillingReturnUrl(env: CloudflareBindings): string {
+/** Where the portal sends the user back: the standalone page, else Pollen. */
+type BillingReturn = { topUp?: boolean; redirect?: string };
+
+function getBillingReturnUrl(
+    env: CloudflareBindings,
+    returnTo?: BillingReturn,
+): string {
     const baseUrl = env.STRIPE_SUCCESS_URL || PUBLIC_URLS.enter.production;
-    const url = new URL("/pollen", baseUrl);
+    const url = new URL(returnTo?.topUp ? "/top-up" : "/pollen", baseUrl);
+    if (returnTo?.redirect) url.searchParams.set("redirect", returnTo.redirect);
     url.searchParams.set("stripe_billing_return", "true");
     return url.toString();
 }

--- a/enter.pollinations.ai/test/code-agent.test.ts
+++ b/enter.pollinations.ai/test/code-agent.test.ts
@@ -2,6 +2,7 @@ import { runtimeModule, sdkModules } from "virtual:code-agent-sdk";
 import { generateText, jsonSchema, tool } from "ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createWorker as createComposioWorker } from "../../apps/composio-mcp/worker.js";
+import { functionOutputText } from "../../shared/schemas/response-function-items.ts";
 import {
     deleteCodeAgent,
     deployCodeAgent,
@@ -230,14 +231,22 @@ describe("code agent AI SDK", () => {
         ).toEqual([
             expect.objectContaining({
                 call_id: "lookup-call",
-                output: fail
-                    ? JSON.stringify({
-                          isError: true,
-                          content: [
-                              { type: "text", text: "Lookup unavailable" },
-                          ],
-                      })
-                    : '{"answer":42}',
+                output: [
+                    {
+                        type: "input_text",
+                        text: fail
+                            ? JSON.stringify({
+                                  isError: true,
+                                  content: [
+                                      {
+                                          type: "text",
+                                          text: "Lookup unavailable",
+                                      },
+                                  ],
+                              })
+                            : '{"answer":42}',
+                    },
+                ],
             }),
         ]);
         const replay = await responseBody(
@@ -419,7 +428,9 @@ describe("code agent AI SDK", () => {
             (item) => item.type === "function_call_output",
         );
         expect(results).toHaveLength(17);
-        expect(JSON.parse(results[16].output)).toMatchObject({ isError: true });
+        expect(
+            JSON.parse(functionOutputText(results[16].output)),
+        ).toMatchObject({ isError: true });
     });
 });
 

--- a/enter.pollinations.ai/test/integration/stripe.test.ts
+++ b/enter.pollinations.ai/test/integration/stripe.test.ts
@@ -612,6 +612,64 @@ test("POST /api/stripe/billing/portal creates a Stripe Portal session", async ({
     });
 });
 
+test("POST /api/stripe/billing/portal returns to standalone top-up without changing the shared default", async ({
+    sessionToken,
+    mocks,
+}) => {
+    await mocks.enable("stripe", "tinybird");
+    const response = await SELF.fetch(`${base}/billing/portal`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            cookie: `better-auth.session_token=${sessionToken}`,
+        },
+        body: JSON.stringify({
+            return: "top-up",
+            redirect: "https://app.example/chat",
+        }),
+    });
+    expect(response.status).toBe(200);
+    const request = mocks.stripe.state.requests.find(
+        (request) => request.path === "/v1/billing_portal/sessions",
+    );
+    const url = new URL(String(request?.body.return_url));
+    expect(url.origin).toBe(new URL(env.STRIPE_SUCCESS_URL).origin);
+    expect(url.pathname).toBe("/top-up");
+    expect(url.searchParams.get("redirect")).toBe("https://app.example/chat");
+    expect(url.searchParams.get("stripe_billing_return")).toBe("true");
+    const defaultUrl = new URL(
+        String(mocks.stripe.state.portalConfigurations[0].default_return_url),
+    );
+    expect(defaultUrl.pathname).toBe("/pollen");
+    expect(defaultUrl.searchParams.has("redirect")).toBe(false);
+});
+
+test("POST /api/stripe/billing/portal returns to Pollen for any other return value", async ({
+    sessionToken,
+    mocks,
+}) => {
+    await mocks.enable("stripe", "tinybird");
+    for (const value of ["/top-up", "https://evil.example", 123, null]) {
+        mocks.stripe.state.requests.length = 0;
+        const response = await SELF.fetch(`${base}/billing/portal`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                cookie: `better-auth.session_token=${sessionToken}`,
+            },
+            body: JSON.stringify({ return: value }),
+        });
+        expect(response.status).toBe(200);
+        const request = mocks.stripe.state.requests.find(
+            (request) => request.path === "/v1/billing_portal/sessions",
+        );
+        const url = new URL(String(request?.body.return_url));
+        expect(url.origin).toBe(new URL(env.STRIPE_SUCCESS_URL).origin);
+        expect(url.pathname).toBe("/pollen");
+        expect(url.searchParams.get("stripe_billing_return")).toBe("true");
+    }
+});
+
 test("POST /api/stripe/billing/portal updates existing Stripe Portal headline", async ({
     sessionToken,
     mocks,
@@ -3381,4 +3439,66 @@ test("POST /api/webhooks/stripe emits checkout.session.expired to Tinybird witho
     // Exact serialization: the expired handler does not emit the offered
     // payment methods, so the shared mapper must not synthesize them here.
     expect(emitted.payment_methods_offered).toBe("");
+});
+
+test("GET /api/stripe/checkout/p5?return=top-up returns to the standalone page", async ({
+    sessionToken,
+    mocks,
+}) => {
+    await mocks.enable("stripe", "tinybird");
+
+    const response = await SELF.fetch(
+        `${base}/checkout/p5?return=top-up&redirect=${encodeURIComponent("https://app.example/chat")}`,
+        {
+            method: "GET",
+            headers: { cookie: `better-auth.session_token=${sessionToken}` },
+            redirect: "manual",
+        },
+    );
+    expect(response.status).toBe(302);
+
+    const body = mocks.stripe.state.requests.find(
+        (request) => request.path === "/v1/checkout/sessions",
+    )?.body;
+    const successUrl = new URL(String(body?.success_url));
+    expect(successUrl.origin).toBe(new URL(env.STRIPE_SUCCESS_URL).origin);
+    expect(successUrl.pathname).toBe("/top-up");
+    expect(successUrl.searchParams.get("redirect")).toBe(
+        "https://app.example/chat",
+    );
+    expect(successUrl.searchParams.get("pack")).toBe("p5");
+    expect(successUrl.searchParams.get("stripe_success")).toBe("true");
+    expect(new URL(String(body?.cancel_url)).pathname).toBe("/top-up");
+});
+
+test("GET /api/stripe/checkout/p5 returns to Pollen for any other return value", async ({
+    sessionToken,
+    mocks,
+}) => {
+    await mocks.enable("stripe", "tinybird");
+
+    for (const value of ["/top-up", "https://evil.example/x", "elsewhere"]) {
+        mocks.stripe.state.requests.length = 0;
+        const response = await SELF.fetch(
+            `${base}/checkout/p5?return=${encodeURIComponent(value)}`,
+            {
+                method: "GET",
+                headers: {
+                    cookie: `better-auth.session_token=${sessionToken}`,
+                },
+                redirect: "manual",
+            },
+        );
+        expect(response.status).toBe(302);
+        const body = mocks.stripe.state.requests.find(
+            (request) => request.path === "/v1/checkout/sessions",
+        )?.body;
+        for (const target of [body?.success_url, body?.cancel_url]) {
+            const url = new URL(String(target));
+            expect(url.origin, value).toBe(
+                new URL(env.STRIPE_SUCCESS_URL).origin,
+            );
+            expect(url.pathname, value).toBe("/pollen");
+        }
+    }
 });

--- a/enter.pollinations.ai/test/top-up-search.test.ts
+++ b/enter.pollinations.ai/test/top-up-search.test.ts
@@ -1,0 +1,33 @@
+import { defaultParseSearch } from "@tanstack/react-router";
+import { expect, test } from "vitest";
+import { validateTopUpSearch } from "../frontend/src/lib/top-up-search.ts";
+
+test.each([
+    "stripe_success",
+    "stripe_canceled",
+    "stripe_billing_return",
+])("preserves %s after the router parses a Stripe return URL", (flag) => {
+    const search = validateTopUpSearch(
+        defaultParseSearch(
+            `?${flag}=true&pack=p5&redirect=https%3A%2F%2Fapp.example%2Fchat`,
+        ),
+    );
+    expect(search).toMatchObject({
+        [flag]: true,
+        pack: "p5",
+        redirect: "https://app.example/chat",
+    });
+});
+
+test.each([
+    "false",
+    "0",
+    "anything",
+    "",
+])("does not treat %s as a successful or canceled payment", (value) => {
+    const search = validateTopUpSearch(
+        defaultParseSearch(`?stripe_success=${value}&stripe_canceled=${value}`),
+    );
+    expect(search.stripe_success).toBeUndefined();
+    expect(search.stripe_canceled).toBeUndefined();
+});

--- a/gen.pollinations.ai/src/middleware/text-balance-notice.ts
+++ b/gen.pollinations.ai/src/middleware/text-balance-notice.ts
@@ -1,8 +1,10 @@
 import { PaymentRequiredError } from "@shared/http/payment-required-error.ts";
+import { PUBLIC_URLS } from "@shared/public-urls.ts";
 import type {
     CreateChatCompletionRequest,
     CreateResponseRequest,
 } from "@shared/schemas/openai.ts";
+import type { Context } from "hono";
 import { createMiddleware } from "hono/factory";
 import type { Env } from "../env.ts";
 import {
@@ -19,12 +21,63 @@ import {
 // Set false to restore HTTP 402 for every insufficient-balance response.
 export const TEXT_BALANCE_NOTICE_ENABLED = true;
 
-const MESSAGE =
-    "The account behind this API key doesn't have enough credits. " +
-    "Please " +
-    "[top up](https://enter.pollinations.ai/pollen?ref=agent_low_balance_topup) or " +
-    "[complete a quest](https://enter.pollinations.ai/quests?ref=agent_low_balance_quests), then try again.\n\n" +
+const NOT_YOUR_ACCOUNT =
     "If this isn’t your Pollinations account, contact whoever runs the app or service you’re using.";
+
+/** Staging gen links to staging enter, where the Open WebUI staging user is logged in. */
+function enterUrl(environment: string): string {
+    return environment === "staging"
+        ? PUBLIC_URLS.enter.staging
+        : PUBLIC_URLS.enter.production;
+}
+
+function enterLink(
+    environment: string,
+    path: string,
+    params: Record<string, string | null | undefined>,
+): string {
+    const url = new URL(path, enterUrl(environment));
+    for (const [key, value] of Object.entries(params)) {
+        if (value) url.searchParams.set(key, value);
+    }
+    return url.toString();
+}
+
+function appOrigin(c: Context<Env>): string | null {
+    const stored = c.var.auth?.apiKey?.metadata?.redirectOrigin;
+    if (typeof stored === "string") return stored;
+    const referer = c.req.header("referer");
+    if (!referer) return null;
+    try {
+        return new URL(referer).origin;
+    } catch {
+        return null;
+    }
+}
+
+export function balanceNoticeMessage(
+    environment: string,
+    error: Pick<PaymentRequiredError, "errorCode" | "paidOnly">,
+    keyId: string | undefined,
+    redirect: string | null,
+): string {
+    if (error.errorCode === "KEY_BUDGET_EXHAUSTED") {
+        return (
+            "The API key used for this request has reached its budget. " +
+            "Please " +
+            `[raise the key budget](${enterLink(environment, "/edit-key", { id: keyId, ref: "agent_key_budget", redirect })}), then try again.\n\n` +
+            `Topping up the wallet does not raise this limit. ${NOT_YOUR_ACCOUNT}`
+        );
+    }
+    const topUp = `[top up](${enterLink(environment, "/top-up", { ref: "agent_low_balance_topup", redirect })})`;
+    const remedy = error.paidOnly
+        ? `This model needs paid Pollen. Please ${topUp}, then try again.`
+        : `Please ${topUp} or [complete a quest](${enterLink(environment, "/quests", { ref: "agent_low_balance_quests" })}), then try again.`;
+    return (
+        "The account behind this API key doesn't have enough credits. " +
+        `${remedy}\n\n${NOT_YOUR_ACCOUNT}`
+    );
+}
 
 /** Wrap tracking and caching so they capture the original 402 before formatting. */
 export const textBalanceNotice = createMiddleware<Env>(async (c, next) => {
@@ -34,10 +87,15 @@ export const textBalanceNotice = createMiddleware<Env>(async (c, next) => {
     if (
         !TEXT_BALANCE_NOTICE_ENABLED ||
         c.res.status !== 402 ||
-        !(error instanceof PaymentRequiredError) ||
-        error.errorCode !== "INSUFFICIENT_BALANCE"
+        !(error instanceof PaymentRequiredError)
     )
         return;
+    const message = balanceNoticeMessage(
+        c.env.ENVIRONMENT,
+        error,
+        c.var.auth?.apiKey?.id,
+        appOrigin(c),
+    );
 
     const isResponses = c.req.path === "/v1/responses";
     const request = c.req.valid(
@@ -69,12 +127,12 @@ export const textBalanceNotice = createMiddleware<Env>(async (c, next) => {
         c.req.path !== "/v1/chat/completions"
     ) {
         headers.set("Content-Type", "text/plain; charset=utf-8");
-        c.res = new Response(MESSAGE, { headers });
+        c.res = new Response(message, { headers });
         return;
     }
 
     const model = c.var.model.requested ?? c.var.model.resolved;
-    const response = createTextResponse(model, MESSAGE, {
+    const response = createTextResponse(model, message, {
         input_tokens: 0,
         output_tokens: 0,
         total_tokens: 0,

--- a/gen.pollinations.ai/src/text/agents/mcp.ts
+++ b/gen.pollinations.ai/src/text/agents/mcp.ts
@@ -4,9 +4,10 @@ import {
     safeMcpOutput,
 } from "@shared/agents/mcp-output.ts";
 
-import type {
-    ResponseFunctionCall,
-    ResponseFunctionCallOutput,
+import {
+    functionOutputText,
+    type ResponseFunctionCall,
+    type ResponseFunctionCallOutput,
 } from "@shared/schemas/response-function-items.ts";
 import { z } from "zod";
 
@@ -159,7 +160,7 @@ export function formatFunctionCall(
             name: tool?.name ?? call.name,
             arguments: call.arguments,
             status: "completed",
-            output: result.output,
+            output: functionOutputText(result.output),
             error: null,
         },
         seenUrls,

--- a/gen.pollinations.ai/src/utils/generation-access.ts
+++ b/gen.pollinations.ai/src/utils/generation-access.ts
@@ -46,7 +46,7 @@ export async function checkBalance(
     if (typeof apiKeyBudget === "number" && apiKeyBudget < requiredBudget) {
         throw new PaymentRequiredError(
             "KEY_BUDGET_EXHAUSTED",
-            `API key budget too low. This request costs ~${estimatedCost.toFixed(4)} pollen, but this key has ${Math.max(0, apiKeyBudget).toFixed(4)}. Increase the key budget at https://enter.pollinations.ai/keys; topping up the wallet does not increase this limit.`,
+            `API key budget too low. This request costs ~${estimatedCost.toFixed(4)} pollen, but this key has ${Math.max(0, apiKeyBudget).toFixed(4)}. Increase the key budget at https://enter.pollinations.ai/edit-key?id=${auth.apiKey?.id ?? ""}; topping up the wallet does not increase this limit.`,
         );
     }
 
@@ -58,7 +58,8 @@ export async function checkBalance(
             : Math.max(userBalance.tierBalance, userBalance.packBalance);
         throw new PaymentRequiredError(
             "INSUFFICIENT_BALANCE",
-            `Insufficient balance. This request costs ~${estimatedCost.toFixed(4)} pollen, but your available ${isPaidOnly ? "paid " : ""}balance is ${Math.max(0, available).toFixed(4)}. Top up at https://enter.pollinations.ai/pollen.`,
+            `Insufficient balance. This request costs ~${estimatedCost.toFixed(4)} pollen, but your available ${isPaidOnly ? "paid " : ""}balance is ${Math.max(0, available).toFixed(4)}. Top up at https://enter.pollinations.ai/top-up.`,
+            isPaidOnly,
         );
     }
 

--- a/gen.pollinations.ai/test/text-balance-notice.test.ts
+++ b/gen.pollinations.ai/test/text-balance-notice.test.ts
@@ -324,10 +324,76 @@ describe("text balance notice", () => {
     });
 });
 
-it("keeps API key budget exhaustion as HTTP 402", async () => {
+it.each([
+    { metadata: undefined, referer: undefined, redirect: null },
+    {
+        metadata: { redirectOrigin: "https://app.example" },
+        referer: "https://chat.example/c/1",
+        redirect: "https://app.example",
+    },
+    {
+        metadata: undefined,
+        referer: "https://chat.example/c/1",
+        redirect: "https://chat.example",
+    },
+])("links key budget exhaustion to the key editor (redirect=$redirect)", async ({
+    metadata,
+    referer,
+    redirect,
+}) => {
     const caller = await createTestApiKey({
         user: { packBalance: 10 },
         pollenBudget: 0,
+        metadata,
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        Response.json({ data: [] }),
+    );
+    const ctx = createExecutionContext();
+    const response = await worker.fetch(
+        new Request("https://gen.pollinations.ai/v1/chat/completions", {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${caller.key}`,
+                "Content-Type": "application/json",
+                ...(referer && { Referer: referer }),
+            },
+            body: JSON.stringify({
+                model,
+                messages: [{ role: "user", content: "hello" }],
+            }),
+        }),
+        env,
+        ctx,
+    );
+    const text = await response.text();
+    if (!TEXT_BALANCE_NOTICE_ENABLED) {
+        expect(response.status, text).toBe(402);
+        expect(text).toContain("KEY_BUDGET_EXHAUSTED");
+    } else {
+        expect(response.status, text).toBe(200);
+        const link = new URL(
+            `https://enter.pollinations.ai/edit-key?id=${caller.id}&ref=agent_key_budget`,
+        );
+        if (redirect) link.searchParams.set("redirect", redirect);
+        expect(text).toContain(`[raise the key budget](${link})`);
+        expect(text).toContain("Topping up the wallet does not raise");
+        expect(text).not.toContain("complete a quest");
+    }
+    await waitOnExecutionContext(ctx);
+});
+
+it("omits the quest link when only paid Pollen can cover the model", async () => {
+    const paidOnlyModel = "inception/mercury-2";
+    await env.KV.put(
+        "model-stats-v3",
+        JSON.stringify({
+            value: { data: [{ model: paidOnlyModel, avg_cost_usd: 0.001 }] },
+            ttl: 3600,
+        }),
+    );
+    const caller = await createTestApiKey({
+        user: { tierBalance: 100, packBalance: 0 },
     });
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
         Response.json({ data: [] }),
@@ -341,14 +407,22 @@ it("keeps API key budget exhaustion as HTTP 402", async () => {
                 "Content-Type": "application/json",
             },
             body: JSON.stringify({
-                model,
+                model: paidOnlyModel,
                 messages: [{ role: "user", content: "hello" }],
             }),
         }),
         env,
         ctx,
     );
-    expect(response.status).toBe(402);
-    expect(await response.text()).toContain("KEY_BUDGET_EXHAUSTED");
+    const text = await response.text();
+    if (!TEXT_BALANCE_NOTICE_ENABLED) {
+        expect(response.status, text).toBe(402);
+        expect(text).toContain("INSUFFICIENT_BALANCE");
+    } else {
+        expect(response.status, text).toBe(200);
+        expect(text).toContain("needs paid Pollen");
+        expect(text).toContain("/top-up?ref=agent_low_balance_topup");
+        expect(text).not.toContain("complete a quest");
+    }
     await waitOnExecutionContext(ctx);
 });

--- a/gen.pollinations.ai/test/text/agents/responses.test.ts
+++ b/gen.pollinations.ai/test/text/agents/responses.test.ts
@@ -230,7 +230,12 @@ describe("shared agent Responses adapter", () => {
                 {
                     type: "function_call_output",
                     call_id: "lookup-call",
-                    output: JSON.stringify(toolOutput),
+                    output: [
+                        {
+                            type: "input_text",
+                            text: JSON.stringify(toolOutput),
+                        },
+                    ],
                 },
                 { type: "message", content: [{ text: "The answer is 42." }] },
             ],
@@ -285,7 +290,12 @@ describe("shared agent Responses adapter", () => {
                 { type: "function_call", name: "lookup" },
                 {
                     type: "function_call_output",
-                    output: JSON.stringify(toolOutput),
+                    output: [
+                        {
+                            type: "input_text",
+                            text: JSON.stringify(toolOutput),
+                        },
+                    ],
                 },
             ],
         });
@@ -1150,10 +1160,15 @@ describe("managed agent Responses runtime", () => {
         expect(output[4]).toMatchObject({
             call_id: "call_search",
             status: "completed",
-            output: JSON.stringify({
-                isError: true,
-                content: [{ type: "text", text: "Search unavailable" }],
-            }),
+            output: [
+                {
+                    type: "input_text",
+                    text: JSON.stringify({
+                        isError: true,
+                        content: [{ type: "text", text: "Search unavailable" }],
+                    }),
+                },
+            ],
         });
         expect(JSON.stringify(output)).not.toContain("PRIVATE_");
         expect(
@@ -1235,9 +1250,19 @@ describe("managed agent Responses runtime", () => {
             },
         );
         vi.stubGlobal("fetch", fetchMock);
+        // Open WebUI replays stored items without status, and outputs
+        // without id; the Responses API makes both optional on input.
+        const replayed = output.map((item) => {
+            const { status: _status, ...rest } = item as Record<
+                string,
+                unknown
+            >;
+            if (rest.type === "function_call_output") delete rest.id;
+            return rest;
+        });
         const response = await handlePromptAgentResponsesRequest(
             request({
-                input: [...output, { role: "user", content: "Continue" }],
+                input: [...replayed, { role: "user", content: "Continue" }],
             }),
             new AbortController().signal,
             RUNTIME,

--- a/gen.pollinations.ai/test/text/agents/runtime.test.ts
+++ b/gen.pollinations.ai/test/text/agents/runtime.test.ts
@@ -1,4 +1,5 @@
 import type { AgentOutputItem } from "@shared/agents/output.ts";
+import { functionOutputText } from "@shared/schemas/response-function-items.ts";
 import OpenAI from "openai";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -252,9 +253,14 @@ describe("prompt-agent runtime", () => {
             type: "function_call_output",
             call_id: "c1",
             status: "completed",
-            output: JSON.stringify({
-                content: [{ type: "text", text: "found" }],
-            }),
+            output: [
+                {
+                    type: "input_text",
+                    text: JSON.stringify({
+                        content: [{ type: "text", text: "found" }],
+                    }),
+                },
+            ],
         });
         expect(chatOutputText(json)).toBe(
             "checking \n\n" +
@@ -1155,7 +1161,7 @@ describe("prompt-agent runtime", () => {
             });
             expect(events[5]).toMatchObject({
                 output_index: 1,
-                item: { ...output[1], output: "", status: "in_progress" },
+                item: { ...output[1], output: [], status: "in_progress" },
             });
             const chunks = responseStreamEvents(
                 await new Response(chatStream).text(),
@@ -1191,23 +1197,28 @@ describe("prompt-agent runtime", () => {
                     id: expect.stringMatching(/^fco_/),
                     call_id: "c1",
                     status: "completed",
-                    output: JSON.stringify({
-                        content: [
-                            {
-                                type: "text",
-                                text: "[image output omitted; use an HTTPS resource link]",
-                            },
-                            {
-                                type: "resource_link",
-                                uri: "https://images.example/pirate.png",
-                                name: "Generated image",
-                            },
-                            {
-                                type: "text",
-                                text: '{"data":[{"url":"https://images.example/pirate.png"}]}',
-                            },
-                        ],
-                    }),
+                    output: [
+                        {
+                            type: "input_text",
+                            text: JSON.stringify({
+                                content: [
+                                    {
+                                        type: "text",
+                                        text: "[image output omitted; use an HTTPS resource link]",
+                                    },
+                                    {
+                                        type: "resource_link",
+                                        uri: "https://images.example/pirate.png",
+                                        name: "Generated image",
+                                    },
+                                    {
+                                        type: "text",
+                                        text: '{"data":[{"url":"https://images.example/pirate.png"}]}',
+                                    },
+                                ],
+                            }),
+                        },
+                    ],
                 },
                 {
                     type: "message",
@@ -1849,7 +1860,7 @@ describe("prompt-agent runtime", () => {
             id: expect.stringMatching(/^fco_/),
             call_id: "c1",
             status: "completed",
-            output: expect.any(String),
+            output: [{ type: "input_text", text: expect.any(String) }],
         };
         expect(json).toMatchObject({
             status: "completed",
@@ -1870,7 +1881,7 @@ describe("prompt-agent runtime", () => {
         if (toolResult.type !== "function_call_output") {
             throw new Error("Missing completed tool result");
         }
-        expect(JSON.parse(toolResult.output)).toEqual({
+        expect(JSON.parse(functionOutputText(toolResult.output))).toEqual({
             isError: true,
             content: [
                 { type: "text", text: expect.stringContaining(failureMessage) },

--- a/operations/model-monitor/src/model-data.js
+++ b/operations/model-monitor/src/model-data.js
@@ -21,6 +21,8 @@ export function normalizeCatalogModel(model) {
 
 // Match statistics by the recorded ID only. An alias may have represented
 // another version in the past, so it must never transfer historical health.
+// Identity is the exception: what a model *is* comes from catalog metadata,
+// never from the shape of the recorded ID or the endpoint it was served on.
 export function mergeModelHealth(models, healthStats, catalogAvailable) {
     const stats = healthStats.filter((row) => row.model !== "undefined");
     const matchesEndpoint = (model, row) =>
@@ -46,11 +48,22 @@ export function mergeModelHealth(models, healthStats, catalogAvailable) {
                 ),
         )
         .map((row) => {
-            const type = row.event_type?.replace("generate.", "") || "unknown";
+            const eventType =
+                row.event_type?.replace("generate.", "") || "unknown";
             const sameName = models.filter((model) => model.name === row.model);
+            const aliased = models.find(
+                (model) =>
+                    model.aliases.includes(row.model) &&
+                    matchesEndpoint(model, row),
+            );
             let catalogStatus = "unregistered";
             let description = "Unregistered model";
             let community = row.provider === "community";
+            // Endpoints are coarser than categories: video and 3D both record
+            // image events. Only fall back to the event type when no catalog
+            // entry claims this ID.
+            let type = eventType;
+            let endpointType = eventType;
             if (catalogAvailable === false) {
                 catalogStatus = "catalog-unavailable";
                 description = "Unknown model while live catalog is unavailable";
@@ -58,23 +71,20 @@ export function mergeModelHealth(models, healthStats, catalogAvailable) {
                 catalogStatus = "anomaly";
                 community = sameName.some((model) => model.community);
                 const types = [...new Set(sameName.map((model) => model.type))];
-                description = `Unexpected ${type} traffic; registered as ${types.sort().join("/")}`;
-            } else if (
-                models.some(
-                    (model) =>
-                        model.aliases.includes(row.model) &&
-                        matchesEndpoint(model, row),
-                )
-            ) {
+                description = `Unexpected ${eventType} traffic; registered as ${types.sort().join("/")}`;
+            } else if (aliased) {
                 catalogStatus = "historical";
                 description =
                     "Historical ID, now an alias. Recorded traffic is kept separate from current model health.";
+                community = aliased.community;
+                type = aliased.type;
+                endpointType = aliased.endpointType;
             }
             return {
                 name: row.model || "(unknown)",
                 community,
                 type,
-                endpointType: type,
+                endpointType,
                 provider: row.provider,
                 description,
                 catalogStatus,

--- a/operations/model-monitor/src/model-data.test.js
+++ b/operations/model-monitor/src/model-data.test.js
@@ -122,9 +122,47 @@ test("video aliases use image events while preserving video favorites", () => {
         true,
     );
     assert.equal(results[1].catalogStatus, "historical");
+    assert.equal(results[1].type, "video");
+    assert.equal(results[1].endpointType, "image");
     assert.deepEqual(migrateFavorites(["video-old-video"], results), [
         "video-publisher/video-1",
     ]);
+});
+
+test("renamed community models keep their catalog category and scope", () => {
+    const renamed = normalizeCatalogModel({
+        name: "community/owner/seedance",
+        category: "video",
+        community: true,
+        aliases: ["owner/seedance"],
+    });
+    const [, historical] = mergeModelHealth(
+        [renamed],
+        [
+            {
+                model: "owner/seedance",
+                event_type: "generate.image",
+                provider: "community",
+                total_requests: 3,
+                status_2xx: 3,
+            },
+        ],
+        true,
+    );
+    assert.equal(historical.catalogStatus, "historical");
+    assert.equal(historical.type, "video");
+    assert.equal(historical.community, true);
+});
+
+test("unregistered traffic still falls back to the event type", () => {
+    const [unregistered] = mergeModelHealth(
+        [],
+        [{ model: "owner/deleted", event_type: "generate.image" }],
+        true,
+    );
+    assert.equal(unregistered.catalogStatus, "unregistered");
+    assert.equal(unregistered.type, "image");
+    assert.equal(unregistered.community, false);
 });
 
 test("favorites migrate and deduplicate without erasing unknown selections", () => {

--- a/packages/ui/src/compositions/AccountIdentity.tsx
+++ b/packages/ui/src/compositions/AccountIdentity.tsx
@@ -1,0 +1,62 @@
+import type { ReactNode } from "react";
+import { cn } from "../lib/cn.ts";
+
+export type AccountIdentityProps = {
+    name: string;
+    avatarUrl?: string | null;
+    secondaryContent?: ReactNode;
+    className?: string;
+};
+
+function initials(name: string) {
+    const parts = name.trim().split(/\s+/).filter(Boolean);
+    if (parts.length === 0) return "?";
+    if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+    return `${parts[0][0] ?? ""}${parts.at(-1)?.[0] ?? ""}`.toUpperCase();
+}
+
+/** The account menu's identity display, also usable without menu actions. */
+export function AccountIdentity({
+    name,
+    avatarUrl,
+    secondaryContent,
+    className,
+}: AccountIdentityProps) {
+    return (
+        <span
+            className={cn(
+                "polli:flex polli:min-w-0 polli:items-center polli:gap-2 polli:rounded-full polli:bg-ink-100/80 polli:p-1 polli:pr-3",
+                className,
+            )}
+        >
+            {avatarUrl ? (
+                <img
+                    src={avatarUrl}
+                    alt=""
+                    className="polli:h-8 polli:w-8 polli:shrink-0 polli:rounded-full polli:object-cover"
+                />
+            ) : (
+                <span
+                    role="img"
+                    aria-label={`${name} avatar`}
+                    className="polli:flex polli:h-8 polli:w-8 polli:shrink-0 polli:items-center polli:justify-center polli:rounded-full polli:bg-theme-bg-pale polli:text-xs polli:font-semibold polli:text-theme-text-strong"
+                >
+                    {initials(name)}
+                </span>
+            )}
+            <span className="polli:flex polli:min-w-0 polli:flex-1 polli:flex-col polli:items-start polli:text-left">
+                <span
+                    className="polli:max-w-full polli:truncate polli:text-sm polli:font-medium polli:text-theme-text-strong"
+                    title={name}
+                >
+                    {name}
+                </span>
+                {secondaryContent != null && (
+                    <span className="polli:max-w-full polli:truncate polli:text-xs polli:text-theme-text-base">
+                        {secondaryContent}
+                    </span>
+                )}
+            </span>
+        </span>
+    );
+}

--- a/packages/ui/src/compositions/AccountMenu.tsx
+++ b/packages/ui/src/compositions/AccountMenu.tsx
@@ -1,27 +1,18 @@
-import type { ReactNode } from "react";
 import { cn } from "../lib/cn.ts";
 import { ChevronIcon } from "../primitives/ChevronIcon.tsx";
 import { Dropdown, type DropdownProps } from "../primitives/Dropdown.tsx";
+import {
+    AccountIdentity,
+    type AccountIdentityProps,
+} from "./AccountIdentity.tsx";
 
-export type AccountMenuProps = {
-    name: string;
-    avatarUrl?: string | null;
-    /** Optional display content, such as the app allowance or session context. */
-    secondaryContent?: ReactNode;
+export type AccountMenuProps = AccountIdentityProps & {
     /** The caller owns navigation, permissions and sign-out behavior. */
     children: DropdownProps["children"];
-    className?: string;
     menuClassName?: string;
     side?: "top" | "bottom";
     menuLabel?: string;
 };
-
-function initials(name: string) {
-    const parts = name.trim().split(/\s+/).filter(Boolean);
-    if (parts.length === 0) return "?";
-    if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
-    return `${parts[0][0] ?? ""}${parts.at(-1)?.[0] ?? ""}`.toUpperCase();
-}
 
 export function AccountMenu({
     name,
@@ -51,31 +42,12 @@ export function AccountMenu({
                         className,
                     )}
                 >
-                    {avatarUrl ? (
-                        <img
-                            src={avatarUrl}
-                            alt=""
-                            className="polli:h-8 polli:w-8 polli:shrink-0 polli:rounded-full polli:object-cover"
-                        />
-                    ) : (
-                        <span
-                            role="img"
-                            aria-label={`${name} avatar`}
-                            className="polli:flex polli:h-8 polli:w-8 polli:shrink-0 polli:items-center polli:justify-center polli:rounded-full polli:bg-theme-bg-pale polli:text-xs polli:font-semibold polli:text-theme-text-strong"
-                        >
-                            {initials(name)}
-                        </span>
-                    )}
-                    <span className="polli:flex polli:min-w-0 polli:flex-1 polli:flex-col polli:items-start polli:text-left">
-                        <span className="polli:max-w-full polli:truncate polli:text-sm polli:font-medium">
-                            {name}
-                        </span>
-                        {secondaryContent != null && (
-                            <span className="polli:max-w-full polli:truncate polli:text-xs polli:text-theme-text-base">
-                                {secondaryContent}
-                            </span>
-                        )}
-                    </span>
+                    <AccountIdentity
+                        name={name}
+                        avatarUrl={avatarUrl}
+                        secondaryContent={secondaryContent}
+                        className="polli:flex-1 polli:bg-transparent polli:p-0 polli:pr-0"
+                    />
                     <ChevronIcon
                         expanded={open}
                         className="polli:ml-auto polli:h-4 polli:w-4 polli:text-theme-text-strong"

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,4 +1,8 @@
 export {
+    AccountIdentity,
+    type AccountIdentityProps,
+} from "./compositions/AccountIdentity.tsx";
+export {
     AccountMenu,
     type AccountMenuProps,
 } from "./compositions/AccountMenu.tsx";

--- a/shared/agents/output.ts
+++ b/shared/agents/output.ts
@@ -174,14 +174,16 @@ export function collectOutput(
                 type: "function_call_output",
                 id: `fco_${crypto.randomUUID()}`,
                 call_id: call.call_id,
-                output: JSON.stringify(result),
+                // Content parts rather than a bare string: Open WebUI iterates
+                // the output of every function_call_output item it receives.
+                output: [{ type: "input_text", text: JSON.stringify(result) }],
                 status: "completed",
             });
             items.push(item);
             const output_index = items.length - 1;
             send?.("response.output_item.added", {
                 output_index,
-                item: { ...item, output: "", status: "in_progress" },
+                item: { ...item, output: [], status: "in_progress" },
             });
             send?.("response.output_item.done", { output_index, item });
         },

--- a/shared/agents/responses.ts
+++ b/shared/agents/responses.ts
@@ -14,11 +14,12 @@ import {
     ResponseUsageSchema,
 } from "../schemas/openai.ts";
 import {
-    type FunctionCall,
-    FunctionCallOutputSchema,
-    FunctionCallSchema,
-    parseFunctionName,
-} from "./function-items.ts";
+    functionOutputText,
+    type ResponseFunctionCall,
+    ResponseFunctionCallOutputSchema,
+    ResponseFunctionCallSchema,
+} from "../schemas/response-function-items.ts";
+import { parseFunctionName } from "./function-items.ts";
 import { safeMcpModelOutput } from "./mcp-output.ts";
 import { type AgentOutputItem, collectOutput } from "./output.ts";
 import type {
@@ -190,7 +191,7 @@ async function inputMessages(
 
     const itemIds = new Set<string>();
     const toolCallIds = new Set<string>();
-    const pendingCalls = new Map<string, FunctionCall>();
+    const pendingCalls = new Map<string, ResponseFunctionCall>();
     let calls: ToolCallPart[] = [];
     let results: ToolResultPart[] = [];
     for (const raw of request.input) {
@@ -206,10 +207,12 @@ async function inputMessages(
             itemIds.add(id);
         }
         if (item.type === "function_call") {
-            const parsed = FunctionCallSchema.safeParse(item);
+            // Input items carry optional id and status, unlike the items the
+            // agent emits: Open WebUI strips both when it replays history.
+            const parsed = ResponseFunctionCallSchema.safeParse(item);
             if (
                 !parsed.success ||
-                parsed.data.status !== "completed" ||
+                (parsed.data.status ?? "completed") !== "completed" ||
                 toolCallIds.has(parsed.data.call_id)
             ) {
                 invalidRequest(
@@ -247,13 +250,13 @@ async function inputMessages(
             continue;
         }
         if (item.type === "function_call_output") {
-            const parsed = FunctionCallOutputSchema.safeParse(item);
+            const parsed = ResponseFunctionCallOutputSchema.safeParse(item);
             const call = parsed.success
                 ? pendingCalls.get(parsed.data.call_id)
                 : undefined;
             if (
                 !parsed.success ||
-                parsed.data.status !== "completed" ||
+                (parsed.data.status ?? "completed") !== "completed" ||
                 !call
             ) {
                 invalidRequest(
@@ -264,7 +267,9 @@ async function inputMessages(
             const isMcp = Boolean(parseFunctionName(call.name));
             let output: z.infer<ReturnType<typeof z.json>>;
             try {
-                output = z.json().parse(JSON.parse(parsed.data.output));
+                output = z
+                    .json()
+                    .parse(JSON.parse(functionOutputText(parsed.data.output)));
                 if (isMcp) {
                     const result = objectValue(output, "input.output");
                     if (

--- a/shared/http/payment-required-error.ts
+++ b/shared/http/payment-required-error.ts
@@ -4,6 +4,8 @@ export class PaymentRequiredError extends HTTPException {
     constructor(
         readonly errorCode: "KEY_BUDGET_EXHAUSTED" | "INSUFFICIENT_BALANCE",
         message: string,
+        /** Only paid Pollen can cover this model, so quests are no remedy. */
+        readonly paidOnly = false,
     ) {
         super(402, { message });
     }

--- a/shared/schemas/response-function-items.ts
+++ b/shared/schemas/response-function-items.ts
@@ -11,13 +11,29 @@ export const ResponseFunctionCallSchema = z.object({
     status: ItemStatusSchema.optional(),
 });
 
+// Tool output is a string or content parts, as in the OpenAI Responses API.
+// Non-text parts (input_image, input_file) are accepted but carry no text.
+const FunctionOutputPartSchema = z.union([
+    z.object({ type: z.literal("input_text"), text: z.string() }),
+    z.object({ type: z.string() }).loose(),
+]);
+
 export const ResponseFunctionCallOutputSchema = z.object({
     type: z.literal("function_call_output"),
     id: z.string().min(1).optional(),
     call_id: z.string().min(1),
-    output: z.string(),
+    output: z.union([z.string(), z.array(FunctionOutputPartSchema)]),
     status: ItemStatusSchema.optional(),
 });
+
+export function functionOutputText(
+    output: z.infer<typeof ResponseFunctionCallOutputSchema>["output"],
+): string {
+    if (typeof output === "string") return output;
+    return output
+        .map((part) => (part.type === "input_text" ? String(part.text) : ""))
+        .join("");
+}
 
 export type ResponseFunctionCall = z.infer<typeof ResponseFunctionCallSchema>;
 export type ResponseFunctionCallOutput = z.infer<


### PR DESCRIPTION
Promotes 3 commits merged since the 2026-09-12 promotion (#14785).

**Standalone top-up and key editor (#14740)** — new enter routes `/top-up` and `/edit-key`, linked from the in-chat 402 notice so a user who runs out mid-conversation can fix it and return. The notice now also covers an exhausted key budget (links to the key editor, not top-up) and drops the quest link for paid-only models. Stripe checkout and the billing portal take a fixed page token, never a caller-supplied path. Exercised end to end on staging enter, staging gen and Open WebUI staging.

**Agent tool results as content parts (#14761)** — changes the shape agents emit for tool results in the Responses API.

**Model monitor categories (#14786)** — operations dashboard only; derives category from catalog metadata instead of the recorded event type.

No migrations, no wrangler or binding changes, no secret file changes.

Note: `apps/openwebui/worker.js` changed, so `Deploy / Applications` will redeploy the Open WebUI worker and re-push its existing (unchanged) secrets. That deploy adds `Referrer-Policy: no-referrer-when-downgrade`, which makes links out of a chat carry the chat URL rather than just the origin, so third-party sites linked from a chat can see it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015mNrP6DkRQmm3YStNjfFv3
