### PR TITLE
refactor: key image generations on their own request

### DIFF
--- a/gen.pollinations.ai/src/middleware/generation-cache.ts
+++ b/gen.pollinations.ai/src/middleware/generation-cache.ts
@@ -22,8 +22,6 @@ export type GenerationCacheVariables = {
         adapter: GenerationCacheAdapter;
         key: string;
     };
-    /** Alternate request identity for routes which wrap a media response. */
-    generationCacheUrl?: URL;
     /** Native route replayed when a public endpoint only formats its result. */
     generationRequestUrl?: URL;
     generationRequestMethod?: string;
@@ -135,7 +133,12 @@ export const prepareGenerationRequest = createMiddleware<GenerationCacheEnv>(
             if (typeof body === "string") {
                 c.set("generationRequestBody", identity);
             }
-            c.set("generationCacheBody", identity);
+            // A route that already declared its cache identity keeps it: the
+            // replayable body carries fields, such as the response format,
+            // that do not change the generated file.
+            if (c.var.generationCacheBody === undefined) {
+                c.set("generationCacheBody", identity);
+            }
             return next();
         }
 

--- a/gen.pollinations.ai/src/middleware/legacy-media-cache.ts
+++ b/gen.pollinations.ai/src/middleware/legacy-media-cache.ts
@@ -62,10 +62,8 @@ export function legacyMediaCacheKey(
 async function requestLegacyKey(
     c: Context<GenerationCacheEnv>,
 ): Promise<string> {
-    const url = new URL(
-        c.var.generationCacheUrl ?? c.var.generationRequestUrl ?? c.req.url,
-    );
-    if (!c.var.generationCacheUrl && c.var.generationCacheBody) {
+    const url = new URL(c.var.generationRequestUrl ?? c.req.url);
+    if (c.var.generationCacheBody) {
         url.searchParams.set(
             "__request_body",
             await hashGenerationCacheIdentity(
@@ -77,7 +75,7 @@ async function requestLegacyKey(
     const variables = c.var as typeof c.var & Partial<ModelVariables>;
     return legacyMediaCacheKey(
         url,
-        c.var.generationCacheUrl ? undefined : c.req.header(SAFETY_HEADER_NAME),
+        c.req.header(SAFETY_HEADER_NAME),
         getRequiredSafetyFeatures(variables.model),
     );
 }

--- a/gen.pollinations.ai/src/middleware/media-cache.ts
+++ b/gen.pollinations.ai/src/middleware/media-cache.ts
@@ -41,12 +41,8 @@ function mediaCacheAdapter(config: MediaCacheConfig): GenerationCacheAdapter {
         label: config.label,
         async getKey(c) {
             const variables = c.var as typeof c.var & Partial<ModelVariables>;
-            const cacheUrl = new URL(
-                c.var.generationCacheUrl ??
-                    c.var.generationRequestUrl ??
-                    c.req.url,
-            );
-            if (!c.var.generationCacheUrl && c.var.generationCacheBody) {
+            const cacheUrl = new URL(c.var.generationRequestUrl ?? c.req.url);
+            if (c.var.generationCacheBody) {
                 cacheUrl.searchParams.set(
                     "__request_body",
                     await hashGenerationCacheIdentity(
@@ -57,9 +53,7 @@ function mediaCacheAdapter(config: MediaCacheConfig): GenerationCacheAdapter {
             }
             return generateCacheKey(
                 cacheUrl,
-                c.var.generationCacheUrl
-                    ? undefined
-                    : c.req.header(SAFETY_HEADER_NAME),
+                c.req.header(SAFETY_HEADER_NAME),
                 getRequiredSafetyFeatures(variables.model),
             );
         },

--- a/gen.pollinations.ai/src/routes/images.ts
+++ b/gen.pollinations.ai/src/routes/images.ts
@@ -5,7 +5,6 @@
  */
 
 import { UpstreamError } from "@shared/error.ts";
-import { getPublicOrigin } from "@shared/public-origin.ts";
 import {
     buildUsageHeaders,
     FALLBACK_TARGET_HEADER,
@@ -18,11 +17,7 @@ import {
     CreateImageEditRequestSchema,
     type CreateImageRequest,
 } from "@shared/schemas/openai.ts";
-import {
-    normalizeSafeValue,
-    SAFETY_HEADER_NAME,
-    type SafeValue,
-} from "@shared/schemas/safety.ts";
+import { normalizeSafeValue, type SafeValue } from "@shared/schemas/safety.ts";
 import type { Context } from "hono";
 import { createMiddleware } from "hono/factory";
 import type { Env } from "@/env.ts";
@@ -81,14 +76,6 @@ function responseImageUsage(
     const fallbackTarget = response.headers.get(FALLBACK_TARGET_HEADER);
     if (fallbackTarget) c.header(FALLBACK_TARGET_HEADER, fallbackTarget);
     return usageToOpenAIImageUsage(usage);
-}
-
-function setUrlParam(url: URL, name: string, value: unknown): void {
-    if (value === undefined || value === null) return;
-    url.searchParams.set(
-        name,
-        Array.isArray(value) ? value.join("|") : String(value),
-    );
 }
 
 /** Resolve OpenAI params to Pollinations equivalents. */
@@ -294,12 +281,11 @@ export const prepareOpenAIImageEditReplay = createMiddleware<Env>(
     },
 );
 
-/** Resolve the POST body to the equivalent public media URL used for caching. */
+/** Normalize the generation body and hash the parts that shape the file. */
 export const prepareOpenAIImageGeneration = createMiddleware<Env>(
     async (c, next) => {
         const body = c.req.valid("json" as never) as CreateImageRequest &
             Record<string, unknown>;
-        const model = c.var.model.resolved;
 
         // This endpoint returns a complete image/JSON, never an SSE stream.
         // A passthrough stream flag must not bypass durable media storage.
@@ -315,23 +301,20 @@ export const prepareOpenAIImageGeneration = createMiddleware<Env>(
             prompt: safePrompt,
         });
         c.set("generationRequestBody", JSON.stringify(body));
-
-        const imageUrl = new URL(
-            `/image/${encodeURIComponent(body.prompt)}`,
-            getPublicOrigin(c),
+        // Only the prompt, the model and the generation parameters change the
+        // bytes. Response formatting and caller metadata are left out so they
+        // do not split one image across several cache entries.
+        c.set(
+            "generationCacheBody",
+            normalizedJsonBody(
+                JSON.stringify({
+                    prompt: safePrompt,
+                    model: c.var.model.resolved,
+                    ...resolved,
+                    ...collectPassthrough(body, ...CACHE_PARAMS),
+                }),
+            ),
         );
-        for (const [name, value] of Object.entries({
-            model,
-            ...resolved,
-            ...collectPassthrough(body, ...CACHE_PARAMS),
-        })) {
-            setUrlParam(imageUrl, name, value);
-        }
-        const safeValue = normalizeSafeValue(
-            (body.safe ?? c.req.header(SAFETY_HEADER_NAME)) as SafeValue,
-        );
-        if (safeValue) imageUrl.searchParams.set("safe", safeValue);
-        c.set("generationCacheUrl", imageUrl);
 
         await next();
     },

--- a/gen.pollinations.ai/test/legacy-media-cache.test.ts
+++ b/gen.pollinations.ai/test/legacy-media-cache.test.ts
@@ -36,23 +36,13 @@ const app = new Hono<GenerationCacheEnv>()
     .use("*", async (c, next) => {
         c.set("log", log);
         c.set("requestId", "migration-test");
-        // Image generations already supply this URL before the cache adapter runs.
-        if (c.req.path === "/v1/images/generations") {
-            c.set(
-                "generationCacheUrl",
-                new URL(
-                    "https://gen.pollinations.ai/image/wrapped?model=flux&seed=42",
-                ),
-            );
-        }
         await next();
     })
     .get("/image/:prompt", imageCache, generate)
     .get("/video/:prompt", imageCache, generate)
     .get("/audio/:prompt", audioCache, generate)
     .get("/3d/:prompt", model3dCache, generate)
-    .post("/v1/audio/speech", prepareGenerationRequest, audioCache, generate)
-    .post("/v1/images/generations", imageCache, generate);
+    .post("/v1/audio/speech", prepareGenerationRequest, audioCache, generate);
 
 async function request(path: string, init?: RequestInit) {
     const ctx = createExecutionContext();
@@ -69,43 +59,6 @@ async function request(path: string, init?: RequestInit) {
 afterEach(() => vi.restoreAllMocks());
 
 describe("temporary legacy media cache", () => {
-    it("promotes a legacy image through the real OpenAI route", async () => {
-        const url = new URL(
-            "https://gen.pollinations.ai/image/legacy-openai?model=black-forest-labs%2Fflux.1-schnell&quality=medium&seed=42&width=1024&height=1024",
-        );
-        const key = legacyMediaCacheKey(url);
-        await env.LEGACY_MEDIA_BUCKET.put(key, "image bytes", {
-            httpMetadata: { contentType: "image/png" },
-        });
-        const lookup = vi.spyOn(env.LEGACY_MEDIA_BUCKET, "get");
-        const ctx = createExecutionContext();
-        const response = await worker.fetch(
-            new Request("https://gen.pollinations.ai/v1/images/generations", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                    model: "flux",
-                    prompt: "legacy-openai",
-                    seed: 42,
-                    response_format: "url",
-                }),
-            }),
-            env,
-            ctx,
-        );
-        const body = await response.json();
-        await waitOnExecutionContext(ctx);
-        expect(lookup).toHaveBeenCalledWith(key);
-        expect(response.status).toBe(200);
-        expect(body).toMatchObject({
-            data: [
-                {
-                    url: `https://media.pollinations.ai/${await generateCacheKey(url)}`,
-                },
-            ],
-        });
-    });
-
     fixtureTest(
         "serves a migrated hit through the real worker without spending",
         async ({ budgetedApiKey }) => {
@@ -257,25 +210,6 @@ describe("temporary legacy media cache", () => {
             .mockRejectedValue(new Error("old cache unavailable"));
         expect((await request(path)).body).toBe("current");
         expect(oldRead).not.toHaveBeenCalled();
-    });
-
-    it("uses the existing image-generation cache URL", async () => {
-        const url = new URL(
-            "https://gen.pollinations.ai/image/wrapped?model=flux&seed=42",
-        );
-        await env.LEGACY_MEDIA_BUCKET.put(
-            legacyMediaCacheKey(url),
-            "image bytes",
-            { httpMetadata: { contentType: "image/png" } },
-        );
-        const result = await request("/v1/images/generations", {
-            method: "POST",
-        });
-        expect(result.response.status).toBe(200);
-        expect(result.body).toBe("image bytes");
-        expect(result.response.headers.get("Link")).toBe(
-            `<https://media.pollinations.ai/${await generateCacheKey(url)}>; rel="enclosure"`,
-        );
     });
 
     it("includes normalized POST bodies in the old key", async () => {

--- a/gen.pollinations.ai/test/openai-image-cache.test.ts
+++ b/gen.pollinations.ai/test/openai-image-cache.test.ts
@@ -10,7 +10,11 @@ import { createTestR2Bucket } from "@shared/test/mocks/r2.ts";
 import { Hono } from "hono";
 import { describe, expect, it } from "vitest";
 import type { Env } from "@/env.ts";
-import { prepareGenerationRequest } from "@/middleware/generation-cache.ts";
+import {
+    hashGenerationCacheIdentity,
+    normalizedJsonBody,
+    prepareGenerationRequest,
+} from "@/middleware/generation-cache.ts";
 import { imageCache } from "@/middleware/media-cache.ts";
 import { generateCacheKey } from "@/utils/media-cache.ts";
 import { MediaUpload } from "../../media.pollinations.ai/src/media-upload.ts";
@@ -312,8 +316,26 @@ describe("OpenAI image cache", () => {
         "b64_json",
     ])("serves %s and a file link for objects cached before model metadata was stored", async (response_format) => {
         const bucket = createTestR2Bucket();
+        // The request identifies itself: its own path plus a hash of the
+        // parameters that shape the file. Response format is not one of them.
         const cacheUrl = new URL(
-            "https://gen.pollinations.ai/image/a%20cat?model=flux&width=1024&height=1024&quality=medium&seed=7",
+            "https://gen.pollinations.ai/v1/images/generations",
+        );
+        cacheUrl.searchParams.set(
+            "__request_body",
+            await hashGenerationCacheIdentity(
+                "media",
+                normalizedJsonBody(
+                    JSON.stringify({
+                        prompt: "a cat",
+                        model: "flux",
+                        width: 1024,
+                        height: 1024,
+                        quality: "medium",
+                        seed: 7,
+                    }),
+                ),
+            ),
         );
         await bucket.put(
             await generateCacheKey(cacheUrl),

--- a/gen.pollinations.ai/test/safety.test.ts
+++ b/gen.pollinations.ai/test/safety.test.ts
@@ -343,7 +343,7 @@ describe("applySafetyToInput text", { timeout: 30000 }, () => {
         expect(await stored?.text()).toBe(secondPrompt);
     });
 
-    it("uses the redacted prompt for OpenAI image cache URLs", async () => {
+    it("uses the redacted prompt for the OpenAI image cache identity", async () => {
         guardrailResponse = intervened(
             {
                 sensitiveInformationPolicy: {
@@ -378,7 +378,7 @@ describe("applySafetyToInput text", { timeout: 30000 }, () => {
                 c.json({
                     prompt: (c.req.valid("json" as never) as { prompt: string })
                         .prompt,
-                    url: c.var.generationCacheUrl?.toString(),
+                    identity: c.var.generationCacheBody,
                 }),
             );
 
@@ -396,12 +396,12 @@ describe("applySafetyToInput text", { timeout: 30000 }, () => {
         );
         const result = await response.json<{
             prompt: string;
-            url: string;
+            identity: string;
         }>();
 
         expect(result.prompt).toBe("portrait of {EMAIL}");
-        expect(result.url).toContain("portrait%20of%20%7BEMAIL%7D");
-        expect(result.url).not.toContain("a%40example.com");
+        expect(result.identity).toContain("portrait of {EMAIL}");
+        expect(result.identity).not.toContain("a@example.com");
     });
 
     it("accepts safety from the request header", async () => {


### PR DESCRIPTION
POST `/v1/images/generations` used to rebuild its request as a synthetic `GET /image/{prompt}?...` URL purely so its cache key would collide with the native route. That meant a hand-maintained param allowlist, URL encoding, `getPublicOrigin`, and a `generationCacheUrl` variable with special branches in two cache adapters.

- Hashes the request itself — its own path plus a normalized body identity — the way `/v1/images/edits` and `/v1/audio/speech` already do
- Deletes `generationCacheUrl`, the URL builder, and the `setUrlParam` helper
- `prepareGenerationRequest` no longer overwrites an identity a route already declared
- Identity covers prompt, model and generation params only, so `url` and `b64_json` still share one image

### Cost

- Every cached POST `/v1/images/generations` entry gets a new key, so those `media.pollinations.ai` ids change and the endpoint regenerates once at GPU cost. `GET /image` and chat/responses image entries are untouched.
- POST no longer promotes objects out of the retired binary cache under the `/image` identity. GET `/image` promotion and POST-body promotion (`/v1/audio/speech`) still work.
- GET and POST no longer share a cache entry for the same image.

Conflicts with #14784 on one line in `prepareOpenAIImageGeneration`; whichever merges first, the other keeps `listedModels?.join(",") ?? resolved` as the identity's model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0161ggPVjwNMTu6oaevEScZw
